### PR TITLE
Replaces mob vore pref with devourable pref, makes hostile mobs attempt to incapacitate targets before noms

### DIFF
--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -287,9 +287,9 @@
 
 	switch(user.allowmobvore)
 		if(1)
-			dat += "<a href='?src=\ref[src];togglemv=1'>Toggle Mob Vore</a>"
+			dat += "<a href='?src=\ref[src];togglemv=1'>Toggle Consumption</a>"	//CIT CHANGE - changes "mob vore" to consumption
 		if(0)
-			dat += "<a href='?src=\ref[src];togglemv=1'><span style='color:green;'>Toggle Mob Vore</span></a>"
+			dat += "<a href='?src=\ref[src];togglemv=1'><span style='color:green;'>Toggle Consumption</span></a>"	//CIT CHANGE - changes "mob vore" to consumption
 
 	dat += "<br><a href='?src=\ref[src];toggle_dropnom_prey=1'>Toggle Drop-nom Prey</a>" //These two get their own, custom row, too.
 	dat += "<a href='?src=\ref[src];toggle_dropnom_pred=1'>Toggle Drop-nom Pred</a>"
@@ -804,16 +804,16 @@
 			user.client.prefs_vr.digestable = user.digestable
 
 	if(href_list["togglemv"])
-		var/choice = alert(user, "This button is for those who don't like being eaten by mobs. Messages admins when changed, so don't try to use it for mechanical benefit. Set it once and save it. Mobs are currently: [user.allowmobvore ? "Allowed to eat" : "Prevented from eating"] you.", "", "Allow Mob Predation", "Cancel", "Prevent Mob Predation")
+		var/choice = alert(user, "This button is for those who don't like the idea of diving down a gullet. Set it once and save it. Others are currently: [user.allowmobvore ? "Allowed to eat" : "Prevented from eating"] you.", "", "Allow Consumption", "Cancel", "Prevent Consumption")//CIT CHANGE - changes the flavor text for the mob vore preference to reflect its new status as a devourable toggle
 		switch(choice)
 			if("Cancel")
 				return 0
-			if("Allow Mob Predation")
+			if("Allow Consumption")
 				user.allowmobvore = TRUE
-			if("Prevent Mob Predation")
+			if("Prevent Consumption")
 				user.allowmobvore = FALSE
 
-		message_admins("[key_name(user)] toggled their mob vore preference to [user.allowmobvore] ([user ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[user.loc.];Y=[user.loc.y];Z=[user.loc.z]'>JMP</a>" : "null"])")
+		//message_admins("[key_name(user)] toggled their mob vore preference to [user.allowmobvore] ([user ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[user.loc.];Y=[user.loc.y];Z=[user.loc.z]'>JMP</a>" : "null"])") CIT CHANGE - We don't need this.
 
 		if(user.client.prefs_vr)
 			user.client.prefs_vr.allowmobvore = user.allowmobvore

--- a/modular_citadel/code/modules/mob/living/simple_animal/simple_animal_vr.dm
+++ b/modular_citadel/code/modules/mob/living/simple_animal/simple_animal_vr.dm
@@ -1,0 +1,7 @@
+/mob/living/simple_animal/will_eat(var/mob/living/M)
+	. = ..()
+	if(.)	//insanely negligible performance buff
+		if(istype(M) && hostile && !M.incapacitated(INCAPACITATION_ALL))
+			ai_log("vr/wont eat [M] because i lust for blood", 3)
+			return FALSE
+	return

--- a/modular_citadel/code/modules/vore/eating/living_vr.dm
+++ b/modular_citadel/code/modules/vore/eating/living_vr.dm
@@ -1,0 +1,9 @@
+/mob/living/perform_the_nom(var/mob/living/user, var/mob/living/prey, var/mob/living/pred, var/obj/belly/belly, var/delay)
+	if(istype(prey) && istype(user))
+		if(!prey.allowmobvore)
+			if(user == pred)
+				to_chat(user, "<span class='warning'>[prey] doesn't look very appetizing.</span>")
+			else
+				to_chat(user, "<span class='warning'>It doesn't seem like you're able to fit [prey] into [pred].</span>")
+			return FALSE
+	. = ..()

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2892,4 +2892,6 @@
 #include "maps\tether\tether.dm"
 #include "maps\~map_system\maps.dm"
 #include "modular_citadel\code\modules\admin\chat_commands.dm"
+#include "modular_citadel\code\modules\mob\living\simple_animal\simple_animal_vr.dm"
+#include "modular_citadel\code\modules\vore\eating\living_vr.dm"
 // END_INCLUDE


### PR DESCRIPTION
Title.
This renames the "mob vore" pref to "consumption", and makes it apply to normal players. If you try to shove someone with consumption off into your maw, you'll get a message telling you that the person you're trying to consume is unappetizing.
This also makes it so that hostile mobs will attempt to attack their targets before consumption. Hostile mobs will now only consider consuming their targets if the target is incapacitated. This makes hostile mob encounters a lot more fair for those that wanna keep consumption on.