### PR TITLE
Allows construction of the ED-CLN

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -113,6 +113,18 @@
 			qdel(src)
 		else
 			to_chat(user, "<span class='warning'>You need one sheet of metal to arm the robot frame.</span>")
+	if(istype(W, /obj/item/stack/material) && W.get_material_name() == "plastic" && !l_arm && !r_arm && !l_leg && !r_leg && !chest && !head)
+		var/obj/item/stack/material/M = W
+		if (M.use(1))
+			var/obj/item/weapon/secbot_assembly/edCLN_assembly/B = new /obj/item/weapon/secbot_assembly/edCLN_assembly
+			B.loc = get_turf(src)
+			to_chat(user, "<span class='notice'>You add a plastic covering to the robot frame.</span>")
+			if (user.get_inactive_hand()==src)
+				user.remove_from_mob(src)
+				user.put_in_inactive_hand(B)
+			qdel(src)
+		else
+			to_chat(user, "<span class='warning'>You need one sheet of plastic to cover the robot frame.</span>")
 	if(istype(W, /obj/item/robot_parts/l_leg))
 		if(src.l_leg)	return
 		user.drop_item()


### PR DESCRIPTION
## About The Pull Request

Allows roboticists to construct the ED-CLN by adding plastic sheets to a robot frame.

## Why It's Good For The Game

This good cleaning boi was previously impossible to make, since its assembly had no recipe. Now it can be made.

## Changelog
:cl:
add: Adds a way to create the ED-CLN assembly by adding plastic sheets to a robot frame
/:cl: