### PR TITLE
GPS self-z functionality

### DIFF
--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -154,7 +154,7 @@
 			Z_LEVEL_SPACE_MID,
 			Z_LEVEL_SPACE_HIGH)
 	else
-		return ..()
+		return list(srcz) //may prevent runtimes, but more importantly gives gps units a shortwave-esque function
 
 // For making the 6-in-1 holomap, we calculate some offsets
 #define TETHER_MAP_SIZE 140 // Width and height of compiled in tether z levels.


### PR DESCRIPTION
## About The Pull Request

A single-line change to the tether_defines that causes gps units and crew monitoring computers to return the contents of their own zlevel if no other data is available. I've done some testing and haven't encountered any major issues.

Partially referenced from [Polaris PR #6247](https://github.com/PolarisSS13/Polaris/pull/6247). We don't seem to use the same modular computers sytem, so the full PR can't be ported, but it seems to function fine without the modular computer change.

## Why It's Good For The Game

Riddle me this; why are the Explorers issued handheld tracker units that can't track each other away from the station, where such devices would _actually be useful_? Normally, the trackers only function on a handful of preset levels. Despite this, handheld trackers can be found in several POIs and in the abductor (where they'd be *ESPECIALLY* useful!). A few POIs even have hidden signal broadcasters that can never be seen without a change like this!

Now, if the explorers remember to pack and turn on their trackers, they can now more easily reunite if one of them wanders off and get lost... or, at the very least, the body/remains/possessions can (probably) be retrieved without the team having to bumble around in the dark for hours. If miners carry an active GPS, they can also be tracked in the underdark.

Note that any explorers on different planets or miners in the underdark will still be out of tracking range of any stationside units

As a side-effect this may or may not fix some runtime issues with trying to use the CMC at Central.

## Changelog
:cl:
tweak: single line tweak to tether_defines.dm
/:cl: