### PR TITLE
Protean balance tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
@@ -234,7 +234,7 @@
 
 	//Blob form
 	if(temporary_form)
-		if(health < maxHealth*0.5)
+		if(health < maxHealth*0.35)
 			to_chat(temporary_form,"<span class='warning'>You need to regenerate more nanites first!</span>")
 		else if(temporary_form.stat)
 			to_chat(temporary_form,"<span class='warning'>You can only do this while not stunned.</span>")

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
@@ -290,7 +290,7 @@
 		var/obj/item/organ/O = organ
 		// Fix internal damage
 		if(O.damage > 0)
-			O.damage = max(0,O.damage-0.1)
+			O.damage = max(0,O.damage-1)
 		// If not damaged, but dead, fix it
 		else if(O.status & ORGAN_DEAD)
 			O.status &= ~ORGAN_DEAD //Unset dead if we repaired it entirely


### PR DESCRIPTION
Protean balancing. Current heal does not allow for proteans to heal large toxins without a long wait time (~5 minutes and with multiple times required to absorb steel) 100 units of steel heals 0.1 toxins. So total heal of 10,000 steel is... 10 toxins.

Suggestion, revert the latter change if balance proves to be good for the health regeneration tweak.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Tweaked: 	O.damage = max(0,O.damage-0.1) to 	O.damage = max(0,O.damage-1). Allows for proteans to heal 100 toxins without waiting forever and running out of metal. Current rate is 0.1 for 100 steel, new rate will be 1 for 100 steel.

Tweaked:	if(health < maxHealth*0.5) to 	if(health < maxHealth*0.35) to allow for protean to still be somewhat useful in combat (current forces proteans to auto-blob at half health)
The max health change should be reverted if the heal rate is not as slow as currently.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
