### PR TITLE
[DNM] Maybe makes the Rnd console use uppercase letters 

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -60,7 +60,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			return_name = "Silver"
 		if("phoron")
 			return_name = "Solid Phoron"
-		if("Plastic")
+		if("plastic")
 			return_name = "Plastic"
 		if("osmium")
 			return_name = "Osmium"

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -51,7 +51,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	var/return_name = ID
 	switch(return_name)
 		if("metal")
-			return_name = "Metal"
+			return_name = "Steel"
 		if("glass")
 			return_name = "Glass"
 		if("gold")
@@ -60,6 +60,10 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			return_name = "Silver"
 		if("phoron")
 			return_name = "Solid Phoron"
+		if("Plastic")
+			return_name = "Plastic"
+		if("osmium")
+			return_name = "Osmium"
 		if("uranium")
 			return_name = "Uranium"
 		if("diamond")


### PR DESCRIPTION
Changlings
Makes Rnd console maybe display Steel as Steel, Osmium as Osmium, and Plastic as Plastic 
Hos is a Ling?
Do gold/diams/green/sliver/glass being all uppercase and the three up their not being upper case
Rather annoying to me