### PR TITLE
Makes robotic sci boggo able to repair Synths

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -391,6 +391,8 @@
 	src.modules += new /obj/item/weapon/gripper/research(src)
 	src.modules += new /obj/item/weapon/gripper/no_use/loader(src)
 	src.modules += new /obj/item/weapon/tool/screwdriver/cyborg(src)
+	src.modules += new /obj/item/stack/cable_coil/cyborg(src)
+	src.modules += new /obj/item/weapon/weldingtool/electric/mounted/cyborg(src)
 	src.modules += new /obj/item/weapon/reagent_containers/glass/beaker/large(src)
 	src.modules += new /obj/item/weapon/storage/part_replacer(src)
 	src.emag = new /obj/item/weapon/hand_tele(src)


### PR DESCRIPTION
Changlings
Gives the proper tools and such to sci-doggo for repairing a nifs/synths
Why
Legit engine borg is more useful then a sci-doggo for no reason when it comes to them. Making it a useless model to be after 15 mins in game