### PR TITLE
Spacebike buff

### DIFF
--- a/code/datums/supplypacks/robotics.dm
+++ b/code/datums/supplypacks/robotics.dm
@@ -189,7 +189,7 @@
 /datum/supply_pack/robotics/bike
 	name = "Spacebike Crate"
 	contains = list()
-	cost = 350
+	cost = 200
 	containertype = /obj/structure/largecrate/vehicle/bike
 	containername = "Spacebike Crate"
 
@@ -203,6 +203,6 @@
 /datum/supply_pack/robotics/quadtrailer
 	name = "ATV Trailer Crate"
 	contains = list()
-	cost = 250
+	cost = 50
 	containertype = /obj/structure/largecrate/vehicle/quadtrailer
 	containername = "ATV Trailer Crate"

--- a/code/modules/vehicles/bike.dm
+++ b/code/modules/vehicles/bike.dm
@@ -17,8 +17,8 @@
 	brute_dam_coeff = 0.5
 	var/protection_percent = 60
 
-	var/land_speed = 1.5 //if 0 it can't go on turf
-	var/space_speed = 0.5
+	var/land_speed = 0.5 //if 0 it can't go on turf
+	var/space_speed = 0.4
 	var/bike_icon = "bike"
 	var/custom_icon = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases the speed of space bikes on land, and reduces cargo cost.

## Why It's Good For The Game

They have a dumbly high power usage and the batteries last about 10 minutes, they are also slow. Instead of changing the power usage I made them significantly faster

Cargo cost has also been reduced because I feel it is a bit much, while doing this I noticed that for some gay reason ATV TRAILERS(Not the ATV itself) were priced at some dumb shit and reduced it.

## Changelog
:cl:
tweak: Reduces ATV trailer cost from 250 to 50
tweak: Reduces bike cost from cargo from 350 to 200
balance:  Increase bike speed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
