### PR TITLE
Replace Library Conference Room w/ DnD Room

### DIFF
--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -595,6 +595,7 @@
 	layer = 2.9
 	},
 /obj/random/maintenance/medical,
+/obj/item/weapon/flame/lighter/zippo/gonzo,
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
 "abC" = (
@@ -5563,7 +5564,7 @@
 /turf/simulated/floor/wood,
 /area/engineering/break_room)
 "apO" = (
-/obj/structure/flora/pottedplant,
+/obj/structure/flora/pottedplant/smelly,
 /turf/simulated/floor/wood,
 /area/engineering/break_room)
 "apP" = (
@@ -7025,6 +7026,10 @@
 /obj/random/junk,
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
+"atV" = (
+/obj/item/weapon/bananapeel,
+/turf/simulated/floor,
+/area/tether/station/excursion_dock)
 "atW" = (
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
@@ -10688,6 +10693,9 @@
 /area/library)
 "aEh" = (
 /obj/structure/table/woodentable,
+/obj/machinery/photocopier/faxmachine{
+	department = "Head of Personnel's Office"
+	},
 /turf/simulated/floor/carpet,
 /area/library)
 "aEk" = (
@@ -11096,6 +11104,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/machinery/bookbinder,
 /turf/simulated/floor/carpet,
 /area/library)
 "aFq" = (
@@ -11693,10 +11702,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/library_conference_room)
-"aHH" = (
-/obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/wood,
-/area/library_conference_room)
 "aHK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11761,19 +11766,11 @@
 /obj/machinery/teleport/station,
 /turf/simulated/floor/tiled/dark,
 /area/teleporter)
-"aHW" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/library_conference_room)
 "aHX" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/folder/yellow,
-/obj/item/weapon/pen,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "aHY" = (
@@ -11792,7 +11789,8 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_eva)
 "aIa" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/bed/chair/comfy/beige{
+	icon_state = "comfychair_preview";
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -11972,9 +11970,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/teleporter)
 "aIw" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
+/obj/structure/table/wooden_reinforced,
+/obj/item/weapon/storage/pill_bottle/dice_nerd,
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "aIy" = (
@@ -11994,9 +11991,8 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
 "aIC" = (
-/obj/machinery/bookbinder{
-	pixel_y = 0
-	},
+/obj/structure/table/wooden_reinforced,
+/obj/item/toy/character/wizard,
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "aIE" = (
@@ -12010,10 +12006,11 @@
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "aIG" = (
-/obj/machinery/photocopier,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 25
 	},
+/obj/structure/table/wooden_reinforced,
+/obj/item/toy/character/voidone,
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "aIJ" = (
@@ -20021,15 +20018,12 @@
 /turf/simulated/floor/tiled,
 /area/teleporter)
 "bKh" = (
-/obj/structure/table/woodentable,
 /obj/machinery/ai_status_display{
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/item/device/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
-	},
+/obj/structure/table/wooden_reinforced,
+/obj/item/weapon/flame/candle/candelabra/everburn,
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "bKi" = (
@@ -20049,7 +20043,6 @@
 	pixel_x = 0;
 	pixel_y = 26
 	},
-/obj/structure/closet/emcloset,
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "bKo" = (
@@ -20118,19 +20111,7 @@
 	},
 /turf/simulated/floor/wood,
 /area/library_conference_room)
-"bMm" = (
-/obj/structure/bed/chair/office/dark,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/library_conference_room)
 "bMn" = (
-/obj/structure/bed/chair/office/dark,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -20179,8 +20160,6 @@
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "bMU" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/tape_roll,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -20192,19 +20171,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/recharger,
+/obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "bMV" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/weapon/packageWrap,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "bNK" = (
@@ -20280,16 +20254,19 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
+/obj/structure/table/wooden_reinforced,
+/obj/item/toy/character/cleric,
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "bOf" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/bed/chair/comfy/beige{
+	icon_state = "comfychair_preview";
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/library_conference_room)
@@ -20302,33 +20279,25 @@
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "bOk" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/book/codex,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/table/wooden_reinforced,
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "bOq" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/dice/d20,
-/obj/item/weapon/dice,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/table/wooden_reinforced,
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "bOr" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/deck/cards,
-/obj/item/device/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
-	},
+/obj/structure/table/wooden_reinforced,
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "bOt" = (
@@ -20337,6 +20306,8 @@
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
+/obj/structure/table/wooden_reinforced,
+/obj/item/toy/character/lich,
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "bOz" = (
@@ -20367,6 +20338,8 @@
 	layer = 3.3;
 	pixel_x = 26
 	},
+/obj/structure/table/wooden_reinforced,
+/obj/item/toy/character/thief,
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "bOU" = (
@@ -21044,10 +21017,8 @@
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "bYa" = (
-/obj/structure/table/woodentable,
-/obj/machinery/photocopier/faxmachine{
-	department = "Library Conference Room"
-	},
+/obj/structure/table/wooden_reinforced,
+/obj/item/weapon/flame/candle/candelabra/everburn,
 /turf/simulated/floor/wood,
 /area/library_conference_room)
 "bYf" = (
@@ -21148,7 +21119,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/heads/chief)
 "bYN" = (
-/obj/item/device/instrument/violin,
+/obj/structure/device/piano,
 /turf/simulated/floor,
 /area/vacant/vacant_restaurant_lower)
 "bYP" = (
@@ -21397,6 +21368,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
+"cPd" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/toy/character/warrior,
+/turf/simulated/floor/wood,
+/area/library_conference_room)
 "dbI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -21689,6 +21665,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
+"hOV" = (
+/obj/item/clothing/under/rank/clown,
+/turf/simulated/floor,
+/area/tether/station/excursion_dock)
 "hPi" = (
 /obj/machinery/light/small,
 /turf/simulated/floor,
@@ -21789,6 +21769,12 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/station/atrium)
+"jYf" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen/fountain,
+/turf/simulated/floor/wood,
+/area/library_conference_room)
 "jZN" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
@@ -22151,6 +22137,13 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
+"oHM" = (
+/obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/clowndouble,
+/obj/effect/decal/remains,
+/obj/item/clothing/mask/gas/clown_hat,
+/turf/simulated/floor,
+/area/tether/station/excursion_dock)
 "oVP" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/wall_mounted{
 	dir = 1;
@@ -22365,6 +22358,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
+"sVb" = (
+/obj/structure/bed/chair/comfy/beige{
+	icon_state = "comfychair_preview";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/library_conference_room)
 "sZd" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -22446,6 +22446,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
+"tOi" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/weapon/flame/lighter/zippo/red,
+/turf/simulated/floor/wood,
+/area/library_conference_room)
+"tOH" = (
+/obj/item/weapon/bikehorn,
+/turf/simulated/floor,
+/area/tether/station/excursion_dock)
 "tWI" = (
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 1
@@ -22494,6 +22503,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_prep)
+"uoR" = (
+/obj/item/toy/figure/clown,
+/turf/simulated/floor,
+/area/tether/station/excursion_dock)
 "uzS" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/blue,
@@ -22739,6 +22752,10 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/tether/station/explorer_meeting)
+"wUh" = (
+/obj/machinery/partyalarm,
+/turf/simulated/wall,
+/area/library_conference_room)
 "wZn" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/weapon/cell/super;
@@ -22788,6 +22805,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
+/area/tether/station/excursion_dock)
+"xkD" = (
+/obj/item/clothing/shoes/clown_shoes,
+/turf/simulated/floor,
 /area/tether/station/excursion_dock)
 "xHs" = (
 /obj/structure/disposalpipe/segment,
@@ -31939,7 +31960,7 @@ aad
 aae
 aae
 aae
-aae
+aad
 aae
 aae
 aae
@@ -32081,7 +32102,7 @@ aad
 aae
 aae
 aae
-aae
+aad
 aae
 aae
 aae
@@ -32223,7 +32244,7 @@ aad
 aae
 aae
 aae
-aae
+aad
 aae
 aae
 aae
@@ -32362,10 +32383,10 @@ aac
 aac
 aac
 aad
+hOV
 aae
-aae
-aae
-aae
+atV
+aad
 aae
 aae
 aae
@@ -32505,9 +32526,9 @@ aac
 aac
 aad
 aae
-aae
-aae
-aae
+oHM
+uoR
+aad
 aae
 aae
 aae
@@ -32646,10 +32667,10 @@ aac
 aac
 aac
 aad
+xkD
 aae
-aae
-aae
-aae
+tOH
+aad
 aae
 aae
 aae
@@ -32791,7 +32812,7 @@ aad
 aae
 aae
 aae
-aae
+aad
 aae
 aae
 aae
@@ -32933,7 +32954,7 @@ aad
 aae
 aae
 aae
-aae
+aad
 aae
 aae
 aae
@@ -33075,7 +33096,7 @@ aad
 aae
 aae
 aae
-aae
+aad
 aae
 aae
 aae
@@ -34979,7 +35000,7 @@ aGL
 aGL
 aGL
 aGL
-aGL
+wUh
 aGL
 aGL
 aac
@@ -35121,7 +35142,7 @@ aGL
 bMj
 bMT
 bOd
-aHn
+cPd
 aIC
 aGL
 aat
@@ -35403,9 +35424,9 @@ aBx
 aGL
 aHm
 aHG
-aHW
-bOf
 aHn
+bOf
+bYa
 aHn
 aIJ
 aat
@@ -35544,7 +35565,7 @@ aBx
 aBx
 aGM
 aHn
-aHH
+aHn
 aHX
 bOq
 aIw
@@ -35686,10 +35707,10 @@ bCj
 bCj
 bJk
 bKi
-bMm
+bKi
 bMU
 bOk
-aIw
+sVb
 aIE
 aIJ
 aat
@@ -35698,7 +35719,7 @@ aaa
 aaa
 aaa
 aaa
-aab
+aaa
 aaa
 aaa
 aaa
@@ -35831,8 +35852,8 @@ aHp
 bMn
 bMV
 bOr
-aIw
-aHn
+tOi
+jYf
 aIJ
 aat
 aat
@@ -35971,9 +35992,9 @@ bHq
 aGL
 bKn
 aHK
-aIa
-aIa
 aHn
+aIa
+bYa
 aHn
 aIJ
 aat

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -10114,6 +10114,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/weapon/tape_roll,
 /turf/simulated/floor/carpet,
 /area/library)
 "aCA" = (
@@ -10694,7 +10695,7 @@
 "aEh" = (
 /obj/structure/table/woodentable,
 /obj/machinery/photocopier/faxmachine{
-	department = "Head of Personnel's Office"
+	department = "Library"
 	},
 /turf/simulated/floor/carpet,
 /area/library)
@@ -19451,6 +19452,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/item/weapon/book/codex,
 /turf/simulated/floor/carpet,
 /area/library)
 "bFC" = (
@@ -22252,6 +22254,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/station/excursion_dock)
+"qiJ" = (
+/obj/machinery/photocopier,
+/turf/simulated/floor/wood,
+/area/library)
 "qzk" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -35420,7 +35426,7 @@ aEe
 aEI
 bFr
 aFE
-aBx
+qiJ
 aGL
 aHm
 aHG

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -22759,7 +22759,6 @@
 /turf/simulated/floor/plating,
 /area/tether/station/explorer_meeting)
 "wUh" = (
-/obj/machinery/partyalarm,
 /turf/simulated/wall,
 /area/library_conference_room)
 "wZn" = (


### PR DESCRIPTION
Replaces library conference room with kitted DnD room. Book binder and fax from conference room moved into librarians area. Also deletes space carp spawn directly below window (who wants a DnD session ruined because of a space carp)

Adds small clown stash beside the excursion shuttle in large empty room.

Replaces broken violin with a piano.


![MapImage1](https://user-images.githubusercontent.com/20429794/57320468-feae8400-70cc-11e9-9f92-52d53075fd01.png)
![MapImage2](https://user-images.githubusercontent.com/20429794/57320470-ff471a80-70cc-11e9-9b99-3b44605d36fa.png)
![MapImage3](https://user-images.githubusercontent.com/20429794/57320471-ff471a80-70cc-11e9-8b10-4e5d6d2ede05.png)
![MapImage4](https://user-images.githubusercontent.com/20429794/57320472-ff471a80-70cc-11e9-94a8-ba10ec94cdcd.png)




