### PR TITLE
Fixes Bulletproof and Ablative Plate Carrier Attatchments having no Icon.

### DIFF
--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -130,7 +130,7 @@
 /obj/item/clothing/accessory/armor/armguards/laserproof
 	name = "ablative arm guards"
 	desc = "These arm guards will protect your arms from energy weapons."
-	icon_state = "armguards_laser"
+	icon_state = "armguards_ablative"
 	item_state_slots = list(slot_r_hand_str = "swat", slot_l_hand_str = "swat")
 	siemens_coefficient = 0.4 //This is worse than the other ablative pieces, to avoid this from becoming the poor warden's insulated gloves.
 	armor = list(melee = 10, bullet = 10, laser = 80, energy = 50, bomb = 0, bio = 0, rad = 0)
@@ -138,7 +138,7 @@
 /obj/item/clothing/accessory/armor/armguards/bulletproof
 	name = "bullet resistant arm guards"
 	desc = "These arm guards will protect your arms from ballistic weapons."
-	icon_state = "armguards_bullet"
+	icon_state = "armguards_ballistic"
 	item_state_slots = list(slot_r_hand_str = "swat", slot_l_hand_str = "swat")
 	siemens_coefficient = 0.7
 	armor = list(melee = 10, bullet = 80, laser = 10, energy = 50, bomb = 0, bio = 0, rad = 0)
@@ -189,7 +189,7 @@
 /obj/item/clothing/accessory/armor/legguards/laserproof
 	name = "ablative leg guards"
 	desc = "These will protect your legs from energy weapons."
-	icon_state = "legguards_laser"
+	icon_state = "legguards_ablative"
 	item_state_slots = list(slot_r_hand_str = "jackboots", slot_l_hand_str = "jackboots")
 	siemens_coefficient = 0.1
 	armor = list(melee = 10, bullet = 10, laser = 80, energy = 50, bomb = 0, bio = 0, rad = 0)
@@ -197,7 +197,7 @@
 /obj/item/clothing/accessory/armor/legguards/bulletproof
 	name = "bullet resistant leg guards"
 	desc = "These will protect your legs from ballistic weapons."
-	icon_state = "legguards_bullet"
+	icon_state = "legguards_ballistic"
 	item_state_slots = list(slot_r_hand_str = "jackboots", slot_l_hand_str = "jackboots")
 	siemens_coefficient = 0.7
 	armor = list(melee = 10, bullet = 80, laser = 10, energy = 10, bomb = 0, bio = 0, rad = 0)


### PR DESCRIPTION
Literally what it says on the tin. It was a slight icon mishap.

Changed icon_state = "armguards_bullet" & icon_state = "armguards_laser" to icon_state = "armguards_ballistic" & icon_state = "armguards_ablative"
Same story with legs.