### PR TITLE
fixes some words/phrasing in bloodloss messages

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -96,11 +96,11 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 			if(!pale)
 				pale = 1
 				update_icons_body()
-				var/word = pick("dizzy","woosey","faint")
-				src << "<font color='red'>You feel [word]</font>"
+				var/word = pick("dizzy","woozy","faint","disoriented","unsteady")
+				src << "<font color='red'>You feel a little [word]</font>"
 			if(prob(1))
-				var/word = pick("dizzy","woosey","faint")
-				src << "<font color='red'>You feel [word]</font>"
+				var/word = pick("dizzy","woozy","faint","disoriented","unsteady")
+				src << "<font color='red'>You feel a little [word]</font>"
 			if(getOxyLoss() < 20 * threshold_coef)
 				adjustOxyLoss(3 * dmg_coef)
 		else if(blood_volume >= BLOOD_VOLUME_BAD)
@@ -113,13 +113,13 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 			adjustOxyLoss(1 * dmg_coef)
 			if(prob(15))
 				Paralyse(rand(1,3))
-				var/word = pick("dizzy","woosey","faint")
-				src << "<font color='red'>You feel extremely [word]</font>"
+				var/word = pick("dizzy","woozy","faint","disoriented","unsteady")
+				src << "<font color='red'>You feel rather [word]</font>"
 		else if(blood_volume >= BLOOD_VOLUME_SURVIVE)
 			adjustOxyLoss(5 * dmg_coef)
 			adjustToxLoss(3 * dmg_coef)
 			if(prob(15))
-				var/word = pick("dizzy","woosey","faint")
+				var/word = pick("dizzy","woozy","faint","disoriented","unsteady")
 				src << "<font color='red'>You feel extremely [word]</font>"
 		else //Not enough blood to survive (usually)
 			if(!pale)


### PR DESCRIPTION
## About The Pull Request

Fixes a very weird typo in bloodloss messages, adds a couple of extra descriptors for flavor, and also some minor clarification between minor and moderate bloodloss levels.

## Why It's Good For The Game

'Woosey' isn't a goddamn word and I swear someone mentions it every time bloodloss comes up. Also it makes things a bit clearer where you're at vs minor/moderate/major bloodloss.

## Changelog
:cl:
tweak: added a couple extra words to bloodloss states
spellcheck: fixed a typo
/:cl: