### PR TITLE
did you guys know that phoronguard was supposed to be a flag and not an item_flag? i didn't

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -86,7 +86,7 @@
 	var/airtight = 1 //If set, will adjust AIRTIGHT and STOPPRESSUREDAMAGE flags on components. Otherwise it should leave them untouched.
 
 	var/emp_protection = 0
-	item_flags = PHORONGUARD //VOREStation add
+	flags = PHORONGUARD //VOREStation add
 
 	// Wiring! How exciting.
 	var/datum/wires/rig/wires

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -5,6 +5,7 @@
 /obj/item/clothing/head/helmet/space/rig
 	name = "helmet"
 	item_flags = THICKMATERIAL
+	flags = PHORONGUARD
 	flags_inv = 		 HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
 	heat_protection =    HEAD|FACE|EYES
@@ -22,6 +23,7 @@
 /obj/item/clothing/gloves/gauntlets/rig
 	name = "gauntlets"
 	item_flags = THICKMATERIAL
+	flags = PHORONGUARD
 	body_parts_covered = HANDS
 	heat_protection =    HANDS
 	cold_protection =    HANDS
@@ -30,6 +32,7 @@
 
 /obj/item/clothing/shoes/magboots/rig
 	name = "boots"
+	flags = PHORONGUARD
 	body_parts_covered = FEET
 	cold_protection = FEET
 	heat_protection = FEET
@@ -39,6 +42,7 @@
 
 /obj/item/clothing/suit/space/rig
 	name = "chestpiece"
+	flags = PHORONGUARD
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	heat_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
@@ -113,7 +117,7 @@
 	body_parts_covered = HEAD|FACE|EYES
 	heat_protection =    HEAD|FACE|EYES
 	cold_protection =    HEAD|FACE|EYES
-	flags =              THICKMATERIAL|AIRTIGHT
+	flags =              THICKMATERIAL|AIRTIGHT|PHORONGUARD
 
 /obj/item/clothing/suit/lightrig
 	name = "suit"
@@ -122,13 +126,14 @@
 	heat_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	cold_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	flags_inv =          HIDEJUMPSUIT
-	flags =              THICKMATERIAL
+	flags =              THICKMATERIAL|PHORONGUARD
 
 /obj/item/clothing/shoes/lightrig
 	name = "boots"
 	body_parts_covered = FEET
 	cold_protection = FEET
 	heat_protection = FEET
+	flags = PHORONGUARD
 	species_restricted = null
 	gender = PLURAL
 
@@ -138,5 +143,6 @@
 	body_parts_covered = HANDS
 	heat_protection =    HANDS
 	cold_protection =    HANDS
+	flags = PHORONGUARD
 	species_restricted = null
 	gender = PLURAL

--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -47,7 +47,8 @@
 	suit_type = "alien"
 	icon_state = "vox_rig"
 	armor = list(melee = 60, bullet = 50, laser = 40, energy = 15, bomb = 30, bio = 100, rad = 50)
-	item_flags = THICKMATERIAL|PHORONGUARD
+	flags = PHORONGUARD
+	item_flags = THICKMATERIAL
 	siemens_coefficient = 0.2
 	offline_slowdown = 5
 	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit)

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -56,7 +56,7 @@
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.02
 	flags = PHORONGUARD
-	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL | PHORONGUARD
+	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/emergency/oxygen,/obj/item/device/suit_cooling_unit)
 	slowdown = 3

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -8,7 +8,8 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
 	siemens_coefficient = 0.9
-	item_flags = THICKMATERIAL | PHORONGUARD
+	flags = PHORONGUARD
+	item_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/bio_suit
 	name = "bio suit"
@@ -23,7 +24,8 @@
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 20)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL|HIDETIE|HIDEHOLSTER
 	siemens_coefficient = 0.9
-	item_flags = THICKMATERIAL | PHORONGUARD
+	flags = PHORONGUARD
+	item_flags = THICKMATERIAL
 
 //Standard biosuit, orange stripe
 /obj/item/clothing/head/bio_hood/general


### PR DESCRIPTION
## About The Pull Request
remakes #1334, makes rig pieces phoronguarded
## Why It's Good For The Game
you literally cant wash rig pieces in a washing machine so this is the next best thing
## Changelog
:cl:
tweak: Hardsuit pieces (gauntlets, boots, chestpiece, helmet) now have PHORONGUARD.
code: PHORONGUARD is supposed to be a flag and not an item_flag. Adjustments made. Probably.
/:cl:
