### PR TITLE
replace ambiance with ambience

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -267,7 +267,7 @@
 			used_environ += amount
 
 
-var/list/mob/living/forced_ambiance_list = new
+var/list/mob/living/forced_ambience_list = new
 
 /area/Entered(A)
 	if(!istype(A,/mob/living))	return
@@ -288,20 +288,20 @@ var/list/mob/living/forced_ambiance_list = new
 
 /area/proc/play_ambience(var/mob/living/L)
 	// Ambience goes down here -- make sure to list each area seperately for ease of adding things in later, thanks! Note: areas adjacent to each other should have the same sounds to prevent cutoff when possible.- LastyScratch
-	if(!(L && L.is_preference_enabled(/datum/client_preference/play_ambiance)))	return
+	if(!(L && L.is_preference_enabled(/datum/client_preference/play_ambience)))	return
 
-	// If we previously were in an area with force-played ambiance, stop it.
-	if(L in forced_ambiance_list)
+	// If we previously were in an area with force-played ambience, stop it.
+	if(L in forced_ambience_list)
 		L << sound(null, channel = CHANNEL_AMBIENCE_FORCED)
-		forced_ambiance_list -= L
+		forced_ambience_list -= L
 
 	if(forced_ambience)
 		if(forced_ambience.len)
-			forced_ambiance_list |= L
-			var/sound/chosen_ambiance = pick(forced_ambience)
-			if(!istype(chosen_ambiance))
-				chosen_ambiance = sound(chosen_ambiance, repeat = 1, wait = 0, volume = 25, channel = CHANNEL_AMBIENCE_FORCED)
-			L << chosen_ambiance
+			forced_ambience_list |= L
+			var/sound/chosen_ambience = pick(forced_ambience)
+			if(!istype(chosen_ambience))
+				chosen_ambience = sound(chosen_ambience, repeat = 1, wait = 0, volume = 25, channel = CHANNEL_AMBIENCE_FORCED)
+			L << chosen_ambience
 		else
 			L << sound(null, channel = CHANNEL_AMBIENCE_FORCED)
 	else if(src.ambience.len && prob(35))

--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -68,11 +68,11 @@ var/list/_client_preferences_by_type
 	else
 		preference_mob.client.media.stop_music()
 
-/datum/client_preference/play_ambiance
+/datum/client_preference/play_ambience
 	description ="Play ambience"
 	key = "SOUND_AMBIENCE"
 
-/datum/client_preference/play_ambiance/toggled(var/mob/preference_mob, var/enabled)
+/datum/client_preference/play_ambience/toggled(var/mob/preference_mob, var/enabled)
 	if(!enabled)
 		preference_mob << sound(null, repeat = 0, wait = 0, volume = 0, channel = 1)
 		preference_mob << sound(null, repeat = 0, wait = 0, volume = 0, channel = 2)

--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -154,7 +154,7 @@
 	set category = "Preferences"
 	set desc = "Toggles the playing of ambience."
 
-	var/pref_path = /datum/client_preference/play_ambiance
+	var/pref_path = /datum/client_preference/play_ambience
 
 	toggle_preference(pref_path)
 


### PR DESCRIPTION
This replaces all mentions of ambiance with ambience to make it more consistent to work with