### PR TITLE
Reduces Light Power Consumption to Be More Realistic

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -709,7 +709,7 @@
 // timed process
 // use power
 
-#define LIGHTING_POWER_FACTOR 20		//20W per unit luminosity
+#define LIGHTING_POWER_FACTOR 5		//5W per unit luminosity - because 20W per tile-range illuminated??? Seriously??
 
 
 /obj/machinery/light/process()


### PR DESCRIPTION
## About The Pull Request
Changes the power factor for lights from 20W to 5W.
This change has been carefully tweaked, as previously a single average light tube used about 160W. That same light tube now uses about 40W, which would be in line with a real-world T12 grade florescent tube light.

## Why It's Good For The Game
This change is multifaceted, and is a fairly substantial shake up to the power-grid balance.
This PR has been made on the assumption that the station shouldn't be entirely power-able by the solar array alone. (I dunno if I agree with this, I'm just assuming it's the defacto balance.)
But the current power usage from lighting, on such a large map is absolutely absurd, requiring in some cases more power than a default map-spawn engine set up would provide.
To summarize, this PR is designed (and from my testing achieves) the balance that:
1. An engine is required to power the station.
2. Non-standard engine modifications are not required to power the station.
3. The lights now actually use a realistic amount of power. (According to real-world technology, so this isn't even future tech.)

## Changelog
:cl:
balance: reduced light tube / light bulb power consumption
/:cl:
