### PR TITLE
Adds Advanced and phasic medical scanners to Rnd

### DIFF
--- a/code/modules/research/designs/medical.dm
+++ b/code/modules/research/designs/medical.dm
@@ -133,6 +133,24 @@
 	build_path = /obj/item/device/healthanalyzer/improved
 	sort_string = "MBBAG"
 
+/datum/design/item/medical/advanced_analyzer
+	name = "advanced health analyzer"
+	desc = "A prototype version of the improved health analyzer, able to distinguish the location of more serious injuries as well as accurately determine radiation levels, and neurological analysis suites"
+	id = "improved_analyzer"
+	req_tech = list(TECH_MAGNET = 6, TECH_BIO = 7, TECH_PHORON = 4)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "silver" = 1000, "gold" = 1500, "uranium" = 2000, "plastic" = 100)
+	build_path = /obj/item/device/healthanalyzer/advanced
+	sort_string = "MBBAH"
+
+/datum/design/item/medical/phasic_analyzer
+	name = "improved health analyzer"
+	desc = "A prototype version of the regular health analyzer, able to distinguish the location of more serious injuries as well as accurately determine radiation levels, and neurological analysis suites. This analyzer even picks up chemicals in the patient's stomach"
+	id = "improved_analyzer"
+	req_tech = list(TECH_MAGNET = 7, TECH_BIO = 8, TECH_BLUESPACE = 6, TECH_PHORON = 5)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "silver" = 1000, "gold" = 1500, "uranium" = 2000, "diamond" = 1000, "osmium" = 100, "phoron" = 500, "plastic" = 100)
+	build_path = /obj/item/device/healthanalyzer/phasic
+	sort_string = "MBBAI"
+
 /datum/design/item/implant
 	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 

--- a/code/modules/research/designs/medical.dm
+++ b/code/modules/research/designs/medical.dm
@@ -136,16 +136,16 @@
 /datum/design/item/medical/advanced_analyzer
 	name = "advanced health analyzer"
 	desc = "A prototype version of the improved health analyzer, able to distinguish the location of more serious injuries as well as accurately determine radiation levels, and neurological analysis suites"
-	id = "improved_analyzer"
+	id = "advanced_analyzer"
 	req_tech = list(TECH_MAGNET = 6, TECH_BIO = 7, TECH_PHORON = 4)
 	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "silver" = 1000, "gold" = 1500, "uranium" = 2000, "plastic" = 100)
 	build_path = /obj/item/device/healthanalyzer/advanced
 	sort_string = "MBBAH"
 
 /datum/design/item/medical/phasic_analyzer
-	name = "improved health analyzer"
+	name = "phasic health analyzer"
 	desc = "A prototype version of the regular health analyzer, able to distinguish the location of more serious injuries as well as accurately determine radiation levels, and neurological analysis suites. This analyzer even picks up chemicals in the patient's stomach"
-	id = "improved_analyzer"
+	id = "phasic_analyzer"
 	req_tech = list(TECH_MAGNET = 7, TECH_BIO = 8, TECH_BLUESPACE = 6, TECH_PHORON = 5)
 	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "silver" = 1000, "gold" = 1500, "uranium" = 2000, "diamond" = 1000, "osmium" = 100, "phoron" = 500, "plastic" = 100)
 	build_path = /obj/item/device/healthanalyzer/phasic


### PR DESCRIPTION
Changlings
phasic heath scanner and Advanced health scanner can now be made at insane prices and techs ment for late in the round!
Why?
So people have a reason to bring osmium and other mats to rnd for use!
So medical can have a easier life as they can get fancy heath scanners... To make better malpractice 