### PR TITLE
Adds an option to fix conveyor movement direction

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -108,6 +108,21 @@
 					C.conveyors |= src
 			return
 
+	if(istype(I, /obj/item/weapon/tool/wrench))
+		if(panel_open)
+			if(operating != 0)
+				to_chat(user, "<span class='notice'>Turn the conveyor off first!</span>")
+				return
+			else if(dir & (dir-1)) // Diagonal. Forwards is *away* from dir, curving to the right.
+				forwards = turn(dir, 135)
+				backwards = turn(dir, 45)
+			else
+				forwards = dir
+				backwards = turn(dir, 180)
+			playsound(src.loc, I.usesound, 50, 1)
+			to_chat(user, "<span class='notice'>You adjust the gears and motors to spin in the conveyor's direction.</span>")
+			return
+
 	user.drop_item(get_turf(src))
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For one reason or another, conveyors, when constructed by players, have south and north set as their forwards and backwards directions, despite the conveyor's actual direction. I couldn't find a way to just make it fix on spawning, but, I did the next best thing.
This only adds a wrench option on conveyors. If you use a wrench on a conveyor that isn't operating and has its panel open, it runs the direction-setting part again, fixing the forwards and backwards directions.

## Why It's Good For The Game

Simply put, actually being able to create conveyors. I do hope, however, that people don't actually proceed to use this for the old banana peel conveyor circle. I also hope, that it isn't shortly used to crash the server. You people are better than that, aren't you?

## Changelog
:cl:
add: You can now use a wrench on a conveyor with an open panel to fix the direction it's supposed to move objects in.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
