### PR TITLE
Main SMES changes

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -50,6 +50,7 @@
 	var/lastenginealert = 0
 	var/lastcharge = 2e+007
 	var/lastcheck = 0
+	var/percentfull
 
 /obj/machinery/power/smes/drain_power(var/drain_check, var/surge, var/amount = 0)
 
@@ -379,6 +380,10 @@
 				output_level = (input(usr, "Enter new output level (0-[output_level_max/1000] kW)", "SMES Output Power Control", output_level/1000) as num) * 1000
 		output_level = max(0, min(output_level_max, output_level))	// clamp to range
 
+	else if( href_list["mute"] )
+		lastsolaralert = world.time + 6000
+		lastenginealert = world.time + 6000
+
 	investigate_log("input/output; <font color='[input_level>output_level?"green":"red"][input_level]/[output_level]</font> | Output-mode: [output_attempt?"<font color='green'>on</font>":"<font color='red'>off</font>"] | Input-mode: [input_attempt?"<font color='green'>auto</font>":"<font color='red'>off</font>"] by [usr.key]","singulo")
 	log_game("SMES([x],[y],[z]) [key_name(usr)] changed settings: I:[input_level]([input_attempt]), O:[output_level]([output_attempt])")
 	return 1
@@ -455,11 +460,14 @@
 	output_level = 1000000
 
 /obj/machinery/power/smes/buildable/main/process()
-	if(charge < 7200000 && charge > 4800000 && world.time >= lastsolaralert && charge < lastcharge)
+
+	percentfull = 100.0*charge/capacity
+
+	if(percentfull < 30 && percentfull > 20 && world.time >= lastsolaralert && charge < lastcharge)
 		global_announcer.autosay("WARNING: Main Facility SMES unit now under 30 percent charge and seems to be discharging. Non-Engineering personnel are advised to set up solars if not already done.", "SMES Monitor")
 		lastsolaralert = world.time + 1800
 
-	if(charge < 4800000 && world.time >= lastenginealert && charge < lastcharge)
+	if(percentfull < 20 && world.time >= lastenginealert && charge < lastcharge)
 		global_announcer.autosay("WARNING: Main Facility SMES unit now under 20 percent charge and seems to be discharging. Non-Engineering personnel are now advised to attempt engine startup procedures if not already being done.", "SMES Monitor")
 		lastenginealert = world.time + 1800
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -49,6 +49,7 @@
 	var/lastsolaralert = 0
 	var/lastenginealert = 0
 	var/lastcharge = 2e+007
+	var/lastcheck = 0
 
 /obj/machinery/power/smes/drain_power(var/drain_check, var/surge, var/amount = 0)
 
@@ -459,10 +460,12 @@
 		lastsolaralert = world.time + 1800
 
 	if(charge < 4800000 && world.time >= lastenginealert && charge < lastcharge)
-		global_announcer.autosay("WARNING: Main Facility SMES unit now under 20 percent charge and seems to be discharging. Non-Engineering personnel are now permitted to attempt engine startup procedures.", "SMES Monitor")
+		global_announcer.autosay("WARNING: Main Facility SMES unit now under 20 percent charge and seems to be discharging. Non-Engineering personnel are now advised to attempt engine startup procedures if not already being done.", "SMES Monitor")
 		lastenginealert = world.time + 1800
 
-	lastcharge = charge
+	if(lastcheck <= world.time ||lastcheck == 0)
+		lastcharge = charge
+		lastcheck = world.time + 20
 	..()
 
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -453,11 +453,11 @@
 	output_level = 1000000
 
 /obj/machinery/power/smes/buildable/main/process()
-	if(charge < 7200000 && charge > 4800000 && world.time >= lastsolaralert)
+	if(charge < 7200000 && charge > 4800000 && world.time >= lastsolaralert && inputting == 0)
 		global_announcer.autosay("WARNING: Main Facility SMES unit now under 20 percent charge. Non-Engineering personnel are advised to set up solars if not already done.", "SMES Monitor")
 		lastsolaralert = world.time + 1800
 
-	if(charge < 4800000 && world.time >= lastenginealert )
+	if(charge < 4800000 && world.time >= lastenginealert && inputting == 0)
 		global_announcer.autosay("WARNING: Main Facility SMES unit now under 10 percent charge. Non-Engineering personnel are now permitted to attempt engine startup procedures.", "SMES Monitor")
 		lastenginealert = world.time + 1800
 	..()

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -41,10 +41,13 @@
 
 	var/open_hatch = 0
 	var/name_tag = null
-	var/building_terminal = 0 //Suggestions about how to avoid clickspam building several terminals accepted!
+	var/building_terminal = 0 		//Suggestions about how to avoid clickspam building several terminals accepted!
 	var/obj/machinery/power/terminal/terminal = null
-	var/should_be_mapped = 0 // If this is set to 0 it will send out warning on New()
-	var/grid_check = FALSE // If true, suspends all I/O.
+	var/should_be_mapped = 0 		// If this is set to 0 it will send out warning on New()
+	var/grid_check = FALSE 			// If true, suspends all I/O.
+
+	var/lastsolaralert = 0 		//really big number because I'm not sure how else to do this right now
+	var/lastenginealert = 0
 
 /obj/machinery/power/smes/drain_power(var/drain_check, var/surge, var/amount = 0)
 
@@ -441,3 +444,22 @@
 /obj/machinery/power/smes/magical/process()
 	charge = 5000000
 	..()
+
+/obj/machinery/power/smes/buildable/main
+	name = "main smes"
+	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. This is the main one for facility power."
+	charge = 2e+007
+	input_level = 500000
+	output_level = 1000000
+
+/obj/machinery/power/smes/buildable/main/process()
+	if(charge < 7200000 && charge > 4800000 && world.time >= lastsolaralert)
+		global_announcer.autosay("WARNING: Main Facility SMES unit now under 20 percent charge. Non-Engineering personnel are advised to set up solars if not already done.", "SMES Monitor")
+		lastsolaralert = world.time + 1800
+
+	if(charge < 4800000 && world.time >= lastenginealert )
+		global_announcer.autosay("WARNING: Main Facility SMES unit now under 10 percent charge. Non-Engineering personnel are now permitted to attempt engine startup procedures.", "SMES Monitor")
+		lastenginealert = world.time + 1800
+	..()
+
+

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -46,8 +46,9 @@
 	var/should_be_mapped = 0 		// If this is set to 0 it will send out warning on New()
 	var/grid_check = FALSE 			// If true, suspends all I/O.
 
-	var/lastsolaralert = 0 		//really big number because I'm not sure how else to do this right now
+	var/lastsolaralert = 0
 	var/lastenginealert = 0
+	var/lastcharge = 2e+007
 
 /obj/machinery/power/smes/drain_power(var/drain_check, var/surge, var/amount = 0)
 
@@ -453,13 +454,17 @@
 	output_level = 1000000
 
 /obj/machinery/power/smes/buildable/main/process()
-	if(charge < 7200000 && charge > 4800000 && world.time >= lastsolaralert && inputting == 0)
-		global_announcer.autosay("WARNING: Main Facility SMES unit now under 20 percent charge. Non-Engineering personnel are advised to set up solars if not already done.", "SMES Monitor")
+	if(charge < 7200000 && charge > 4800000 && world.time >= lastsolaralert && charge < lastcharge)
+		global_announcer.autosay("WARNING: Main Facility SMES unit now under 30 percent charge. Non-Engineering personnel are advised to set up solars if not already done.", "SMES Monitor")
 		lastsolaralert = world.time + 1800
 
-	if(charge < 4800000 && world.time >= lastenginealert && inputting == 0)
-		global_announcer.autosay("WARNING: Main Facility SMES unit now under 10 percent charge. Non-Engineering personnel are now permitted to attempt engine startup procedures.", "SMES Monitor")
+
+	if(charge < 4800000 && world.time >= lastenginealert && charge < lastcharge)
+		global_announcer.autosay("WARNING: Main Facility SMES unit now under 20 percent charge. Non-Engineering personnel are now permitted to attempt engine startup procedures.", "SMES Monitor")
 		lastenginealert = world.time + 1800
+
+	lastcharge = charge
+
 	..()
 
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -449,7 +449,7 @@
 /obj/machinery/power/smes/buildable/main
 	name = "main smes"
 	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. This is the main one for facility power."
-	charge = 2e+007
+	charge = 2e7
 	input_level = 500000
 	output_level = 1000000
 
@@ -468,3 +468,9 @@
 	..()
 
 
+/obj/machinery/power/smes/buildable/engine
+	name = "engine smes"
+	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. This is the one dedicated to the engine."
+	charge = 2e6
+	input_level = 100000
+	output_level = 200000

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -81,6 +81,10 @@
 	charge = 0
 	should_be_mapped = 1
 
+/obj/machinery/power/smes/buildable/main
+	cur_coils = 4
+	RCon_tag = "Power - Main"
+
 /obj/machinery/power/smes/buildable/Destroy()
 	qdel(wires)
 	wires = null

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -192,14 +192,7 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/excursion/tether)
 "aaG" = (
-/obj/machinery/power/smes/buildable{
-	charge = 2e+007;
-	cur_coils = 4;
-	input_attempt = 1;
-	input_level = 500000;
-	output_level = 1e+006;
-	RCon_tag = "Power - Main"
-	},
+/obj/machinery/power/smes/buildable/main,
 /obj/structure/cable{
 	icon_state = "0-4";
 	d2 = 4

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -95,24 +95,18 @@
 /turf/simulated/shuttle/wall/voidcraft,
 /area/shuttle/excursion/tether)
 "aar" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/excursion/tether)
-"aas" = (
-/obj/machinery/power/smes/buildable{
-	charge = 2e+006;
-	input_attempt = 1;
-	input_level = 100000;
-	output_level = 200000;
-	RCon_tag = "Engine - Core"
-	},
 /obj/structure/cable/cyan{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/power/smes/buildable/engine,
 /turf/simulated/floor,
 /area/engineering/engine_smes)
+"aas" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/excursion/tether)
 "aat" = (
 /turf/simulated/mineral/floor/vacuum,
 /area/mine/explored/upper_level)
@@ -29096,7 +29090,7 @@ aaa
 aaa
 aaa
 acL
-aas
+aar
 aaR
 abr
 abD
@@ -33803,7 +33797,7 @@ aeo
 aaq
 aaq
 aau
-aar
+aas
 avK
 avN
 aad
@@ -33945,7 +33939,7 @@ amF
 avG
 adB
 aaq
-aar
+aas
 avK
 avN
 aad
@@ -34087,7 +34081,7 @@ amF
 avG
 adB
 aaq
-aar
+aas
 avK
 auH
 aad
@@ -34939,7 +34933,7 @@ aaD
 avG
 tIi
 aaq
-aar
+aas
 avK
 auQ
 aad
@@ -35081,7 +35075,7 @@ amL
 aob
 dbI
 aaq
-aar
+aas
 avK
 qgR
 aad
@@ -35223,7 +35217,7 @@ aep
 aeu
 aev
 aau
-aar
+aas
 avK
 qgR
 aad

--- a/nano/templates/smes.tmpl
+++ b/nano/templates/smes.tmpl
@@ -102,3 +102,11 @@
 		</div>
 	</div>
 </div>
+
+<div class ="item">
+	<div class ="itemContent">
+		<div style="clear: both; padding-top: 4px;">
+			{{:helper.link('Mute Alert for 10 minutes', null, {'mute' : 'mute'}, null)}}	
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
The main SMES is now a subtype, rather than a mapmaker var-edited normal one. This also means that it now sends a stationwide alert every 3 minutes when between 30 and 20% to alert the station to set up solars, and when below 20% to alert the station that non-Engineering personnel are now permitted to attempt an engine startup. 
It **shouldn't** output the message when the SMES is actively charging, so it doesn't spam the message when you charge it after a discharge for upgrades. The unfortunate thing is, it will paste the message every 3 minutes during controlled discharges for upgrades but, this is hardly spam.
Also makes the main SMES a SMES subtype, so this can be put on any map at any time just by using the /main SMES subtype. Cool. Engine SMES is also now a subtype, but with no new added features. Just ease of mapping.