### PR TITLE
Because Boop Doesn't Do This

### DIFF
--- a/code/datums/autolathe/tools.dm
+++ b/code/datums/autolathe/tools.dm
@@ -1,7 +1,6 @@
 /datum/category_item/autolathe/general/cable
 	name = "cable"
 	path =/obj/item/stack/cable_coil
-	is_stack = 1
 
 /datum/category_item/autolathe/tools/crowbar
 	name = "crowbar"

--- a/code/datums/autolathe/tools.dm
+++ b/code/datums/autolathe/tools.dm
@@ -1,6 +1,7 @@
 /datum/category_item/autolathe/general/cable
 	name = "cable"
 	path =/obj/item/stack/cable_coil
+	is_stack =1
 
 /datum/category_item/autolathe/tools/crowbar
 	name = "crowbar"

--- a/code/datums/autolathe/tools.dm
+++ b/code/datums/autolathe/tools.dm
@@ -1,7 +1,7 @@
 /datum/category_item/autolathe/general/cable
 	name = "cable"
 	path =/obj/item/stack/cable_coil
-	is_stack =1
+	is_stack = 1
 
 /datum/category_item/autolathe/tools/crowbar
 	name = "crowbar"

--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -486,6 +486,7 @@
 	src.modules += new /obj/item/weapon/tool/wirecutters/cyborg(src)
 	src.modules += new /obj/item/device/multitool(src)
 	src.modules += new /obj/item/device/t_scanner(src)
+	src.modules += new /obj/item/device/analyzer(src)
 	src.modules += new /obj/item/taperoll/engineering(src)
 	src.modules += new /obj/item/weapon/inflatable_dispenser/robot(src)
 	src.modules += new /obj/item/weapon/pickaxe(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Probably final change to this, but I didn't think of it earlier. BOOP module doesn't get the contents of pipes, and as that's kind of semi important for an engineering borg, added in the base analyzer alongside the BOOP module. If I had knowledge to get BOOP to analyze contents of pipes and canisters, I would.

## Why It's Good For The Game

Getting that module in ship shape.

## Changelog
:cl:
add: Analyzer to engihound
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
