### PR TITLE
Miners With Magboots + Toggle Magboots

### DIFF
--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -93,6 +93,7 @@
 
 	if(boots)
 		if (H.equip_to_slot_if_possible(boots, slot_shoes))
+			to_chat(M, "Your suit's magboots deploy with a click.")
 			boots.canremove = 0
 
 	if(helmet)
@@ -183,12 +184,17 @@
 			to_chat(H, "<span class='info'>You deploy your suit helmet, sealing you off from the world.</span>")
 			playsound(src, 'modular_citadel/sound/items/helmetdeploy.ogg', 40, 1)
 	helmet.update_light(H)
-// below is code for the action button method. im dumb. but it works? if you figure out a way to make it better tell me
-/obj/item/clothing/suit/space/void/attack_self(mob/user)
+
+/obj/item/clothing/suit/space/void/verb/toggle_magboots()
+
+	set name = "Toggle Magboots"
+	set category = "Object"
+	set src in usr
+
 	if(!istype(src.loc,/mob/living)) return
 
-	if(!helmet)
-		to_chat(usr, "There is no helmet installed.")
+	if(!boots)
+		to_chat(usr, "There are no magboots installed.")
 		return
 
 	var/mob/living/carbon/human/H = usr
@@ -200,22 +206,21 @@
 	if(H.wear_suit != src)
 		return
 
-	if(H.head == helmet)
-		to_chat(H, "<span class='notice'>You retract your suit helmet.</span>")
-		playsound(src, 'modular_citadel/sound/items/helmetdeploy.ogg', 40, 1)
-		helmet.canremove = 1
-		H.drop_from_inventory(helmet)
-		helmet.forceMove(src)
+	if(H.shoes == boots)
+		to_chat(H, "<span class='notice'>You retract your magboots.</span>")
+		boots.canremove = 1
+		H.drop_from_inventory(boots)
+		boots.forceMove(src)
 	else
-		if(H.head)
-			to_chat(H, "<span class='danger'>You cannot deploy your helmet while wearing \the [H.head].</span>")
-			return
-		if(H.equip_to_slot_if_possible(helmet, slot_head))
-			helmet.pickup(H)
-			helmet.canremove = 0
-			to_chat(H, "<span class='info'>You deploy your suit helmet, sealing you off from the world.</span>")
-			playsound(src, 'modular_citadel/sound/items/helmetdeploy.ogg', 40, 1)
-	helmet.update_light(H)
+		if(H.equip_to_slot_if_possible(boots, slot_shoes))
+			boots.pickup(H)
+			boots.canremove = 0
+			to_chat(H, "<span class='info'>You deploy your magboots.</span>")
+
+// below is code for the action button method. im dumb. but it works? if you figure out a way to make it better tell me // hey peesh i made it better -hatter
+/obj/item/clothing/suit/space/void/attack_self(mob/user)
+	toggle_helmet()
+	return
 
 /obj/item/clothing/suit/space/void/verb/eject_tank()
 
@@ -223,7 +228,8 @@
 	set category = "Object"
 	set src in usr
 
-	if(!istype(src.loc,/mob/living)) return
+	if(!istype(src.loc,/mob/living))
+		return
 
 	if(!tank && !cooler)
 		to_chat(usr, "There is no tank or cooling unit inserted.")

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -186,12 +186,12 @@
 	helmet.update_light(H)
 
 /obj/item/clothing/suit/space/void/verb/toggle_magboots()
-
 	set name = "Toggle Magboots"
 	set category = "Object"
 	set src in usr
 
-	if(!istype(src.loc,/mob/living)) return
+	if(!istype(src.loc,/mob/living))
+		return
 
 	if(!boots)
 		to_chat(usr, "There are no magboots installed.")

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -2208,6 +2208,7 @@
 /area/tether/surfacebase/mining_main/eva)
 "aea" = (
 /obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
 /obj/item/clothing/suit/space/void/mining,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space/void/mining,
@@ -2218,6 +2219,7 @@
 /area/tether/surfacebase/mining_main/eva)
 "aeb" = (
 /obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
 /obj/item/clothing/suit/space/void/mining,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space/void/mining,


### PR DESCRIPTION
## About The Pull Request
The miners now get magnetic boots. This should help if they're pulled into an expedition or if their mining locale of choice suddenly loses all of the atmosphere.

Toggling magboots is good because sometimes you just want to be able to pull a knife out of your boots, even in a voidsuit. Somehow.
## Why It's Good For The Game
Boot knife accessibility, magboots for magboot equality.
## Changelog
:cl:
add: Miners now get magboots. They're not required, but you might as well have them anyway.
tweak: There is now a toggle magboots verb for voidsuits - right-click on your voidsuit or access the objects tab to use it.
/:cl: