### PR TITLE
Pathfinder Access Tweaks

### DIFF
--- a/maps/southern_cross/southern_cross_jobs_vr.dm
+++ b/maps/southern_cross/southern_cross_jobs_vr.dm
@@ -1,5 +1,12 @@
 var/const/PATHFINDER 		=(1<<13) //VOREStation Edit - Added Pathfinder
 
+var/const/access_pathfinder = 44
+
+/datum/access/pathfinder
+	id = access_pathfinder
+	desc = "Pathfinder"
+	region = ACCESS_REGION_GENERAL
+
 /obj/item/weapon/card/id/science/head/pathfinder
 	name = "\improper Pathfinder's ID"
 	desc = "A card which represents discovery of the unknown."
@@ -21,6 +28,6 @@ var/const/PATHFINDER 		=(1<<13) //VOREStation Edit - Added Pathfinder
 	economic_modifier = 7
 	minimal_player_age = 7
 
-	access = list(access_eva, access_maint_tunnels, access_external_airlocks, access_pilot, access_explorer, access_research, access_gateway)
-	minimal_access = list(access_eva, access_pilot, access_explorer, access_research, access_gateway)
+	access = list(access_eva, access_maint_tunnels, access_external_airlocks, access_pilot, access_explorer, access_pathfinder, access_tox, access_research, access_gateway)
+	minimal_access = list(access_eva, access_pilot, access_explorer, access_pathfinder, access_tox, access_research, access_gateway)
 	outfit_type = /decl/hierarchy/outfit/job/pathfinder

--- a/maps/southern_cross/structures/closets/misc_vr.dm
+++ b/maps/southern_cross/structures/closets/misc_vr.dm
@@ -7,7 +7,7 @@
 	icon_opened = "secureexpopen"
 	icon_broken = "secureexpbroken"
 	icon_off = "secureexpoff"
-	req_access = list(access_gateway)
+	req_access = list(access_pathfinder)
 
 	starts_with = list(
 		/obj/item/clothing/under/explorer,

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -22596,7 +22596,7 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/research{
 	name = "Pathfinder's Office";
-	req_access = list(62)
+	req_access = list(44)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -22758,9 +22758,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/tether/station/explorer_meeting)
-"wUh" = (
-/turf/simulated/wall,
-/area/library_conference_room)
 "wZn" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/weapon/cell/super;
@@ -35005,7 +35002,7 @@ aGL
 aGL
 aGL
 aGL
-wUh
+aGL
 aGL
 aGL
 aac


### PR DESCRIPTION
## About The Pull Request

Gives Pathfinders access to the main R&D lab and the Firing Range, and assigns them their own unique access ID number (44). This means the PF's office & locker aren't keyed to Gateway Access any more.

This doesn't give Pathfinders access to any other parts of science: they still can't get into xenoflora, xenobio, robotics, or the anomaly lab.

## Why It's Good For The Game

1) Explorers and the Pathfinder can already get into the Firing Range by going through maintenance, so there's little reason to keep them out.
2) Exploration team is the most likely to need to acquire additional supplies from R&D, but sometimes no staff are available or even on-shift. This allows the PF to acquire said supplies if nobody is available.
3) Heads with Gateway Access (HoS, RD) can no longer just march into the PF's office like it's no big deal.

## Changelog
:cl:
add: Added PF Access Level 44
tweak: Updated PF Access Levels and the PF's Office Door Access Level accordingly
/:cl: