### PR TITLE
adds tracking implants to warden and head of security lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -158,6 +158,7 @@
 		/obj/item/clothing/accessory/badge/holo/warden,
 		/obj/item/weapon/storage/box/flashbangs,
 		/obj/item/weapon/storage/belt/security,
+		/obj/item/weapon/storage/box/trackimp,
 		/obj/item/weapon/reagent_containers/spray/pepper,
 		/obj/item/weapon/melee/baton/loaded,
 		/obj/item/weapon/gun/energy/gun,

--- a/code/game/objects/structures/crates_lockers/closets/secure/security_vr.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security_vr.dm
@@ -46,6 +46,7 @@
 		/obj/item/taperoll/police,
 		/obj/item/weapon/shield/riot/tele,
 		/obj/item/weapon/storage/box/holobadge/hos,
+		/obj/item/weapon/storage/box/trackimp,
 		/obj/item/clothing/accessory/badge/holo/hos,
 		/obj/item/weapon/reagent_containers/spray/pepper,
 		/obj/item/weapon/tool/crowbar/red,

--- a/code/game/objects/structures/crates_lockers/closets/secure/security_vr.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security_vr.dm
@@ -46,7 +46,6 @@
 		/obj/item/taperoll/police,
 		/obj/item/weapon/shield/riot/tele,
 		/obj/item/weapon/storage/box/holobadge/hos,
-		/obj/item/weapon/storage/box/trackimp,
 		/obj/item/clothing/accessory/badge/holo/hos,
 		/obj/item/weapon/reagent_containers/spray/pepper,
 		/obj/item/weapon/tool/crowbar/red,

--- a/modular_citadel/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/modular_citadel/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -22,6 +22,7 @@
 		/obj/item/weapon/reagent_containers/spray/pepper,
 		/obj/item/weapon/crowbar/red,
 		/obj/item/weapon/storage/box/flashbangs,
+		/obj/item/weapon/storage/box/trackimp,
 		/obj/item/weapon/storage/belt/security,
 		/obj/item/device/flash,
 		/obj/item/weapon/melee/baton/loaded,


### PR DESCRIPTION
Several crimes have mandatory tracking implants listed as punishment, but security doesn't actually have access to any. This remedies the inconsistency.