### PR TITLE
Sandstone Plant Plots

### DIFF
--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -114,7 +114,7 @@
 	recipes += new/datum/stack_recipe("roller bed", /obj/item/roller, 5, time = 30, on_floor = 1)
 	recipes += new/datum/stack_recipe("whetstone", /obj/item/weapon/whetstone, 2, time = 10)
 
-/datum/material/sandstone/generate_recipes()
+/datum/material/stone/generate_recipes()
 	..()
 	recipes += new/datum/stack_recipe("planting bed", /obj/machinery/portable_atmospherics/hydroponics/soil, 3, time = 10, one_per_turf = 1, on_floor = 1)
 


### PR DESCRIPTION
## About The Pull Request
Fixes a bug, I guess.
## Changelog
:cl:
fix: Sandstone can now be used for making plant plots.
/:cl: