### PR TITLE
Makes Blood + blue space slime = a real bluespace rock

### DIFF
--- a/code/modules/xenobio/items/extracts.dm
+++ b/code/modules/xenobio/items/extracts.dm
@@ -712,7 +712,7 @@
 	icon_state = "bluespace slime extract"
 	description_info = "This extract creates slime crystals.  When injected with water, it creates five 'lesser' slime crystals, which allow for limited \
 	short ranged, random teleporting.  When injected with phoron, it creates one 'greater' slime crystal, which allows for a one time precise teleport to \
-	a specific area."
+	a specific area. But when injected with blood will make a single bluespace crystal."
 
 /datum/chemical_reaction/slime/bluespace_lesser
 	name = "Slime Lesser Tele"
@@ -735,6 +735,17 @@
 
 /datum/chemical_reaction/slime/bluespace_greater/on_reaction(var/datum/reagents/holder)
 	new /obj/item/weapon/disposable_teleporter/slime(get_turf(holder.my_atom))
+	..()
+
+/datum/chemical_reaction/slime/bloodcrystal
+	name = "Soild Bluespace"
+	id = "bloodcrystal"
+	required_reagents = list("blood" = 5)
+	result_amount = 1
+	required = /obj/item/slime_extract/bluespace
+
+/datum/chemical_reaction/slime/bloodcrystal/on_reaction(var/datum/reagents/holder)
+	new /obj/item/weapon/ore/bluespace_crystal(get_turf(holder.my_atom))
 	..()
 
 // *******************


### PR DESCRIPTION
[Changlogs]
Makes it so that when you inject a slime of blue space with blood it will make a real bluespace rock
[Why?]
For telecoms to work as intented. This can also be used in rnd to get a level in bluespace tho its pointless