### PR TITLE
Head of Security sidearm gunbox

### DIFF
--- a/code/game/objects/items/gunbox_vr.dm
+++ b/code/game/objects/items/gunbox_vr.dm
@@ -16,3 +16,26 @@
 			if(istype(AM, /obj/item/weapon/gun))
 				to_chat(user, "You have chosen \the [AM]. Say hello to your new friend.")
 		qdel(src)
+
+/obj/item/gunbox/hos
+	name = "Head of Security sidearm box"
+	desc = "A secure box containing a security sidearm."
+
+/obj/item/gunbox/attack_self(mob/living/user)
+	var/list/options = list()
+	options["M1911 Dynamic (.45)"] = list(/obj/item/weapon/gun/projectile/colt/detective, /obj/item/ammo_magazine/m45/rubber, /obj/item/ammo_magazine/m45/rubber)
+	options["'Consul' Revolver (.44)"] = list(/obj/item/weapon/gun/projectile/revolver/consul, /obj/item/ammo_magazine/s44/rubber, /obj/item/ammo_magazine/s44/rubber)
+	options["SW 625 Revolver (.45)"] = list(/obj/item/weapon/gun/projectile/revolver/detective45, /obj/item/ammo_magazine/s45/rubber, /obj/item/ammo_magazine/s45/rubber)
+	options["Webley Service Revolver (.44)"] = list(/obj/item/weapon/gun/projectile/revolver/webley, /obj/item/ammo_magazine/s44/rubber, /obj/item/ammo_magazine/s44/rubber)
+	options["Lumoco Arms HE Colt (.357 LETHAL)"] = list(/obj/item/weapon/gun/projectile/revolver, /obj/item/ammo_magazine/s357, /obj/item/ammo_magazine/s357) // Yikes, lethals only for .357s. I'll have to fix that later.
+	options["'Mateba' Revolver (.357 LETHAL)"] = list(/obj/item/weapon/gun/projectile/revolver/mateba, /obj/item/ammo_magazine/s357, /obj/item/ammo_magazine/s357)
+	options["Deckard .38 (.38)"] = list(/obj/item/weapon/gun/projectile/revolver/deckard, /obj/item/ammo_magazine/s38/rubber, /obj/item/ammo_magazine/s38/rubber)
+	options["P92X (9mm)"] = list(/obj/item/weapon/gun/projectile/p92x/sec, /obj/item/ammo_magazine/m9mm/rubber, /obj/item/ammo_magazine/m9mm/rubber)
+	var/choice = input(user,"Would you prefer a pistol or a revolver?") as null|anything in options
+	if(src && choice)
+		var/list/things_to_spawn = options[choice]
+		for(var/new_type in things_to_spawn) // Spawn all the things, the gun and the ammo.
+			var/atom/movable/AM = new new_type(get_turf(src))
+			if(istype(AM, /obj/item/weapon/gun))
+				to_chat(user, "You have chosen \the [AM]. Say hello to your new friend.")
+		qdel(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security_vr.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security_vr.dm
@@ -57,7 +57,8 @@
 		/obj/item/clothing/head/beret/sec/corporate/hos,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/security,
 		/obj/item/clothing/shoes/boots/winter/security,
-		/obj/item/device/flashlight/maglight)
+		/obj/item/device/flashlight/maglight,
+		/obj/item/gunbox/hos)
 
 //Custom NT Security Lockers, Only found at central command
 /obj/structure/closet/secure_closet/nanotrasen_security


### PR DESCRIPTION
## About The Pull Request

Adds a gunbox to the HoS' gear locker. It is similar to the gunboxes available in the armoury, however this unique box contains five additional choices of sidearms. 

![image](https://user-images.githubusercontent.com/50751907/58119862-57daf380-7c47-11e9-8041-40ade12b6e86.png)


## Why It's Good For The Game

Allows a greater selection of sidearms for the Head of Security. While intended mainly to add a bit of flair for those playing the role, it also allows players the option of having a far less overkill lethal firearm than those available in the armoury, that being shotguns, laser rifles, or machine pistols.

More firearm options for the gunbox are planned from not only myself but other contributors too using this sidearm box, potentially not even limited to just sidearms if Kevinz gets around to implementing his ideas. 

An issue I do see with the sidearm box is that a HoS player may choose a sidearm using it, then cryo out later, disallowing new arrivals the ability to choose their own. However, adding the sidearm box to standard HoS kit may see multiple sidearms piling up in the HoS' locker depending on how many players end up playing the role in one round. Because of this, the placement of the sidearm box spawn may change in the future.

## Changelog
:cl:
add: Added the Head of Security sidearm box, featuring additional sidearm options.
tweak: Added the HoS sidearm box to the HoS gear locker. 
/:cl: