### PR TITLE
Cures the entire station of HIV - makes infections a lot harder to get

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -52,8 +52,8 @@
 #define ORGAN_NANOFORM 4 // VOREStation Add - Fully nanoswarm organ
 
 //Germs and infections.
-#define GERM_LEVEL_AMBIENT  110 // Maximum germ level you can reach by standing still.
-#define GERM_LEVEL_MOVE_CAP 200 // Maximum germ level you can reach by running around.
+#define GERM_LEVEL_AMBIENT  30 // Maximum germ level you can reach by standing still.		//CITADEL CHANGE - reduces this value from 110 to 30 to make infections harder to get
+#define GERM_LEVEL_MOVE_CAP 110 // Maximum germ level you can reach by running around.	//CITADEL CHANGE - reduces this value from 200 to 110 to make infections harder to get
 
 #define INFECTION_LEVEL_ONE   100
 #define INFECTION_LEVEL_TWO   500


### PR DESCRIPTION
Title. This decreases the ambient germ cap from 110 to 30, which means the ambient germ cap is no longer sufficient for an object to be capable of causing infections. The germ level cap for moving has been decreased from 200 to 110, meaning it's no longer possible to make items cause instant stage 2 infections later in the shift.