### PR TITLE
Fixes machines that spawned an empty frame and runtimed on dismantle attempts

### DIFF
--- a/code/game/machinery/doorbell_vr.dm
+++ b/code/game/machinery/doorbell_vr.dm
@@ -47,8 +47,8 @@
 	src.add_fingerprint(user)
 	if(default_deconstruction_screwdriver(user, W))
 		return
-	else if(default_deconstruction_crowbar(user, W))
-		return
+//	else if(default_deconstruction_crowbar(user, W))  //NOTICE: NO CIRCUITBOARD
+//		return
 	else if(default_part_replacement(user, W))
 		return
 	else if(panel_open && istype(W, /obj/item/device/multitool))

--- a/code/game/machinery/exonet_node.dm
+++ b/code/game/machinery/exonet_node.dm
@@ -16,6 +16,8 @@
 
 	var/list/logs = list() // Gets written to by exonet's send_message() function.
 
+	circuit = /obj/item/weapon/circuitboard/telecomms/exonet_node
+
 // Proc: New()
 // Parameters: None
 // Description: Adds components to the machine for deconstruction.
@@ -23,7 +25,7 @@
 	..()
 
 	component_parts = list()
-	component_parts += new /obj/item/weapon/circuitboard/telecomms/exonet_node(src)
+//	component_parts += new /obj/item/weapon/circuitboard/telecomms/exonet_node(src)
 	component_parts += new /obj/item/weapon/stock_parts/subspace/ansible(src)
 	component_parts += new /obj/item/weapon/stock_parts/subspace/sub_filter(src)
 	component_parts += new /obj/item/weapon/stock_parts/manipulator(src)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -402,6 +402,8 @@ Class Procs:
 
 /obj/machinery/proc/dismantle()
 	playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
+	if(!circuit)
+		return 0
 	var/obj/structure/frame/A = new /obj/structure/frame(src.loc)
 	var/obj/item/weapon/circuitboard/M = circuit
 	A.circuit = M

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -96,8 +96,13 @@
 
 	if(default_deconstruction_screwdriver(user, W))
 		return
-	if(default_deconstruction_crowbar(user, W))
+	if(W.is_wrench())
+		playsound(src, W.usesound, 100, 1)
+		to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure \the [src].</span>")
+		anchored = !anchored
 		return
+//	if(default_deconstruction_crowbar(user, W)) //NOTICE: NO CIRCUITBOARD
+//		return
 	if(istype(W,/obj/item/weapon/disk/botany))
 		if(loaded_disk)
 			to_chat(user, "There is already a data disk loaded.")

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -299,12 +299,13 @@
 	desc = "A machinery brace for an industrial drill. It looks easily two feet thick."
 	icon_state = "mining_brace"
 	var/obj/machinery/mining/drill/connected
+	circuit = /obj/item/weapon/circuitboard/miningdrillbrace
 
 /obj/machinery/mining/brace/New()
 	..()
 
 	component_parts = list()
-	component_parts += new /obj/item/weapon/circuitboard/miningdrillbrace(src)
+	//component_parts += new /obj/item/weapon/circuitboard/miningdrillbrace(src)
 
 /obj/machinery/mining/brace/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(connected && connected.active)

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -78,22 +78,20 @@
 /obj/machinery/power/smes/batteryrack/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob) //these can only be moved by being reconstructed, solves having to remake the powernet.
 	..() //SMES attackby for now handles screwdriver, cable coils and wirecutters, no need to repeat that here
 	if(open_hatch)
+
 		if(W.is_crowbar())
-			if (charge < (capacity / 100))
-				if (!output_attempt && !input_attempt)
-					playsound(src, W.usesound, 50, 1)
-					var/obj/structure/frame/M = new /obj/structure/frame(src.loc)
-					M.frame_type = "machine"
-					M.state = 2
-					M.icon_state = "machine_1"
-					for(var/obj/I in component_parts)
-						I.loc = src.loc
-					qdel(src)
-					return 1
-				else
-					to_chat(user, "<span class='warning'>Turn off the [src] before dismantling it.</span>")
+			if(charge < (capacity/100))
+				if(output_attempt || input_attempt)
+					to_chat(user, "<span class='warning'>Turn off \the [src] before dismantling it.</span>")
+					return
+				if(terminal)
+					to_chat(user, "<span class='warning'>You have to disassemble the terminal first!</span>")
+					return
+				return dismantle()
 			else
-				to_chat(user, "<span class='warning'>Better let [src] discharge before dismantling it.</span>")
+				to_chat(user, "<span class='warning'>Better let \the [src] discharge before dismantling it.</span>")
+				return
+
 		else if ((istype(W, /obj/item/weapon/stock_parts/capacitor) && (capacitors_amount < 5)) || (istype(W, /obj/item/weapon/cell) && (cells_amount < 5)))
 			if (charge < (capacity / 100))
 				if (!output_attempt && !input_attempt)

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -105,6 +105,7 @@
 
 	can_buckle = TRUE
 	buckle_lying = FALSE
+	circuit = /obj/item/weapon/circuitboard/grounding_rod
 
 /obj/machinery/power/grounding_rod/pre_mapped
 	anchored = TRUE


### PR DESCRIPTION
by adding circuits to most of them, and removing the ability to crowbar deconstruct for the rest.
_also for my boys in xenobotany:_ while i'm at it, xenobotany machines are wrenchable and can be unanchored now.

## Changelog
:cl:
tweak: Xenobotany machines (centrifuge and delivery system) can now be unwrenched and moved.
fix: Machines no longer dismantle() if they have no circuit board by default.
fix: Removed the ability to use a crowbar on certain machines that didn't have a circuit board.
fix: Gave drill braces, grounding rods, and exonet nodes their circuit boards back.
/:cl: