### PR TITLE
adds bridge officers to command secretary alt titles

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -85,5 +85,6 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 
 	access = list(access_heads, access_keycard_auth)
 	minimal_access = list(access_heads, access_keycard_auth)
+	alt_titles = list("Bridge Officer")
 
 	outfit_type = /decl/hierarchy/outfit/job/secretary


### PR DESCRIPTION
Because obviously it's a good thing to add a responsible title to an ERP job BEFORE we add responsible things for them to do like piloting ships :)