### PR TITLE
Submap Generation Respects Config

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -60,12 +60,10 @@
 	// This is kinda important. Set up details of what the hell things are made of.
 	populate_material_list()
 
-	// Loads all the pre-made submap templates.
-	load_map_templates()
-
 	if(config.generate_map)
 		if(using_map.perform_map_generation())
-			using_map.refresh_mining_turfs()
+			using_map.refresh_mining_turfs() // Generates mining turfs.
+			load_map_templates() // Loads all the pre-made submap templates.
 
 	// Create frame types.
 	populate_frame_types()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -61,9 +61,9 @@
 	populate_material_list()
 
 	if(config.generate_map)
+		load_map_templates() // Loads all the pre-made submap templates.
 		if(using_map.perform_map_generation())
 			using_map.refresh_mining_turfs() // Generates mining turfs.
-			load_map_templates() // Loads all the pre-made submap templates.
 
 	// Create frame types.
 	populate_frame_types()


### PR DESCRIPTION
## About The Pull Request
Makes submap generation/map template placement respect GENERATE_MAP in config.txt.
## Why It's Good For The Game
Faster initializations for faster debugging by aspiring coders.
## Changelog
:cl:
code: Disabling the GENERATE_MAP setting in config.txt now prevents submaps from generating. This prevents the use of shuttles, but also makes the whole map initialize really, really fast.
/:cl: