### PR TITLE
Fixes conveyors, for real this time

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -25,15 +25,18 @@
 	// create a conveyor
 /obj/machinery/conveyor/initialize(mapload, newdir, on = 0)
 	. = ..()
+
+
 	if(newdir)
 		set_dir(newdir)
 
-	if(dir & (dir-1)) // Diagonal. Forwards is *away* from dir, curving to the right.
-		forwards = turn(dir, 135)
-		backwards = turn(dir, 45)
-	else
-		forwards = dir
-		backwards = turn(dir, 180)
+	spawn(5)
+		if(src.dir & (src.dir-1)) // Diagonal. Forwards is *away* from dir, curving to the right.
+			forwards = turn(src.dir, 135)
+			backwards = turn(src.dir, 45)
+		else
+			forwards = src.dir
+			backwards = turn(src.dir, 180)
 
 	if(on)
 		operating = 1
@@ -46,6 +49,8 @@
 	component_parts += new /obj/item/weapon/stock_parts/motor(src)
 	component_parts += new /obj/item/stack/cable_coil(src,5)
 	RefreshParts()
+
+
 
 /obj/machinery/conveyor/proc/setmove()
 	if(operating == 1)
@@ -113,14 +118,16 @@
 			if(operating != 0)
 				to_chat(user, "<span class='notice'>Turn the conveyor off first!</span>")
 				return
-			else if(dir & (dir-1)) // Diagonal. Forwards is *away* from dir, curving to the right.
-				forwards = turn(dir, 135)
-				backwards = turn(dir, 45)
 			else
-				forwards = dir
-				backwards = turn(dir, 180)
+				dir = turn(dir, 45)
+				if(dir & (dir-1)) // Diagonal. Forwards is *away* from dir, curving to the right.
+					forwards = turn(dir, 135)
+					backwards = turn(dir, 45)
+				else
+					forwards = dir
+					backwards = turn(dir, 180)
 			playsound(src.loc, I.usesound, 50, 1)
-			to_chat(user, "<span class='notice'>You adjust the gears and motors to spin in the conveyor's direction.</span>")
+			to_chat(user, "<span class='notice'>You rotate the conveyor..</span>")
 			return
 
 	user.drop_item(get_turf(src))


### PR DESCRIPTION
## About The Pull Request

Now, this might not be that much better, I'll await input from those more experienced. But, after noting that objects that are already in the map set movement properly, I decided to just try delaying the movement setting slightly. And, well... It works. That's the most important thing, right?
With the wrench option now redundant, I replaced it for turning the conveyor. The icon does change together with the dir without calling an update icon function. I tested.

## Why It's Good For The Game

Being able to use conveyors as they properly should be used is nice.

## Changelog
:cl:
fix: fixed conveyors
/:cl:
