### PR TITLE
why the fuck do fuzzycuffs act as standards

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -141,7 +141,7 @@ var/last_chew = 0
 	name = "fuzzy cuffs"
 	icon_state = "fuzzycuff"
 	desc = "Use this to keep... 'prisoners' in line."
-	breakkouttime = 30 //3sec breakout time. why did this not exist before. bruh moment.
+	breakouttime = 30 //3sec breakout time. why did this not exist before. bruh moment.
 
 /obj/item/weapon/handcuffs/cable
 	name = "cable restraints"

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -141,6 +141,7 @@ var/last_chew = 0
 	name = "fuzzy cuffs"
 	icon_state = "fuzzycuff"
 	desc = "Use this to keep... 'prisoners' in line."
+	breakkouttime = 30 //3sec breakout time. why did this not exist before. bruh moment.
 
 /obj/item/weapon/handcuffs/cable
 	name = "cable restraints"

--- a/code/game/objects/items/weapons/handcuffs_vr.dm
+++ b/code/game/objects/items/weapons/handcuffs_vr.dm
@@ -3,3 +3,4 @@
 	desc = "Use this to keep... 'prisoners' in line."
 	icon = 'icons/obj/items_vr.dmi'
 	icon_state = "fuzzylegcuff"
+	breakouttime = 30 //3sec


### PR DESCRIPTION
## About The Pull Request
fuzzycuffs are now 3 seconds to break out of instead of 120
fuzzy legcuffs are now 3 seconds to break out of instead of 30 or whatever
## Why It's Good For The Game
>>>kinkshit taking as long to break out of as standard
## Changelog
:cl:
tweak: Fuzzy handcuffs, like the ones you kinky bastards use, are now 3 seconds to break out of instead of 120. Who thought this through? Clearly, someone didn't.
tweak: Fuzzy legcuffs take 3 seconds to break out of instead of 30. Yikes, bro.
/:cl:
