### PR TITLE
Removes off-duty presonnel from alt. title list of Visitor's

### DIFF
--- a/modular_citadel/code/game/jobs/job/assistant_cit.dm
+++ b/modular_citadel/code/game/jobs/job/assistant_cit.dm
@@ -5,6 +5,5 @@
 /datum/job/assistant
 	alt_titles = list(
 					"Entertainer",
-					"Morale Officer",
-					"Off-Duty Employee"
+					"Morale Officer"
 					)


### PR DESCRIPTION
Since normal off-duty code is now officially works.