### PR TITLE
thin fax machine

### DIFF
--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -11,6 +11,7 @@ var/list/adminfaxes = list()	//cache for faxes that have been sent to admins
 	insert_anim = "faxsend"
 	req_one_access = list(access_lawyer, access_heads, access_armory, access_qm)
 
+	density = 0
 	use_power = 1
 	idle_power_usage = 30
 	active_power_usage = 200


### PR DESCRIPTION
## About The Pull Request
makes fax machines density = 0
## Why It's Good For The Game
a fax machine is not dummy thicc enough to stop people from climbing around it
note: may make spare stealing easier and less easy to spot instantly due to "why is the fax machine on the fucking floor"
## Changelog
:cl:
tweak: fax machines are no longer dense
/:cl: