### PR TITLE
whats a fuckign balance - SPICY NEW MECH WEAPONS THAT ARE ADMINSPAWN ONLY

### DIFF
--- a/modular_citadel/code/game/mecha/equipment/weapons/weapons.dm
+++ b/modular_citadel/code/game/mecha/equipment/weapons/weapons.dm
@@ -1,0 +1,37 @@
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/hmg
+	name = "\improper \"Sturmk�nig\" RAC/5"
+	desc = "A superior version of the standard Ultra AC 2 design. Bigger bullets, larger burst, tears through ammo stores."
+	icon_state = "mecha_uac2"
+	equip_cooldown = 5
+	projectile = /obj/item/projectile/bullet/rifle/a762
+	fire_sound = 'sound/weapons/machinegun.ogg'
+	projectiles = 60
+	projectiles_per_shot = 6
+	deviation = 0.4
+	projectile_energy_cost = 25
+	fire_cooldown = 0.5
+
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/burstlaser
+	equip_cooldown = 3
+	name = "\improper c-MPL \"Slagger\" rapid-cycling laser"
+	desc = "A laser carbine's firing system, overcharged for lower cooldowns between shots and mounted on a high-powered exosuit weapon socket."
+	icon_state = "mecha_laser"
+	energy_drain = 40
+	projectile = /obj/item/projectile/beam
+	fire_sound = 'sound/weapons/Laser.ogg'
+
+/obj/item/projectile/bullet/rifle/a145/slow
+	hitscan = 0
+
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/amr
+	name = "\improper \"Bishop\" UAC/20"
+	desc = "A bastardized Ultra AC/2. A larger barrel firing the same kind of shells you'd find in the HI PTR-7, but on a larger, two-shot-burst scale."
+	icon_state = "mecha_uac2"
+	equip_cooldown = 10
+	projectile = /obj/item/projectile/bullet/rifle/a145/slow
+	fire_sound = 'sound/weapons/svd_shot.ogg'
+	projectiles = 20
+	projectiles_per_shot = 2
+	deviation = 0
+	projectile_energy_cost = 60
+	fire_cooldown = 1.5

--- a/modular_citadel/code/game/mecha/equipment/weapons/weapons.dm
+++ b/modular_citadel/code/game/mecha/equipment/weapons/weapons.dm
@@ -1,5 +1,5 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/hmg
-	name = "\improper \"Sturmk�nig\" RAC/5"
+	name = "\improper \"Sturmkönig\" RAC/5"
 	desc = "A superior version of the standard Ultra AC 2 design. Bigger bullets, larger burst, tears through ammo stores."
 	icon_state = "mecha_uac2"
 	equip_cooldown = 5

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3012,6 +3012,7 @@
 #include "modular_citadel\code\game\jobs\job\assistant_cit.dm"
 #include "modular_citadel\code\game\jobs\job\engineering_cit.dm"
 #include "modular_citadel\code\game\jobs\job\z_all_jobs_cit.dm"
+#include "modular_citadel\code\game\mecha\equipment\weapons\weapons.dm"
 #include "modular_citadel\code\game\objects\items\upgradekit.dm"
 #include "modular_citadel\code\game\objects\items\devices\communicator.dm"
 #include "modular_citadel\code\game\objects\items\devices\defib.dm"


### PR DESCRIPTION
the Sturmkönig is a machinegun that fires 7.62 (35 brute, +10 compared to the UAC/2's 25 brute) with a 6 round burst.

the Slagger shoots really fast - almost as fast as you can click. still does 40 burn, but it drains more power to assist in cycling the lasers

the Bishop is a marksman's cannon - 2 round burst, but each shell fired is a 14.5mm shell, so...y'know. hit 'em hard, hit 'em fast.