### PR TITLE
Removes the "has this user been here before" check from bans

### DIFF
--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -44,16 +44,6 @@ datum/admins/proc/DB_ban_record(var/bantype, var/mob/banned_mob, var/duration = 
 		computerid = bancid
 		ip = banip
 
-	var/DBQuery/query = dbcon.NewQuery("SELECT id FROM erro_player WHERE ckey = '[ckey]'")
-	query.Execute()
-	var/validckey = 0
-	if(query.NextRow())
-		validckey = 1
-	if(!validckey)
-		if(!banned_mob || (banned_mob && !IsGuestKey(banned_mob.key)))
-			message_admins("<font color='red'>[key_name_admin(usr)] attempted to ban [ckey], but [ckey] has not been seen yet. Please only ban actual players.</font>",1)
-			return
-
 	var/a_ckey
 	var/a_computerid
 	var/a_ip


### PR DESCRIPTION
Admins aren't stupid enough to flood bans for nonexistant users, and if they really did want to do that because they were malicious there's far worse things to do, all this does is annoy the shit out of us when we try to preemptively ban/mirror a ban a problematic person.