### PR TITLE
Vox Defibrillation, with fixed checks

### DIFF
--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -262,7 +262,7 @@
 
 //Checks for various conditions to see if the mob is revivable
 /obj/item/weapon/shockpaddles/proc/can_defib(mob/living/carbon/human/H) //This is checked before doing the defib operation
-	if((H.species.flags & NO_SCAN && !(H.species.reagent_tag & IS_VOX)))
+	if((H.species.flags & NO_SCAN && !(H.species.reagent_tag & IS_VOX))) //Citadel change - gives vox a different defib message
 		return "buzzes, \"Unrecogized physiology. Operation aborted.\""
 	else if(H.isSynthetic() && !use_on_synthetic)
 		return "buzzes, \"Synthetic Body. Operation aborted.\""

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -262,7 +262,7 @@
 
 //Checks for various conditions to see if the mob is revivable
 /obj/item/weapon/shockpaddles/proc/can_defib(mob/living/carbon/human/H) //This is checked before doing the defib operation
-	if((H.species.flags & NO_SCAN &! H.species.reagent_tag & IS_VOX))
+	if((H.species.flags & NO_SCAN && !(H.species.reagent_tag & IS_VOX)))
 		return "buzzes, \"Unrecogized physiology. Operation aborted.\""
 	else if(H.isSynthetic() && !use_on_synthetic)
 		return "buzzes, \"Synthetic Body. Operation aborted.\""

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -262,10 +262,12 @@
 
 //Checks for various conditions to see if the mob is revivable
 /obj/item/weapon/shockpaddles/proc/can_defib(mob/living/carbon/human/H) //This is checked before doing the defib operation
-	if((H.species.flags & NO_SCAN))
+	if((H.species.flags & NO_SCAN &! H.species.reagent_tag & IS_VOX))
 		return "buzzes, \"Unrecogized physiology. Operation aborted.\""
 	else if(H.isSynthetic() && !use_on_synthetic)
 		return "buzzes, \"Synthetic Body. Operation aborted.\""
+	else if(H.species.reagent_tag & IS_VOX && combat == 0)
+		return "buzzes, \"Voltage rating insufficient. Operation aborted.\""
 	else if(!H.isSynthetic() && use_on_synthetic)
 		return "buzzes, \"Organic Body. Operation aborted.\""
 

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -266,7 +266,7 @@
 		return "buzzes, \"Unrecogized physiology. Operation aborted.\""
 	else if(H.isSynthetic() && !use_on_synthetic)
 		return "buzzes, \"Synthetic Body. Operation aborted.\""
-	else if(H.species.reagent_tag & IS_VOX && combat == 0)
+	else if(H.species.reagent_tag & IS_VOX && combat == 0) //Citadel change - gives vox a different defib message
 		return "buzzes, \"Voltage rating insufficient. Operation aborted.\""
 	else if(!H.isSynthetic() && use_on_synthetic)
 		return "buzzes, \"Organic Body. Operation aborted.\""


### PR DESCRIPTION
Only works on organic vox; For now, that can be considered working as intended, as FBPs are harder to actually kill than organics are, beyond electricity and EMP/Ion effects.