### PR TITLE
Reverts ATM resprite

### DIFF
--- a/modular_citadel/icons/icon_overrides.dm
+++ b/modular_citadel/icons/icon_overrides.dm
@@ -202,10 +202,6 @@
 /obj/item/weapon/rsf
 	icon = 'icons/obj/tools.dmi'
 
-//code/modules/economy/atm.dm
-/obj/machinery/atm
-	icon = 'modular_citadel/icons/obj/terminals.dmi'
-
 //code/game/objects/items/weapons/storage/briefcase.dm
 /obj/item/weapon/storage/briefcase
 	icon = 'modular_citadel/icons/obj/storage.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reverts ATM resprite
## Why It's Good For The Game
New ATM looked out of place and worse off than the old one.
## Changelog
:cl:
del: ATM sprites reverted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
