### PR TITLE
[EXPERIMENTAL!] adds *.dm -text to gitattributes to fix the mirror bot having metric fuckloads of line ending changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,6 @@
 
 # force changelog merging to use union
 html/changelog.html merge=union
+
+# make all .dm files completely ignore eol conversion
+*.dm -text


### PR DESCRIPTION
the diff having line ending changes here is quite ironic

## Changelog
:cl:
code: The git attributes file now forces all .dm files to (HOPEFULLY!) completely ignore line ending changes
/:cl:
