### PR TITLE
Unwhitelists Gutter

### DIFF
--- a/code/modules/mob/language/station_vr.dm
+++ b/code/modules/mob/language/station_vr.dm
@@ -82,5 +82,4 @@
 /datum/language/seromi
 	flags = 0
 /datum/language/gutter
-	flags = WHITELISTED
-	machine_understands = FALSE
+	flags = 0


### PR DESCRIPTION
Whitelists are stupid. In the case of this language in particular, whitelisting makes it completely pointless as no one can even speak it.

Also makes it understandable by translators, because no widely-spoken language should be untranslateable. That's also stupid.