### PR TITLE
Pilot PDA Switch

### DIFF
--- a/maps/southern_cross/job/outfits.dm
+++ b/maps/southern_cross/job/outfits.dm
@@ -46,7 +46,7 @@ Keep outfits simple. Spawn with basic uniforms and minimal gear. Gear instead go
 	l_ear = /obj/item/device/radio/headset/pilot/alt
 	id_slot = slot_wear_id
 	pda_slot = slot_belt
-	pda_type = /obj/item/device/pda/cargo // Brown looks more rugged
+	pda_type = /obj/item/device/pda
 	id_type = /obj/item/weapon/card/id/civilian/pilot
 	id_pda_assignment = "Pilot"
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_COMPREHENSIVE_SURVIVAL


### PR DESCRIPTION
## About The Pull Request

Changes Pilot PDAs to be generic greys with no cart.

## Why It's Good For The Game

Pilots are not in the Cargo Department and should not receive Cargo Department Relay Messages.

## Changelog
:cl:
tweak: changes Pilot's PDA type
/:cl: