### PR TITLE
Delay before unbuckling someone from a wheelchair.

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -130,8 +130,12 @@
 		MouseDrop(usr)
 	else
 		if(has_buckled_mobs())
-			for(var/A in buckled_mobs)
-				user_unbuckle_mob(A, user)
+			user.visible_message("<span class='warning'>[user] starts undoing the straps of the wheelchair</span>")
+			if(do_mob(user,src, 20))
+				for(var/A in buckled_mobs)
+					user_unbuckle_mob(A, user)
+			else
+				user.visible_message("<span class='warning'>[user] has stopped undoing the straps of the wheelchair</span>")
 	return
 
 /obj/structure/bed/chair/wheelchair/CtrlClick(var/mob/user)


### PR DESCRIPTION
Adds the usual do_mob() delay and a message warning when doing so.

This is important because it's kind of LRP that you can throw someone off a wheelchair in a single click, insta-stunning them.