### PR TITLE
Reduce Nif wear of Mass Alteration

### DIFF
--- a/code/modules/nifsoft/software/15_misc.dm
+++ b/code/modules/nifsoft/software/15_misc.dm
@@ -123,7 +123,7 @@
 	desc = "A system that allows one to change their size, through drastic mass rearrangement. Causes significant wear when installed."
 	list_pos = NIF_SIZECHANGE
 	cost = 750
-	wear = 10
+	wear = 3
 
 	activate()
 		if((. = ..()))


### PR DESCRIPTION
a simple line change to make it 3 wear on the nif. It was already absurdly high compared to literally everything else in the nif shop. I brought it down and it will be discussed at the round table. Since it's not meant for combat in the first place, the intense nif wear just felt strange.