### PR TITLE
Unapologetic Alraune Buffs

### DIFF
--- a/code/__defines/chemistry_vr.dm
+++ b/code/__defines/chemistry_vr.dm
@@ -2,3 +2,4 @@
 #define IS_SERGAL  10
 #define IS_AKULA   11
 #define IS_NEVREAN 12
+#define IS_ALRAUNE 13

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -315,6 +315,8 @@
 				var/obj/item/organ/O = new limb_path(src)
 				organ_data["descriptor"] = O.name
 				to_chat(src, "<span class='notice'>You feel a slithering sensation as your [O.name] reform.</span>")
+		UpdateAppearance()
+		sync_organ_dna()
 		update_icons_body()
 		active_regen = FALSE
 	else

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -285,10 +285,20 @@
 	if(do_after(src,delay_length))
 		nutrition -= 200
 
-		for(var/obj/item/organ/I in internal_organs)
-			if(I.damage > 0)
-				I.damage = max(I.damage - 30, 0) //Repair functionally half of a dead internal organ.
-				to_chat(src, "<span class='notice'>You feel a soothing sensation within your [I.name]...</span>")
+		for(var/organ_tag in src.species.has_organ)
+			var/obj/item/organ/internal/I = src.internal_organs_by_name[organ_tag]
+			if(I && I.damage > 0)
+				I.damage = max(I.damage - 30, 0) // Repair functionally half of a dead internal organ.
+				to_chat(src, span("notice", "You feel a soothing sensation within your [I.name]..."))
+			if(!I)
+				var/organ_path = src.species.has_organ[organ_tag]
+				var/obj/item/organ/internal/IO = new organ_path(src,1)
+				if(organ_tag != IO.organ_tag)
+					warning("[IO.type] has a default organ tag \"[IO.organ_tag]\" that differs from the species' organ tag \"[organ_tag]\". Updating organ_tag to match.")
+				IO.organ_tag = organ_tag
+				IO.damage = 30 // starts off as half-damaged, need to regen again to heal it
+				src.internal_organs_by_name[organ_tag] = IO
+				to_chat(src, span("notice", "You feel a soothing sensation as your missing [IO.name] reforms."))
 
 		// Replace completely missing limbs.
 		for(var/limb_type in src.species.has_limbs)

--- a/code/modules/mob/living/carbon/human/species/station/alraune.dm
+++ b/code/modules/mob/living/carbon/human/species/station/alraune.dm
@@ -2,16 +2,17 @@
 	name = SPECIES_ALRAUNE
 	name_plural = "Alraunes"
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite)
-	num_alternate_languages = 2
+	num_alternate_languages = 3 //cit lore change
 	slowdown = 1 //slow, they're plants. Not as slow as full diona.
 	total_health = 100 //standard
 	brute_mod = 1 //nothing special
 	burn_mod = 1.5 //plants don't like fire
+	radiation_mod = 0.7 //cit change: plants seem to be pretty resilient. shouldn't come up much.
 	metabolic_rate = 0.75 // slow metabolism
 	item_slowdown_mod = 0.25 //while they start slow, they don't get much slower
 	bloodloss_rate = 0.1 //While they do bleed, they bleed out VERY slowly
 	min_age = 18
-	max_age = 250
+	max_age = 500 //cit lore change
 	health_hud_intensity = 1.5
 	base_species = SPECIES_ALRAUNE
 	selects_bodytype = TRUE
@@ -50,6 +51,7 @@
 		/mob/living/carbon/human/proc/succubus_drain_finalize,
 		/mob/living/carbon/human/proc/succubus_drain_lethal,
 		/mob/living/carbon/human/proc/bloodsuck,
+		/mob/living/carbon/human/proc/regenerate,
 		/mob/living/carbon/human/proc/alraune_fruit_select) //Give them the voremodes related to wrapping people in vines and sapping their fluids
 
 	color_mult = 1
@@ -59,27 +61,27 @@
 	blood_color = "#edf4d0" //sap!
 	base_color = "#1a5600"
 
-	blurb = "Alraunes are a rare sight in space. Their bodies are reminiscent of that of plants, and yet they share many\
-	traits with other humanoid beings.\
+	reagent_tag = IS_ALRAUNE
+
+	blurb = "Alraunes are an uncommon sight in space. Their bodies are reminiscent of that of plants, and yet they share many\
+	traits with other humanoid beings, occasionally mimicking their forms to lure in prey.\
 	\
-	Most Alraunes are not interested in traversing space, their heavy preference for natural environments and general\
-	disinterest in things outside it keeps them as a species at a rather primal stage.\
+	Most Alraune are rather opportunistic in nature, being primarily self-serving; however, this does not mean they are selfish or unable to empathise with others.\
 	\
-	However, after their discovery by the angels of Sanctum, many alraunes succumbed to their curiosity, and took the offer\
-	to learn of the world and venture out, whether it's to Sanctum, or elsewhere in the galaxy."
+	They are highly adaptable both mentally and physically, but tend to have a collecting intra-species mindset."
 
 	has_limbs = list(
-		BP_TORSO =  list("path" = /obj/item/organ/external/chest),
-		BP_GROIN =  list("path" = /obj/item/organ/external/groin),
-		BP_HEAD =   list("path" = /obj/item/organ/external/head),
-		BP_L_ARM =  list("path" = /obj/item/organ/external/arm),
-		BP_R_ARM =  list("path" = /obj/item/organ/external/arm/right),
-		BP_L_LEG =  list("path" = /obj/item/organ/external/leg),
-		BP_R_LEG =  list("path" = /obj/item/organ/external/leg/right),
-		BP_L_HAND = list("path" = /obj/item/organ/external/hand),
-		BP_R_HAND = list("path" = /obj/item/organ/external/hand/right),
-		BP_L_FOOT = list("path" = /obj/item/organ/external/foot),
-		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right)
+		BP_TORSO =  list("path" = /obj/item/organ/external/chest/unbreakable/plant),
+		BP_GROIN =  list("path" = /obj/item/organ/external/groin/unbreakable/plant),
+		BP_HEAD =   list("path" = /obj/item/organ/external/head/unbreakable/plant),
+		BP_L_ARM =  list("path" = /obj/item/organ/external/arm/unbreakable/plant),
+		BP_R_ARM =  list("path" = /obj/item/organ/external/arm/right/unbreakable/plant),
+		BP_L_LEG =  list("path" = /obj/item/organ/external/leg/unbreakable/plant),
+		BP_R_LEG =  list("path" = /obj/item/organ/external/leg/right/unbreakable/plant),
+		BP_L_HAND = list("path" = /obj/item/organ/external/hand/unbreakable/plant),
+		BP_R_HAND = list("path" = /obj/item/organ/external/hand/right/unbreakable/plant),
+		BP_L_FOOT = list("path" = /obj/item/organ/external/foot/unbreakable/plant),
+		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right/unbreakable/plant) //cit change - unbreakable, can survive decapitation, but damage spreads to nearby neighbors when at max dmg.
 		)
 
 	// limited organs, 'cause they're simple

--- a/code/modules/mob/new_player/sprite_accessories_vr.dm
+++ b/code/modules/mob/new_player/sprite_accessories_vr.dm
@@ -878,10 +878,9 @@
 		body_parts = list(BP_L_FOOT,BP_R_FOOT)
 
 	alurane
-		name = "Alurane Body"
+		name = "Alraune Body"
 		icon_state = "alurane"
 		body_parts = list(BP_L_FOOT,BP_R_FOOT,BP_L_LEG,BP_R_LEG,BP_L_ARM,BP_R_ARM,BP_L_HAND,BP_R_HAND,BP_GROIN,BP_TORSO,BP_HEAD)
-		ckeys_allowed = list("natje")
 
 	body_tone
 		name = "Body toning (for emergency contrast loss)"

--- a/code/modules/organs/subtypes/alraune.dm
+++ b/code/modules/organs/subtypes/alraune.dm
@@ -1,0 +1,34 @@
+/obj/item/organ/external/chest/unbreakable/plant
+	spread_dam = 1
+
+/obj/item/organ/external/groin/unbreakable/plant
+	spread_dam = 1
+
+/obj/item/organ/external/arm/unbreakable/plant
+	spread_dam = 1
+
+/obj/item/organ/external/arm/right/unbreakable/plant
+	spread_dam = 1
+
+/obj/item/organ/external/leg/unbreakable/plant
+	spread_dam = 1
+
+/obj/item/organ/external/leg/right/unbreakable/plant
+	spread_dam = 1
+
+/obj/item/organ/external/foot/unbreakable/plant
+	spread_dam = 1
+
+/obj/item/organ/external/foot/right/unbreakable/plant
+	spread_dam = 1
+
+/obj/item/organ/external/hand/unbreakable/plant
+	spread_dam = 1
+
+/obj/item/organ/external/hand/right/unbreakable/plant
+	spread_dam = 1
+
+/obj/item/organ/external/head/unbreakable/plant	//They don't need this anymore.
+	cannot_gib = 0
+	vital = 0
+	spread_dam = 1

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -96,7 +96,11 @@
 		strength_mod = 0
 	if(alien == IS_SLIME)
 		strength_mod *= 2 // VOREStation Edit - M.adjustToxLoss(removed)
-	
+	if(alien == IS_ALRAUNE)
+		if(prob(5))
+			M << "<span class='danger'>You feel your leaves start to wilt.</span>"
+		strength_mod *=5 //cit change - alcohol ain't good for plants
+
 	M.add_chemical_effect(CE_ALCOHOL, 1)
 	var/effective_dose = dose * strength_mod * (1 + volume/60) //drinking a LOT will make you go down faster
 
@@ -281,6 +285,12 @@
 	reagent_state = SOLID
 	color = "#832828"
 
+/datum/reagent/phosphorus/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_ALRAUNE)
+		if(prob(5))
+			M << "<span class='vox'>You feel a rush of nutrients fill your body.</span>"
+		M.nutrition += removed * 2 //cit change - phosphorus is good for plants
+
 /datum/reagent/potassium
 	name = "Potassium"
 	id = "potassium"
@@ -458,6 +468,12 @@
 		else
 			M.sleeping = max(M.sleeping, 20)
 			M.drowsyness = max(M.drowsyness, 60)
+
+	if(alien == IS_ALRAUNE) //cit change - too much sugar isn't good for plants
+		if(effective_dose < 2)
+			if(prob(5))
+				M << "<span class='danger'>You feel an imbalance of energy.</span>"
+			M.make_jittery(4)
 
 /datum/reagent/sulfur
 	name = "Sulfur"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -38,7 +38,7 @@
 	if(!injectable && alien != IS_SLIME)
 		M.adjustToxLoss(0.1 * removed)
 		return
-	affect_ingest(M, alien, removed) 
+	affect_ingest(M, alien, removed)
 	*/ //VOREStation Removal End
 	if(injectable) //vorestation addition/replacement
 		affect_ingest(M, alien, removed)
@@ -142,6 +142,12 @@
 	reagent_state = SOLID
 	nutriment_factor = 5
 	color = "#302000"
+
+/datum/reagent/nutriment/coco/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_ALRAUNE) //cit change: choccy is full of natural easily digestible plant fats
+		if(prob(5))
+			M << "<span class='vox'>You feel a rush of nutrients fill your body.</span>"
+		M.nutrition += removed * 5
 
 /datum/reagent/nutriment/soysauce
 	name = "Soysauce"
@@ -335,6 +341,11 @@
 /datum/reagent/capsaicin/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
+	if(alien == IS_ALRAUNE) //cit change: it wouldn't effect plants that much.
+		if(prob(5))
+			M << "<span class='rose'>You feel a pleasant sensation in your mouth.</span>"
+		M.bodytemperature += rand(10, 25)
+		return
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(!H.can_feel_pain())
@@ -384,6 +395,9 @@
 
 	if(alien == IS_SKRELL)	//Larger eyes means bigger targets.
 		effective_strength = 8
+
+	if(alien == IS_ALRAUNE) //cit change: plants find the base form tasty, still mildly inconvenient to be affected by this.
+		effective_strength = 4
 
 	if(istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
@@ -736,11 +750,19 @@
 	glass_name = "chocolate milk"
 	glass_desc = "Deliciously fattening!"
 
+/datum/reagent/drink/milk/chocolate/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_ALRAUNE) //cit change: choccy is full of natural easily digestible plant fats
+		if(prob(5))
+			M << "<span class='vox'>You feel a rush of nutrients fill your body.</span>"
+		M.nutrition += removed * 5
 
 /datum/reagent/drink/milk/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	if(alien == IS_DIONA)
 		return
+	if(alien == IS_ALRAUNE) //cit change: milk good for plant.
+		M << "<span class='vox'>You feel nourished by the milk.</span>"
+		M.nutrition += removed * 3
 	M.heal_organ_damage(0.5 * removed, 0)
 	holder.remove_reagent("capsaicin", 10 * removed)
 
@@ -1026,6 +1048,12 @@
 	cup_name = "cup of hot chocolate"
 	cup_desc = "Made with love! And cocoa beans."
 
+/datum/reagent/drink/hot_coco/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_ALRAUNE) //cit change: choccy is full of natural easily digestible plant fats
+		if(prob(5))
+			M << "<span class='vox'>You feel a rush of nutrients fill your body.</span>"
+		M.nutrition += removed * 5
+
 /datum/reagent/drink/soda/sodawater
 	name = "Soda Water"
 	id = "sodawater"
@@ -1144,6 +1172,12 @@
 
 	glass_name = "Chocolate Milkshake"
 	glass_desc = "A refreshing chocolate milkshake, just like mom used to make."
+
+/datum/reagent/drink/milkshake/chocoshake/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_ALRAUNE) //cit change: choccy is full of natural easily digestible plant fats
+		if(prob(5))
+			M << "<span class='vox'>You feel a rush of nutrients fill your body.</span>"
+		M.nutrition += removed * 5
 
 /datum/reagent/drink/milkshake/berryshake
 	name = "Berry Milkshake"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -146,6 +146,8 @@
 /datum/reagent/dexalin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_VOX)
 		M.adjustToxLoss(removed * 24) //VOREStation Edit
+	if(alien == IS_ALRAUNE)
+		M.adjustToxLoss(removed * 10) //cit change: oxygen is waste for plants
 	else if(alien == IS_SLIME && dose >= 15)
 		M.add_chemical_effect(CE_PAINKILLER, 15)
 		if(prob(15))
@@ -170,6 +172,8 @@
 /datum/reagent/dexalinp/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_VOX)
 		M.adjustToxLoss(removed * 9)
+	if(alien == IS_ALRAUNE)
+		M.adjustToxLoss(removed * 5) //cit change: oxygen is waste for plants
 	else if(alien == IS_SLIME && dose >= 10)
 		M.add_chemical_effect(CE_PAINKILLER, 25)
 		if(prob(25))
@@ -698,7 +702,7 @@
 		M.make_dizzy(5)
 	if(prob(20))
 		M.hallucination = max(M.hallucination, 10)
-	
+
 	//One of the levofloxacin side effects is 'spontaneous tendon rupture', which I'll immitate here. 1:1000 chance, so, pretty darn rare.
 	if(ishuman(M) && rand(1,10000) == 1) //VOREStation Edit (more rare)
 		var/obj/item/organ/external/eo = pick(H.organs) //Misleading variable name, 'organs' is only external organs

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -292,6 +292,13 @@
 	reagent_state = GAS
 	color = "#404030"
 
+/datum/reagent/ammonia/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_ALRAUNE)
+		if(prob(5))
+			M << "<span class='vox'>You feel a rush of nutrients fill your body.</span>"
+		M.nutrition += removed * 2 //cit change: fertilizer is waste for plants
+		return
+
 /datum/reagent/diethylamine
 	name = "Diethylamine"
 	id = "diethylamine"
@@ -299,6 +306,13 @@
 	taste_description = "iron"
 	reagent_state = LIQUID
 	color = "#604030"
+
+/datum/reagent/diethylamine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_ALRAUNE)
+		if(prob(5))
+			M << "<span class='vox'>You feel a rush of nutrients fill your body.</span>"
+		M.nutrition += removed * 5 //cit change: fertilizer is waste for plants
+		return
 
 /datum/reagent/fluorosurfactant // Foam precursor
 	name = "Fluorosurfactant"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -309,7 +309,7 @@
 		alien_weeds.healthcheck()
 
 /datum/reagent/toxin/plantbgone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_DIONA
+	if(alien == IS_DIONA)
 		M.adjustToxLoss(50 * removed)
 
 	if(alien == IS_ALRAUNE)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -264,6 +264,13 @@
 	strength = 0.5 // It's not THAT poisonous.
 	color = "#664330"
 
+/datum/reagent/toxin/fertilizer/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_ALRAUNE) //cit change: fertilizer is full of natural easily digestible plant fats
+		if(prob(5))
+			M << "<span class='vox'>You feel a rush of nutrients fill your body.</span>"
+		M.nutrition += removed * 5
+		return
+
 /datum/reagent/toxin/fertilizer/eznutrient
 	name = "EZ Nutrient"
 	id = "eznutrient"
@@ -302,11 +309,11 @@
 		alien_weeds.healthcheck()
 
 /datum/reagent/toxin/plantbgone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_DIONA)
+	if(alien == IS_DIONA|IS_ALRAUNE)
 		M.adjustToxLoss(50 * removed)
 
 /datum/reagent/toxin/plantbgone/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_DIONA)
+	if(alien == IS_DIONA|IS_ALRAUNE)
 		M.adjustToxLoss(50 * removed)
 
 /datum/reagent/acid/polyacid

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -309,11 +309,17 @@
 		alien_weeds.healthcheck()
 
 /datum/reagent/toxin/plantbgone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_DIONA|IS_ALRAUNE)
+	if(alien == IS_DIONA
+		M.adjustToxLoss(50 * removed)
+
+	if(alien == IS_ALRAUNE)
 		M.adjustToxLoss(50 * removed)
 
 /datum/reagent/toxin/plantbgone/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_DIONA|IS_ALRAUNE)
+	if(alien == IS_DIONA)
+		M.adjustToxLoss(50 * removed)
+
+	if(alien == IS_ALRAUNE)
 		M.adjustToxLoss(50 * removed)
 
 /datum/reagent/acid/polyacid

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2410,6 +2410,7 @@
 #include "code\modules\organs\internal\lungs.dm"
 #include "code\modules\organs\internal\organ_internal.dm"
 #include "code\modules\organs\internal\voicebox.dm"
+#include "code\modules\organs\subtypes\alraune.dm"
 #include "code\modules\organs\subtypes\diona.dm"
 #include "code\modules\organs\subtypes\indestructible.dm"
 #include "code\modules\organs\subtypes\machine.dm"


### PR DESCRIPTION
Alraune now have regenerate. Regenerate now covers lost organs, but they start off damaged. (Regenerate now regens body markings.)

In preparation for future code, Alraune have an extra language slot, as they will have two languages. Buffs max age to fit lore. 
Their limbs now cascade damage to other limbs when at max damage. (Their limbs do not regenerate damage (unless lost) if they don't have a steady flow of carbon dioxide, and don't if they have any toxin dmg)

 Ethanol now hits them extremely hard, making toxin damage almost a certainty. Phosphorus, and all other chemicals that function as nutriment for plants, function as nutriment for Alraune. As does milk and chocolate. Dexalin and plant-b-gone are highly lethal to them. Regular non-pepperspray capsaicin is tasty to them.