### PR TITLE
QoL Updates to the text boxes for talking & emotes

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1541,7 +1541,7 @@
 /////// Messages and Log ///////
 ////////////////////////////////
 
-/obj/mecha/proc/occupant_message(message as text)
+/obj/mecha/proc/occupant_message(message as text|null)
 	if(message)
 		if(src.occupant && src.occupant.client)
 			src.occupant << "\icon[src] [message]"

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -1,27 +1,27 @@
 /mob/proc/say()
 	return
 
-/mob/verb/whisper(message as text)
+/mob/verb/whisper(message as text|null)
 	set name = "Whisper"
 	set category = "IC"
 
 	usr.say(message,whispering=1)
 
-/mob/verb/say_verb(message as text)
+/mob/verb/say_verb(message as text|null)
 	set name = "Say"
 	set category = "IC"
 
 	set_typing_indicator(FALSE)
 	usr.say(message)
 
-/mob/verb/me_verb(message as text)
+/mob/verb/me_verb(message as message|null)
 	set name = "Me"
 	set category = "IC"
 
 	if(say_disabled)	//This is here to try to identify lag problems
 		usr << "<font color='red'>Speech is currently admin-disabled.</font>"
 		return
-	
+
 	message = sanitize_or_reflect(message,src) //VOREStation Edit - Reflect too-long messages (within reason)
 
 	set_typing_indicator(FALSE)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -1,20 +1,20 @@
 /mob/proc/say()
 	return
 
-/mob/verb/whisper(message as text|null)
+/mob/verb/whisper(message as text)
 	set name = "Whisper"
 	set category = "IC"
 
 	usr.say(message,whispering=1)
 
-/mob/verb/say_verb(message as text|null)
+/mob/verb/say_verb(message as text)
 	set name = "Say"
 	set category = "IC"
 
 	set_typing_indicator(FALSE)
 	usr.say(message)
 
-/mob/verb/me_verb(message as message|null)
+/mob/verb/me_verb(message as message)
 	set name = "Me"
 	set category = "IC"
 

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -2,7 +2,7 @@
 ////////////////////SUBTLE COMMAND////////////////////
 //////////////////////////////////////////////////////
 
-/mob/verb/me_verb_subtle(message as text) //This would normally go in say.dm
+/mob/verb/me_verb_subtle(message as message|null) //This would normally go in say.dm
 	set name = "Subtle"
 	set category = "IC"
 	set desc = "Emote to nearby people (and your pred/prey)"
@@ -64,14 +64,14 @@
 
 #define MAX_HUGE_MESSAGE_LEN 8192
 #define POST_DELIMITER_STR "\<\>"
-/proc/sanitize_or_reflect(message,user)	
+/proc/sanitize_or_reflect(message,user)
 	//Way too long to send
 	if(length(message) > MAX_HUGE_MESSAGE_LEN)
 		fail_to_chat(user)
 		return
 
 	message = sanitize(message, max_length = MAX_HUGE_MESSAGE_LEN)
-	
+
 	//Came back still too long to send
 	if(length(message) > MAX_MESSAGE_LEN)
 		fail_to_chat(user,message)
@@ -83,7 +83,7 @@
 	if(!message)
 		to_chat(user,"<span class='danger'>Your message was NOT SENT, either because it was FAR too long, or sanitized to nothing at all.</span>")
 		return
-	
+
 	var/length = length(message)
 	var/posts = CEILING(length/MAX_MESSAGE_LEN, 1)
 	to_chat(user,message)

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -2,7 +2,7 @@
 ////////////////////SUBTLE COMMAND////////////////////
 //////////////////////////////////////////////////////
 
-/mob/verb/me_verb_subtle(message as message|null) //This would normally go in say.dm
+/mob/verb/me_verb_subtle(message as message) //This would normally go in say.dm
 	set name = "Subtle"
 	set category = "IC"
 	set desc = "Emote to nearby people (and your pred/prey)"

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -28,9 +28,9 @@
 	set hidden = 1
 
 	set_typing_indicator(TRUE)
-	var/message = input("","say (text)") as text
+	var/message = input("","say (text)") as text|null
 	set_typing_indicator(FALSE)
-	
+
 	if(message)
 		say_verb(message)
 
@@ -39,7 +39,7 @@
 	set hidden = 1
 
 	set_typing_indicator(TRUE)
-	var/message = input("","me (text)") as text
+	var/message = input("","me (text)") as message|null
 	set_typing_indicator(FALSE)
 
 	if(message)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates the "Say" and "Whisper" text boxes to have a cancel button and the "Me" and "Subtle" emotes to display in multiline text boxes as opposed to the single line boxes that they used to use.

## Why It's Good For The Game

Allows immediate backing out of speaking IC by hitting cancel instead of being forced to wipe all the text in the box and sending an empty message. The emote changes mean you can proof-read your para posts with greater ease now.

## Changelog
:cl:
tweak: "Say" and "Whisper" now have a cancel button on their pop-up box. "Me" and "Subtle" also have this, in addition to being a multiline text box now instead of the old single line one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
