### PR TITLE
Medbay Area Fix

### DIFF
--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -23189,7 +23189,7 @@
 	},
 /obj/item/device/defib_kit/loaded,
 /turf/simulated/floor/tiled/white,
-/area/space)
+/area/medical/sleeper)
 "Lp" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,


### PR DESCRIPTION
## About The Pull Request

Fixes the area assigned to a tile in medbay. I could've sworn this was fixed a while back but apparently not?

## Why It's Good For The Game

Once you notice the lighting's weird you'll never **not** notice it. It's driving me up the wall.

## Changelog
:cl:
fix: fixed a tile in the treatment center being assigned to the 'space' area
/:cl: