### PR TITLE
Renames the "Visitor" role to "Assistant"

### DIFF
--- a/code/__defines/misc_vr.dm
+++ b/code/__defines/misc_vr.dm
@@ -36,7 +36,7 @@
 #define BLUE_SHIELDED 2 // Shield from bluespace teleportation (telescience)
 
 //Assistant/Visitor/Whatever
-#define USELESS_JOB "Visitor"
+#define USELESS_JOB "Assistant"
 
 //Herm Gender
 #define HERM "herm"

--- a/code/datums/outfits/jobs/civilian.dm
+++ b/code/datums/outfits/jobs/civilian.dm
@@ -3,8 +3,8 @@
 	id_type = /obj/item/weapon/card/id/assistant
 
 /decl/hierarchy/outfit/job/assistant/visitor
-	name = OUTFIT_JOB_NAME("Visitor")
-	id_pda_assignment = "Visitor"
+	name = OUTFIT_JOB_NAME("Assistant")
+	id_pda_assignment = "Assistant"
 	uniform = /obj/item/clothing/under/assistantformal
 
 /decl/hierarchy/outfit/job/assistant/resident

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -113,5 +113,5 @@ datum/announcement/proc/Log(message as text, message_title as text)
 			rank = character.mind.role_alt_title
 		AnnounceArrivalSimple(character.real_name, rank, join_message)
 
-/proc/AnnounceArrivalSimple(var/name, var/rank = "visitor", var/join_message = "will arrive at the station shortly") //VOREStation Edit - Remove shuttle reference
+/proc/AnnounceArrivalSimple(var/name, var/rank = "assistant", var/join_message = "will arrive at the station shortly") //VOREStation Edit - Remove shuttle reference
 	global_announcer.autosay("[name], [rank], [join_message].", "Arrivals Announcement Computer")

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -13,7 +13,7 @@
 	access = list()			//See /datum/job/assistant/get_access()
 	minimal_access = list()	//See /datum/job/assistant/get_access()
 	outfit_type = /decl/hierarchy/outfit/job/assistant/intern
-	alt_titles = list("Apprentice Engineer","Medical Intern","Lab Assistant","Security Cadet","Jr. Cargo Tech","Assistant") //VOREStation Edit
+	alt_titles = list("Apprentice Engineer","Medical Intern","Lab Assistant","Security Cadet","Jr. Cargo Tech") //VOREStation Edit
 	timeoff_factor = 0 //VOREStation Edit - Interns, noh
 
 //VOREStation Add

--- a/code/game/jobs/job/job_vr.dm
+++ b/code/game/jobs/job/job_vr.dm
@@ -6,7 +6,7 @@
 	var/latejoin_only = 0
 
 	//Every hour playing this role gains this much time off. (Can be negative for off duty jobs!)
-	var/timeoff_factor = 3
+	var/timeoff_factor = 1
 
 // Check client-specific availability rules.
 /datum/job/proc/player_has_enough_pto(client/C)

--- a/code/game/jobs/job/offduty_vr.dm
+++ b/code/game/jobs/job/offduty_vr.dm
@@ -3,7 +3,7 @@
 //
 
 /datum/job/offduty_civilian
-	title = "Off-Duty Worker"
+	title = "Off-Duty Employee"
 	latejoin_only = TRUE
 	timeoff_factor = -1
 	total_positions = -1

--- a/code/game/jobs/job/offduty_vr.dm
+++ b/code/game/jobs/job/offduty_vr.dm
@@ -5,7 +5,7 @@
 /datum/job/offduty_civilian
 	title = "Off-Duty Employee"
 	latejoin_only = TRUE
-	timeoff_factor = -1
+	timeoff_factor = 0
 	total_positions = -1
 	faction = "Station"
 	department = "Civilian"
@@ -18,7 +18,7 @@
 /datum/job/offduty_cargo
 	title = "Off-duty Cargo"
 	latejoin_only = TRUE
-	timeoff_factor = -1
+	timeoff_factor = 0
 	total_positions = -1
 	faction = "Station"
 	department = "Cargo"
@@ -31,7 +31,7 @@
 /datum/job/offduty_engineering
 	title = "Off-duty Engineer"
 	latejoin_only = TRUE
-	timeoff_factor = -1
+	timeoff_factor = 0
 	total_positions = -1
 	faction = "Station"
 	department = "Engineering"
@@ -44,7 +44,7 @@
 /datum/job/offduty_medical
 	title = "Off-duty Medic"
 	latejoin_only = TRUE
-	timeoff_factor = -1
+	timeoff_factor = 0
 	total_positions = -1
 	faction = "Station"
 	department = "Medical"
@@ -57,7 +57,7 @@
 /datum/job/offduty_science
 	title = "Off-duty Scientist"
 	latejoin_only = TRUE
-	timeoff_factor = -1
+	timeoff_factor = 0
 	total_positions = -1
 	faction = "Station"
 	department = "Science"
@@ -70,7 +70,7 @@
 /datum/job/offduty_security
 	title = "Off-duty Officer"
 	latejoin_only = TRUE
-	timeoff_factor = -1
+	timeoff_factor = 0
 	total_positions = -1
 	faction = "Station"
 	department = "Security"
@@ -84,7 +84,7 @@
 /datum/job/offduty_command
 	title = "Off-duty CO"
 	latejoin_only = TRUE
-	timeoff_factor = -1
+	timeoff_factor = 0
 	total_positions = -1
 	faction = "Station"
 	department = "Command"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -406,7 +406,7 @@
 		if(character.mind.role_alt_title)
 			rank = character.mind.role_alt_title
 		// can't use their name here, since cyborg namepicking is done post-spawn, so we'll just say "A new Cyborg has arrived"/"A new Android has arrived"/etc.
-		global_announcer.autosay("A new[rank ? " [rank]" : " visitor" ] [join_message ? join_message : "has arrived on the station"].", "Arrivals Announcement Computer")
+		global_announcer.autosay("A new[rank ? " [rank]" : " assistant" ] [join_message ? join_message : "has arrived on the station"].", "Arrivals Announcement Computer")
 
 /mob/new_player/proc/LateChoices()
 	var/name = client.prefs.be_random_name ? "friend" : client.prefs.real_name


### PR DESCRIPTION
Also removes Assistant as an alt-title for intern, and renames "Off Duty Worker" to "Off Duty Employee." ~~This may come with a config change to disable the PTO tracking, which should make off-duty 100% free of any constraints.~~
Instead, you now require 1 hour in a department to gain PTO, but it never gets spent. So, you can't join off duty medic without actually having played it.