### PR TITLE
Allows collars to be named/tagged with a pen

### DIFF
--- a/modular_citadel/code/modules/clothing/under/accessories/accessory_cit.dm
+++ b/modular_citadel/code/modules/clothing/under/accessories/accessory_cit.dm
@@ -1,0 +1,19 @@
+//
+// Allows collars to be renamed with pen.
+//
+
+/obj/item/clothing/accessory/collar/attackby(obj/item/weapon/P as obj, mob/user as mob)
+	. = ..()
+	if(istype(P, /obj/item/weapon/pen))
+		to_chat(user,"<span class='notice'>You write on [name]'s tag.</span>")
+		var/str = copytext(reject_bad_text(input(user,"Tag text?","Set tag","")),1,MAX_NAME_LEN)
+
+		if(!str || !length(str))
+			to_chat(user,"<span class='notice'>[name]'s tag set to be blank.</span>")
+			name = initial(name)
+			desc = initial(desc)
+		else
+			to_chat(user,"<span class='notice'>You set the [name]'s tag to '[str]'.</span>")
+			name = initial(name) + " ([str])"
+			desc = initial(desc) + " The tag says \"[str]\"."
+	return

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3076,6 +3076,7 @@
 #include "modular_citadel\code\modules\clothing\suits\storage.dm"
 #include "modular_citadel\code\modules\clothing\under\donatoruniform.dm"
 #include "modular_citadel\code\modules\clothing\under\miscellaneous_vr.dm"
+#include "modular_citadel\code\modules\clothing\under\accessories\accessory_cit.dm"
 #include "modular_citadel\code\modules\clothing\under\accessories\clothing_cit.dm"
 #include "modular_citadel\code\modules\clothing\under\accessories\donatoraccessory.dm"
 #include "modular_citadel\code\modules\clothing\under\accessories\holster.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Minor addition, that allows all collars to be named without using label machine. While testing, shock collar and holo-collar could be named with one way or another without issues. **Modularised**.
_Suggested by Jaded Cargo Birb/yourdoom9898._
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's good for RPers who like to wear collars ~~for some reason~~ and don't want to use holo/shock collars. Also, label machines doesn't allow you to blank the collar tag if you messed up or changed your mind, while with this addition it will be now possible.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Anonymous
tweak: All collars can be now tagged with pen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
