### PR TITLE
V2/V4 3x high activity retry

### DIFF
--- a/maps/submaps/surface_submaps/mountains/mountains.dm
+++ b/maps/submaps/surface_submaps/mountains/mountains.dm
@@ -60,181 +60,183 @@
 	name = "Abandoned Relay"
 	desc = "An unregistered comms relay, abandoned to the elements."
 	mappath = 'maps/submaps/surface_submaps/mountains/deadBeacon.dmm'
-	cost = 10
+	cost = 3
 
 /datum/map_template/surface/mountains/normal/prepper1
 	name = "Prepper Bunker"
 	desc = "A little hideaway for someone with more time and money than sense."
 	mappath = 'maps/submaps/surface_submaps/mountains/prepper1.dmm'
-	cost = 10
+	cost = 4
 
 /datum/map_template/surface/mountains/normal/qshuttle
 	name = "Quarantined Shuttle"
 	desc = "An emergency landing turned viral outbreak turned tragedy."
 	mappath = 'maps/submaps/surface_submaps/mountains/quarantineshuttle.dmm'
-	cost = 20
+	cost = 6
 
 /datum/map_template/surface/mountains/normal/Mineshaft1
 	name = "Abandoned Mineshaft 1"
 	desc = "An abandoned minning tunnel from a lost money making effort."
 	mappath = 'maps/submaps/surface_submaps/mountains/Mineshaft1.dmm'
-	cost = 5
+	cost = 1
 
 /datum/map_template/surface/mountains/normal/crystal1
 	name = "Crystal Cave 1"
 	desc = "A small cave with glowing gems and diamonds."
 	mappath = 'maps/submaps/surface_submaps/mountains/crystal1.dmm'
-	cost = 5
+	cost = 1
 	allow_duplicates = TRUE
 
 /datum/map_template/surface/mountains/normal/crystal2
 	name = "Crystal Cave 2"
 	desc = "A moderate sized cave with glowing gems and diamonds."
 	mappath = 'maps/submaps/surface_submaps/mountains/crystal2.dmm'
-	cost = 10
+	cost = 2
 	allow_duplicates = TRUE
 
 /datum/map_template/surface/mountains/normal/crystal2
 	name = "Crystal Cave 3"
 	desc = "A large spiral of crystals with diamonds in the center."
 	mappath = 'maps/submaps/surface_submaps/mountains/crystal3.dmm'
-	cost = 15
+	cost = 5
 
 /datum/map_template/surface/mountains/normal/lost_explorer
 	name = "Lost Explorer"
 	desc = "The remains of an explorer who rotted away ages ago, and their equipment."
 	mappath = 'maps/submaps/surface_submaps/mountains/lost_explorer.dmm'
-	cost = 5
+	cost = 2
 	allow_duplicates = TRUE
 
 /datum/map_template/surface/mountains/normal/Rockb1
 	name = "Rocky Base 1"
 	desc = "Someones underground hidey hole"
 	mappath = 'maps/submaps/surface_submaps/mountains/Rockb1.dmm'
-	cost = 15
+	cost = 5
 
 /datum/map_template/surface/mountains/normal/corgiritual
 	name = "Dark Ritual"
 	desc = "Who put all these plushies here? What are they doing?"
 	mappath = 'maps/submaps/surface_submaps/mountains/ritual.dmm'
-	cost = 15
+	cost = 5
 
 /datum/map_template/surface/mountains/normal/abandonedtemple
 	name = "Abandoned Temple"
 	desc = "An ancient temple, long since abandoned. Perhaps alien in origin?"
 	mappath = 'maps/submaps/surface_submaps/mountains/temple.dmm'
-	cost = 20
+	cost = 6
 
 /datum/map_template/surface/mountains/normal/crashedmedshuttle
 	name = "Crashed Med Shuttle"
 	desc = "A medical response shuttle that went missing some time ago. So this is where they went."
 	mappath = 'maps/submaps/surface_submaps/mountains/CrashedMedShuttle1.dmm'
-	cost = 20
+	cost = 6
 
 /datum/map_template/surface/mountains/normal/digsite
 	name = "Dig Site"
 	desc = "A small abandoned dig site."
 	mappath = 'maps/submaps/surface_submaps/mountains/digsite.dmm'
-	cost = 10
+	cost = 3
 
 /datum/map_template/surface/mountains/normal/vault1
 	name = "Mine Vault 1"
 	desc = "A small vault with potential loot."
 	mappath = 'maps/submaps/surface_submaps/mountains/vault1.dmm'
-	cost = 5
+	cost = 2
 	allow_duplicates = TRUE
 
 /datum/map_template/surface/mountains/normal/vault2
 	name = "Mine Vault 2"
 	desc = "A small vault with potential loot."
 	mappath = 'maps/submaps/surface_submaps/mountains/vault2.dmm'
-	cost = 5
+	cost = 2
 	allow_duplicates = TRUE
 
 /datum/map_template/surface/mountains/normal/vault3
 	name = "Mine Vault 3"
 	desc = "A small vault with potential loot. Also a horrible suprise."
 	mappath = 'maps/submaps/surface_submaps/mountains/vault3.dmm'
-	cost = 15
+	cost = 5
 
 /datum/map_template/surface/mountains/normal/IceCave1A
 	name = "Ice Cave 1A"
 	desc = "This cave's slippery ice makes it hard to navigate, but determined explorers will be rewarded."
 	mappath = 'maps/submaps/surface_submaps/mountains/IceCave1A.dmm'
-	cost = 10
+	cost = 3
 
 /datum/map_template/surface/mountains/normal/IceCave1B
 	name = "Ice Cave 1B"
 	desc = "This cave's slippery ice makes it hard to navigate, but determined explorers will be rewarded."
 	mappath = 'maps/submaps/surface_submaps/mountains/IceCave1B.dmm'
-	cost = 10
+	cost = 3
 
 /datum/map_template/surface/mountains/normal/IceCave1C
 	name = "Ice Cave 1C"
 	desc = "This cave's slippery ice makes it hard to navigate, but determined explorers will be rewarded."
 	mappath = 'maps/submaps/surface_submaps/mountains/IceCave1C.dmm'
-	cost = 10
+	cost = 3
 
 /datum/map_template/surface/mountains/normal/SwordCave
 	name = "Cursed Sword Cave"
 	desc = "An underground lake. The sword on the lake's island holds a terrible secret."
 	mappath = 'maps/submaps/surface_submaps/mountains/SwordCave.dmm'
+	cost = 8
 
 /datum/map_template/surface/mountains/normal/supplydrop1
 	name = "Supply Drop 1"
 	desc = "A drop pod that landed deep within the mountains."
 	mappath = 'maps/submaps/surface_submaps/mountains/SupplyDrop1.dmm'
-	cost = 10
+	cost = 4
 	allow_duplicates = TRUE
 
 /datum/map_template/surface/mountains/normal/crashedcontainmentshuttle
 	name = "Crashed Cargo Shuttle"
 	desc = "A severely damaged military shuttle, its cargo seems to remain intact."
 	mappath = 'maps/submaps/surface_submaps/mountains/crashedcontainmentshuttle.dmm'
-	cost = 30
+	cost = 10
 
 /datum/map_template/surface/mountains/normal/deadspy
 	name = "Spy Remains"
 	desc = "W+M1 = Salt."
 	mappath = 'maps/submaps/surface_submaps/mountains/deadspy.dmm'
-	cost = 15
+	cost = 5
 
 
 /**************
  * Deep Caves *
  **************/
 
-/datum/map_template/surface/mountains/deep/lost_explorer
-	name = "Lost Explorer, Deep"
-	desc = "The remains of an explorer who rotted away ages ago, and their equipment. Again."
-	mappath = 'maps/submaps/surface_submaps/mountains/lost_explorer.dmm'
-	cost = 5
-	allow_duplicates = FALSE //Citadel change; A million of these spawning instead of interesting stuff in the deep part sucks.
+///datum/map_template/surface/mountains/deep/lost_explorer
+//	name = "Lost Explorer, Deep"
+//	desc = "The remains of an explorer who rotted away ages ago, and their equipment. Again."
+//	mappath = 'maps/submaps/surface_submaps/mountains/lost_explorer.dmm'
+//	cost = 1
+//	allow_duplicates = FALSE //Citadel change; A million of these spawning instead of interesting stuff in the deep part sucks.
+//Cit change; Removal, with 3x high activity changes, there will already be quite a few scattered on the lower half, no need to waste space where space is needed.
 
 /datum/map_template/surface/mountains/deep/crashed_ufo
 	name = "Crashed UFO"
 	desc = "A (formerly) flying saucer that is now embedded into the mountain, yet it still seems to be running..."
 	mappath = 'maps/submaps/surface_submaps/mountains/crashed_ufo.dmm'
-	cost = 40
+	cost = 15
 	discard_prob = 50
 
 /datum/map_template/surface/mountains/deep/Scave1
 	name = "Spider Cave 1"
 	desc = "A minning tunnel home to an aggressive collection of spiders."
 	mappath = 'maps/submaps/surface_submaps/mountains/Scave1.dmm'
-	cost = 20
+	cost = 6
 
 /datum/map_template/surface/mountains/deep/CaveTrench
 	name = "Cave River"
 	desc = "A strange underground river."
 	mappath = 'maps/submaps/surface_submaps/mountains/CaveTrench.dmm'
-	cost = 20
+	cost = 6
 
 /datum/map_template/surface/mountains/deep/Cavelake
 	name = "Cave Lake"
 	desc = "A large underground lake."
 	mappath = 'maps/submaps/surface_submaps/mountains/Cavelake.dmm'
-	cost = 20
+	cost = 6
 
 //Citadel change
 //Vaults 1-3 kept in the normal area, since they're basically just a box and two xenos.
@@ -242,42 +244,42 @@
 	//name = "Mine Vault 1"
 	//desc = "A small vault with potential loot."
 	//mappath = 'maps/submaps/surface_submaps/mountains/vault1.dmm'
-	//cost = 5
+	//cost = 3
 	//allow_duplicates = TRUE
 
 //datum/map_template/surface/mountains/deep/vault2
 	//name = "Mine Vault 2"
 	//desc = "A small vault with potential loot."
 	//mappath = 'maps/submaps/surface_submaps/mountains/vault2.dmm'
-	//cost = 5
+	//cost = 3
 	//low_duplicates = TRUE
 
 //datum/map_template/surface/mountains/deep/vault3
 	//name = "Mine Vault 3"
 	//desc = "A small vault with potential loot. Also a horrible suprise."
 	//mappath = 'maps/submaps/surface_submaps/mountains/vault3.dmm'
-	//cost = 15
+	//cost = 5
 
 /datum/map_template/surface/mountains/deep/vault4
 	name = "Mine Vault 4"
 	desc = "A small xeno vault with potential loot. Also horrible suprises."
 	mappath = 'maps/submaps/surface_submaps/mountains/vault4.dmm'
-	cost = 20
+	cost = 6
 
 /datum/map_template/surface/mountains/deep/vault5
 	name = "Mine Vault 5"
 	desc = "A small xeno vault with potential loot. Also major horrible suprises."
 	mappath = 'maps/submaps/surface_submaps/mountains/vault5.dmm'
-	cost = 25
+	cost = 8
 
 /datum/map_template/surface/mountains/deep/BlastMine1
 	name = "Blast Mine 1"
 	desc = "An abandoned blast mining site, seems that local wildlife has moved in."
 	mappath = 'maps/submaps/surface_submaps/mountains/BlastMine1.dmm'
-	cost = 20
+	cost = 6
 
 /datum/map_template/surface/mountains/deep/cultmine
 	name = "Cult Mine"
 	desc = "A mining operation that found more than it bargained for."
 	mappath = 'maps/submaps/surface_submaps/mountains/cultmine.dmm'
-	cost = 30
+	cost = 10

--- a/maps/submaps/surface_submaps/wilderness/wilderness.dm
+++ b/maps/submaps/surface_submaps/wilderness/wilderness.dm
@@ -34,6 +34,7 @@
 // POIs here spawn in two different sections, the top half and bottom half of the map.
 // The top half connects to the outpost z-level, and is seperated from the bottom half by a river. It should provide a challenge to a well equiped Explorer team.
 // The bottom half should be even more dangerous, where only the robust, fortunate, or lucky can survive.
+// Cit change: This seems to control V2 now for whatever reason, though the stuff said above applies for spawning, as the lower half still houses the dangerous stuff.
 
 /datum/map_template/surface/wilderness
 	name = "Surface Content - Wildy"
@@ -52,160 +53,163 @@
 	desc = "A small spider nest, in the forest."
 	mappath = 'maps/submaps/surface_submaps/wilderness/spider1.dmm'
 	allow_duplicates = TRUE
-	cost = 5
+	cost = 1
 
 /datum/map_template/surface/wilderness/normal/Flake
 	name = "Forest Lake"
 	desc = "A serene lake sitting amidst the surface."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Flake.dmm'
-	cost = 10
+	cost = 3
 
 /datum/map_template/surface/wilderness/normal/Mcamp1
 	name = "Military Camp 1"
 	desc = "A derelict military camp host to some unsavory dangers"
 	mappath = 'maps/submaps/surface_submaps/wilderness/MCamp1.dmm'
-	cost = 5
+	cost = 1
 
 /datum/map_template/surface/wilderness/normal/Mudpit
 	name = "Mudpit"
 	desc = "What happens when someone is a bit too careless with gas.."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Mudpit.dmm'
-	cost = 5
+	cost = 1
 
 /datum/map_template/surface/wilderness/normal/Rocky1
 	name = "Rocky1"
 	desc = "DununanununanununuNAnana"
 	mappath = 'maps/submaps/surface_submaps/wilderness/Rocky1.dmm'
 	allow_duplicates = TRUE
-	cost = 5
+	cost = 1
 
 /datum/map_template/surface/wilderness/normal/Rocky2
 	name =  "Rocky2"
 	desc = "More rocks."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Rocky2.dmm'
 	allow_duplicates = TRUE
-	cost = 5
+	cost = 1
 
 /datum/map_template/surface/wilderness/normal/Rocky3
 	name = "Rocky3"
 	desc = "More and more and more rocks."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Rocky3.dmm'
 	desc = "DununanununanununuNAnana"
-	cost = 5
+	cost = 1
 
 /datum/map_template/surface/wilderness/normal/Shack1
 	name = "Shack1"
 	desc = "A small shack in the middle of nowhere, Your halloween murder happens here"
 	mappath = 'maps/submaps/surface_submaps/wilderness/Shack1.dmm'
-	cost = 5
+	allow_duplicates = FALSE //Cit change; these spawn everywhere, cluttering the place with pretty much nothing, and wasting points
+	cost = 3
 
-/datum/map_template/surface/wilderness/normal/Smol1
-	name = "Smol1"
-	desc = "A tiny grove of trees, The Nemesis of thicc"
-	mappath = 'maps/submaps/surface_submaps/wilderness/Smol1.dmm'
-	cost = 5
+///datum/map_template/surface/wilderness/normal/Smol1
+//	name = "Smol1"
+//	desc = "A tiny grove of trees, The Nemesis of thicc"
+//	mappath = 'maps/submaps/surface_submaps/wilderness/Smol1.dmm'
+//	cost = 2
+//cit change; this dosnt even spawn in v2, or anywhere else and eats up a fuckton of init time, disabled.
 
 /datum/map_template/surface/wilderness/normal/Snowrock1
 	name = "Snowrock1"
 	desc = "A rocky snow covered area"
 	mappath = 'maps/submaps/surface_submaps/wilderness/Snowrock1.dmm'
-	cost = 5
+	cost = 3
 
-/datum/map_template/surface/wilderness/normal/Cragzone1
-	name = "Cragzone1"
-	desc = "Rocks and more rocks."
-	mappath = 'maps/submaps/surface_submaps/wilderness/Cragzone1.dmm'
-	cost = 5
-	allow_duplicates = TRUE
+///datum/map_template/surface/wilderness/normal/Cragzone1
+//	name = "Cragzone1"
+//	desc = "Rocks and more rocks."
+//	mappath = 'maps/submaps/surface_submaps/wilderness/Cragzone1.dmm'
+//	cost = 5
+//	allow_duplicates = TRUE
+//Cit change; I dunno why this is here it takes up a massive space with no loot, a default cost of 5, and it ALLOWS FOR MORE THAN ONE??
 
 /datum/map_template/surface/wilderness/normal/Lab1
 	name = "Lab1"
 	desc = "An isolated small robotics lab."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Lab1.dmm'
-	cost = 5
+	cost = 1
 
 /datum/map_template/surface/wilderness/normal/Rocky4
 	name = "Rocky4"
 	desc = "An interesting geographic formation."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Rocky4.dmm'
-	cost = 5
+	cost = 1
 
 /datum/map_template/surface/wilderness/deep/DJOutpost1
 	name = "DJOutpost1"
 	desc = "Home of Sif Free Radio, the best - and only - radio station for miles around."
 	mappath = 'maps/submaps/surface_submaps/wilderness/DJOutpost1.dmm'
 	template_group = "Sif Free Radio"
-	cost = 5
+	cost = 2
 
 /datum/map_template/surface/wilderness/deep/DJOutpost2
 	name = "DJOutpost2"
 	desc = "The cratered remains of Sif Free Radio, the best - and only - radio station for miles around."
 	mappath = 'maps/submaps/surface_submaps/wilderness/DJOutpost2.dmm'
 	template_group = "Sif Free Radio"
-	cost = 5
+	cost = 2
 
 /datum/map_template/surface/wilderness/deep/Boombase
 	name = "Boombase"
 	desc = "What happens when you don't follow SOP."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Boombase.dmm'
-	cost = 5
+	cost = 2
 
 /datum/map_template/surface/wilderness/deep/BSD
 	name = "Black Shuttle Down"
 	desc = "You REALLY shouldn't be near this."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Blackshuttledown.dmm'
-	cost = 30
+	cost = 10
 
 /datum/map_template/surface/wilderness/deep/Rockybase
 	name = "Rocky Base"
 	desc = "A guide to upsetting Icarus and the EIO"
 	mappath = 'maps/submaps/surface_submaps/wilderness/Rockybase.dmm'
-	cost = 35
+	cost = 12
 
 /datum/map_template/surface/wilderness/deep/MHR
 	name = "Manhack Rock"
 	desc = "A rock filled with nasty Synthetics."
 	mappath = 'maps/submaps/surface_submaps/wilderness/MHR.dmm'
-	cost = 15
+	cost = 2
 
 /datum/map_template/surface/wilderness/normal/GovPatrol
 	name = "Government Patrol"
 	desc = "A long lost SifGuard ground survey patrol. Now they have you guys!"
 	mappath = 'maps/submaps/surface_submaps/wilderness/GovPatrol.dmm'
-	cost = 5
+	cost = 1
 
 /datum/map_template/surface/wilderness/normal/DecoupledEngine
 	name = "Decoupled Engine"
 	desc = "A damaged fission engine jettisoned from a starship long ago."
 	mappath = 'maps/submaps/surface_submaps/wilderness/DecoupledEngine.dmm'
-	cost = 15
+	cost = 3
 
 /datum/map_template/surface/wilderness/deep/DoomP
 	name = "DoomP"
 	desc = "Witty description here."
 	mappath = 'maps/submaps/surface_submaps/wilderness/DoomP.dmm'
-	cost = 30
+	cost = 10
 
 /datum/map_template/surface/wilderness/deep/Cave
 	name = "CaveS"
 	desc = "Chitter chitter!"
 	mappath = 'maps/submaps/surface_submaps/wilderness/CaveS.dmm'
-	cost = 20
+	cost = 6
 
 /datum/map_template/surface/wilderness/normal/Drugden
 	name = "Drugden"
 	desc = "The remains of ill thought out whims."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Drugden.dmm'
-	cost = 20
+	cost = 6
 
 /datum/map_template/surface/wilderness/normal/Musk
 	name = "Musk"
 	desc = "0 to 60 in 1.9 seconds."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Musk.dmm'
-	cost = 10
+	cost = 3
 
 /datum/map_template/surface/wilderness/deep/Manor1
 	name = "Manor1"
 	desc = "Whodunit"
 	mappath = 'maps/submaps/surface_submaps/wilderness/Manor1.dmm'
-	cost = 20
+	cost = 6


### PR DESCRIPTION
Re-enables a few old ruins that were removed 4no raisin, as well as removes a few that are either impractical, spawn over and over regardless of not containing anything, or just don't work in the first place. Map inits are only increased by 50-80 seconds, compared to the previous 300 last time.