### PR TITLE
Adds a (for now) admin-only consume objective

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -217,7 +217,7 @@
 			if(!def_value)//If it's a custom objective, it will be an empty string.
 				def_value = "custom"
 
-		var/new_obj_type = input("Select objective type:", "Objective type", def_value) as null|anything in list("assassinate", "debrain", "protect", "prevent", "harm", "brig", "hijack", "escape", "survive", "steal", "download", "mercenary", "capture", "absorb", "custom")
+		var/new_obj_type = input("Select objective type:", "Objective type", def_value) as null|anything in list("assassinate", "debrain", "protect", "prevent", "harm", "brig", "hijack", "escape", "survive", "steal", "download", "mercenary", "capture", "absorb", "consume", "custom") //CITADEL EDIT - adds "consume" to this list
 		if (!new_obj_type) return
 
 		var/datum/objective/new_objective = null
@@ -254,6 +254,10 @@
 					new_objective.owner = src
 					new_objective:target = M.mind
 					new_objective.explanation_text = "[objective_type] [M.real_name], the [M.mind.special_role ? M.mind:special_role : M.mind:assigned_role]."
+
+			if("consume") //CIT CHANGE - adds consume to the list of objectives that can be added
+				new_objective = new /datum/objective/consume //CIT CHANGE - ditto
+				new_objective.owner = src //CIT CHANGE - ditto.
 
 			if ("prevent")
 				new_objective = new /datum/objective/block

--- a/modular_citadel/code/game/gamemodes/objective.dm
+++ b/modular_citadel/code/game/gamemodes/objective.dm
@@ -1,0 +1,33 @@
+/datum/objective/consume
+
+/datum/objective/consume/find_target()
+	var/list/possible_targets = list()
+	for(var/datum/mind/possible_target in ticker.minds)
+		if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.stat != 2) && (possible_target.current.vantag_pref == VANTAG_VORE))
+			possible_targets += possible_target
+	if(possible_targets.len > 0)
+		target = pick(possible_targets)
+	if(target && target.current)
+		explanation_text = "[target.current.real_name], the [target.assigned_role], needs to be taught their place. Make sure they're inside someone's gut by the end of the shift. Preferably yours."
+	else
+		explanation_text = "Free Objective"
+	return target
+
+/datum/objective/consume/find_target_by_role(role, role_type=0)
+	for(var/datum/mind/possible_target in ticker.minds)
+		if((possible_target != owner) && ishuman(possible_target.current) && ((role_type ? possible_target.special_role : possible_target.assigned_role) == role) && (possible_target.current.vantag_pref == VANTAG_VORE))
+			target = possible_target
+			break
+	if(target && target.current)
+		explanation_text = "[target.current.real_name], the [!role_type ? target.assigned_role : target.special_role], needs to be taught their place. Make sure they're inside someone's gut by the end of the shift. Preferably yours."
+	else
+		explanation_text = "Free Objective"
+	return target
+
+/datum/objective/consume/check_completion()
+	if(target && target.current)
+		if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current)) //Borgs/brains/AIs count as dead for traitor objectives. --NeoFite
+			return 0
+		if(isbelly(target.loc))
+			return 1
+	return 0

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2937,6 +2937,7 @@
 #include "modular_citadel\code\global_cit.dm"
 #include "modular_citadel\code\datums\outfits\jobs\centcom.dm"
 #include "modular_citadel\code\datums\supplypacks\security.dm"
+#include "modular_citadel\code\game\gamemodes\objective.dm"
 #include "modular_citadel\code\game\jobs\job\assistant_cit.dm"
 #include "modular_citadel\code\game\jobs\job\engineering_cit.dm"
 #include "modular_citadel\code\game\objects\items\upgradekit.dm"


### PR DESCRIPTION
Title.

When the consume objective is added, it'll make a list of everyone that has their event preference set to "Be Prey" and choose a random person from that list.

The objective will be marked as complete so long as the target is alive and inside of a stomach. Simple stuff really.

This PR is also untested.