### PR TITLE
Makes the respawn timer not make me wanna commit oof()

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -373,8 +373,8 @@
 		var/deathtimeseconds = round((deathtime - deathtimeminutes * 600) / 10,1)
 		to_chat(usr, "You have been dead for[pluralcheck] [deathtimeseconds] seconds.")
 
-		if ((deathtime < (5 * 600)) && (ticker && ticker.current_state > GAME_STATE_PREGAME))
-			to_chat(usr, "You must wait 5 minutes to respawn!")
+		if ((deathtime < (150)) && (ticker && ticker.current_state > GAME_STATE_PREGAME))
+			to_chat(usr, "You must wait 15 seconds to respawn!")
 			return
 		else
 			to_chat(usr, "You can respawn now, enjoy your new life!")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -373,8 +373,8 @@
 		var/deathtimeseconds = round((deathtime - deathtimeminutes * 600) / 10,1)
 		to_chat(usr, "You have been dead for[pluralcheck] [deathtimeseconds] seconds.")
 
-		if ((deathtime < (150)) && (ticker && ticker.current_state > GAME_STATE_PREGAME))
-			to_chat(usr, "You must wait 15 seconds to respawn!")
+		if ((deathtime < (1 * 600)) && (ticker && ticker.current_state > GAME_STATE_PREGAME))
+			to_chat(usr, "You must wait 1 minute to respawn!")
 			return
 		else
 			to_chat(usr, "You can respawn now, enjoy your new life!")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -373,8 +373,8 @@
 		var/deathtimeseconds = round((deathtime - deathtimeminutes * 600) / 10,1)
 		to_chat(usr, "You have been dead for[pluralcheck] [deathtimeseconds] seconds.")
 
-		if ((deathtime < (1 * 600)) && (ticker && ticker.current_state > GAME_STATE_PREGAME))
-			to_chat(usr, "You must wait 1 minute to respawn!")
+		if ((deathtime < (3 * 600)) && (ticker && ticker.current_state > GAME_STATE_PREGAME))
+			to_chat(usr, "You must wait 3 minutes to respawn!")
 			return
 		else
 			to_chat(usr, "You can respawn now, enjoy your new life!")


### PR DESCRIPTION
Respawn timer is unreasonably long because Vir devs make me want to scream.  This changes it to fifteen seconds, that way it still can't be spammed with any sort of speed, but it's still convenient enough that anyone who's legitimately checking out a round isn't inconvenienced.  Suggested the change to Kevinz, he asked me to make a pull. 

Edit: Upped the time from fifteen seconds to a minute, a time that isn't quite as quick, but still isn't a speedbump in the slightest for people that are using respawn for legitimate reasons.