### PR TITLE
Fixes issue #447.

### DIFF
--- a/modular_citadel/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/modular_citadel/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -1,0 +1,4 @@
+/obj/structure/bed/chair/wheelchair/buckle_mob(mob/living/M, forced = FALSE, check_loc = TRUE)
+	if(issilicon(M)) // No abusing wheelchairs.
+		return
+	..()


### PR DESCRIPTION
This should fix #447 by means of disallowing silicons from being buckled into a wheelchair.
I made this PR while on a Chromebook, so bear with me.