### PR TITLE
removes KHI NIFs from cargo

### DIFF
--- a/modular_citadel/code/datums/supplypacks/misc_vr.dm
+++ b/modular_citadel/code/datums/supplypacks/misc_vr.dm
@@ -1,8 +1,0 @@
-/datum/supply_packs/misc/khi_nif
-	name = "KHI Nanite Implant Framework"
-	contains = list(
-			/obj/item/device/nif/authentic = 1
-			)
-	cost = 4000
-	containertype = /obj/structure/closet/crate
-	containername = "Kitsuhana Heavy Industries Crate"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2936,7 +2936,6 @@
 #include "maps\~map_system\maps.dm"
 #include "modular_citadel\code\global_cit.dm"
 #include "modular_citadel\code\datums\outfits\jobs\centcom.dm"
-#include "modular_citadel\code\datums\supplypacks\misc_vr.dm"
 #include "modular_citadel\code\datums\supplypacks\security.dm"
 #include "modular_citadel\code\game\jobs\job\assistant_cit.dm"
 #include "modular_citadel\code\game\jobs\job\engineering_cit.dm"


### PR DESCRIPTION
Title. KHI NIFs are meant to be exclusive to admin events, you shouldn't be able to get them just from 10 minutes worth of mining assuming good RNG. Heads siphoning department funds just to buy themselves KHI NIFs is also pretty bad. The sheer amount of drama that comes out of people losing their KHI NIFs is pretty ridiculous, as well.

The RP server simply can't be trusted with fun shit