### PR TITLE
Loadout Webbing Buff

### DIFF
--- a/modular_citadel/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/modular_citadel/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -1,0 +1,15 @@
+/datum/gear/accessory/brown_vest
+  display_name = "webbing vest, brown"
+  allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor", "Quartermaster", "Cargo Technician", "Shaft Miner", "Explorer", "Pathfinder", "Colony Director")
+/datum/gear/accessory/black_vest
+  display_name = "webbing vest, black"
+  allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor", "Quartermaster", "Cargo Technician", "Shaft Miner", "Explorer", "Pathfinder", "Colony Director")
+/datum/gear/accessory/white_vest
+  display_name = "webbing vest, med-white"
+  allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor", "Quartermaster", "Cargo Technician", "Shaft Miner", "Explorer", "Pathfinder", "Colony Director")
+/datum/gear/accessory/brown_drop_pouches
+  allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor", "Quartermaster", "Cargo Technician", "Shaft Miner", "Explorer", "Pathfinder", "Colony Director")
+/datum/gear/accessory/black_drop_pouches
+  allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor", "Quartermaster", "Cargo Technician", "Shaft Miner", "Explorer", "Pathfinder", "Colony Director")
+/datum/gear/accessory/white_drop_pouches
+  allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor", "Quartermaster", "Cargo Technician", "Shaft Miner", "Explorer", "Pathfinder", "Colony Director")

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3035,6 +3035,7 @@
 #include "modular_citadel\code\modules\client\preference_setup\loadout.dm"
 #include "modular_citadel\code\modules\client\preference_setup\loadout_accessories_cit.dm"
 #include "modular_citadel\code\modules\client\preference_setup\loadout_donator.dm"
+#include "modular_citadel\code\modules\client\preference_setup\loadout\loadout_accessories.dm"
 #include "modular_citadel\code\modules\client\preference_setup\loadout\loadout_shoes_cit.dm"
 #include "modular_citadel\code\modules\client\preference_setup\loadout\loadout_suit_cit.dm"
 #include "modular_citadel\code\modules\client\preference_setup\loadout\loadout_uniform_cit.dm"


### PR DESCRIPTION
gives the fancy expanded webbings (and drop pouches) to the CD, the Pathfinder, explorers, and shaft miners

also changes the webbing vest loadout names from "webbing, [color]" to "webbing vest, [color]", with the white webbing being dubbed "medical-white" because of that dinky ass lil blue cross on the neckline or whatever