### PR TITLE
Yet Another Mining Buff From Hatterhat - Binocs and Washing Machines

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1326,13 +1326,13 @@
 
 		var/tmp/glasses_processed = 0
 		var/obj/item/weapon/rig/rig = back
-		if(istype(rig) && rig.visor && !looking_elsewhere)
+		if(istype(rig) && rig.visor) //&& !looking_elsewhere)
 			if(!rig.helmet || (head && rig.helmet == head))
 				if(rig.visor && rig.visor.vision && rig.visor.active && rig.visor.vision.glasses)
 					glasses_processed = 1
 					process_glasses(rig.visor.vision.glasses)
 
-		if(glasses && !glasses_processed && !looking_elsewhere)
+		if(glasses && !glasses_processed) // && !looking_elsewhere)
 			glasses_processed = 1
 			process_glasses(glasses)
 		if(XRAY in mutations)
@@ -1349,7 +1349,7 @@
 			var/viewflags = machine.check_eye(src)
 			if(viewflags < 0)
 				reset_view(null, 0)
-			else if(viewflags && !looking_elsewhere)
+			else if(viewflags) //&& !looking_elsewhere)
 				sight |= viewflags
 		else if(eyeobj)
 			if(eyeobj.owner != src)

--- a/maps/submaps/shelters/shelter_2.dmm
+++ b/maps/submaps/shelters/shelter_2.dmm
@@ -161,7 +161,7 @@
 	icon_state = "pwindow";
 	dir = 1
 	},
-/obj/machinery/holoplant,
+/obj/machinery/washing_machine,
 /turf/simulated/floor/carpet/bcarpet,
 /area/survivalpod)
 "w" = (
@@ -178,6 +178,7 @@
 	dir = 4;
 	pixel_x = -13
 	},
+/obj/machinery/holoplant,
 /turf/simulated/floor/carpet/bcarpet,
 /area/survivalpod)
 "z" = (

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -2094,6 +2094,7 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 10
 	},
+/obj/item/device/binoculars,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/storage)
 "adR" = (

--- a/modular_citadel/code/datums/supplypacks/misc.dm
+++ b/modular_citadel/code/datums/supplypacks/misc.dm
@@ -1,8 +1,8 @@
 /datum/supply_pack/misc/rations
 	name = "Emergency LiquidFood Rations"
 	contains = list(
-	/obj/item/weapon/reagent_containers/food/snacks/liquidfood = 8
+	/obj/item/weapon/reagent_containers/food/snacks/liquidfood = 10
 	)
-	cost = 10
+	cost = 5
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "emergency rations"


### PR DESCRIPTION
- HUDs from hardsuit visors and optical scanners and everything else work through binocs. Theoretically.
- A pair of binoculars was thrown into Mining again, on top of the cell charger.
- There's a washing machine in the luxury survival pod.
- The holoplant is now tucked in the corner next to the sink.
- Ration crates now have a lower point cost, and have two extra rations.