### PR TITLE
Makes Phoron scrubbers stronger

### DIFF
--- a/maps/tether/tether_phoronlock.dm
+++ b/maps/tether/tether_phoronlock.dm
@@ -91,6 +91,28 @@ obj/machinery/airlock_sensor/phoron/airlock_exterior
 	radio_connection.post_signal(src, signal, radio_filter = RADIO_AIRLOCK)
 	return 1
 
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock		//Special scrubber with bonus inbuilt heater
+	volume_rate = 40000
+	active_power_usage = 2000
+	var/target_temp = T20C
+	var/heating_power = 150000
+
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock/process()
+	..()
+
+	if(on)
+		var/datum/gas_mixture/env = loc.return_air()
+		if(env && abs(env.temperature - target_temp) > 0.1)
+			var/datum/gas_mixture/removed = env.remove_ratio(0.99)
+			if(removed)
+				var/heat_transfer = removed.get_thermal_energy_change(target_temp)
+				removed.add_thermal_energy(min(heating_power,heat_transfer))
+				env.merge(removed)
+
+		var/transfer_moles = min(1, volume_rate/env.volume)*env.total_moles
+		for(var/i=1 to 3)	//Scrubs 4 times as fast
+			scrub_gas(src, scrubbing_gas, env, air_contents, transfer_moles, active_power_usage)
+
 //
 // PHORON LOCK CONTROLLER
 //
@@ -175,7 +197,7 @@ obj/machinery/airlock_sensor/phoron/airlock_exterior
 	memory["external_sensor_phoron"] = VIRGO3B_MOL_PHORON
 	memory["internal_sensor_phoron"] = 0
 	memory["scrubber_status"] = "unknown"
-	memory["target_phoron"] = 0.25
+	memory["target_phoron"] = 0.1
 	memory["secure"] = 1
 
 	if (istype(M, /obj/machinery/embedded_controller/radio/airlock/phoron))	//if our controller is an airlock controller than we can auto-init our tags


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Port of https://github.com/VOREStation/VOREStation/pull/5470
Makes the Phoron Scubbers work almost twice as fast, while taking slightly more power. They now heat the air while working, preventing atmos alarms from the cold. They now filter down to a lower phoron amount, preventing leftover phoron in the connecting area.

## Why It's Good For The Game
Makes getting into and out of the station easier, faster, and safer. Mainly a QoL change, as waiting for an airlock to cycle is booty.

## Changelog
:cl:
tweak: Makes Phoron Scrubbers work much faster, adds air heating to them as well
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
