### PR TITLE
Dubbles rapid part exchange device holding space

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -391,7 +391,7 @@
 	icon_state = "RPED"
 	w_class = ITEMSIZE_HUGE
 	can_hold = list(/obj/item/weapon/stock_parts)
-	storage_slots = 50
+	storage_slots = 100 // Cit change
 	use_to_pickup = 1
 	allow_quick_gather = 1
 	allow_quick_empty = 1


### PR DESCRIPTION
[What dose this do?]
50 parts WERE the max but now with the power of sci it can hold a 100 parts!
[Whys?]
*Dies in side well trying to make space for more stock parts well still keeping two other parts*
QoL and ect. Not all that power game-y or creep I think