### PR TITLE
Hardy No Longer Suffers With Negative Slowdown

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -121,7 +121,8 @@
 		var/obj/item/pulled = pulling
 		item_tally += max(pulled.slowdown, 0)
 
-	item_tally *= species.item_slowdown_mod
+	if(item_tally >= 0)
+		item_tally *= species.item_slowdown_mod
 
 	tally += item_tally
 


### PR DESCRIPTION
## About The Pull Request
Adds a single line and a tab that makes slowdown only be affected by species' item slowdown modifier when it's positive.
## Why It's Good For The Game
Fixes an issue. Probably introduces powergaming issues. Who knows.
## Changelog
:cl:
tweak: Wearing equipment with negative slowdown values (i.e. alien enhancement vests) will no longer be useless if you've taken an equipment-slowdown-affecting trait such as Major Hardy.
/:cl: