### PR TITLE
Makes upwards pointing atmos pipes not hide under tiles.

### DIFF
--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -150,9 +150,10 @@ obj/machinery/atmospherics/pipe/zpipe/up/atmos_init()
 					node2 = target
 					break
 
-//	Citadel change, why are upwards pipes capable of being hidden by tiles????
-//	var/turf/T = src.loc			// hide if turf is not intact
-//	hide(!T.is_plating())
+/*	Citadel change, why are upwards pipes capable of being hidden by tiles????
+	var/turf/T = src.loc			// hide if turf is not intact
+	hide(!T.is_plating())
+*/
 
 ///////////////////////
 // and the down pipe //

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -150,9 +150,9 @@ obj/machinery/atmospherics/pipe/zpipe/up/atmos_init()
 					node2 = target
 					break
 
-
-	var/turf/T = src.loc			// hide if turf is not intact
-	hide(!T.is_plating())
+//	Citadel change, why are upwards pipes capable of being hidden by tiles????
+//	var/turf/T = src.loc			// hide if turf is not intact
+//	hide(!T.is_plating())
 
 ///////////////////////
 // and the down pipe //

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -512,6 +512,13 @@
 /obj/structure/railing,
 /turf/simulated/floor/virgo3b,
 /area/tether/surfacebase/outside/outside1)
+"abg" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4;
+	name = "Waste To Scrubbers"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/atmos/processing)
 "abh" = (
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/refinery)
@@ -14622,12 +14629,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/anomaly_lab/containment_one)
-"aIP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/engineering/atmos/processing)
 "aIQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -38692,7 +38693,7 @@ bRl
 bSP
 aIv
 aIA
-aIP
+abg
 aJe
 aIv
 aIv


### PR DESCRIPTION
Because why the fuck can upwards facing pipes be hidden under a tile????
also, renames a pipe adapter in atmos because it's fucking dumb. More atmos changes will be coming down the pipeline but I needed this.

If the code change for the pipe can be easily modularised let me know, but outside of just like, overriding the entire file I wasn't really sure how to go about that.