### PR TITLE
Adds Junior Scientist, Junior Engineer, Medical Resident

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -44,7 +44,7 @@
 	economic_modifier = 5
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics)
 	minimal_access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction)
-	alt_titles = list("Maintenance Technician","Engine Technician","Electrician","Operational Support")
+	alt_titles = list("Maintenance Technician","Engine Technician","Electrician","Operational Support","Junior Engineer")
 
 	minimal_player_age = 3
 

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -44,7 +44,8 @@
 		"Surgeon" = /decl/hierarchy/outfit/job/medical/doctor/surgeon,
 		"Emergency Physician" = /decl/hierarchy/outfit/job/medical/doctor/emergency_physician,
 		"Nurse" = /decl/hierarchy/outfit/job/medical/doctor/nurse,
-		"Virologist" = /decl/hierarchy/outfit/job/medical/doctor/virologist)
+		"Virologist" = /decl/hierarchy/outfit/job/medical/doctor/virologist,
+		"Medical Resident")
 
 //Chemist is a medical job damnit	//YEAH FUCK YOU SCIENCE	-Pete	//Guys, behave -Erro
 /datum/job/chemist

--- a/code/game/jobs/job/z_all_jobs_vr.dm
+++ b/code/game/jobs/job/z_all_jobs_vr.dm
@@ -52,4 +52,4 @@
 	spawn_positions = 3
 	
 /datum/job/scientist
-	alt_titles = list("Xenoarcheologist", "Anomalist", "Phoron Researcher", "Circuit Designer")
+	alt_titles = list("Xenoarcheologist", "Anomalist", "Phoron Researcher", "Circuit Designer","Junior Scientist")


### PR DESCRIPTION
these should provide a good intermediary between interning and working the full role, while still broadcasting 'i'm learning, teach me!'

todo: potentially better title than 'junior scientist'? just waiting on nicc to ask a friend about it.
update: only 'good' alternative was 'associate scientist', which sounds a bit too ambiguous. junior scientist will do.


## Changelog
:cl:
add: 'Junior' alt titles for Science, Engineering, and Medical; Junior Scientist, Junior Engineer, and Medical Resident.
/:cl: