### PR TITLE
Fixes the chirp emote for human mobs

### DIFF
--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -127,7 +127,7 @@
 			m_type = 2
 			playsound(loc, 'modular_citadel/sound/voice/peep.ogg', 50, 1, -1)
 		if("chirp")
-			message = "<B>The [src.name]</B> chirps!"
+			message = "lets out a chirp."
 			playsound(src.loc, 'sound/misc/nymphchirp.ogg', 50, 0)
 			m_type = 2
 		if ("weh")

--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -127,7 +127,7 @@
 			m_type = 2
 			playsound(loc, 'modular_citadel/sound/voice/peep.ogg', 50, 1, -1)
 		if("chirp")
-			message = "lets out a chirp."
+			message = "chirps!"
 			playsound(src.loc, 'sound/misc/nymphchirp.ogg', 50, 0)
 			m_type = 2
 		if ("weh")

--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -123,7 +123,7 @@
 						Logout(src)
 ///////////////////////// EMOTES PORTED FROM MAIN END
 		if ("peep")
-			message = "peeps like a bird."
+			message = "lets out a peep."
 			m_type = 2
 			playsound(loc, 'modular_citadel/sound/voice/peep.ogg', 50, 1, -1)
 		if("chirp")

--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -123,7 +123,7 @@
 						Logout(src)
 ///////////////////////// EMOTES PORTED FROM MAIN END
 		if ("peep")
-			message = "lets out a peep."
+			message = "peeps like a bird."
 			m_type = 2
 			playsound(loc, 'modular_citadel/sound/voice/peep.ogg', 50, 1, -1)
 		if("chirp")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turns out copy pasting code from non human mobs into human code might bork things, who'd've thunk

## Why It's Good For The Game
Allows people to chirp to their heart's content without it stating their name twice.

## Changelog
:cl:
fix: fixed the chirp emote saying a human mob's name twice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
