### PR TITLE
Sidearms but Cooler

### DIFF
--- a/code/datums/supplypacks/munitions.dm
+++ b/code/datums/supplypacks/munitions.dm
@@ -17,7 +17,7 @@
 			/obj/item/weapon/reagent_containers/spray/pepper = 2,
 			/obj/item/weapon/melee/baton/loaded = 2,
 			/obj/item/weapon/gun/energy/taser = 2,
-			/obj/item/weapon/gun/projectile/colt/detective = 2,
+			/obj/item/gunbox = 2,
 			/obj/item/weapon/storage/box/flashbangs = 2
 			)
 	cost = 40

--- a/code/game/objects/items/gunbox_vr.dm
+++ b/code/game/objects/items/gunbox_vr.dm
@@ -4,8 +4,8 @@
 
 /obj/item/gunbox/attack_self(mob/living/user)
 	var/list/options = list()
-	options["M1911 (.45)"] = list(/obj/item/weapon/gun/projectile/colt/detective, /obj/item/ammo_magazine/m45/rubber, /obj/item/ammo_magazine/m45/rubber)
-	options["NT Mk58 (.45)"] = list(/obj/item/weapon/gun/projectile/sec, /obj/item/ammo_magazine/m45/rubber, /obj/item/ammo_magazine/m45/rubber)
+	options["M1911 Dynamic (.45)"] = list(/obj/item/weapon/gun/projectile/colt/detective, /obj/item/ammo_magazine/m45/rubber, /obj/item/ammo_magazine/m45/rubber)
+	//options["NT Mk58 (.45)"] = list(/obj/item/weapon/gun/projectile/sec, /obj/item/ammo_magazine/m45/rubber, /obj/item/ammo_magazine/m45/rubber)
 	options["SW 625 Revolver (.45)"] = list(/obj/item/weapon/gun/projectile/revolver/detective45, /obj/item/ammo_magazine/s45/rubber, /obj/item/ammo_magazine/s45/rubber)
 	options["P92X (9mm)"] = list(/obj/item/weapon/gun/projectile/p92x/sec, /obj/item/ammo_magazine/m9mm/rubber, /obj/item/ammo_magazine/m9mm/rubber)
 	var/choice = input(user,"Would you prefer a pistol or a revolver?") as null|anything in options

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -65,7 +65,7 @@
 	if(src && choice && !M.stat && in_range(M,src))
 		icon_state = options[choice]
 		unique_reskin = options[choice]
-		M << "Your gun is now sprited as [choice]. Say hello to your new friend."
+		M << "Your gun is now a(n) [choice]. Say hello to your new friend."
 		return 1
 
 /*//apart of reskins that have two sprites, touching may result in frustration and breaks

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -52,11 +52,12 @@
 /obj/item/weapon/gun/projectile/revolver/detective/verb/rename_gun()
 	set name = "Name Gun"
 	set category = "Object"
-	set desc = "Click to rename your gun. If you're the detective."
+	set desc = "Rename your gun. If you're Security."
 
 	var/mob/M = usr
 	if(!M.mind)	return 0
-	if(!M.mind.assigned_role == "Detective")
+	var/job = M.mind.assigned_role
+	if(job != "Detective" && job != "Security Officer" && job != "Warden" && job != "Head of Security")
 		M << "<span class='notice'>You don't feel cool enough to name this gun, chump.</span>"
 		return 0
 


### PR DESCRIPTION
Gunboxes. Oh, God, it's Gunboxes.
-
- Instead of reskinnable M1911s in the Security Basic Equipment crate, it's gun boxes now.
- Gun boxes dropped the NT Mk58 in favor of the respriteable M1911. Just right-click the gun that comes out to reskin it if you really want another Mk58.
- Everyone in Security can now rename detective .45 revolvers.