### PR TITLE
Adds missing air alarms, emergency shutters and air supply

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -4811,6 +4811,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central1{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/monofloor{
 	dir = 1
 	},
@@ -6037,14 +6038,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 5
-	},
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/visible/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/research)
 "akO" = (
@@ -6331,6 +6332,12 @@
 	},
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/research)
 "alu" = (
@@ -7335,6 +7342,7 @@
 	name = "Atmospherics";
 	req_access = list(24)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "any" = (
@@ -9039,6 +9047,7 @@
 	name = "Atmospherics Substation";
 	req_access = list(24)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "aqS" = (
@@ -12941,7 +12950,6 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
 "ayd" = (
-/obj/machinery/meter,
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
@@ -12949,6 +12957,7 @@
 	icon_state = "bordercolor";
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "aye" = (
@@ -13250,7 +13259,6 @@
 	icon_state = "bordercolorcorner";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "ayJ" = (
@@ -13749,6 +13757,7 @@
 	dir = 1;
 	name = "West Hallway"
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/monofloor,
 /area/tether/surfacebase/north_stairs_one)
 "azv" = (
@@ -15506,17 +15515,6 @@
 "aCI" = (
 /turf/simulated/floor/plating,
 /area/vacant/vacant_site/east)
-"aCJ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos)
 "aCK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/effect/floor_decal/borderfloor{
@@ -15730,15 +15728,16 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "aDn" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 8
-	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/bordercorner{
 	icon_state = "bordercolorcorner";
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	icon_state = "intact";
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
@@ -27869,7 +27868,6 @@
 "bOa" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/yellow/bordercorner,
-/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/effect/floor_decal/steeldecal/steel_decals8{
 	icon_state = "steel_decals8";
 	dir = 4
@@ -32312,8 +32310,8 @@
 "hND" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/yellow/bordercorner,
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
@@ -32869,17 +32867,6 @@
 /obj/effect/floor_decal/techfloor/hole,
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/public_garden_one)
-"ptl" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor/tiled,
-/area/engineering/atmos)
 "pxT" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -44006,12 +43993,12 @@ aqT
 atv
 auD
 hND
-ptl
+atb
 ayI
-azY
-azY
+aqT
+aqT
 bOa
-aCJ
+atb
 aDn
 atN
 ewV

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -8169,6 +8169,12 @@
 	dir = 10
 	},
 /obj/structure/flora/pottedplant/subterranean,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/lower/lobby)
 "ra" = (
@@ -10700,6 +10706,12 @@
 	dir = 9
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/lower/atmos_eva)
 "vp" = (
@@ -10843,6 +10855,11 @@
 /obj/machinery/camera/network/engineering{
 	dir = 8
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "vA" = (
@@ -10918,6 +10935,10 @@
 /obj/effect/floor_decal/corner/purple/border/shifted{
 	icon_state = "bordercolor_shifted";
 	dir = 1
+	},
+/obj/machinery/alarm{
+	frequency = 1441;
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
 /area/janitor)
@@ -18684,6 +18705,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"Sc" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/shieldgen,
+/obj/machinery/alarm{
+	frequency = 1441;
+	pixel_y = 22
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos/storage)
 "Sv" = (
 /obj/machinery/door/airlock/maintenance/engi,
 /obj/structure/cable{
@@ -18858,6 +18888,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/maintenance/lower/bar)
+"VA" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor/wood,
+/area/engineering/lower/breakroom)
 "VM" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table/standard{
@@ -31008,7 +31045,7 @@ qe
 qQ
 rE
 sl
-te
+Sc
 tW
 uQ
 vC
@@ -31574,7 +31611,7 @@ oL
 oK
 qh
 oK
-oK
+VA
 sl
 tg
 tY

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -2690,6 +2690,7 @@
 "agE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor,
 /area/hallway/station/atrium)
 "agF" = (
@@ -14770,6 +14771,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/station/atrium)
 "bbq" = (
@@ -21098,13 +21100,16 @@
 "bYz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor,
 /area/hallway/station/docks)
 "bYC" = (
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor,
 /area/hallway/station/docks)
 "bYD" = (
 /obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor,
 /area/hallway/station/docks)
 "bYE" = (


### PR DESCRIPTION
Here's a simple first PR from me.
I couldn't knock together a whole new map within 20 minutes so I've settled for second best and added a few fixes to Tether instead.
The full list of changes are as follows:
- Added air alarms in: Atmospherics second floor, Custodial closet.
- Added emergency shutters in: Atmospherics first floor, Surface 1 staircase/Primary Tool Storage corridor, Station 1 Vacant Restaurant (in line with Station 2 Vacant Restaurant that already had shutters.)
- Fixed atmospheric supply/scrubber pipes actually going into atmospherics.
- Fixed missing green mixing pipe in atmospherics.

Here's an image of all the changes, highlighted:
![air_pr](https://user-images.githubusercontent.com/16629824/53434010-8bfa9b80-39ed-11e9-9456-c8318b8280c0.png)
