### PR TITLE
[DNM] Main SMES changes.

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -468,7 +468,7 @@
 
 	if(restrained()) //Check to see if we can do things
 		return 0
-/*
+
 	//Check to see if we slipped
 	if(prob(Process_Spaceslipping(5)) && !buckled)
 		src << "<font color='blue'><B>You slipped!</B></font>"
@@ -478,7 +478,7 @@
 	//If not then we can reset inertia and move
 	inertia_dir = 0
 	return 1
-*/
+
 /mob/proc/Check_Dense_Object() //checks for anything to push off in the vicinity. also handles magboots on gravity-less floors tiles
 
 	var/dense_object = 0

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -41,10 +41,13 @@
 
 	var/open_hatch = 0
 	var/name_tag = null
-	var/building_terminal = 0 //Suggestions about how to avoid clickspam building several terminals accepted!
+	var/building_terminal = 0 		//Suggestions about how to avoid clickspam building several terminals accepted!
 	var/obj/machinery/power/terminal/terminal = null
-	var/should_be_mapped = 0 // If this is set to 0 it will send out warning on New()
-	var/grid_check = FALSE // If true, suspends all I/O.
+	var/should_be_mapped = 0 		// If this is set to 0 it will send out warning on New()
+	var/grid_check = FALSE 			// If true, suspends all I/O.
+
+	var/lastsolaralert = 0 		//really big number because I'm not sure how else to do this right now
+	var/lastenginealert = 0
 
 /obj/machinery/power/smes/drain_power(var/drain_check, var/surge, var/amount = 0)
 
@@ -441,3 +444,22 @@
 /obj/machinery/power/smes/magical/process()
 	charge = 5000000
 	..()
+
+/obj/machinery/power/smes/buildable/main
+	name = "main smes"
+	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. This is the main one for facility power."
+	charge = 2e+007
+	input_level = 500000
+	output_level = 1000000
+
+/obj/machinery/power/smes/buildable/main/process()
+	if(charge < 7200000 && charge > 4800000 && world.time >= lastsolaralert)
+		global_announcer.autosay("WARNING: Main Facility SMES unit now under 20 percent charge. Non-Engineering personnel are advised to set up solars if not already done.", "SMES Monitor")
+		lastsolaralert = world.time + 1800
+
+	if(charge < 4800000 && world.time >= lastenginealert )
+		global_announcer.autosay("WARNING: Main Facility SMES unit now under 10 percent charge. Non-Engineering personnel are now permitted to attempt engine startup procedures.", "SMES Monitor")
+		lastenginealert = world.time + 1800
+	..()
+
+

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -81,6 +81,10 @@
 	charge = 0
 	should_be_mapped = 1
 
+/obj/machinery/power/smes/buildable/main
+	cur_coils = 4
+	RCon_tag = "Power - Main"
+
 /obj/machinery/power/smes/buildable/Destroy()
 	qdel(wires)
 	wires = null

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -94,6 +94,14 @@
 "aaq" = (
 /turf/simulated/shuttle/wall/voidcraft,
 /area/shuttle/excursion/tether)
+"aar" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/smes/buildable/main,
+/turf/simulated/floor,
+/area/engineering/engine_smes)
 "aas" = (
 /obj/machinery/power/smes/buildable{
 	charge = 2e+006;
@@ -158,36 +166,25 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_smes)
+"aaB" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/excursion/tether)
 "aaC" = (
-/obj/machinery/power/grid_checker,
 /obj/structure/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
 	icon_state = "0-4";
 	d2 = 4
 	},
+/obj/machinery/power/grid_checker,
 /turf/simulated/floor,
 /area/engineering/engine_smes)
 "aaD" = (
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/excursion/tether)
-"aaG" = (
-/obj/machinery/power/smes/buildable{
-	charge = 2e+007;
-	cur_coils = 4;
-	input_attempt = 1;
-	input_level = 500000;
-	output_level = 1e+006;
-	RCon_tag = "Power - Main"
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/simulated/floor,
-/area/engineering/engine_smes)
 "aaH" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -2561,11 +2558,6 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
-"afV" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/excursion/tether)
 "afX" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -29385,7 +29377,7 @@ aaa
 aaa
 aaa
 acL
-aaG
+aar
 abe
 aeb
 abI
@@ -33666,7 +33658,7 @@ aeo
 aaq
 aaq
 aau
-afV
+aaB
 avK
 avN
 aad
@@ -33808,7 +33800,7 @@ amF
 avG
 adB
 aaq
-afV
+aaB
 avK
 avN
 aad
@@ -33950,7 +33942,7 @@ amF
 avG
 adB
 aaq
-afV
+aaB
 avK
 auH
 aad
@@ -34802,7 +34794,7 @@ aaD
 avG
 tIi
 aaq
-afV
+aaB
 avK
 auQ
 aad
@@ -34944,7 +34936,7 @@ amL
 aob
 dbI
 aaq
-afV
+aaB
 avK
 qgR
 aad
@@ -35086,7 +35078,7 @@ aep
 aeu
 aev
 aau
-afV
+aaB
 avK
 qgR
 aad


### PR DESCRIPTION
The main SMES is now a subtype, rather than a mapmaker var-edited normal one. This also means that it now sends a stationwide alert every 3 minutes when between 40 and 20% to alert the station to set up solars, and when below 20% to alert the station that non-Engineering personnel are now permitted to attempt an engine startup. Not ready for merge yet, still need to set it up to not alert when the SMES is or was recently charging.
