### PR TITLE
Digging Fiddling

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1146,7 +1146,7 @@ proc/is_hot(obj/item/W as obj)
 		istype(W, /obj/item/weapon/flame/lighter/zippo)			  || \
 		istype(W, /obj/item/weapon/flame/match)            		  || \
 		istype(W, /obj/item/clothing/mask/smokable/cigarette) 		      || \
-		istype(W, /obj/item/weapon/shovel) \
+		istype(W, /obj/item/weapon/pickaxe/shovel) \
 	)
 
 /proc/is_surgery_tool(obj/item/W as obj)

--- a/code/datums/supplypacks/supply.dm
+++ b/code/datums/supplypacks/supply.dm
@@ -104,7 +104,7 @@
 			/obj/item/device/analyzer,
 			/obj/item/weapon/storage/bag/ore,
 			/obj/item/device/flashlight/lantern,
-			/obj/item/weapon/shovel,
+			/obj/item/weapon/pickaxe/shovel,
 			/obj/item/weapon/pickaxe,
 			/obj/item/weapon/mining_scanner,
 			/obj/item/clothing/glasses/material,

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -64,7 +64,7 @@
 
 // Todo: Add a version that gradually reaccumulates over time by means of alpha transparency. -Spades
 /obj/effect/overlay/snow/attackby(obj/item/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/weapon/shovel))
+	if (istype(W, /obj/item/weapon/pickaxe/shovel))
 		user.visible_message("<span class='notice'>[user] begins to shovel away \the [src].</span>")
 		if(do_after(user, 40))
 			user << "<span class='notice'>You have finished shoveling!</span>"

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -71,7 +71,7 @@
 
 /obj/structure/closet/grave/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(src.opened)
-		if(istype(W, /obj/item/weapon/shovel))
+		if(istype(W, /obj/item/weapon/pickaxe/shovel))
 			user.visible_message("<span class='notice'>[user] piles dirt into \the [src.name].</span>", \
 								 "<span class='notice'>You start to pile dirt into \the [src.name].</span>", \
 								 "<span class='notice'>You hear dirt being moved.</span>")
@@ -107,7 +107,7 @@
 		if(W)
 			W.forceMove(src.loc)
 	else
-		if(istype(W, /obj/item/weapon/shovel))
+		if(istype(W, /obj/item/weapon/pickaxe/shovel))
 			if(user.a_intent == I_HURT)	// Hurt intent means you're trying to kill someone, or just get rid of the grave
 				user.visible_message("<span class='notice'>[user] begins to smoothe out the dirt of \the [src.name].</span>", \
 									 "<span class='notice'>You start to smoothe out the dirt of \the [src.name].</span>", \

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -86,7 +86,7 @@
 		/obj/item/device/analyzer,
 		/obj/item/weapon/storage/bag/ore,
 		/obj/item/device/flashlight/lantern,
-		/obj/item/weapon/shovel,
+		/obj/item/weapon/pickaxe/shovel,
 		/obj/item/weapon/pickaxe,
 		/obj/item/clothing/glasses/material,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/miner,

--- a/code/game/objects/structures/flora/trees.dm
+++ b/code/game/objects/structures/flora/trees.dm
@@ -19,7 +19,7 @@
 		return ..()
 
 	if(is_stump)
-		if(istype(W,/obj/item/weapon/shovel))
+		if(istype(W,/obj/item/weapon/pickaxe/shovel))
 			if(do_after(user, 5 SECONDS))
 				visible_message("<span class='notice'>\The [user] digs up \the [src] stump with \the [W].</span>")
 				qdel(src)

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -141,7 +141,7 @@
 		make_plating(1)
 		playsound(src, W.usesound, 80, 1)
 		return 1
-	else if(istype(W, /obj/item/weapon/shovel) && (flooring.flags & TURF_REMOVE_SHOVEL))
+	else if(istype(W, /obj/item/weapon/pickaxe/shovel) && (flooring.flags & TURF_REMOVE_SHOVEL))
 		to_chat(user, "<span class='notice'>You shovel off the [flooring.descriptor].</span>")
 		make_plating(1)
 		playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)

--- a/code/game/turfs/simulated/outdoors/snow.dm
+++ b/code/game/turfs/simulated/outdoors/snow.dm
@@ -24,7 +24,7 @@
 		add_overlay(image(icon = 'icons/turf/outdoors.dmi', icon_state = "snow_footprints", dir = text2num(d)))
 
 /turf/simulated/floor/outdoors/snow/attackby(var/obj/item/W, var/mob/user)
-	if(istype(W, /obj/item/weapon/shovel))
+	if(istype(W, /obj/item/weapon/pickaxe/shovel))
 		to_chat(user, "<span class='notice'>You begin to remove \the [src] with your [W].</span>")
 		if(do_after(user, 4 SECONDS * W.toolspeed))
 			to_chat(user, "<span class='notice'>\The [src] has been dug up, and now lies in a pile nearby.</span>")

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -262,7 +262,7 @@
 	item_state_slots = list(slot_r_hand_str = "skrell_suit_black", slot_l_hand_str = "skrell_suit_black")
 	armor = list(melee = 40, bullet = 15, laser = 25,energy = 35, bomb = 30, bio = 100, rad = 70)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/stack/flag,/obj/item/device/healthanalyzer,/obj/item/device/gps,/obj/item/device/radio/beacon, \
-	/obj/item/weapon/shovel,/obj/item/ammo_magazine,/obj/item/weapon/gun)
+	/obj/item/weapon/pickaxe/shovel,/obj/item/ammo_magazine,/obj/item/weapon/gun)
 
 /obj/item/clothing/head/helmet/space/void/exploration/alt
 	desc = "A radiation-resistant helmet retrofitted for exploring unknown planetary environments."

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -22,7 +22,7 @@
 	w_class = ITEMSIZE_LARGE
 	matter = list(DEFAULT_WALL_MATERIAL = 3750)
 	var/digspeed = 40 //moving the delay to an item var so R&D can make improved picks. --NEO
-	var/shovelspeed = 0
+	var/shovelspeed = -1 // ooga dig. -1 = cant drill, 4head
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	attack_verb = list("hit", "pierced", "sliced", "attacked")
 	var/drill_sound = 'sound/weapons/Genhit.ogg'
@@ -44,7 +44,7 @@
 	icon_state = "handdrill"
 	item_state = "jackhammer"
 	digspeed = 30
-	shovelspeed = 11
+	shovelspeed = 15
 	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	desc = "Yours is the drill that will pierce through the rock walls."
 	drill_verb = "drilling"
@@ -111,31 +111,31 @@
 
 /*****************************Shovel********************************/
 
-/obj/item/weapon/shovel
+/obj/item/weapon/pickaxe/shovel
 	name = "shovel"
 	desc = "A large tool for digging and moving dirt."
-	icon = 'icons/obj/items.dmi'
 	icon_state = "shovel"
-	flags = CONDUCT
-	slot_flags = SLOT_BELT
 	force = 8.0
 	throwforce = 4.0
 	item_state = "shovel"
 	w_class = ITEMSIZE_NORMAL
-	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 50)
 	attack_verb = list("bashed", "bludgeoned", "thrashed", "whacked")
-	var/shovelspeed = 20
+	digspeed = 50
+	shovelspeed = 20
+	drill_verb = "violently bashing" // dont mine with a shovel 4head
 	sharp = 0
 	edge = 1
 
-/obj/item/weapon/shovel/spade
+/obj/item/weapon/pickaxe/shovel/spade
 	name = "spade"
 	desc = "A small tool for digging and moving dirt."
 	icon_state = "spade"
 	item_state = "spade"
 	force = 5.0
 	throwforce = 7.0
+	digspeed = 120
+	drill_verb = "violently chipping away"
+	matter = list(DEFAULT_WALL_MATERIAL = 50)
 	w_class = ITEMSIZE_SMALL
 
 

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -22,6 +22,7 @@
 	w_class = ITEMSIZE_LARGE
 	matter = list(DEFAULT_WALL_MATERIAL = 3750)
 	var/digspeed = 40 //moving the delay to an item var so R&D can make improved picks. --NEO
+	var/shovelspeed = 0
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	attack_verb = list("hit", "pierced", "sliced", "attacked")
 	var/drill_sound = 'sound/weapons/Genhit.ogg'
@@ -43,6 +44,7 @@
 	icon_state = "handdrill"
 	item_state = "jackhammer"
 	digspeed = 30
+	shovelspeed = 11
 	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	desc = "Yours is the drill that will pierce through the rock walls."
 	drill_verb = "drilling"
@@ -93,6 +95,7 @@
 	icon_state = "diamonddrill"
 	item_state = "jackhammer"
 	digspeed = 5 //Digs through walls, girders, and can dig up sand
+	shovelspeed = 4
 	origin_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 5)
 	desc = "Yours is the drill that will pierce the heavens!"
 	drill_verb = "drilling"
@@ -102,6 +105,7 @@
 	icon_state = "jackhammer"
 	item_state = "jackhammer"
 	digspeed = 15
+	shovelspeed = 10
 	desc = "Cracks rocks with sonic blasts. This one seems like an improved design."
 	drill_verb = "hammering"
 
@@ -121,6 +125,7 @@
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	matter = list(DEFAULT_WALL_MATERIAL = 50)
 	attack_verb = list("bashed", "bludgeoned", "thrashed", "whacked")
+	var/shovelspeed = 20
 	sharp = 0
 	edge = 1
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -260,7 +260,7 @@ var/list/mining_overlay_cache = list()
 			/obj/item/weapon/pickaxe/borgdrill
 			)
 
-		var/valid_tool
+		var/shovelspeed = W.shovelspeed
 		for(var/valid_type in usable_tools)
 			if(istype(W,valid_type))
 				valid_tool = 1
@@ -277,8 +277,7 @@ var/list/mining_overlay_cache = list()
 
 			to_chat(user, "<span class='notice'>You start digging.</span>")
 			playsound(user.loc, 'sound/effects/rustle1.ogg', 50, 1)
-
-			if(!do_after(user,20)) return
+			if(!do_after(user,shovelspeed)) return
 
 			to_chat(user, "<span class='notice'>You dug a hole.</span>")
 			GetDrilled()

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -246,39 +246,25 @@ var/list/mining_overlay_cache = list()
 
 //Not even going to touch this pile of spaghetti
 /turf/simulated/mineral/attackby(obj/item/weapon/W as obj, mob/user as mob)
-
 	if (!(istype(usr, /mob/living/carbon/human) || ticker) && ticker.mode.name != "monkey")
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 
 	if(!density)
-
-		var/list/usable_tools = list(
-			/obj/item/weapon/shovel,
-			/obj/item/weapon/pickaxe/diamonddrill,
-			/obj/item/weapon/pickaxe/drill,
-			/obj/item/weapon/pickaxe/borgdrill
-			)
-
-		var/shovelspeed = W.shovelspeed
-		for(var/valid_type in usable_tools)
-			if(istype(W,valid_type))
-				valid_tool = 1
-				break
-
-		if(valid_tool)
-			if (sand_dug)
+		if(istype(W,/obj/item/weapon/pickaxe))
+			var/obj/item/weapon/pickaxe/P = W
+			if(P.digspeed == -1)
+				return
+			if(sand_dug)
 				to_chat(user, "<span class='warning'>This area has already been dug.</span>")
 				return
 
 			var/turf/T = user.loc
-			if (!(istype(T)))
+			if(!(istype(T)))
 				return
-
 			to_chat(user, "<span class='notice'>You start digging.</span>")
 			playsound(user.loc, 'sound/effects/rustle1.ogg', 50, 1)
-			if(!do_after(user,shovelspeed)) return
-
+			if(!do_after(user,P.shovelspeed)) return
 			to_chat(user, "<span class='notice'>You dug a hole.</span>")
 			GetDrilled()
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -253,7 +253,7 @@ var/list/mining_overlay_cache = list()
 	if(!density)
 		if(istype(W,/obj/item/weapon/pickaxe))
 			var/obj/item/weapon/pickaxe/P = W
-			if(P.digspeed == -1)
+			if(P.shovelspeed == -1)
 				return
 			if(sand_dug)
 				to_chat(user, "<span class='warning'>This area has already been dug.</span>")

--- a/code/modules/mob/living/silicon/robot/robot_modules/event.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/event.dm
@@ -66,7 +66,7 @@
 	modules += new /obj/item/weapon/robot_harvester(src)
 
 	// For digging and beautifying graves
-	modules += new /obj/item/weapon/shovel(src)
+	modules += new /obj/item/weapon/pickaxe/shovel(src)
 	modules += new /obj/item/weapon/gripper/gravekeeper(src)
 
 	// For really persistent looters

--- a/code/modules/xenoarcheaology/artifacts/replicator.dm
+++ b/code/modules/xenoarcheaology/artifacts/replicator.dm
@@ -57,7 +57,7 @@
 	/obj/item/weapon/light/bulb,
 	/obj/item/weapon/light/tube,
 	/obj/item/weapon/pickaxe,
-	/obj/item/weapon/shovel,
+	/obj/item/weapon/pickaxe/shovel,
 	/obj/item/weapon/weldingtool,
 	/obj/item/weapon/tool/wirecutters,
 	/obj/item/weapon/tool/wrench,

--- a/maps/RandomZLevels/labyrinth.dmm
+++ b/maps/RandomZLevels/labyrinth.dmm
@@ -927,7 +927,7 @@
 /obj/item/weapon/tool/wrench,
 /obj/item/device/measuring_tape,
 /obj/item/stack/flag/yellow,
-/obj/item/weapon/shovel/spade,
+/obj/item/weapon/pickaxe/shovel/spade,
 /turf/unsimulated/floor{
 	icon_state = "white"
 	},
@@ -1267,7 +1267,7 @@
 	},
 /area/awaymission/labyrinth/arrival)
 "de" = (
-/obj/item/weapon/shovel/spade,
+/obj/item/weapon/pickaxe/shovel/spade,
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "asteroid";
@@ -1276,7 +1276,7 @@
 	},
 /area/awaymission/labyrinth/arrival)
 "df" = (
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "asteroid";

--- a/maps/RandomZLevels/snowfield.dmm
+++ b/maps/RandomZLevels/snowfield.dmm
@@ -80,7 +80,7 @@
 	amount = 2;
 	icon_state = "coil2"
 	},
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /obj/machinery/light/small{
 	dir = 1
 	},

--- a/maps/RandomZLevels/stationCollision.dmm
+++ b/maps/RandomZLevels/stationCollision.dmm
@@ -4643,7 +4643,7 @@
 /area/awaymission/arrivalblock)
 "lQ" = (
 /obj/structure/table/standard,
-/obj/item/weapon/shovel/spade,
+/obj/item/weapon/pickaxe/shovel/spade,
 /obj/item/weapon/reagent_containers/spray/plantbgone,
 /turf/simulated/floor,
 /area/awaymission/arrivalblock)

--- a/maps/cit_tether/tether-01-surface1.dmm
+++ b/maps/cit_tether/tether-01-surface1.dmm
@@ -1799,7 +1799,7 @@
 /obj/item/weapon/pickaxe/hammer,
 /obj/item/weapon/wrench,
 /obj/item/weapon/crowbar,
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
 /obj/effect/floor_decal/borderfloor/corner2,
@@ -1811,7 +1811,7 @@
 /obj/item/weapon/pickaxe,
 /obj/item/weapon/wrench,
 /obj/item/weapon/crowbar,
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
@@ -11360,8 +11360,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/weapon/shovel,
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /obj/item/weapon/soap,
 /obj/item/device/radio/intercom{
 	dir = 1;

--- a/maps/endeavor/endeavor-01-ship1.dmm
+++ b/maps/endeavor/endeavor-01-ship1.dmm
@@ -17772,14 +17772,14 @@
 /area/maintenance/research)
 "Hd" = (
 /obj/structure/table/reinforced,
-/obj/item/weapon/shovel{
+/obj/item/weapon/pickaxe/shovel{
 	pixel_x = 10
 	},
-/obj/item/weapon/shovel{
+/obj/item/weapon/pickaxe/shovel{
 	pixel_x = 5
 	},
-/obj/item/weapon/shovel,
-/obj/item/weapon/shovel{
+/obj/item/weapon/pickaxe/shovel,
+/obj/item/weapon/pickaxe/shovel{
 	pixel_x = -5
 	},
 /obj/item/stack/flag/blue{

--- a/maps/endeavor/endeavor-03-ship3.dmm
+++ b/maps/endeavor/endeavor-03-ship3.dmm
@@ -2635,7 +2635,7 @@
 	desc = "Use on a hydroponics tray to freeze your crops into stasis if you don't want them to die while you're out of the room. You can also use this on airlocks or APCs to try to hack them without cutting wires, but that's immoral.";
 	name = "hydroponics multitool"
 	},
-/obj/item/weapon/shovel/spade,
+/obj/item/weapon/pickaxe/shovel/spade,
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
@@ -2729,7 +2729,7 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/item/weapon/shovel/spade,
+/obj/item/weapon/pickaxe/shovel/spade,
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
 	},
@@ -5774,7 +5774,7 @@
 	desc = "Use on a hydroponics tray to freeze your crops into stasis if you don't want them to die while you're out of the room. You can also use this on airlocks or APCs to try to hack them without cutting wires, but that's immoral.";
 	name = "hydroponics multitool"
 	},
-/obj/item/weapon/shovel/spade,
+/obj/item/weapon/pickaxe/shovel/spade,
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},

--- a/maps/endeavor/submaps/odin5a-desert/odin5a-cave.dmm
+++ b/maps/endeavor/submaps/odin5a-desert/odin5a-cave.dmm
@@ -106,7 +106,7 @@
 "x" = (
 /obj/structure/table/steel,
 /obj/item/weapon/pickaxe,
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /turf/simulated/floor/plating,
 /area/endeavor_away/cave/unexplored/normal)
 "y" = (

--- a/maps/northern_star/polaris-1.dmm
+++ b/maps/northern_star/polaris-1.dmm
@@ -60540,7 +60540,7 @@
 /obj/item/weapon/pickaxe{
 	pixel_x = 5
 	},
-/obj/item/weapon/shovel{
+/obj/item/weapon/pickaxe/shovel{
 	pixel_x = -5
 	},
 /obj/structure/table/rack{

--- a/maps/northern_star/polaris-5.dmm
+++ b/maps/northern_star/polaris-5.dmm
@@ -15701,7 +15701,7 @@
 /obj/item/weapon/pickaxe,
 /obj/item/weapon/tool/wrench,
 /obj/item/weapon/tool/crowbar,
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/storage)
@@ -15710,7 +15710,7 @@
 /obj/item/weapon/pickaxe,
 /obj/item/weapon/tool/wrench,
 /obj/item/weapon/tool/crowbar,
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/storage)
 "EE" = (

--- a/maps/southern_cross/southern_cross-1.dmm
+++ b/maps/southern_cross/southern_cross-1.dmm
@@ -16924,7 +16924,7 @@
 /obj/item/weapon/pickaxe{
 	pixel_x = 5
 	},
-/obj/item/weapon/shovel{
+/obj/item/weapon/pickaxe/shovel{
 	pixel_x = -5
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{

--- a/maps/southern_cross/southern_cross-3.dmm
+++ b/maps/southern_cross/southern_cross-3.dmm
@@ -751,7 +751,7 @@
 /obj/item/weapon/pickaxe,
 /obj/item/weapon/tool/wrench,
 /obj/item/weapon/tool/crowbar,
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
 	},
@@ -762,7 +762,7 @@
 /obj/item/weapon/pickaxe,
 /obj/item/weapon/tool/wrench,
 /obj/item/weapon/tool/crowbar,
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
 	},

--- a/maps/submaps/surface_submaps/mountains/backup/cultmine.dmm
+++ b/maps/submaps/surface_submaps/mountains/backup/cultmine.dmm
@@ -893,7 +893,7 @@
 /turf/simulated/floor/cult,
 /area/submap/cave/cultmine)
 "dn" = (
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /turf/simulated/mineral/floor/ignore_mapgen,
 /area/submap/cave/cultmine)
 "do" = (

--- a/maps/submaps/surface_submaps/mountains/cultmine.dmm
+++ b/maps/submaps/surface_submaps/mountains/cultmine.dmm
@@ -893,7 +893,7 @@
 /turf/simulated/floor/cult,
 /area/submap/cave/cultmine)
 "dn" = (
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /turf/simulated/mineral/floor/ignore_mapgen,
 /area/submap/cave/cultmine)
 "do" = (

--- a/maps/submaps/surface_submaps/mountains/digsite.dmm
+++ b/maps/submaps/surface_submaps/mountains/digsite.dmm
@@ -132,7 +132,7 @@
 /area/submap/cave/digsite)
 "E" = (
 /obj/structure/table/rack,
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /turf/simulated/mineral/floor/ignore_mapgen,
 /area/submap/cave/digsite)
 "F" = (

--- a/maps/submaps/surface_submaps/mountains/quarantineshuttle.dmm
+++ b/maps/submaps/surface_submaps/mountains/quarantineshuttle.dmm
@@ -466,7 +466,7 @@
 /area/submap/cave/qShuttle)
 "bk" = (
 /obj/structure/table/rack,
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /turf/simulated/shuttle/floor{
 	 icon_state = "floor_yellow"
 	},

--- a/maps/submaps/surface_submaps/plains/construction1.dmm
+++ b/maps/submaps/surface_submaps/plains/construction1.dmm
@@ -100,7 +100,7 @@
 /turf/simulated/floor/tiled/external,
 /area/submap/construction1)
 "A" = (
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /turf/simulated/floor/plating/external,
 /area/submap/construction1)
 "B" = (

--- a/maps/submaps/surface_submaps/wilderness/Manor1.dmm
+++ b/maps/submaps/surface_submaps/wilderness/Manor1.dmm
@@ -395,7 +395,7 @@
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bC" = (
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bD" = (

--- a/maps/submaps/surface_submaps/wilderness/Rocky2.dmm
+++ b/maps/submaps/surface_submaps/wilderness/Rocky2.dmm
@@ -44,7 +44,7 @@
 /turf/template_noop,
 /area/submap/Rocky2)
 "A" = (
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /turf/template_noop,
 /area/submap/Rocky2)
 

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -2134,7 +2134,7 @@
 /obj/item/weapon/pickaxe,
 /obj/item/weapon/tool/wrench,
 /obj/item/weapon/tool/crowbar,
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
 /obj/effect/floor_decal/borderfloor/corner2,
@@ -2146,7 +2146,7 @@
 /obj/item/weapon/pickaxe,
 /obj/item/weapon/tool/wrench,
 /obj/item/weapon/tool/crowbar,
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
@@ -14512,8 +14512,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/weapon/shovel,
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /obj/item/weapon/soap,
 /obj/item/device/radio/intercom{
 	dir = 1;

--- a/maps/virgo/virgo-1.dmm
+++ b/maps/virgo/virgo-1.dmm
@@ -60493,7 +60493,7 @@
 /obj/item/weapon/pickaxe{
 	pixel_x = 5
 	},
-/obj/item/weapon/shovel{
+/obj/item/weapon/pickaxe/shovel{
 	pixel_x = -5
 	},
 /obj/structure/table/rack{

--- a/maps/virgo/virgo-5.dmm
+++ b/maps/virgo/virgo-5.dmm
@@ -15091,7 +15091,7 @@
 /obj/item/weapon/pickaxe/hammer,
 /obj/item/weapon/wrench,
 /obj/item/weapon/crowbar,
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/storage)
 "Dg" = (
@@ -15099,7 +15099,7 @@
 /obj/item/weapon/pickaxe,
 /obj/item/weapon/wrench,
 /obj/item/weapon/crowbar,
-/obj/item/weapon/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/storage)


### PR DESCRIPTION
## About The Pull Request
Shovels are now a pickaxe subtype. They are bad at mining. Please do not use them to mine.
Tools that mine faster also dig faster. It's still really only the advanced drill, the borg's jackhammer, the diamond drill, and the shovel.
## Why It's Good For The Game
Hard-coded digging speeds were dumb, anyways.
## Changelog
:cl:
add: Shovels are now capable of hitting rockwalls for mining! This does not work very well.
add: Some tools dig sand up faster than others.
code: Shovels are now pickaxe subtypes.
/:cl: