### PR TITLE
Removes RIGsuit handcuff protection

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -70,9 +70,9 @@
 		to_chat(user, "<span class='danger'>\The [H] needs at least two wrists before you can cuff them together!</span>")
 		return 0
 
-	if(istype(H.gloves,/obj/item/clothing/gloves/gauntlets/rig) && !elastic) // Can't cuff someone who's in a deployed hardsuit.
-		to_chat(user, "<span class='danger'>\The [src] won't fit around \the [H.gloves]!</span>")
-		return 0
+	//if(istype(H.gloves,/obj/item/clothing/gloves/gauntlets/rig) && !elastic) // Can't cuff someone who's in a deployed hardsuit. // CITADEL CHANGE - nah
+	//	to_chat(user, "<span class='danger'>\The [src] won't fit around \the [H.gloves]!</span>")
+	//	return 0
 
 	user.visible_message("<span class='danger'>\The [user] is attempting to put [cuff_type] on \the [H]!</span>")
 


### PR DESCRIPTION
RIGsuits already provide an extreme level of protection for their user--in addition to the resistances provided as a baseline, they also cannot be removed except through surgery by anyone other than the person wearing it. 

In addition to that, they also made you immune to handcuffs. This alters that behavior so that people in RIGsuits can be restrained like an ordinary crewmember, though they still retain their high resistance values and their suit cannot be removed without surgical interference. 