### PR TITLE
Makes GPS and real bluespace crystals printable 

### DIFF
--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -5,7 +5,7 @@ var/list/GPS_list = list()
 	desc = "Triangulates the approximate co-ordinates using a nearby satellite network. Alt+click to toggle power."
 	icon = 'icons/obj/gps.dmi'
 	icon_state = "gps-c"
-	w_class = ITEMSIZE_TINY
+	w_class = ITEMSIZE_SMALL
 	slot_flags = SLOT_BELT
 	origin_tech = list(TECH_MATERIAL = 2, TECH_BLUESPACE = 2, TECH_MAGNET = 1)
 	matter = list(DEFAULT_WALL_MATERIAL = 500)

--- a/code/modules/telesci/construction.dm
+++ b/code/modules/telesci/construction.dm
@@ -47,7 +47,8 @@
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_PHORON = 4, TECH_BLUESPACE = 5)
 	build_path = /obj/item/weapon/circuitboard/telesci_pad
 	sort_string = "HAAEB"
-/* Normal GPS has all the fancy features now
+
+//Normal GPS has all the fancy features now
 /datum/design/item/telesci_gps
 	name = "GPS device"
 	id = "telesci_gps"
@@ -55,7 +56,7 @@
 	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 1000)
 	build_path = /obj/item/device/gps/advanced
 	sort_string = "HAAEB"
-*/
+
 /datum/design/circuit/quantum_pad
 	name = "Quantum Pad"
 	id = "quantum_pad"
@@ -70,3 +71,11 @@
 	materials = list("diamond" = 1500, "phoron" = 1500)
 	build_path = /obj/item/weapon/ore/bluespace_crystal/artificial
 	sort_string = "HAAED"
+
+/datum/design/item/bluespace_crystal_real
+	name = "Bluespace Crystal"
+	id = "bluespace_crystal_real"
+	req_tech = list(TECH_BLUESPACE = 6, TECH_PHORON = 4)
+	materials = list("diamond" = 5300, "phoron" = 5500)
+	build_path = /obj/item/weapon/ore/bluespace_crystal
+	sort_string = "HAAEE"

--- a/code/modules/telesci/gps_advanced.dm
+++ b/code/modules/telesci/gps_advanced.dm
@@ -8,7 +8,7 @@
 	desc = "Helping lost spacemen find their way through the planets since 1995."
 	icon = 'icons/obj/telescience.dmi'
 	icon_state = "gps-c"
-	w_class = ITEMSIZE_SMALL
+	w_class = ITEMSIZE_TINY
 	slot_flags = SLOT_BELT
 	origin_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	var/gpstag = "COM0"


### PR DESCRIPTION
Changling
Uncommits out GPSs and adds in blue space crystals
Makes the real bluespace crystals take 3 times more mats then fakes
Makes Adv GPSs Tiny well basic GPS small meaning theirs a reason to upgrade
Hos is a ling
GPSs are useful for Engi or mining, as well as exploitation teams to be smaller for space!
Bluespace real crystals do affect Tele-coms and other types of sci things, making more uses and better affect people safer.