### PR TITLE
[READY] Ore Scanner Range Toggle (Altclick) + Ore Boxes No Longer Explode

### DIFF
--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -56,7 +56,7 @@
 
 
 // When destroyed by explosions, properly handle contents.
-obj/structure/ex_act(severity)
+/obj/structure/transit_tube_pod/ex_act(severity)
 	switch(severity)
 		if(1.0)
 			for(var/atom/movable/AM in contents)

--- a/code/modules/mining/drilling/scanner.dm
+++ b/code/modules/mining/drilling/scanner.dm
@@ -1,11 +1,29 @@
 /obj/item/weapon/mining_scanner
 	name = "ore detector"
-	desc = "A complex device used to locate ore deep underground in a 3 by 3 area around you."
+	desc = "A complex device used to locate ore deep underground around you."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "forensic0-old" //GET A BETTER SPRITE.
 	item_state = "electronic"
 	origin_tech = list(TECH_MAGNET = 1, TECH_ENGINEERING = 1)
 	matter = list(DEFAULT_WALL_MATERIAL = 150)
+	var/scanrange = 2
+	var/maxscanrange = 2
+
+/obj/item/weapon/mining_scanner/examine()
+	. = ..()
+	var/rangesteps = scanrange - 1
+	to_chat(usr, "Current scan range is [rangesteps] step(s) from user's current location, including current location. Alt-Click to change scan range.")
+
+/obj/item/weapon/mining_scanner/AltClick(mob/user)
+	var/newscan = text2num(input(usr,"What would you like to set the scan range to? Maximum of [maxscanrange].","New Scan Range",maxscanrange))
+	newscan = round(newscan,1)
+	if(newscan >= maxscanrange)
+		newscan = maxscanrange
+	if(newscan < 0)
+		newscan = 0
+	scanrange = newscan
+	to_chat(usr, "New scan range set to [scanrange] step(s) around user, including current location.")
+	. = ..()
 
 /obj/item/weapon/mining_scanner/attack_self(mob/user)
 	to_chat(user,"You begin sweeping \the [src] about, scanning for metal deposits.")
@@ -21,7 +39,7 @@
 		"exotic matter" = 0
 		)
 
-	for(var/turf/simulated/T in range(2, get_turf(user)))
+	for(var/turf/simulated/T in range(scanrange, get_turf(user)))
 
 		if(!T.has_resources)
 			continue
@@ -51,11 +69,13 @@
 
 /obj/item/weapon/mining_scanner/advanced
 	name = "advanced ore detector"
-	desc = "A compact, complex device used to quickly locate ore deep underground in a 5 by 5 area around you."
+	desc = "A compact, complex device used to quickly locate ore deep underground around you."
 	icon_state = "mining-scanner" //thank you eris spriters
 	w_class = ITEMSIZE_SMALL
 	origin_tech = list(TECH_MAGNET = 4, TECH_ENGINEERING = 4)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000)
+	scanrange = 5
+	maxscanrange = 5
 
 /obj/item/weapon/mining_scanner/advanced/attack_self(mob/user)
 	to_chat(user,"You sweep \the [src] about, quickly pinging for ore deposits.")
@@ -77,7 +97,7 @@
 		"hydrogen" = 0
 			)
 
-	for(var/turf/simulated/T in range(5, get_turf(user)))
+	for(var/turf/simulated/T in range((scanrange), get_turf(user)))
 
 		if(!T.has_resources)
 			continue

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -107,11 +107,3 @@
 			if(!contents.len)
 				to_chat(usr,"<span class='notice'>You empty the ore box.</span>")
 				return
-
-/obj/structure/ore_box/ex_act(severity)
-	if(severity == 1.0 || (severity < 3.0 && prob(50)))
-		for (var/obj/item/weapon/ore/O in contents)
-			O.loc = src.loc
-			O.ex_act(severity++)
-		qdel(src)
-		return

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -10,6 +10,9 @@
 	var/last_update = 0
 	var/list/stored_ore = list()
 
+/obj/structure/ore_box/ex_act(severity)
+	return //if an overstuffed ore box explodes it crashes the server, thank you GC
+
 /obj/structure/ore_box/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/ore))
 		user.remove_from_mob(W)


### PR DESCRIPTION
## About The Pull Request
Ore scanners can now have their range fiddled with when alt-clicked. Ore boxes no longer get destroyed on explosions.
## Why It's Good For The Game
Ore scanners - More precise usage of scanners, primarily the advanced scanner variant. Only available for handhelds, todo is adding the modifying functionality to the hardsuit module itself.
Ore boxes - I crashed the server once by blowing up an ore box that was stuffed with ores. This is a stopgap measure. (Why doesn't it just have variables or datums or whatever for ores? I don't know, but I hate it. ORMs when, kevinz?)
## Changelog
:cl:
add: Ore scanners can now have their range switched around with an alt-click!
tweak: Ore boxes no longer explode and drop all their contents on ex_act(), meaning that they probably shouldn't crash servers when they get broken. I hope.
/:cl: