### PR TITLE
Small tweaks/fixes for the RPD.

### DIFF
--- a/code/game/machinery/pipe/pipe_recipes.dm
+++ b/code/game/machinery/pipe/pipe_recipes.dm
@@ -9,17 +9,17 @@ var/global/list/all_pipe_recipes = null
 /hook/startup/proc/init_pipe_recipes()
 	global.atmos_pipe_recipes = list(
 		"Pipes" = list(
-			new /datum/pipe_recipe/pipe("Pipe",					/obj/machinery/atmospherics/pipe/simple),
-			new /datum/pipe_recipe/pipe("Manifold",				/obj/machinery/atmospherics/pipe/manifold),
+			new /datum/pipe_recipe/pipe("Pipe",					/obj/machinery/atmospherics/pipe/simple, TRUE),
+			new /datum/pipe_recipe/pipe("Manifold",				/obj/machinery/atmospherics/pipe/manifold, TRUE),
 			new /datum/pipe_recipe/pipe("Manual Valve",			/obj/machinery/atmospherics/valve),
 			new /datum/pipe_recipe/pipe("Digital Valve",		/obj/machinery/atmospherics/valve/digital),
-			new /datum/pipe_recipe/pipe("Pipe cap",				/obj/machinery/atmospherics/pipe/cap),
-			new /datum/pipe_recipe/pipe("4-Way Manifold",		/obj/machinery/atmospherics/pipe/manifold4w),
+			new /datum/pipe_recipe/pipe("Pipe cap",				/obj/machinery/atmospherics/pipe/cap, TRUE),
+			new /datum/pipe_recipe/pipe("4-Way Manifold",		/obj/machinery/atmospherics/pipe/manifold4w, TRUE),
 			new /datum/pipe_recipe/pipe("Manual T-Valve",		/obj/machinery/atmospherics/tvalve),
 			new /datum/pipe_recipe/pipe("Digital T-Valve",		/obj/machinery/atmospherics/tvalve/digital),
-			new /datum/pipe_recipe/pipe("Upward Pipe",			/obj/machinery/atmospherics/pipe/zpipe/up),
-			new /datum/pipe_recipe/pipe("Downward Pipe",		/obj/machinery/atmospherics/pipe/zpipe/down),
-			new /datum/pipe_recipe/pipe("Universal Pipe Adaptor",/obj/machinery/atmospherics/pipe/simple/visible/universal),
+			new /datum/pipe_recipe/pipe("Upward Pipe",			/obj/machinery/atmospherics/pipe/zpipe/up, TRUE),
+			new /datum/pipe_recipe/pipe("Downward Pipe",		/obj/machinery/atmospherics/pipe/zpipe/down, TRUE),
+			new /datum/pipe_recipe/pipe("Universal Pipe Adaptor",/obj/machinery/atmospherics/pipe/simple/visible/universal, TRUE),
 		),
 		"Devices" = list(
 			new /datum/pipe_recipe/pipe("Connector",			/obj/machinery/atmospherics/portables_connector),
@@ -81,6 +81,7 @@ var/global/list/all_pipe_recipes = null
 	var/icon_state_m						// This stores the mirrored version of the regular state (if available).
 	var/dirtype								// If using an RPD, this tells more about what previews to show.
 	var/subtype = 0							// Used for certain disposals pipes types.
+	var/paintable = FALSE					// If TRUE, allow the RPD to paint this pipe.
 
 // Render an HTML link to select this pipe type. Returns text.
 /datum/pipe_recipe/proc/Render(dispenser)
@@ -96,7 +97,7 @@ var/global/list/all_pipe_recipes = null
 /datum/pipe_recipe/pipe
 	var/obj/item/pipe/construction_type 		// The type PATH to the type of pipe fitting object the recipe makes.
 
-/datum/pipe_recipe/pipe/New(var/label, var/obj/machinery/atmospherics/path)
+/datum/pipe_recipe/pipe/New(var/label, var/obj/machinery/atmospherics/path, var/colorable=FALSE)
 	name = label
 	pipe_type = path
 	construction_type = initial(path.construction_type)
@@ -104,6 +105,7 @@ var/global/list/all_pipe_recipes = null
 	dirtype = initial(construction_type.dispenser_class)
 	if (dirtype == PIPE_TRIN_M)
 		icon_state_m = "[icon_state]m"
+	paintable = colorable
 
 // Render an HTML link to select this pipe type
 /datum/pipe_recipe/pipe/Render(dispenser)

--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -135,7 +135,7 @@
 	lines += "<a class='[screen == ATMOS_MODE ? "linkOn" : ""]' href='?src=\ref[src];screen=[ATMOS_MODE]'>Atmospherics</a>"
 	lines += "<a class='[screen == DISPOSALS_MODE ? "linkOn" : ""]' href='?src=\ref[src];screen=[DISPOSALS_MODE]'>Disposals</a>"
 	//lines += "<a class='[screen == TRANSIT_MODE ? "linkOn" : ""]' href='?src=\ref[src];screen=[TRANSIT_MODE]'>Transit Tube</a>"
-	lines += "<br><a class='[wrench_mode ? "linkOn" : "linkOff"]' href='?src=\ref[src];switch_wrench=1;wrench_mode=[!wrench_mode]'>Wrench Mode</a>"
+	lines += "<br><a class='[wrench_mode ? "linkOn" : ""]' href='?src=\ref[src];switch_wrench=1;wrench_mode=[!wrench_mode]'>Wrench Mode</a>"
 	lines += "</div>"
 
 	if(screen == ATMOS_MODE)
@@ -230,12 +230,7 @@
 	var/queued_p_dir = p_dir
 	var/queued_p_flipped = p_flipped
 	var/queued_p_subtype = recipe.subtype
-
-	// clicking on an existing component puts the new one on the same layer
-	if(mode == ATMOS_MODE && istype(A, /obj/machinery/atmospherics))
-		var/obj/machinery/atmospherics/AM = A
-		queued_piping_layer = AM.piping_layer
-		A = get_turf(user)
+	var/queued_p_paintable = recipe.paintable
 
 	//make sure what we're clicking is valid for the current mode
 	var/static/list/make_pipe_whitelist // This should probably be changed to be in line with polaris standards. Oh well.
@@ -286,7 +281,8 @@
 					P.update()
 					P.add_fingerprint(usr)
 					P.setPipingLayer(queued_piping_layer)
-					P.color = pipe_colors[paint_color]
+					if (queued_p_paintable)
+						P.color = pipe_colors[paint_color]
 					if(queued_p_flipped)
 						P.do_a_flip()
 					if(wrench_mode)


### PR DESCRIPTION
## About The Pull Request
This PR makes three tiny changes to the RPD that should make it more consistent to the end user.
1: The Wrench Mode button no longer turns grey when it's turned off. (One person reported not seeing it at all.)
2: Pipes that aren't paintable, no longer print pre-painted. While I enjoyed abusing this issue during development, it turns out some pipes disappear entirely if printed pre-painted. Whoopsie.
3: Fast layering has been entirely removed. When I ported the device I wasn't really sure what this feature did, and I think it's fairly clear no one else does either.
Fast layering was a feature that meant you could click a pipe, and the RPD would attempt to automatically attach the next pipe to that one. Obviously, this is confusing, as you might not notice you clicked a pipe, and begin to wonder why the pipes are now printing at your feet instead of where you're clicking.

## Why It's Good For The Game
This should improve user interactions with the RPD, making using it faster, and learning to use it faster.

## Changelog
:cl:
tweak: Tweaked the RPD to be more readily usable.
/:cl:
