### PR TITLE
Adds Cable Coils to Autolathe

### DIFF
--- a/code/datums/autolathe/tools.dm
+++ b/code/datums/autolathe/tools.dm
@@ -1,3 +1,8 @@
+/datum/category_item/autolathe/general/cable
+	name = "cable"
+	path =/obj/item/stack/cable_coil
+	is_stack = 1
+
 /datum/category_item/autolathe/tools/crowbar
 	name = "crowbar"
 	path =/obj/item/weapon/tool/crowbar


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds cable coil to be printed from the autolathe for roughly 64 steel units and 20 glass units and can be printed in 5 cable increments up to 30. Always found it odd it can't be printed, and I've personally run into cases where I wind up using so much cable it becomes inconvenient to scavenge about the station. Only prints out in red because it's either that or a random color each time.

## Why It's Good For The Game

Less faff for getting more cable when needed for projects. Only prints out in red.

## Changelog
:cl:
Add: Cable coils to be printable from the autolathe in a single wire or 5 wire increments up to 30.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
