### PR TITLE
Unprotects admin datum from varedit except for rank/permissions variables

### DIFF
--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -149,6 +149,6 @@ NOTE: It checks usr by default. Supply the "user" argument if you wish to check 
 #ifdef TESTING
 	return ..()
 #endif
-	if(var_name == NAMEOF(src, rank) || var_name == NAMEOF(rights))
+	if(var_name == NAMEOF(src, rank) || var_name == NAMEOF(src, rights))
 		return FALSE
 	return ..()

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -146,4 +146,9 @@ NOTE: It checks usr by default. Supply the "user" argument if you wish to check 
 	*/
 
 /datum/admins/vv_edit_var(var_name, var_value)
-	return FALSE //nice try trialmin
+#ifdef TESTING
+	return ..()
+#endif
+	if(var_name == NAMEOF(src, rank) || var_name == NAMEOF(rights))
+		return FALSE
+	return ..()


### PR DESCRIPTION
I always wanted to edit fakekey and there's a buncha shit in here that is unnecessarily locked.

Also adds a #define TESTING check, as if that's defined it's assumed you're in a debug environment.
