### PR TITLE
Prevents slipping when already weakened.

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -359,7 +359,7 @@
 	return
 
 /mob/living/carbon/slip(var/slipped_on,stun_duration=8)
-	if(buckled)
+	if(buckled || weakened)
 		return 0
 	stop_pulling()
 	src << "<span class='warning'>You slipped on [slipped_on]!</span>"


### PR DESCRIPTION
You make a one-line fix and spend thirty minutes trying to get a test server ready to even test it.

Anyhow, since slipping causes weakened, I just added a check to make sure that you aren't already weakened before trying to apply another slip. 
This will prevent the infinislipping exploit, ie using pull+click to move somebody over a bar of soap or banana peel repeatedly in order to keep them stunned indefinitely.