### PR TITLE
Properly-ish prevents an uninitialized game start via ugly sanity test

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -190,6 +190,7 @@ GLOBAL_VAR_INIT(CURRENT_TICKLIMIT, TICK_LIMIT_RUNNING)
 	log_world(msg)
 
 	if (!current_runlevel)
+		ticker.block_start = FALSE //CitEd: stop blocking start in gameticker.dm.
 		SetRunLevel(RUNLEVEL_LOBBY)
 
 	// Sort subsystems by display setting for easy access.

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -3,6 +3,7 @@ var/global/datum/controller/gameticker/ticker
 /datum/controller/gameticker
 	var/const/restart_timeout = 3 MINUTES //One minute is 600.
 	var/current_state = GAME_STATE_PREGAME
+	var/block_start = TRUE //CitEd: used to prevent setup() if init hasn't cleared.
 
 	var/hide_mode = 0
 	var/datum/game_mode/mode = null
@@ -64,6 +65,18 @@ var/global/datum/controller/gameticker/ticker
 				current_state = GAME_STATE_SETTING_UP
 				Master.SetRunLevel(RUNLEVEL_SETUP)
 			sleep(10)
+
+		/*-----------------------------------------------Citadel-RP Edit-----------------------------------------------*\
+		|Here we abandon sanity and elegance in using a "magic" while loop to wait for init to clear before we setup(). |
+		|The while loop relies on master.dm to set block_start to FALSE in order to exit the while.                     |
+		\*-------------------------------------------------------------------------------------------------------------*/
+		if(block_start)
+			to_chat(world, "Initialization is taking a particularly long time. The game will start after initializations complete.")
+			while(block_start)
+				sleep(20)
+			to_chat(world, "The game is now starting!")
+		//CitEd END
+
 	while (!setup())
 
 


### PR DESCRIPTION
I added a var to the game ticker, block_start. It starts TRUE and is used to conditionally enter an infinite while-sleep loop predicated on if we're still blocking the game from starting or not. It is later set FALSE in master.dm when initializations complete.