### PR TITLE
Icon trash bandaid fix

### DIFF
--- a/modular_citadel/code/game/objects/items/trash.dm
+++ b/modular_citadel/code/game/objects/items/trash.dm
@@ -1,15 +1,15 @@
 /obj/item/trash/brownies
 	name = "brownie tray"
-	icon_state = "brownies"
+	icon_state = "waffles"
 
 /obj/item/trash/snacktray
 	name = "snacktray"
-	icon_state = "snacktray"
+	icon_state = "waffles"
 
 /obj/item/trash/dipbowl
 	name = "dip bowl"
-	icon_state = "dipbowl"
+	icon_state = "waffles"
 
 /obj/item/trash/chipbasket
 	name = "empty basket"
-	icon_state = "chipbasket_empty"
+	icon_state = "waffles"


### PR DESCRIPTION
Fix?
Makes trash items have icons when being trash
Why?
Dead icons are bad icons. This is a temp fix