### PR TITLE
SpaceTalk Expansion Pack 1

### DIFF
--- a/code/modules/busy_space/air_traffic.dm
+++ b/code/modules/busy_space/air_traffic.dm
@@ -3,8 +3,8 @@
 var/datum/lore/atc_controller/atc = new/datum/lore/atc_controller
 
 /datum/lore/atc_controller
-	var/delay_max = 25 MINUTES			//How long between ATC traffic, max.  Default is 25 mins.
-	var/delay_min = 35 MINUTES			//How long between ATC traffic, min.  Default is 40 mins. Slight reduction for +/- 5 consistency.
+	var/delay_min = 25 MINUTES			//How long between ATC traffic, min.  Default is 40 mins. Slight reduction for +/- 5 consistency.
+	var/delay_max = 35 MINUTES			//How long between ATC traffic, max.  Default is 25 mins.
 	var/backoff_delay = 5 MINUTES		//How long to back off if we can't talk and want to.  Default is 5 mins.
 	var/next_message					//When the next message should happen in world.time
 	var/force_chatter_type				//Force a specific type of messages
@@ -30,7 +30,7 @@ var/datum/lore/atc_controller/atc = new/datum/lore/atc_controller
 
 /datum/lore/atc_controller/proc/msg(var/message,var/sender)
 	ASSERT(message)
-	global_announcer.autosay("[message]", sender ? sender : "[using_map.station_short] Space Control")
+	global_announcer.autosay("[message]", sender ? sender : "[using_map.starsys_name] Flight Control")
 
 /datum/lore/atc_controller/proc/reroute_traffic(var/yes = 1)
 	if(yes)
@@ -61,18 +61,21 @@ var/datum/lore/atc_controller/atc = new/datum/lore/atc_controller
 	var/mission = source.ship_prefixes[prefix]		//The value of the prefix is the mission type that prefix does
 	var/shipname = pick(source.ship_names)			//Pick a random ship name
 	var/destname = pick(source.destination_names)		//destination is where?
-	var/scan_exempted = source.scan_exempt			//am I exempted from routine scans and certain other events?
+	var/law_abiding = source.lawful				//do we fully observe system law (or are we otherwise favored by the system owners)?
+	var/system_defense = source.sysdef			//are we system law?
 
 	var/fakeowner = fakeiff.short_name
-	var/fakeprefix = pick(fakeiff.ship_prefixes)			//Pick a random prefix
-	var/fakeshipname = pick(fakeiff.ship_names)			//Pick a random ship name
+	var/fakeprefix = pick(fakeiff.ship_prefixes)		//Pick a random prefix
+	var/fakeshipname = pick(fakeiff.ship_names)		//Pick a random ship name
+	var/law_abiding2 = fakeiff.lawful
+	var/system_defense2 = fakeiff.sysdef
 
 	var/combined_name = "[owner][prefix] [shipname]"
 	var/combined_fake_name = "[fakeowner][fakeprefix] [fakeshipname]"
-	var/alt_atc_names = list("[using_map.station_short] TraCon","[using_map.station_short] Control","[using_map.station_short] STC","[using_map.station_short] StarCon")
-	var/wrong_atc_names = list("Sol Command","New Reykjavik StarCon", "[using_map.dock_name]")
+	
+	var/alt_atc_names = list("[using_map.starsys_name] TraCon","[using_map.starsys_name] System Control","[using_map.starsys_name] Star Control","[using_map.starsys_name] SysCon","[using_map.starsys_name] Tower","[using_map.starsys_name] Flight Control","[using_map.starsys_name] STC","[using_map.starsys_name] StarCon")
 	var/mission_noun = pick(source.flight_types)		//pull from a list of owner-specific flight ops, to allow an extra dash of flavor
-	var/request_verb = list("requesting","calling for","asking for")
+//	var/request_verb = list("requesting","calling for","asking for")	//defunct; always 'requesting' now - more formal
 
 	//First response is 'yes', second is 'no'
 	var/requests = list("[using_map.station_short] transit clearance" = list("permission for transit granted", "permission for transit denied, contact regional on 953.5"),
@@ -81,25 +84,23 @@ var/datum/lore/atc_controller/atc = new/datum/lore/atc_controller
 						"current solar weather info" = list("sending you the relevant information via tightbeam", "cannot fulfill your request at the moment"),
 						"nearby traffic info" = list("sending you current traffic info", "no available info in your area"),
 						"remote telemetry data" = list("sending telemetry now", "no uplink from your ship, recheck your uplink and ask again"),
-						"refueling information" = list("sending refueling information now", "no fuel for your ship class in this sector"),
+						"refueling information" = list("sending refueling information now", "depots currently experiencing fuel shortages, advise you move on"),
 						"a current system time sync" = list("sending time sync ping to you now", "your ship isn't compatible with our time sync, set time manually"),
-						"current system starcharts" = list("transmitting current starcharts", "your request is queued, overloaded right now"),
-						//STC can't possibly oversee every single jump into and out of the system, nor should they try to
-/*						"permission to engage FTL" = list("permission to engage FTL granted, good day", "permission denied, wait for current traffic to pass"),
-						"permission to transit system" = list("permission to transit granted, good day", "permission denied, wait for current traffic to pass"),
-						"permission to depart system" = list("permission to depart granted, good day", "permission denied, wait for current traffic to pass"),
-						"permission to enter system" = list("good day, permission to enter granted", "permission denied, wait for current traffic to pass"),*/
+						"current system starcharts" = list("transmitting current starcharts", "your request is queued, overloaded right now")
 						)
 
 	//Random chance things for variety
 	var/chatter_type = "normal"
 	if(force_chatter_type)
 		chatter_type = force_chatter_type
-	else if(scan_exempted) //I have to offload this from the switch and do it here, otherwise BYOND throws a shitfit because raisins
-		chatter_type = pick(5;"emerg",25;"traveladvisory",30;"dockingrequestgeneric",30;"dockingrequestsupply",30;"dockingrequestrepair",30;"dockingrequestmedical",30;"dockingrequestsecurity",30;"undockingrequest","normal")
-		//a few groups won't be scanned, won't trigger wrong-frequency messages, can be faked, won't report unusual activity, won't receive course warnings, and won't be denied docks or undocks ("hey SDF?" "yeah?" "we impounded you for security violations" "what the fuck steve")
+	else if(law_abiding && !system_defense) //I have to offload this from the chatter_type switch below and do it here, otherwise BYOND throws a shitfit for no discernable reason
+		chatter_type = pick(5;"emerg",25;"policescan",25;"traveladvisory",30;"dockingrequestgeneric",30;"dockingrequestsupply",30;"dockingrequestrepair",30;"dockingrequestmedical",30;"dockingrequestsecurity",30;"undockingrequest","normal",30;"undockingdenied",30;"undockingdelayed")
+	else if(system_defense && !law_abiding2 && !system_defense2) //no SDF scan/flee events with law-abiders or other SDF (in the rare event it manages to roll double SDF)
+		chatter_type = pick(30;"policeshipscan",10;"policeshipflee",30;"dockingrequestgeneric",30;"dockingrequestsupply",30;"dockingrequestrepair",30;"dockingrequestmedical",30;"dockingrequestsecurity",30;"sdfbeginpatrol","normal")
+	else if(system_defense)
+		chatter_type = pick(30;"dockingrequestgeneric",30;"dockingrequestsupply",30;"dockingrequestrepair",30;"dockingrequestmedical",30;"dockingrequestsecurity",30;"undockingrequest",30;"sdfbeginpatrol","normal")
 	else
-		chatter_type = pick(5;"emerg",5;"wrong_freq",25;"policescan",25;"policeflee",10;"strangeactivity",25;"traveladvisory",30;"pathwarning",30;"dockingrequestgeneric",30;"dockingrequestdenied",30;"dockingrequestsupply",30;"dockingrequestrepair",30;"dockingrequestmedical",30;"dockingrequestsecurity",30;"undockingrequest",30;"undockingdenied","normal") //Be nice to have wrong_lang...
+		chatter_type = pick(5;"emerg",25;"policescan",10;"policeflee",10;"strangeactivity",25;"traveladvisory",30;"pathwarning",30;"dockingrequestgeneric",30;"dockingrequestdenied",30;"dockingrequestsupply",30;"dockingrequestrepair",30;"dockingrequestmedical",30;"dockingrequestsecurity",30;"undockingrequest",30;"undockingdenied",30;"undockingdelayed","normal")
 
 	var/yes = prob(90) //Chance for them to say yes vs no
 
@@ -107,142 +108,174 @@ var/datum/lore/atc_controller/atc = new/datum/lore/atc_controller
 	var/callname = pick(alt_atc_names)
 	var/response = requests[request][yes ? 1 : 2] //1 is yes, 2 is no
 
-	//	var/full_request
-	//	var/full_response
-	//	var/full_closure
-
-	//	sometimes you just gotta print something somewhere accessible
-	//	msg("[owner] [prefix] [shipname], [destdebug], [mission] [destname]","Debug Print")
-
 	// what you're about to witness is what feels like an extremely kludgy rework of the system, but it's more 'flexible' and allows events that aren't just ship-stc-ship
 	// something more elegant could probably be done, but it won't be done by somebody as half-competent as me
 	switch(chatter_type)
-		if("wrong_freq")
-			callname = pick(wrong_atc_names)
-			msg("[callname], this is [combined_name] on [mission] [pick(mission_noun)] to [destname], [pick(request_verb)] [request].","[prefix] [shipname]")
-			sleep(5 SECONDS)
-			msg("[combined_name], this is [using_map.station_short] Space Control, wrong frequency. Switch to [rand(700,999)].[rand(1,9)].")
-			sleep(5 SECONDS)
-			msg("[using_map.station_short] Space Control, understood, apologies.","[prefix] [shipname]")
 		if("emerg")
-			var/problem = pick("hull breaches on multiple decks","unknown life forms on board","a drive about to go critical","asteroids impacting the hull","a total loss of engine power","hostile ships closing fast","unidentified boarders")
-			msg("This is [combined_name] declaring an emergency! We have [problem]!","[prefix] [shipname]")
+			var/problem = pick("We have hull breaches on multiple decks","We have unknown hostile life forms on board","Our primary drive is failing","We have asteroids impacting the hull","We're experiencing a total loss of engine power","We have hostile ships closing fast","There's smoke in the cockpit","We have unidentified boarders","Our life support has failed")
+			msg("Mayday, mayday, mayday! This is [combined_name] declaring an emergency! [problem]!","[prefix] [shipname]")
 			sleep(5 SECONDS)
-			msg("[combined_name], this is [using_map.station_short] Space Control, copy. Switch to emergency responder channel [rand(700,999)].[rand(1,9)].")
+			msg("[combined_name], this is [using_map.starsys_name] Flight Control, copy. Switch to emergency responder channel [rand(700,999)].[rand(1,9)].")
 			sleep(5 SECONDS)
-			msg("Understood [using_map.station_short] Space Control, switching now.","[prefix] [shipname]")
+			msg("Understood [using_map.starsys_name] Flight Control, switching now.","[prefix] [shipname]")
 		if("policescan")
 			var/confirm = pick("Understood","Roger that","Affirmative")
 			var/complain = pick("I hope this doesn't take too long.","Can we hurry this up?","Make it quick.","This better not take too long.")
 			var/completed = pick("You're free to proceed.","Everything looks fine, carry on.","Apologies for the delay, you're clear.","Switch to [rand(700,999)].[rand(1,9)] and await further instruction.")
-			msg("[combined_name], this is [using_map.station_short] Space Control, your [pick("ship","vessel","starship")] has been flagged for routine inspection. Hold position and prepare to be scanned.")
+			msg("[combined_name], this is [using_map.starsys_name] Flight Control, your [pick("ship","vessel","starship")] has been flagged for routine inspection. Hold position and prepare to be scanned.")
 			sleep(5 SECONDS)
-			msg("[confirm] [using_map.station_short] Space Control, holding position.","[prefix] [shipname]")
+			msg("[confirm] [using_map.starsys_name] Flight Control, holding position.","[prefix] [shipname]")
 			sleep(5 SECONDS)
 			msg("Your compliance is appreciated, [combined_name]. Scan commencing.")
 			sleep(10 SECONDS)
 			msg(complain,"[prefix] [shipname]")
 			sleep(15 SECONDS)
-			msg("[combined_name], this is [using_map.station_short] Space Control. Scan complete. [completed]")
+			msg("[combined_name], this is [using_map.starsys_name] Flight Control. Scan complete. [completed]")
+		if("policeshipscan")
+			var/confirm = pick("Understood","Roger that","Affirmative")
+			var/complain = pick("I hope this doesn't take too long.","Can we hurry this up?","Make it quick.","This better not take too long.")
+			var/completed = pick("You're free to proceed.","Everything looks fine, carry on.","Apologies for the delay, you're clear.","Switch to [rand(700,999)].[rand(1,9)] and await further instruction.")
+			msg("[combined_fake_name], this is [combined_name], your [pick("ship","vessel","starship")] has been flagged for routine inspection. Hold position and prepare to be scanned.","[prefix] [shipname]")
+			sleep(5 SECONDS)
+			msg("[confirm] [combined_name], holding position.","[fakeprefix] [fakeshipname]")
+			sleep(5 SECONDS)
+			msg("Your compliance is appreciated, [combined_name]. Scan commencing.","[prefix] [shipname]")
+			sleep(10 SECONDS)
+			msg(complain,"[fakeprefix] [fakeshipname]")
+			sleep(15 SECONDS)
+			msg("[combined_fake_name], this is [combined_name]. Scan complete. [completed]","[prefix] [shipname]")
+		if("policeshipflee")
+			var/uhoh = pick("No can do chief, we got places to be.","Sorry but we've got places to be.","Not happening.","Ah fuck, who ratted us out this time?!","You'll never take me alive!","Hey, I have a cloaking device! You can't see me!","I'm going to need to ask for a refund on that stealth drive...","I'm afraid I can't do that, [shipname].")
+			msg("[combined_fake_name], this is [combined_name], your [pick("ship","vessel","starship")] has been flagged for routine inspection. Hold position and prepare to be scanned.","[prefix] [shipname]")
+			sleep(5 SECONDS)
+			msg("[uhoh]","[fakeprefix] [fakeshipname]")
+			sleep(5 SECONDS)
+			msg("[using_map.starsys_name] Defense Control, this is [combined_name], we have a situation here, Code Red. Requesting immediate reinforcement.","[prefix] [shipname]")
+			sleep(5 SECONDS)
+			msg("Defense Control copies, [combined_name], reinforcements en route. Switch further communications to encrypted band [rand(1000,1250)].[rand(1,9)].","[using_map.starsys_name] Defense Control")
 		if("policeflee")
 			var/uhoh = pick("No can do chief, we got places to be.","Sorry but we've got places to be.","Not happening.","Ah fuck, who ratted us out this time?!","You'll never take me alive!","Hey, I have a cloaking device! You can't see me!","I'm going to need to ask for a refund on that stealth drive...","I'm afraid I can't do that, Control.")
-			msg("[combined_fake_name], this is [using_map.station_short] Space Control, your [pick("ship","vessel","starship")] has been flagged for routine inspection. Hold position and prepare to be scanned.")
+			msg("[combined_fake_name], this is [using_map.starsys_name] Flight Control, your [pick("ship","vessel","starship")] has been flagged for routine inspection. Hold position and prepare to be scanned.")
 			sleep(5 SECONDS)
 			msg("[uhoh]","[prefix] [shipname]")
 			sleep(5 SECONDS)
-			msg("This is [using_map.station_short] Space Control to all local SDF assets, the [combined_fake_name] is broadcasting false IFF codes. Registry updated to [combined_name]: vector to interdict and detain. Control out.")
+			msg("This is [using_map.starsys_name] Defense Control to all local assets, the [combined_fake_name] is broadcasting false IFF codes. Registry updated to [combined_name]: vector to interdict and detain. Control out.","[using_map.starsys_name] Defense Control")
 		if("strangeactivity")
 			var/concern = pick("It looks like they're under attack.","I think they're being boarded.","We're not reading any lifesigns aboard.","There's a Vox Marauder right on top of them!","They're maneuvering erratically.","We're picking up some strange radiation patterns.","We can see multiple hull breaches from here.","They're leaking fuel everywhere.","Their drives are misfiring.")
 			var/confirm = pick("Roger that","Affirmative","Understood","Thanks for the heads up")
 			msg("[callname], this is [combined_name]. We're seeing some strange activity over on [combined_fake_name]. [concern]","[prefix] [shipname]")
 			sleep(5 SECONDS)
 			msg("[confirm], [combined_name]. Dispatching SysDef assets to investigate.")
+			sleep(5 SECONDS)
+			msg("SDC confirms investigate order, diverting assets.","[using_map.starsys_name] Defense Control")
 		if("traveladvisory")
-			var/flightwarning = pick("Solar flare activity is spiking and expected to cause issues along main flight lanes [rand(1,33)], [rand(34,67)], and [rand(68,100)]","Pirate activity is on the rise, stay close to SysDef vessels","Vox Marauder activity is higher than usual, report any unusual activity to the nearest System Defense Boat","Quarantine fleet is passing through the system along route [rand(1,100)], please observe minimum safe distance","A prison fleet is passing through the system along route [rand(1,100)], please observe minimum safe distance","Traffic volume is higher than normal, expect processing delays","Anomalous bluespace activity detected, exercise caution","Smugglers have been particularly active lately, expect increased security scans","Depots are currently experiencing a fuel shortage, expect delays and higher rates","Asteroid mining has displaced debris dangerously close to main flight lanes on route [rand(1,100)], watch for potential impactors","[pick("Pirate","Vox Marauder")] and SysDef forces are currently engaged in skirmishes throughout the system, please steer clear of any active combat zones","A fuel tanker has collided with a cargo liner near route [rand(1,100)], watch for loose containers and dispersed fuel","A [pick("fuel tanker","cargo liner","passenger liner")] on route [rand(1,100)] has experienced total engine failure. Emergency response teams are en route, please observe minimum safe distances and do not impede emergency service vessels","Transit routes have been recalculated to adjust for planetary drift. Please synch your astronav computers as soon as possible to avoid delays and difficulties","Bounty hunters are currently searching for a wanted fugitive","Mercenary contractors are currently conducting aggressive [pick("piracy","marauder")] suppression operations",10;"It's space carp breeding season. [pick("Stars","Gods","God","Goddess")] have mercy on you all, because the carp won't")
-			msg("This is [using_map.station_short] Space Control to all vessels in this system. Priority travel advisory follows.")
+			var/flightwarning = pick("Solar flare activity is spiking and expected to cause issues along main flight lanes [rand(1,33)], [rand(34,67)], and [rand(68,100)]","Pirate activity is on the rise, stay close to System Defense vessels","We're seeing a rise in illegal salvage operations, please report any unusual activity to the nearest SDF vessel","Vox Marauder activity is higher than usual, report any unusual activity to the nearest System Defense vessel","A quarantined [pick("fleet","convoy")] is passing through the system along route [rand(1,100)], please observe minimum safe distance","A prison [pick("fleet","convoy")] is passing through the system along route [rand(1,100)], please observe minimum safe distance","Traffic volume is higher than normal, expect processing delays","Anomalous bluespace activity detected, exercise caution","Smugglers have been particularly active lately, expect increased security scans","Depots are currently experiencing a fuel shortage, expect delays and higher rates","Asteroid mining has displaced debris dangerously close to main flight lanes on route [rand(1,100)], watch for potential impactors","[pick("Pirate","Vox Marauder")] and System Defense forces are currently engaged in skirmishes throughout the system, please steer clear of any active combat zones","A [pick("fuel tanker","cargo liner","passenger liner","freighter","transport ship")] has collided with a [pick("fuel tanker","cargo liner","passenger liner","freighter","transport ship")] near route [rand(1,100)], watch for debris and do not impede emergency service vessels","A [pick("fuel tanker","cargo liner","passenger liner","freighter","transport ship")] on route [rand(1,100)] has experienced total engine failure. Emergency response teams are en route, please observe minimum safe distances and do not impede emergency service vessels","Transit routes have been recalculated to adjust for planetary drift. Please synch your astronav computers as soon as possible to avoid delays and difficulties","[pick("Bounty hunters","System Defense officers")] are currently searching for a wanted fugitive, report any sightings of suspicious activity to your nearest System Defense agent","Mercenary contractors are currently conducting aggressive [pick("piracy","marauder")] suppression operations",10;"It's space carp breeding season. [pick("Stars","Gods","God","Goddess")] have mercy on you all, because the carp won't")
+			msg("This is [using_map.starsys_name] Flight Control to all vessels in the [using_map.starsys_name] system. Priority travel advisory follows.")
 			sleep(5 SECONDS)
 			msg("[flightwarning]. Control out.")
 		if("pathwarning")
-			var/navhazard = pick ("a pocket of intense radiation","a pocket of unstable gas","a debris field","a secure installation","an active combat zone","a quarantined ship","a quarantined installation","a quarantined sector")
-			var/confirm = pick("Understood","Roger that","Affirmative","Thanks for the heads up")
-			var/safetravels = pick("Fly safe out there","Good luck","Safe travels","See you next week","Godspeed","Stars guide you")
-			msg("[combined_name], this is [using_map.station_short] Space Control, your [pick("ship","vessel","starship")] is approaching [navhazard], please adjust heading to [rand(1,360)].")
+			var/navhazard = pick ("a pocket of intense radiation","a pocket of unstable gas","a debris field","a secure installation","an active combat zone","a quarantined ship","a quarantined installation","a quarantined sector","a live-fire SDF training exercise","an ongoing Search & Rescue operation")
+			var/confirm = pick("Understood","Roger that","Affirmative","Our bad","Thanks for the heads up")
+			var/safetravels = pick("Fly safe out there","Good luck","Safe travels","Godspeed","Stars guide you","Don't let it happen again")
+			msg("[combined_name], this is [using_map.starsys_name] Flight Control, your [pick("ship","vessel","starship")] is approaching [navhazard], observe minimum safe distance and adjust your heading appropriately.")
 			sleep(5 SECONDS)
-			msg("[confirm] [using_map.station_short] Space Control, adjusting course.","[prefix] [shipname]")
+			msg("[confirm] [using_map.starsys_name] Flight Control, adjusting course.","[prefix] [shipname]")
 			sleep(5 SECONDS)
 			msg("Your compliance is appreciated, [combined_name]. [safetravels].")
 		if("dockingrequestgeneric")
 			var/appreciation = pick("Much appreciated","Many thanks","Understood","Cheers")
-			var/dockingplan = pick("Starting final approach now.","Commencing docking procedures.","Autopilot engaged.")
-			msg("[callname], this is [combined_name], [pick("stopping by","passing through")] on our way to [destname], requesting permission to dock.","[prefix] [shipname]")
+			var/dockingplan = pick("Starting final approach now.","Commencing docking procedures.","Autopilot engaged.","Approach vector locked in.","In the pipe, five by five.")
+			msg("[callname], this is [combined_name], [pick("stopping by","passing through")] on our way to [destname], requesting permission to dock at [using_map.dock_name].","[prefix] [shipname]")
 			sleep(5 SECONDS)
-			msg("[combined_name], this is [using_map.station_short] Space Control. Permission granted, proceed to landing pad [rand(1,42)]. Follow the green lights on your way in.")
+			msg("[combined_name], this is [using_map.starsys_name] Flight Control. Permission granted, proceed to landing pad [rand(1,42)]. Follow the green lights on your way in.")
 			sleep(5 SECONDS)
-			msg("[appreciation], [using_map.station_short] Space Control. [dockingplan]","[prefix] [shipname]")
+			msg("[appreciation], [using_map.starsys_name] Flight Control. [dockingplan]","[prefix] [shipname]")
 		if("dockingrequestdenied")
 			var/reason = pick("we don't have any free landing pads right now","we don't have any free landing pads large enough for your vessel","we don't have the necessary facilities for your vessel type or class","we can't verify your credentials","you're too far away, please close to ten thousand meters and resubmit your request")
-			msg("[callname], this is [combined_name], [pick("stopping by","passing through")] on our way to [destname], requesting permission to dock.","[prefix] [shipname]")
+			msg("[callname], this is [combined_name], [pick("stopping by","passing through")] on our way to [destname], requesting permission to dock at [using_map.dock_name].","[prefix] [shipname]")
 			sleep(5 SECONDS)
-			msg("[combined_name], this is [using_map.station_short] Space Control. Request denied, [reason].")
+			msg("[combined_name], this is [using_map.starsys_name] Flight Control. Request denied, [reason].")
 			sleep(5 SECONDS)
-			msg("Understood, [using_map.station_short] Space Control.","[prefix] [shipname]")
+			msg("Understood, [using_map.starsys_name] Flight Control.","[prefix] [shipname]")
 		if("dockingrequestsupply")
-			var/intensifier = pick("very","pretty","critically","extremely","dangerously","desperately","kinda","a little","a bit","rather","terribly","dreadfully")
+			var/intensifier = pick("very","pretty","critically","extremely","dangerously","desperately","kinda","a little","a bit","rather","terribly","dreadfully","getting","running")
 			var/low_thing = pick("ammunition","oxygen","water","food","repair supplies","medical supplies","reaction mass","hydrogen fuel","phoron fuel","fuel",5;"tea",5;"coffee",5;"pizza",5;"beer",5;"snacks") //very low chance of a less serious shortage
-			var/appreciation = pick("Much appreciated","Many thanks","Understood","You're a lifesaver","We owe you one","I owe you one")
-			var/dockingplan = pick("Starting final approach now.","Commencing docking procedures.","Autopilot engaged.")
-			msg("[callname], this is [combined_name]. We're [intensifier] low on [low_thing] and need to resupply. Requesting permission to dock.","[prefix] [shipname]")
+			var/appreciation = pick("Much appreciated","Many thanks","Understood","You're a lifesaver","We owe you one","I owe you one","Perfect, thank you")
+			var/dockingplan = pick("Starting final approach now.","Commencing docking procedures.","Autopilot engaged.","Approach vector locked in.","In the pipe, five by five.")
+			msg("[callname], this is [combined_name]. We're [intensifier] low on [low_thing]. Requesting permission to dock at [using_map.dock_name] for resupply.","[prefix] [shipname]")
 			sleep(5 SECONDS)
-			msg("[combined_name], this is [using_map.station_short] Space Control. Permission granted, proceed to landing pad [rand(1,42)]. Follow the green lights on your way in.")
+			msg("[combined_name], this is [using_map.starsys_name] Flight Control. Permission granted, proceed to landing pad [rand(1,42)]. Follow the green lights on your way in.")
 			sleep(5 SECONDS)
-			msg("[appreciation], [using_map.station_short] Space Control. [dockingplan]","[prefix] [shipname]")
+			msg("[appreciation], [using_map.starsys_name] Flight Control. [dockingplan]","[prefix] [shipname]")
 		if("dockingrequestrepair")
-			var/damagestate = pick("We're showing some hull damage","We're suffering minor system malfunctions","We're having some technical issues","We're overdue maintenance","We have several minor space debris impacts","We've got some battle damage here","Our reactor output is fluctuating","We're hearing some weird noises from the engines","Our artificial gravity generator has failed","Our life support is failing","Our water recycling system has shorted out","Our systems are glitching out","We just got caught in a solar flare","We had a close call with an asteroid","We have a minor [pick("fuel","water","oxygen")] leak","We have depressurized compartments","We have a hull breach","Our shield generator is on the fritz","Our RCS is acting up")
-			var/appreciation = pick("Much appreciated","Many thanks","Understood","You're a lifesaver","We owe you one","I owe you one")
-			var/dockingplan = pick("Starting final approach now.","Commencing docking procedures.","Autopilot engaged.")
-			msg("[callname], this is [combined_name]. [damagestate]. Requesting permission to dock for repairs.","[prefix] [shipname]")
+			var/damagestate = pick("We're showing some hull damage","We're suffering minor system malfunctions","We're having some technical issues","We're overdue maintenance","We have several minor space debris impacts","We've got some battle damage here","Our reactor output is fluctuating","We're hearing some weird noises from the engines","Our artificial gravity generator has failed","Our life support is failing","Our water recycling system has shorted out","Our systems are glitching out","We just got caught in a solar flare","We had a close call with an asteroid","We have a minor [pick("fuel","water","oxygen")] leak","We have depressurized compartments","We have a hull breach","Our shield generator is on the fritz","Our RCS is acting up","One of our [pick("hydraulic","pneumatic")] systems has depressurized","Our repair bots are malfunctioning")
+			var/appreciation = pick("Much appreciated","Many thanks","Understood","You're a lifesaver","We owe you one","I owe you one","Perfect, thank you")
+			var/dockingplan = pick("Starting final approach now.","Commencing docking procedures.","Autopilot engaged.","Approach vector locked in.","In the pipe, five by five.")
+			msg("[callname], this is [combined_name]. [damagestate]. Requesting permission to dock at [using_map.dock_name] for repairs.","[prefix] [shipname]")
 			sleep(5 SECONDS)
-			msg("[combined_name], this is [using_map.station_short] Space Control. Permission granted, proceed to landing pad [rand(1,42)]. Follow the green lights on your way in. Repair crews are standing by, contact them on channel [rand(700,999)].[rand(1,9)].")
+			msg("[combined_name], this is [using_map.starsys_name] Flight Control. Permission granted, proceed to landing pad [rand(1,42)]. Follow the green lights on your way in. Repair crews are standing by, contact them on channel [rand(700,999)].[rand(1,9)].")
 			sleep(5 SECONDS)
-			msg("[appreciation], [using_map.station_short] Space Control. [dockingplan]","[prefix] [shipname]")
+			msg("[appreciation], [using_map.starsys_name] Flight Control. [dockingplan]","[prefix] [shipname]")
 		if("dockingrequestmedical")
-			var/medicalstate = pick("multiple casualties","several cases of radiation sickness","an unknown virus","an unknown infection","a critically injured VIP","sick refugees","multiple cases of food poisoning","injured passengers","sick passengers","injured engineers","wounded marines","a delicate situation","a pregnant passenger")
-			var/appreciation = pick("Much appreciated","Many thanks","Understood","You're a lifesaver","We owe you one","I owe you one")
-			var/dockingplan = pick("Starting final approach now.","Commencing docking procedures.","Autopilot engaged.")
-			msg("[callname], this is [combined_name]. We have [medicalstate] on board. Requesting permission to dock for medical assistance.","[prefix] [shipname]")
+			var/medicalstate = pick("multiple casualties","several cases of radiation sickness","an unknown virus","an unknown infection","a critically injured VIP","sick refugees","multiple cases of food poisoning","injured passengers","sick passengers","injured engineers","wounded marines","a delicate situation","a pregnant passenger","injured castaways","escape pods","")
+			var/appreciation = pick("Much appreciated","Many thanks","Understood","You're a lifesaver","We owe you one","I owe you one","Perfect, thank you")
+			var/dockingplan = pick("Starting final approach now.","Commencing docking procedures.","Autopilot engaged.","Approach vector locked in.","In the pipe, five by five.")
+			msg("[callname], this is [combined_name]. We have [medicalstate] on board. Requesting permission to dock at [using_map.dock_name] for medical assistance.","[prefix] [shipname]")
 			sleep(5 SECONDS)
-			msg("[combined_name], this is [using_map.station_short] Space Control. Permission granted, proceed to landing pad [rand(1,42)]. Follow the green lights on your way in. Medtechs are standing by, contact them on channel [rand(700,999)].[rand(1,9)].")
+			msg("[combined_name], this is [using_map.starsys_name] Flight Control. Permission granted, proceed to landing pad [rand(1,42)]. Follow the green lights on your way in. Medtechs are standing by, contact them on channel [rand(700,999)].[rand(1,9)].")
 			sleep(5 SECONDS)
-			msg("[appreciation], [using_map.station_short] Space Control. [dockingplan]","[prefix] [shipname]")
+			msg("[appreciation], [using_map.starsys_name] Flight Control. [dockingplan]","[prefix] [shipname]")
 		if("dockingrequestsecurity")
-			var/species = pick("human","unathi","lizard","tajaran","skrell","akula","promethean","sergal","synthetic","teshari","vulpkanin","zorren","unidentified","mixed-species")
+			var/species = pick("human","unathi","lizard","tajaran","skrell","akula","promethean","sergal","synthetic","teshari","vulpkanin","vox","zorren","hybrid","mixed-species")
 			var/securitystate = pick("several [species] convicts","a captured pirate","a wanted criminal","[species] stowaways","incompetent [species] shipjackers","a delicate situation","a disorderly passenger","disorderly [species] passengers","ex-mutineers","a captured vox marauder","stolen goods","a container full of confiscated contraband","containers full of confiscated contraband",5;"a raging case of spiders") //gotta have a little something to lighten the mood now and then
-			var/appreciation = pick("Much appreciated","Many thanks","Understood","You're a lifesaver")
-			var/dockingplan = pick("Starting final approach now.","Commencing docking procedures.","Autopilot engaged.")
-			msg("[callname], this is [combined_name]. We have [securitystate] on board and require security assistance. Requesting permission to dock.","[prefix] [shipname]")
+			var/appreciation = pick("Much appreciated","Many thanks","Understood","You're a lifesaver","Perfect, thank you")
+			var/dockingplan = pick("Starting final approach now.","Commencing docking procedures.","Autopilot engaged.","Approach vector locked in.","In the pipe, five by five.")
+			msg("[callname], this is [combined_name]. We have [securitystate] on board and require security assistance. Requesting permission to dock at [using_map.dock_name].","[prefix] [shipname]")
 			sleep(5 SECONDS)
-			msg("[combined_name], this is [using_map.station_short] Space Control. Permission granted, proceed to landing pad [rand(1,42)]. Follow the green lights on your way in. Security teams are standing by, contact them on channel [rand(700,999)].[rand(1,9)].")
+			msg("[combined_name], this is [using_map.starsys_name] Flight Control. Permission granted, proceed to landing pad [rand(1,42)]. Follow the green lights on your way in. Security teams are standing by, contact them on channel [rand(700,999)].[rand(1,9)].")
 			sleep(5 SECONDS)
-			msg("[appreciation], [using_map.station_short] Space Control. [dockingplan]","[prefix] [shipname]")
+			msg("[appreciation], [using_map.starsys_name] Flight Control. [dockingplan]","[prefix] [shipname]")
 		if("undockingrequest")
 			var/safetravels = pick("Fly safe out there","Good luck","Safe travels","See you next week","Godspeed","Stars guide you")
+			var/thanks = pick("Appreciated","Thanks","Don't worry about us","We'll be fine","You too","So long")
+			msg("[callname], this is [combined_name] at [using_map.dock_name], requesting permission to depart from pad [rand(1,42)].","[prefix] [shipname]")
+			sleep(5 SECONDS)
+			msg("[combined_name], this is [using_map.starsys_name] Flight Control. Permission granted. Docking clamps released. [safetravels].")
+			sleep(5 SECONDS)
+			msg("[thanks], [using_map.starsys_name] Flight Control. This is [combined_name] setting course for [destname], over and out.","[prefix] [shipname]")
+		if("sdfbeginpatrol")
+			var/safetravels = pick("Fly safe out there","Good luck","Good hunting","Safe travels","Godspeed","Stars guide you")
 			var/thanks = pick("Appreciated","Thanks","Don't worry about us","We'll be fine","You too")
-			msg("[callname], this is [combined_name], requesting permission to depart from pad [rand(1,42)].","[prefix] [shipname]")
+			msg("[callname], this is [combined_name] at [using_map.dock_name], requesting permission to depart from pad [rand(1,42)] to begin system patrol.","[prefix] [shipname]")
 			sleep(5 SECONDS)
-			msg("[combined_name], this is [using_map.station_short] Space Control. Permission granted. Docking clamps released. [safetravels].")
+			msg("[combined_name], this is [using_map.starsys_name] Flight Control. Permission granted. Docking clamps released. [safetravels].")
 			sleep(5 SECONDS)
-			msg("[thanks], [using_map.station_short] Space Control. This is [combined_name] setting course for [destname], over and out.","[prefix] [shipname]")
+			msg("[thanks], [using_map.starsys_name] Flight Control. This is [combined_name] beginning system patrol, over and out.","[prefix] [shipname]")
 		if("undockingdenied")
-			var/denialreason = pick("Docking clamp malfunction, please hold","Fuel lines have not been secured","Ground crew are still on the pad","Loose containers are on the pad","Security is requesting a full cargo inspection","Your ship has been impounded for multiple security violations","You need to pass a quick engineering inspection","Your ship is currently under quarantine lockdown","Exhaust deflectors are not yet in position, please hold")
-			msg("[callname], this is [combined_name], requesting permission to depart from pad [rand(1,42)].","[prefix] [shipname]")
+			var/denialreason = pick("Security is requesting a full cargo inspection","Your ship has been impounded for multiple [pick("security","safety")] violations","Your ship is currently under quarantine lockdown","We have reason to believe there's an issue with your papers","Security personnel are currently searching for a fugitive and have ordered all outbound ships remain grounded until further notice")
+			msg("[callname], this is [combined_name] at [using_map.dock_name], requesting permission to depart from pad [rand(1,42)].","[prefix] [shipname]")
 			sleep(5 SECONDS)
 			msg("Negative [combined_name], request denied. [denialreason].")
+		if("undockingdelayed")
+			var/denialreason = pick("Docking clamp malfunction, please hold","Fuel lines have not been secured","Ground crew are still on the pad","Loose containers are on the pad","Exhaust deflectors are not yet in position, please hold","There's heavy traffic right now, it's not safe for your vessel to launch","Another vessel has aerospace priority at this moment","Port officials are still aboard")
+			var/pad = rand(1,42)
+			var/safetravels = pick("Fly safe out there","Good luck","Safe travels","See you next week","Godspeed","Stars guide you")
+			var/thanks = pick("Appreciated","Thanks","Don't worry about us","We'll be fine","You too","So long")
+			msg("[callname], this is [combined_name] at [using_map.dock_name], requesting permission to depart from pad [pad].","[prefix] [shipname]")
+			sleep(5 SECONDS)
+			msg("Negative [combined_name], request denied. [denialreason]. Try again in three minutes.")
+			sleep(180 SECONDS) //yes, three minutes
+			msg("[callname], this is [combined_name] at [using_map.dock_name], requesting permission to depart from pad [pad].","[prefix] [shipname]")
+			sleep(5 SECONDS)
+			msg("[combined_name], this is [using_map.starsys_name] Flight Control. Everything appears to be in order now, permission granted. Docking clamps released. [safetravels].")
+			sleep(5 SECONDS)
+			msg("[thanks], [using_map.starsys_name] Flight Control. This is [combined_name] setting course for [destname], over and out.","[prefix] [shipname]")
 		else //time for generic message
-			msg("[callname], this is [combined_name] on [mission] [pick(mission_noun)] to [destname], [pick(request_verb)] [request].","[prefix] [shipname]")
+			msg("[callname], this is [combined_name] on [mission] [pick(mission_noun)] to [destname], requesting [request].","[prefix] [shipname]")
 			sleep(5 SECONDS)
-			msg("[combined_name], this is [using_map.station_short] Space Control, [response].")
+			msg("[combined_name], this is [using_map.starsys_name] Flight Control, [response].")
 			sleep(5 SECONDS)
-			msg("[using_map.station_short] Space Control, [yes ? "thank you" : "understood"], good day.","[prefix] [shipname]")
+			msg("[using_map.starsys_name] Flight Control, [yes ? "thank you" : "understood"], good day.","[prefix] [shipname]")
 	return //oops, forgot to restore this
 
 /*	//OLD BLOCK, for reference

--- a/code/modules/busy_space/organizations.dm
+++ b/code/modules/busy_space/organizations.dm
@@ -14,7 +14,6 @@
 			"flight",
 			"mission",
 			"route",
-			"operation",
 			"assignment"
 			)
 	var/list/ship_names = list(		//Names of spaceships.  This is a mostly generic list that all the other organizations inherit from if they don't have anything better.
@@ -40,24 +39,60 @@
 			"Surveyor",
 			"Haste",
 			"Radiant",
-			"Luminous"
+			"Luminous",
+			"Calypso",
+			"Eclipse",
+			"Maverick",
+			"Polaris",
+			"Orion",
+			"Odyssey",
+			"Relentless",
+			"Valor",
+			"Zodiac",
+			"Avenger",
+			"Defiant",
+			"Dauntless",
+			"Interceptor",
+			"Providence",
+			"Thunderchild",
+			"Defender",
+			"Ranger",
+			"River",
+			"Jubilee"
 			)
 	var/list/destination_names = list()	//Names of static holdings that the organization's ships visit regularly.
-	var/scan_exempt = FALSE			//Are we exempt from routine inspections? to avoid incidents where SysDef appears to go rogue
+	var/lawful = TRUE			//Are we exempt from routine inspections? to avoid incidents where SysDef appears to go rogue -- defaults to TRUE now
+	var/sysdef = FALSE			//Are we the space cops?
 	var/autogenerate_destination_names = TRUE //Pad the destination lists with some extra random ones?
 
 /datum/lore/organization/New()
 	..()
 	if(autogenerate_destination_names) // Lets pad out the destination names.
-		var/i = rand(7, 12) //was 6-10, now 7-12, slight increase for flavor, especially in 'starved' lists
-		var/list/star_names = list(		
-			"in Sol", "in Alpha Centauri", "in Sirius", "in Vega", "in Tau Ceti", "in Altair", "in Zhu Que", "in Oasis", "in Vir", "in Gavel", "in Ganesha", "in Saint Columbia", "in Altair", "in Sidhe", "in New Ohio", "in Parvati", "in Mahi-Mahi", "in Nyx", "in New Seoul", "in Kess-Gendar", "in Raphael", "in Phact", "in Altair", "in El", "in Eutopia", "in Qerr'valis", "in Qerrna-Lakirr", "in Rarkajar", "in Vazzend", "in Thoth", "in Jahan's Post", "in Kauq'xum", "in Silk", "in New Singapore", "in Stove", "in Viola", "in Love", "in Isavau's Gamble", "in Shelf", "in deep space", "on the frontier")
-		var/list/owners = list("a government", "a civilian", "a corporate", "a private", "an independent", "a mercenary", "a military")
-		var/list/destination_types = list("[pick(owners)] shipyard", "[pick(owners)] dockyard", "[pick(owners)] station", "[pick(owners)] vessel", "a waystation", "[pick(owners)] telecommunications satellite", "a spaceport", "a colony", "[pick(owners)] outpost", "a settlement", "[pick(owners)] research facility", "[pick(owners)] installation", "a freeport", "[pick(owners)] holding", "[pick(owners)] asteroid base", "an orbital refinery", "a classified location", "a trade outpost", "[pick(owners)] supply depot", "[pick(owners)] fuel depot")
+		var/i = rand(7, 12) //was 6-10, now 7-12, slight increase for flavor, especially 'starved' lists
+		
+		//known planets and exoplanets, plus fictional ones
+		var/list/planets = list("Earth", "Luna", "Mars", "Titan", "Europa", "Sif", "Kara", "Rota", "Root", "Toledo, New Ohio", "Meralar", "Adhomai", "Arion", "Arkas", "Orbitar", "Galileo", "Brahe", "Janssen", "Harriot", "Aegir", "Amateru", "Dagon", "Meztli", "Hypatia", "Dulcinea", "Rocinante", "Sancho", "Thestias", "Saffar", "Samh", "Majriti", "Draugr")
+		
+		//existing systems, pruned for duplicates, includes systems that contain suspected or confirmed exoplanets
+		var/list/systems = list(		
+			"Sol", "Alpha Centauri", "Sirius", "Vega", "Tau Ceti", "Altair", "Zhu Que", "Oasis", "Vir", "Gavel", "Ganesha", "Saint Columbia", "Altair", "Sidhe", "New Ohio", "Parvati", "Mahi-Mahi", "Nyx", "New Seoul", "Kess-Gendar", "Raphael", "Phact", "El", "Eutopia", "Qerr'valis", "Qerrna-Lakirr", "Rarkajar", "Vazzend", "Thoth", "Jahan's Post", "Kauq'xum", "Silk", "New Singapore", "Stove", "Viola", "Love", "Isavau's Gamble", "Shelf", "deep space", "Epsilon Eridani", "Fomalhaut", "Mu Arae", "Pollux", "Wolf 359", "Ross 128", "Gliese 1061", "Luyten's Star", "Teegarden's Star", "Kapteyn", "Wolf 1061", "Aldebaran", "Proxima Centauri", "Kepler-90", "HD 10180", "HR 8832", "TRAPPIST-1", "55 Cancri", "Gliese 876", "Upsilon Andromidae", "Mu Arae", "WASP-47", "82 G. Eridani", "Rho Coronae Borealis", "Pi Mensae", "Beta Pictoris", "Gamma Librae", "Gliese 667 C", "Kapteyn", "LHS 1140", "New Ohio", "Samsara", "Angessa's Pearl")
+		var/list/owners = list("a government", "a civilian", "a corporate", "a private", "an independent", "a mercenary", "a military", "a contracted")
+		var/list/purpose = list("an exploration", "a trade", "a research", "a survey", "a military", "a mercenary", "a corporate", "a civilian", "an independent")
+		
+		//unique or special locations
+		var/list/unique = list("the Jovian subcluster")
+		
+		var/list/orbitals = list("[pick(owners)] shipyard","[pick(owners)] dockyard","[pick(owners)] station","[pick(owners)] vessel","a habitat","[pick(owners)] refinery","[pick(owners)] research facility","an industrial platform","[pick(owners)] installation")
+		var/list/surface = list("a colony","a settlement","a trade outpost","[pick(owners)] supply depot","a fuel depot","[pick(owners)] installation","[pick(owners)] research facility")
+		var/list/deepspace = list("[pick(owners)] asteroid base","a freeport","[pick(owners)] shipyard","[pick(owners)] dockyard","[pick(owners)] station","[pick(owners)] vessel","[pick(owners)] orbital habitat","an orbital refinery","a colony","a settlement","a trade outpost","[pick(owners)] supply depot","a fuel depot","[pick(owners)] installation","[pick(owners)] research facility")
+		var/list/frontier = list("[pick(purpose)] [pick("ship","vessel","outpost")]","a waystation","an outpost","a settlement","a colony")
+		
+		//patterns; orbital ("an x orbiting y"), surface ("an x on y"), deep space ("an x in y"), the frontier ("an x on the frontier")
+		//biased towards inhabited space sites
 		while(i)
-			destination_names.Add("[pick(destination_types)] [pick(star_names)]")
+			destination_names.Add("[pick("[pick(orbitals)] orbiting [pick(planets)]","[pick(surface)] on [pick(planets)]","[pick(deepspace)] in [pick(systems)]",20;"[pick(unique)]",30;"[pick(frontier)] on the frontier")]")
 			i--
-	//refactored slightly to improve flexibility; we can now have different owners for a destination (but only for some destinations), and 'stars' can include other star-like destinations
+	//extensive rework for a much greater degree of variety compared to the old system, lists now include known exoplanets and star systems currently suspected or confirmed to have exoplanets
 
 //////////////////////////////////////////////////////////////////////////////////
 
@@ -82,7 +117,7 @@
 	headquarters = "Luna, Sol"
 	motto = ""
 
-	ship_prefixes = list("NSV" = "an exploration", "NTV" = "a hauling", "NDV" = "a patrol", "NRV" = "an emergency response", "NDV" = "an asset protection")
+	ship_prefixes = list("NTV" = "a general operations", "NEV" = "an exploration", "NGV" = "a hauling", "NDV" = "a patrol", "NRV" = "an emergency response", "NDV" = "an asset protection")
 	//Scientist naming scheme
 	ship_names = list(
 			"Bardeen",
@@ -151,40 +186,84 @@
 	headquarters = "Luna, Sol"
 	motto = ""
 
-	ship_prefixes = list("HTV" = "a freight", "HLV" = "a munitions resupply", "HDV" = "an asset protection", "HDV" = "a preemptive deployment")
-	//War God/Soldier Theme
+	ship_prefixes = list("HIV" = "a general operations", "HTV" = "a freight", "HLV" = "a munitions resupply", "HDV" = "an asset protection", "HDV" = "a preemptive deployment")
+	//War God Theme, updated
 	ship_names = list(
-			"Ares",
-			"Athena",
-			"Grant",
-			"Custer",
-			"Puller",
-			"Nike",
-			"Bellona",
-			"Leonides",
+			"Anhur",
 			"Bast",
-			"Jackson",
-			"Lee",
-			"Annan",
-			"Chi Yu",
-			"Shiva",
-			"Tyr",
-			"Nobunaga",
-			"Xerxes",
-			"Alexander",
-			"McArthur",
-			"Samson",
-			"Oya",
-			"Nemain",
-			"Caesar",
-			"Augustus",
+			"Horus",
+			"Maahes",
+			"Neith",
+			"Pakhet",
 			"Sekhmet",
-			"Ku",
-			"Indra",
-			"Innana",
+			"Set",
+			"Sobek",
+			"Maher",
+			"Kokou",
+			"Ogoun",
+			"Oya",
+			"Kovas",
+			"Agrona",
+			"Andraste",
+			"Anann",
+			"Badb",
+			"Belatucadros",
+			"Cicolluis",
+			"Macha",
+			"Neit",
+			"Nemain",
+			"Rudianos",
+			"Chiyou",
+			"Guan Yu",
+			"Jinzha",
+			"Nezha",
+			"Zhao Lang",
+			"Laran",
+			"Menrva",
+			"Tyr",
+			"Woden",
+			"Freya",
+			"Odin",
+			"Ullr",
+			"Ares",
+			"Deimos",
+			"Enyo",
+			"Kratos",
+			"Kartikeya",
+			"Mangala",
+			"Parvati",
+			"Shiva",
+			"Vishnu",
+			"Shaushka",
+			"Wurrukatte",
+			"Hadur",
+			"Futsunushi",
+			"Sarutahiko",
+			"Takemikazuchi",
+			"Neto",
+			"Agasaya",
+			"Belus",
 			"Ishtar",
+			"Shala",
+			"Huitzilopochtli",
+			"Tlaloc",
+			"Xipe-Totec",
 			"Qamaits",
 			"'Oro",
+			"Rongo",
+			"Ku",
+			"Pele",
+			"Maru",
+			"Tumatauenga",
+			"Bellona",
+			"Juno",
+			"Mars",
+			"Minerva",
+			"Victoria",
+			"Anat",
+			"Astarte",
+			"Perun",
+			"Cao Lo"
 			)
 	destination_names = list(
 			"our headquarters on Luna",
@@ -209,7 +288,7 @@
 	headquarters = "Toledo, New Ohio"
 	motto = ""
 
-	ship_prefixes = list("VTV" = "a transportation", "VMV" = "a medical resupply", "VSV" = "a research mission", "VRV" = "an emergency medical support")
+	ship_prefixes = list("VMV" = "a general operations", "VTV" = "a transportation", "VHV" = "a medical resupply", "VSV" = "a research", "VRV" = "an emergency medical support")
 	// Diona names
 	ship_names = list(
 			"Wind That Stirs The Waves",
@@ -235,7 +314,6 @@
 	destination_names = list(
 			"our headquarters on Toledo, New Ohio",
 			"a research facility in Samsara",
-			"an SDTF near Ue-Orsi",
 			"a sapientarian mission in the Almach Rim"
 			)
 
@@ -254,7 +332,7 @@
 	headquarters = "Earth, Sol"
 	motto = ""
 
-	ship_prefixes = list("ZTV" = "a transportation", "ZMV" = "a medical resupply", "ZRV" = "a medical research")
+	ship_prefixes = list("ZHV" = "a general operations", "ZTV" = "a transportation", "ZMV" = "a medical resupply", "ZRV" = "a medical research")
 	//ship names: a selection of famous physicians who advanced the cause of medicine
 	ship_names = list(
 			"Averroes",
@@ -332,7 +410,7 @@
 	headquarters = ""
 	motto = ""
 
-	ship_prefixes = list("WFV" = "a freight", "WTV" = "a transport", "WDV" = "an asset protection")
+	ship_prefixes = list("WTV" = "a general operations", "WTFV" = "a freight", "WTGV" = "a transport", "WTDV" = "an asset protection")
 	ship_names = list(
 			"Comet",
 			"Meteor",
@@ -383,7 +461,7 @@
 	headquarters = ""
 	motto = ""
 
-	ship_prefixes = list("BCTV" = "a transportation", "BCSV" = "a research exchange")
+	ship_prefixes = list("BCV" = "a general operations", "BCTV" = "a transportation", "BCSV" = "a research exchange")
 	//famous mechanical engineers
 	ship_names = list(
 			"Al-Jazari",
@@ -457,7 +535,7 @@
 	headquarters = "Shelf"
 	motto = ""
 
-	ship_prefixes = list("MTV" = "a freight", "MDV" = "a market protection", "MSV" = "an outreach")
+	ship_prefixes = list("MCV" = "a general operations", "MTV" = "a freight", "MDV" = "a market protection", "MSV" = "an outreach")
 	//periodic elements; something 'unusual' for the posibrain TSC without being full on 'quirky' culture ship names (much as I love them, they're done to death)
 	ship_names = list(
 			"Hydrogen",
@@ -542,7 +620,7 @@
 	headquarters = ""
 	motto = ""
 
-	ship_prefixes = list("XTV" = "a hauling", "XFV" = "a bulk transport", "XIV" = "a resupply")
+	ship_prefixes = list("XMV" = "a general operations", "XTV" = "a hauling", "XFV" = "a bulk transport", "XIV" = "a resupply")
 	//martian mountains
 	ship_names = list(
 			"Olympus Mons",
@@ -582,7 +660,7 @@
 			"Peraea Mons",
 			"Octantis Mons",
 			"Galaxius Mons",
-			"Hellas Planitia",
+			"Hellas Planitia"
 			)
 	destination_names = list()
 
@@ -597,7 +675,7 @@
 	headquarters = ""
 	motto = ""
 
-	ship_prefixes = list("ATV" = "a transport", "ARV" = "a research", "ADV" = "a routine patrol", "AEV" = "a raw materials acquisition")
+	ship_prefixes = list("AGV" = "a general operations", "ATV" = "a transport", "ARV" = "a research", "ADV" = "a routine patrol", "AEV" = "a raw materials acquisition")
 	//ship names: blank, because we get some autogenned for us
 	ship_names = list()
 	destination_names = list()
@@ -631,8 +709,8 @@
 	headquarters = ""
 	motto = ""
 	
-	ship_prefixes = list("FTRP" = "a route protection", "FTRR" = "a piracy suppression", "FTLV" = "a logistical support", "FTTV" = "a mercantile", "FTDV" = "a market establishment")
-	//famous merchants and traders, taken from Civ6's Great Merchants
+	ship_prefixes = list("FTV" = "a general operations", "FTRP" = "a trade protection", "FTRR" = "a piracy suppression", "FTLV" = "a logistical support", "FTTV" = "a mercantile", "FTDV" = "a market establishment")
+	//famous merchants and traders, taken from Civ6's Great Merchants, plus the TSC's founder
 	ship_names = list(
 			"Isaac Adler",
 			"Colaeus",
@@ -672,7 +750,7 @@
 	headquarters = "Mars, Sol"
 	motto = "With Major Bill's, you won't pay major bills!"
 
-	ship_prefixes = list("TTV" = "a transport", "TTV" = "a luxury transit", "TTV" = "a priority transit", "TTV" = "a secure data courier")
+	ship_prefixes = list("TTV" = "a general operations", "TTV" = "a transport", "TTV" = "a luxury transit", "TTV" = "a priority transit", "TTV" = "a secure data courier")
 	//ship names: big rivers
 	ship_names = list (
 			"Nile",
@@ -727,20 +805,20 @@
 			"Major Bill's Transportation HQ on Mars",
 			"a Major Bill's warehouse",
 			"a Major Bill's distribution center",
-			"a Major Bill's supply deplot"
+			"a Major Bill's supply depot"
 			)
 
 /datum/lore/organization/tsc/grayson
 	name = "Grayson Manufactories Ltd."
 	short_name = "Grayson "
 	acronym = "GM"
-	desc = "Grayson Manufactories Ltd., true to its name, mines, refines, and produces iron, steel, aluminum, and other metals for use in casing and other production before selling them. They are also known for reviving their old traditions of supplying general materials ready for assembly for construction projects. These parts are interchangeable and considered somewhat cheap, but have proven to be generally and consecutively reliable.<br><br>As of current, Grayson Manufactories has a fairly neutral stance on the other major corporations, though has a history of maintaining a monopoly on specific trades through heavy competition and even rumors of industrial sabotage and use of strikebreakers."
+	desc = "Grayson Manufactories Ltd. is one of the oldest surviving TSCs, having been in 'the biz' almost since mankind began to colonize the rest of the Sol system and thus exploit abundant 'extraterrestrial' resources. Where many choose to go into the high end markets, however, Grayson makes their money by providing foundations for other businesses; they run some of the largest mining and refining operations in all of human-inhabited space. Ore is hauled out of Grayson-owned mines, transported on Grayson-owned ships, and processed in Grayson-owned refineries, then sold by Grayson-licensed vendors to other industries. Several of their relatively newer ventures include heavy industrial equipment, which has earned a reputation for being surprisingly reliable.<br><br>Grayson may maintain a neutral stance towards their fellow TSCs, but can be quite aggressive in the markets that it already holds. A steady stream of rumors suggests they're not shy about engaging in industrial sabotage or calling in strikebreakers, either."
 	history = ""
 	work = ""
-	headquarters = "Mars"
+	headquarters = "Mars, Sol"
 	motto = ""
 	
-	ship_prefixes = list("GMT" = "a transport", "GMR" = "a resourcing", "GMS" = "a surveying", "GMH" = "a bulk transit")
+	ship_prefixes = list("GMV" = "a general operations", "GMT" = "a transport", "GMR" = "a resourcing", "GMS" = "a surveying", "GMH" = "a bulk transit")
 	//rocks
 	ship_names = list(
 			"Adakite",
@@ -796,9 +874,9 @@
 	history = ""
 	work = ""
 	headquarters = ""
-	motto = ""
+	motto = "Dum spiro spero"
 	
-	ship_prefixes = list("AARE" = "a resource extraction", "AARG" = "a gas transport", "AART" = "a transport")
+	ship_prefixes = list("AARV" = "a general operations", "AARE" = "a resource extraction", "AARG" = "a gas transport", "AART" = "a transport")
 	//weather systems/patterns
 	ship_names = list (
 			"Cloud",
@@ -845,7 +923,7 @@
 	headquarters = ""
 	motto = ""
 	
-	ship_prefixes = list("FPH" = "a transport", "FPC" = "an energy relay", "FPT" = "a fuel transport")
+	ship_prefixes = list("FPV" = "a general operations", "FPH" = "a transport", "FPC" = "an energy relay", "FPT" = "a fuel transport")
 	//famous electrical engineers
 	ship_names = list (
 			"Erlang",
@@ -902,17 +980,16 @@
 	work = "luxury, business, and economy passenger flights"
 	headquarters = "Spin Aerostat, Jupiter"
 	motto = "Sic itur ad astra"
-	scan_exempt = TRUE
 	
-	ship_prefixes = list("SFI-X" = "a VIP liner", "SFI-L" = "a luxury liner", "SFI-B" = "a business liner", "SFI-E" = "an economy liner", "SFI-M" = "a mixed class liner", "SFI-S" = "a sightseeing")
+	ship_prefixes = list("SFI-X" = "a VIP liner", "SFI-L" = "a luxury liner", "SFI-B" = "a business liner", "SFI-E" = "an economy liner", "SFI-M" = "a mixed class liner", "SFI-S" = "a sightseeing", "SFI-M" = "a wedding", "SFI-O" = "a marketing", "SFI-S" = "a safari", "SFI-A" = "an aquatic adventure")
 	flight_types = list(		//no military-sounding ones here	
 			"flight",
 			"route",
 			"tour"
 			)
-	ship_names = list(
+	ship_names = list(	//birbs
 			"Rhea",
-			"Ostritch",
+			"Ostrich",
 			"Cassowary",
 			"Emu",
 			"Kiwi",
@@ -946,20 +1023,23 @@
 	destination_names = list(
 			"a resort planet",
 			"a beautiful ring system",
-			"a ski-resort world"
+			"a ski-resort world",
+			"an ocean resort planet",
+			"a desert resort world",
+			"an arctic retreat"
 			)
 
 /datum/lore/organization/tsc/independent
 	name = "Independent Pilots Association"
-	short_name = "Independent "
+	short_name = "" //using the same whitespace hack as USDF
 	acronym = "IPA"
 	desc = "Though less common now than they were in the decades before the Sol Economic Organization took power, independent traders remain an important part of the galactic economy, owing in no small part to protective tariffs established by the Free Trade Union in the late twenty-fourth century. Further out on the frontier, independent pilots are often the only people keeping freight and supplies moving."
 	history = ""
-	work = "trade and transit"
+	work = "everything under the sun"
 	headquarters = "N/A"
 	motto = "N/A"
 
-	ship_prefixes = list("IEV" = "a prospecting", "IEC" = "a prospecting", "IFV" = "a bulk freight", "ITV" = "a passenger transport", "ITC" = "a just-in-time delivery", "IPV" = "a patrol", "IHV" = "a bounty hunting", "ICC" = "an escort")
+	ship_prefixes = list("ISV" = "a general", "IEV" = "a prospecting", "IEC" = "a prospecting", "IFV" = "a bulk freight", "ITV" = "a passenger transport", "ITC" = "a just-in-time delivery", "IPV" = "a patrol", "IHV" = "a bounty hunting", "ICC" = "an escort")
 	flight_types = list(		
 			"flight",
 			"mission",
@@ -969,20 +1049,21 @@
 			"contract"
 			)
 	destination_names = list() //we have no hqs or facilities of our own
+	//ship names: blank, because we use the universal list
 
 // Other
 
 //SPACE LAW
 /datum/lore/organization/other/sysdef
 	name = "System Defense Force"
-	short_name = "SysDef "
+	short_name = "" //whitespace hack again
 	acronym = "SDF"
-	desc = "Localized militias are used to secure systems throughout inhabited space. By levying and maintaining these local militia forces, governments can use their fleets for more important matters. System Defense Forces tend to be fairly poorly trained and modestly equipped compared to genuine military fleets, but are more than capable of contending with small-time pirates, and can generally stall greater threats long enough for reinforcements to arrive. They're also typically responsible for space-based SAR operations in their system."
+	desc = "Localized militias are used to secure systems throughout inhabited space, but are especially common on the frontier. By levying and maintaining these local militia forces, governments can use their fleets for more important matters. System Defense Forces tend to be fairly poorly trained and modestly equipped compared to genuine military fleets, but are more than capable of contending with small-time pirates and can generally stall greater threats long enough for reinforcements to arrive. They're also typically responsible for most search-and-rescue operations in their system."
 	history = ""
 	work = "local security"
 	headquarters = ""
-	motto = ""
-	scan_exempt = TRUE //we're the laaaaaw, we don't impersonate people and stuff
+	motto = "Serve, Protect, Survive"
+	sysdef = TRUE //we're the space law, we don't impersonate people and stuff
 	autogenerate_destination_names = FALSE
 
 	ship_prefixes = list ("SDB" = "a patrol", "SDF" = "a patrol", "SDV" = "a patrol", "SDB" = "an escort", "SDF" = "an escort", "SDV" = "an escort", "SAR" = "a search and rescue", "SDT" = "a logistics", "SDT" = "a resupply", "SDJ" = "a prisoner transport") //b = boat, f = fleet, v = vessel, t = tender
@@ -1054,7 +1135,10 @@
 			"Waypoint Phi",
 			"Waypoint Chi",
 			"Waypoint Psi",
-			"Waypoint Omega"
+			"Waypoint Omega",
+			"an SDF correctional facility",
+			"an SDF processing center",
+			"an SDF outpost"
 			)
 
 // Governments
@@ -1066,15 +1150,14 @@
 	desc = "SolGov is a decentralized confederation of human governmental entities based on Luna, Sol, which defines top-level law for their member states.  \
 	Member states receive various benefits such as defensive pacts, trade agreements, social support and funding, and being able to participate \
 	in the Colonial Assembly.  The majority, but not all human territories are members of SolGov.  As such, SolGov is a major power and \
-	defacto represents humanity on the galactic stage."
+	defacto represents humanity on the galactic stage. Military flight operations fall under the banner of the USDF."
 	history = "" // Todo
 	work = "governing polity of humanity's Confederation"
 	headquarters = "Luna, Sol"
-	motto = "Nil Mortalibus Ardui Est" // Latin, because latin.  Says 'Nothing is too steep for mortals'.
-	scan_exempt = TRUE //it would look pretty weird if the SCG were caught impersonating other people
+	motto = "Nil Mortalibus Ardui Est" // Latin, because latin.  Says 'Nothing is too steep for mortals'
 	autogenerate_destination_names = TRUE
 
-	ship_prefixes = list("SCG-T" = "a transportation", "SCG-D" = "a diplomatic", "SCG-F" = "a freight", "SCG-J" = "a prisoner transfer")
+	ship_prefixes = list("SCG-A" = "an administrative", "SCG-T" = "a transportation", "SCG-D" = "a diplomatic", "SCG-F" = "a freight", "SCG-J" = "a prisoner transfer")
 	//earth's biggest impact craters
 	ship_names = list(
 			"Wabar",
@@ -1151,11 +1234,90 @@
 			"Titan",
 			"Europa",
 			"the Jovian subcluster",
-			"a SolGov embassy"
+			"a SolGov embassy",
+			"a classified location"
 			)
 			// autogen will add a lot of other places as well.
 
+/*
+/datum/lore/organization/gov/tajara_rakar
+	name = "Rakar Empire"
+	short_name = "Rakar "
+	acronym = "TRE"
+	desc = ""
+	history = ""
+	work = ""
+	headquarters = ""
+	motto = ""
+	autogenerate_destination_names = FALSE //big list of own holdings to come
+	
+	ship_prefixes = list("" = "")
+	ship_names = list(
+			"",
+			)
+	destination_names = list(
+			"",
+			)
 
+
+/datum/lore/organization/gov/tajara_selem
+	name = "Selem Hegemony"
+	short_name = "Selem "
+	acronym = "TSH"
+	desc = ""
+	history = ""
+	work = ""
+	headquarters = ""
+	motto = ""
+	autogenerate_destination_names = FALSE //big list of own holdings to come
+	
+	ship_prefixes = list("" = "")
+	ship_names = list(
+			"",
+			)
+	destination_names = list(
+			"",
+			)
+
+
+/datum/lore/organization/gov/tajara_najrir
+	name = "Najrir Republic"
+	short_name = "Republic "
+	acronym = "TNR"
+	desc = ""
+	history = ""
+	work = ""
+	headquarters = ""
+	motto = ""
+	autogenerate_destination_names = FALSE //big list of own holdings to come
+	
+	ship_prefixes = list("" = "")
+	ship_names = list(
+			"",
+			)
+	destination_names = list(
+			"",
+			)
+
+/datum/lore/organization/gov/unathi
+	name = "Moghes Hegemony"
+	short_name = "Hegemony "
+	acronym = "MGH"
+	desc = ""
+	history = ""
+	work = ""
+	headquarters = "Moghes"
+	motto = ""
+	autogenerate_destination_names = FALSE //big list of own holdings to come
+	
+	ship_prefixes = list("" = "")
+	ship_names = list(
+			"",
+			)
+	destination_names = list(
+			"",
+			)
+*/
 // Military
 // Used for Para-Military groups right now! Pair of placeholder-ish PMCs.
 
@@ -1167,11 +1329,10 @@
 	history = ""
 	work = "peacekeeping and piracy suppression"
 	headquarters = "Paris, Earth"
-	motto = ""
-	scan_exempt = TRUE
+	motto = "Si Vis Pacem Para Bellum"
 	autogenerate_destination_names = TRUE
 	
-	ship_prefixes = list ("USDF" = "a logistical", "USDF" = "a training", "USDF" = "a patrol", "USDF" = "a piracy suppression", "USDF" = "a peacekeeping", "USDF" = "a relief", "USDF" = "an escort", "USDF" = "a search and rescue")
+	ship_prefixes = list ("USDF" = "a logistical", "USDF" = "a training", "USDF" = "a patrol", "USDF" = "a piracy suppression", "USDF" = "a peacekeeping", "USDF" = "a relief", "USDF" = "an escort", "USDF" = "a search and rescue", "USDF" = "a classified")
 	ship_names = list(
 			"Aphrodite",
 			"Apollo",
@@ -1238,13 +1399,14 @@
 			"Pallas",
 			"Perses",
 			"Prometheus",
-			"Styx",
+			"Styx"
 			)
 	destination_names = list(
 			"USDF HQ",
 			"a USDF staging facility on the edge of SolGov territory",
 			"a USDF resupply depot",
-			"a USDF shipyard in Sol"
+			"a USDF shipyard in Sol",
+			"a classified location"
 			)
 
 /datum/lore/organization/mil/pcrc
@@ -1256,7 +1418,6 @@
 	work = "risk control and private security"
 	headquarters = "Proxima Centauri"
 	motto = ""
-	scan_exempt = TRUE //we're not the best guys, but we're not actually shady
 	autogenerate_destination_names = TRUE
 	
 	ship_prefixes = list("PCRC" = "a risk control", "PCRC" = "a private security")
@@ -1295,7 +1456,7 @@
 			"Investigator",
 			"Agent",
 			"Prosecutor",
-			"Sergeant",
+			"Sergeant"
 			)
 			
 	destination_names = list(
@@ -1314,7 +1475,6 @@
 	work = "mercenary contractors"
 	headquarters = ""
 	motto = "Strength in Numbers"
-	scan_exempt = TRUE //we're technically kinda-good guys, so we don't do shady stuff
 	autogenerate_destination_names = TRUE
 
 	ship_prefixes = list("HPF" = "a secure freight", "HPT" = "a training", "HPS" = "a logistics", "HPV" = "a patrol", "HPH" = "a bounty hunting", "HPX" = "an experimental", "HPC" = "a command", "HPI" = "a mercy")
@@ -1379,7 +1539,7 @@
 			"Rattlesnake"
 			)
 	destination_names = list(
-			"HIVE Command",
+			"the HIVE Command fleet",
 			"a HIVE patrol fleet",
 			"a HIVE flotilla",
 			"a HIVE training fleet",
@@ -1397,10 +1557,11 @@
 	history = ""
 	work = "mercenary contractors"
 	headquarters = ""
-	motto = ""
+	motto = "Neca Ne Necaris"
+	lawful = FALSE
 	autogenerate_destination_names = TRUE
 
-	ship_prefixes = list("BSF" = "a secure freight", "BST" = "a training", "BSS" = "a logistics", "BSV" = "a patrol", "BSH" = "a security", "BSX" = "an experimental", "BSC" = "a command")
+	ship_prefixes = list("BSF" = "a secure freight", "BST" = "a training", "BSS" = "a logistics", "BSV" = "a patrol", "BSH" = "a security", "BSX" = "an experimental", "BSC" = "a command", "BSK" = "a classified")
 	flight_types = list(		
 			"flight",
 			"mission",


### PR DESCRIPTION
## About The Pull Request

Does some further work on top of #1470 to fix some issues I overlooked, and lay the groundwork for future additions.

As with the original this has been pretty extensively tested besides just checking if it compiles or not.

## Why It's Good For The Game

Fixes stuff. Unbreaks other stuff. Sets up a couple of things that can be built on later if lore is ever prepared.

Main changes are "Station Space Control" to "System Flight Control" as futureproofing for possible planetside maps, and splitting out the 'law abiding' quality into lawful (now defaults to true) and sysdef. Also adds a couple of new events (SDF ships beginning patrols and scanning regular ships, launches being delayed rather than hard denied) and tweaks existing ones slightly.

Probably one of the biggest changes is a rework of autogenerated destinations; the planet and star lists were expanded to roughly double-size based off known or suspected exoplanets/stars-with-exoplanets, taken from wikipedia. The system itself was also reworked so that it can generate with cleaner grammar and such.

## Changelog
:cl:
add: Added a couple of new space chatter events, and added a lot of new destinations.
del: Removed wrong-frequency event, it was super-rare anyway. Might readd later.
tweak: Various other space chatter event adjustments such as most TSCs being lawful, space con->flight con, protocol observance, etc.
/:cl: