### PR TITLE
Finally implements is_cable_coil(), fixes light switch construction.

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -126,6 +126,10 @@ var/list/possible_cable_coil_colours = list(
 // General procedures
 ///////////////////////////////////
 
+//Finally implements is_cable_coil():
+/obj/item/stack/cable_coil/is_cable_coil()
+	return TRUE
+
 //If underfloor, hide the cable
 /obj/structure/cable/hide(var/i)
 	if(istype(loc, /turf))


### PR DESCRIPTION
Fixes vore's light switch frame code. Previously, building light switch would fail because the proc for is_cable_coil() wasn't overridden for the cable coil.

also:
>PR 666
>fixes bringing light to the server
>lucifer is the bringer of light

really makes you think