### PR TITLE
 Some users on RP server want to restore original round end timer. 

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -395,6 +395,8 @@ var/global/list/cont_flavors_musky = list("drenched",
 	paths = typesof(/datum/trait) - /datum/trait
 	for(var/path in paths)
 		var/datum/trait/instance = new path()
+		if(!instance.name)
+			continue //A prototype or something
 		var/cost = instance.cost
 		traits_costs[path] = cost
 		all_traits[path] = instance

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -1,7 +1,7 @@
 var/global/datum/controller/gameticker/ticker
 
 /datum/controller/gameticker
-	var/const/restart_timeout = 2 MINUTES //One minute is 600. /CITADEL CHANGE - reduces the round end restart timer to 2 minutes
+	var/const/restart_timeout = 3 MINUTES //One minute is 600.
 	var/current_state = GAME_STATE_PREGAME
 
 	var/hide_mode = 0


### PR DESCRIPTION
Did a poll on the RP server channel, if you'd like you can check on them until we can get an end round voting system to have a more controllable scenario for when ERT or crew wishing to stay around a bit longer.