### PR TITLE
Allows Vox defibrillation

### DIFF
--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -262,10 +262,12 @@
 
 //Checks for various conditions to see if the mob is revivable
 /obj/item/weapon/shockpaddles/proc/can_defib(mob/living/carbon/human/H) //This is checked before doing the defib operation
-	if((H.species.flags & NO_SCAN))
+	if((H.species.flags & NO_SCAN &! H.species.reagent_tag & IS_VOX))
 		return "buzzes, \"Unrecogized physiology. Operation aborted.\""
 	else if(H.isSynthetic() && !use_on_synthetic)
 		return "buzzes, \"Synthetic Body. Operation aborted.\""
+	else if(H.species.reagent_tag & IS_VOX && combat == 0)
+		return "buzzes, \"Voltage rating insufficient. Operation aborted.\""
 	else if(!H.isSynthetic() && use_on_synthetic)
 		return "buzzes, \"Organic Body. Operation aborted.\""
 


### PR DESCRIPTION
Makes use of the IS_VOX reagent tag to allow Vox to be defibrillated without removing their NO_SCAN tag. Due to Vox having such a high shock resistance (80% base resistance, according to the Seimens Coefficient of 0.2), this feature is restricted to Defibrillators that can bypass armor, voidsuits, and RIG, such as the Paws of Life and Combat Defibrillator. Anything else will return a message declaring that the voltage rating is insufficient and abort the defib attempt.