### PR TITLE
More Rag Volume + Rags Are Ignitable

### DIFF
--- a/modular_citadel/code/modules/detectivework/tools/rag.dm
+++ b/modular_citadel/code/modules/detectivework/tools/rag.dm
@@ -1,4 +1,4 @@
 /obj/item/weapon/reagent_containers/glass/rag
-	amount_per_transfer_from_this = 1
-	possible_transfer_amounts = list(1)
-	volume = 1
+	amount_per_transfer_from_this = 3
+	possible_transfer_amounts = list(3)
+	volume = 4


### PR DESCRIPTION
You ever just fail to light a rag? This fixes that, because rag flammability is determined by weldfuel or ethanol-based reagents having 2 or more units in the rag.