### PR TITLE
Removes Compliance Disks from Trash Pile Pool

### DIFF
--- a/code/game/objects/structures/trash_pile.dm
+++ b/code/game/objects/structures/trash_pile.dm
@@ -216,8 +216,7 @@
 	return I
 
 /obj/structure/trash_pile/proc/produce_beta_item()
-	var/path = pick(prob(10);/obj/item/weapon/disk/nifsoft/compliance, //Citadel Override probability, 3.6%
-					prob(6);/obj/item/weapon/storage/pill_bottle/tramadol,
+	var/path = 			prob(6);/obj/item/weapon/storage/pill_bottle/tramadol,
 					prob(4);/obj/item/weapon/storage/pill_bottle/happy,
 					prob(4);/obj/item/weapon/storage/pill_bottle/zoom,
 					prob(4);/obj/item/weapon/gun/energy/sizegun,


### PR DESCRIPTION
## About The Pull Request

By request, after the results of an rp-emojiocracy poll. NIFSoft disks will remain in-code, but will only accessible via adminspawn or preplaced spawns, not randomly going through the garbage.

## Changelog
:cl:
del: Removed Compliance NIFSoft Disks from Trash Pile Loot
/:cl: