### PR TITLE
Re-enable virology and adds new syndromes

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -177,6 +177,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Containment Breach",	/datum/event/prison_break/station,0,list(ASSIGNMENT_ANY = 5)),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",			/datum/event/meteor_wave,		0,	list(ASSIGNMENT_ENGINEER = 30),	1), //Meteor Strike weight set to 0, Citadel Override. Something's not working right.
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",			/datum/event/spacevine, 		20,	list(ASSIGNMENT_ENGINEER = 15), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Biological Hazard",			/datum/event/viral_outbreak, 		20,	list(ASSIGNMENT_MEDICAL = 25), 1),
 	)
 
 

--- a/code/modules/events/event_container_vr.dm
+++ b/code/modules/events/event_container_vr.dm
@@ -94,7 +94,8 @@
 	available_events = list(
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",				/datum/event/nothing,			900),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Atmos Leak",			/datum/event/atmos_leak, 		30,		list(ASSIGNMENT_ENGINEER = 25), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Strike",		/datum/event/meteor_strike,		0,		list(ASSIGNMENT_ENGINEER = 15)	,1) //Meteor Strike weight set to 0, Citadel Override. Something's not working right.
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Strike",		/datum/event/meteor_strike,		0,		list(ASSIGNMENT_ENGINEER = 15)	,1), //Meteor Strike weight set to 0, Citadel Override. Something's not working right.
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Biological Hazard",			/datum/event/viral_outbreak, 		10,	list(ASSIGNMENT_MEDICAL = 20), 1)
 	)
 	add_disabled_events(list(
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",				/datum/event/blob, 				10,	list(ASSIGNMENT_ENGINEER = 60), 1),
@@ -104,7 +105,7 @@
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",			/datum/event/spacevine, 		20,	list(ASSIGNMENT_ENGINEER = 15), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Supply Demand",		/datum/event/supply_demand,		0,		list(ASSIGNMENT_ANY = 5, ASSIGNMENT_SCIENCE = 15, ASSIGNMENT_GARDENER = 10, ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_MEDICAL = 15), 1),
 	))
-
+//WHY ARE WE OVERIRIDING THE EVENT CONTAINER.Save me from these new() calls - Snow
 #undef ASSIGNMENT_ANY
 #undef ASSIGNMENT_AI
 #undef ASSIGNMENT_CYBORG

--- a/code/modules/events/viral_outbreak.dm
+++ b/code/modules/events/viral_outbreak.dm
@@ -1,14 +1,14 @@
 
-datum/event/viral_outbreak
-	var/severity = 1
-
+/datum/event/viral_outbreak
+	var/oseverity = 1
+//Changed from severeity since it was causing mutiple_definition errors!
 datum/event/viral_outbreak/setup()
 	announceWhen = rand(0, 3000)
 	endWhen = announceWhen + 1
 	severity = rand(2, 4)
 
 datum/event/viral_outbreak/announce()
-	command_alert("Confirmed outbreak of level 7 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert")
+	command_announcement.Announce ("Confirmed outbreak of biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert")
 	world << sound('sound/AI/outbreak7.ogg')
 
 datum/event/viral_outbreak/start()
@@ -19,7 +19,7 @@ datum/event/viral_outbreak/start()
 	if(!candidates.len)	return
 	candidates = shuffle(candidates)//Incorporating Donkie's list shuffle
 
-	while(severity > 0 && candidates.len)
+	while(oseverity > 0 && candidates.len)
 		if(prob(33))
 			infect_mob_random_lesser(candidates[1])
 		else

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -65,11 +65,6 @@
 
 ////////////////////////STAGE 4/////////////////////////////////
 
-/datum/disease2/effect/nothing
-	name = "Nil Syndrome"
-	stage = 4
-	badness = 1
-	chance_maxm = 0
 
 /datum/disease2/effect/gibbingtons
 	name = "Gibbington's Syndrome"
@@ -249,6 +244,60 @@
 			H.adjust_fire_stacks(2)
 			H.IgniteMob()
 
+//Ported from bay 2019 Oct 1 are below
+/datum/disease2/effect/killertoxins
+	name = "Toxification Syndrome"
+	stage = 4
+	badness = 3
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		mob.adjustToxLoss(15*multiplier)
+
+/datum/disease2/effect/dna
+	name = "Reverse Pattern Syndrome"
+	stage = 4
+	badness = 3
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		mob.bodytemperature = max(mob.bodytemperature, 350)
+		scramble(0,mob,10)
+		mob.apply_damage(10, CLONE)
+//Longevity commented out until I figure out what its trying to call on baycode
+///datum/disease2/effect/immortal
+//	name = "Longevity Syndrome"
+//	stage = 4
+//	badness = 3
+//	activate(var/mob/living/carbon/human/mob,var/multiplier)
+//		for (var/external in mob.organs)
+///			var/obj/item/organ/external/E = external
+	//		if (E.status & ORGAN_BROKEN && prob(30))
+	///			to_chat(mob, "<span class='notice'>Your [E.name] suddenly feels much better!</span>")
+		//		E.status ^= ORGAN_BROKEN
+		//		break
+//		for (var/internal in mob.internal_organs)
+//			var/obj/item/organ/internal/I = internal
+///			if (I.damage && prob(30))
+//				to_chat(mob, "<span class='notice'>Your [mob.get_organ(I.parent_organ)] feels a bit warm...</span>")
+//				I.take_internal_damage(-2*multiplier)
+//				break
+//		var/heal_amt = -5*multiplier
+//		mob.apply_damages(heal_amt,heal_amt,heal_amt,heal_amt)
+//
+//	deactivate(var/mob/living/carbon/human/mob,var/multiplier)
+//		to_chat(mob, "<span class='notice'>You suddenly feel hurt and old...</span>")
+//		mob.age += 8
+//		var/backlash_amt = 5*multiplier
+//		mob.apply_damages(backlash_amt,backlash_amt,backlash_amt,backlash_amt)
+
+/datum/disease2/effect/bones
+	name = "Fragile Bones Syndrome"
+	stage = 4
+	badness = 4
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		for (var/obj/item/organ/external/E in mob.organs)
+			E.min_broken_damage = max(5, E.min_broken_damage - 30)
+
+	deactivate(var/mob/living/carbon/human/mob,var/multiplier)
+		for (var/obj/item/organ/external/E in mob.organs)
+			E.min_broken_damage = initial(E.min_broken_damage)
 
 ////////////////////////STAGE 3/////////////////////////////////
 
@@ -288,6 +337,7 @@
 			B.take_damage(5)
 	else
 		mob.setBrainLoss(10)
+
 
 /datum/disease2/effect/hallucinations
 	name = "Hallucination"
@@ -372,6 +422,16 @@
 		for (var/organ in H.organs_by_name)
 			if (O.robotic != ORGAN_ROBOT)
 				O.rejecting = 0
+
+//Ported from bay 2019 Oct 1
+/datum/disease2/effect/telepathic
+	name = "Telepathy Syndrome"
+	stage = 3
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		mob.dna.SetSEState(REMOTETALKBLOCK,1)
+		domutcheck(mob, null, MUTCHK_FORCED)
+
+
 
 
 ////////////////////////STAGE 2/////////////////////////////////
@@ -479,6 +539,7 @@
 	if (prob(50))
 		mob.say("*vomit")
 
+
 ////////////////////////STAGE 1/////////////////////////////////
 
 /datum/disease2/effect/sneeze
@@ -532,3 +593,5 @@
 
 /datum/disease2/effect/headache/activate(var/mob/living/carbon/mob,var/multiplier)
 		mob << "<span class='warning'>Your head hurts a bit.</span>"
+
+

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1773,6 +1773,8 @@
 #include "code\modules\events\spontaneous_appendicitis.dm"
 #include "code\modules\events\spontaneous_appendicitis_vr.dm"
 #include "code\modules\events\supply_demand.dm"
+#include "code\modules\events\viral_infection.dm"
+#include "code\modules\events\viral_outbreak.dm"
 #include "code\modules\events\wallrot.dm"
 #include "code\modules\examine\examine.dm"
 #include "code\modules\examine\stat_icons.dm"


### PR DESCRIPTION
Hopefully I didn't break the branch like I did previously. :1st_place_medal: 
## About The Pull Request

This events adds back viral outbreaks into the game. Further tweaks may be needed to balance virology. Also adds a few bay syndromes.

Current goals:
- [ ] Re-enable viral outbreaks.
- [ ] See if the announcement is still failing silently even though it should be fixed in viral_outbreak
- [ ] Finish porting the longevity syndrome without breaking the game (currently commented out).
- [ ] Find a way to add gibbingtons without the instant no syndromes until level four and then you get gibbed, or keep gibbington disabled.
- [ ] Balance event-spawn chance - **Testmerge and feedback requested**
- [ ] Possibly tweak antibiotic effects on viruses. - **Testmerge and feedback requested**
- [ ] Commit Seppeku for a shameful display by breaking my own fork after this has finished.
## Why It's Good For The Game

This is mainly a rare occurring event that supposed to happen with 2+ medical staff, although I'm not to sure if the current numbers reflect that. May need to change that again in event_container_vr.


## Changelog
:cl:
add: Several syndromes from bay

tweak: tweaked a few things
fix: mutiple_defintion bug with viro_outbreak
/:cl:

