### PR TITLE
Nerfs infection damage for living limbs

### DIFF
--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -161,7 +161,7 @@ var/list/organ_cache = list()
 		infection_damage = max(1, 1 + round((germ_level - INFECTION_LEVEL_THREE)/200,0.25)) //1 Tox plus a little based on germ level
 
 	else if(germ_level > INFECTION_LEVEL_TWO && antibiotics < ANTIBIO_OD)
-		infection_damage = max(0.25, 0.25 + round((germ_level - INFECTION_LEVEL_TWO)/200,0.25))
+		infection_damage = max(0.25, 0.25 + round((germ_level - INFECTION_LEVEL_TWO)/1000,0.25))
 
 	if(infection_damage)
 		owner.adjustToxLoss(infection_damage)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -161,7 +161,7 @@ var/list/organ_cache = list()
 		infection_damage = max(1, 1 + round((germ_level - INFECTION_LEVEL_THREE)/200,0.25)) //1 Tox plus a little based on germ level
 
 	else if(germ_level > INFECTION_LEVEL_TWO && antibiotics < ANTIBIO_OD)
-		infection_damage = max(0.25, 0.25 + round((germ_level - INFECTION_LEVEL_TWO)/1000,0.25))
+		infection_damage = max(0.25, 0.25 + round((germ_level - INFECTION_LEVEL_TWO)/1000,0.25))	//CITADEL EDIT: Increases the /200 here to /1000 to nerf infection damage
 
 	if(infection_damage)
 		owner.adjustToxLoss(infection_damage)


### PR DESCRIPTION
At the absolute minimum germ level that started causing damage, the damage ended up being 2.75 toxin loss per process cycle, increasing with each process cycle whenever no antibiotics are present, for a maximum of 7.75(!!!) toxloss per process cycle.

This nerfs it to 0.75 toxin loss per process cycle at the absolute minimum threshold to take damage from infections, with 1.75 toxinloss per process cycle being the max. This should give people a little bit more leeway to rush to medbay if they got a papercut, as infected limbs will no longer kill you in 25 process cycles or less.