### PR TITLE
Size changer prompt can now be cancelled

### DIFF
--- a/code/modules/nifsoft/software/15_misc.dm
+++ b/code/modules/nifsoft/software/15_misc.dm
@@ -127,7 +127,9 @@
 
 	activate()
 		if((. = ..()))
-			var/new_size = input("Put the desired size (25-200%)", "Set Size", 200) as num
+			var/new_size = input("Put the desired size (25-200%)", "Set Size", 200) as num|null
+			if(isnull(new_size))
+				return
 
 			if (!IsInRange(new_size,25,200))
 				to_chat(nif.human,"<span class='notice'>The safety features of the NIF Program prevent you from choosing this size.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

VIRGOOOOOOOO

## Why It's Good For The Game

Because now you can cancel the NIF sizechanger when you click it on accident, considering it stuns you for a long-ass time.

## Changelog
:cl:
add: NIF Size changer prompt can now be cancelled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
