### PR TITLE
Fire_Stacks capped at effective fire temperature.

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -380,6 +380,7 @@
 	var/turf/location = get_turf(src)
 	location.hotspot_expose(fire_burn_temperature(), 50, 1)
 
+//CIT CHANGES START HERE
 //altered this to cap at the temperature of the fire causing it, using the same 1:1500 value as /mob/living/carbon/human/handle_fire() in human/life.dm
 //TODO: set fire_stacks conversion to a #define? FIRE_STACKS_TEMPERATURE?
 /mob/living/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
@@ -389,6 +390,7 @@
 	else
 		adjust_fire_stacks(2) //some things call fire_act() without defining a temperature. this is fine.
 	IgniteMob()
+//END OF CIT CHANGES
 
 //Share fire evenly between the two mobs
 //Called in MobCollide() and Crossed()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -380,8 +380,14 @@
 	var/turf/location = get_turf(src)
 	location.hotspot_expose(fire_burn_temperature(), 50, 1)
 
-/mob/living/fire_act()
-	adjust_fire_stacks(2)
+//altered this to cap at the temperature of the fire causing it, using the same 1:1500 value as /mob/living/carbon/human/handle_fire() in human/life.dm
+//TODO: set fire_stacks conversion to a #define? FIRE_STACKS_TEMPERATURE?
+/mob/living/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	if(exposed_temperature)
+		if(fire_stacks < exposed_temperature/1500) //avg. phoron leak fire is around 2000-3000K hot for 1-2 stacks.
+			adjust_fire_stacks(2)
+	else
+		adjust_fire_stacks(2) //some things call fire_act() without defining a temperature. this is fine.
 	IgniteMob()
 
 //Share fire evenly between the two mobs


### PR DESCRIPTION
Chayse pointed out that people were still burning to death in hardsuits that ostensibly have 30,000K protection.
This was because 2 fire_stacks were being added every tick a mob stood in fire, and as each fire_stack is worth about 1500K, this lead to a character burning to death within 10 seconds due to having accumulated 20+ fire_stacks for 30,000K+

This changes how fire_stacks are added to living mobs by /mob/living/fire_act() based on the temperature of the fire causing them, using the same 1:1500 conversion found in /mob/living/carbon/human/handle_fire() in human/life.dm
fire_act() calls without a temperature defined still add 2 stacks normally.

TODO: Balance max temperature values for fire-resistant suits. Ordinary firesuit is currently rated for 30,000K and most breach fires barely reach 3000K.
TODO: Possibly turn the fire_stacks:temperature conversion into a define for easy editing? FIRE_STACKS_TEMPERATURE?