### PR TITLE
Numerous fixes to new areas

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -1374,8 +1374,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "bar"
 	sound_env = LARGE_SOFTFLOOR
 
-/area/crew_quarters/loungekitchen
+/area/crew_quarters/lounge/kitchen
 	name = "\improper Lounge Kitchen"
+	icon_state = "kitchen"
+
+/area/crew_quarters/lounge/kitchen_freezer
+	name = "\improper Lounge Kitchen Freezer"
 	icon_state = "kitchen"
 
 /area/library

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -7313,9 +7313,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -12441,6 +12441,7 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
+	dpdir = 11;
 	icon_state = "pipe-j2"
 	},
 /obj/machinery/hologram/holopad,
@@ -14417,9 +14418,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/reception_desk)
 "yL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -14436,6 +14434,10 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 6
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/reception_desk)
@@ -14556,6 +14558,9 @@
 	},
 /obj/effect/floor_decal/corner/mauve/bordercorner2{
 	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/reception_desk)
@@ -15480,10 +15485,6 @@
 /area/hallway/lower/third_south)
 "Av" = (
 /obj/machinery/bookbinder{
-	pixel_y = 0
-	},
-/obj/machinery/light/small{
-	dir = 8;
 	pixel_y = 0
 	},
 /turf/simulated/floor/wood,
@@ -19187,25 +19188,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
-"Fk" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/lower/third_south)
 "Fl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19555,6 +19537,11 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	icon_state = "extinguisher_closed";
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
@@ -22179,6 +22166,24 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
+"MV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/hallway/lower/third_south)
 "MW" = (
 /obj/structure/closet/secure_closet/bar{
 	req_access = list(25)
@@ -23547,6 +23552,11 @@
 /obj/machinery/camera/network/northern_star,
 /turf/simulated/open/virgo3b,
 /area/tether/surfacebase/outside/outside3)
+"Xm" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/hallway/lower/third_south)
 "Xo" = (
 /obj/structure/bed/chair/wood,
 /obj/structure/window/basic{
@@ -35069,7 +35079,7 @@ zl
 zl
 Iu
 vT
-Fk
+Ff
 Gb
 wf
 Gj
@@ -35353,8 +35363,8 @@ zl
 zl
 Iw
 wO
-Ff
-Gb
+MV
+Xm
 wf
 Gj
 Gv

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -12688,11 +12688,6 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_three)
 "wj" = (
-/obj/machinery/computer/guestpass{
-	dir = 1;
-	icon_state = "guest";
-	pixel_y = -28
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -12704,6 +12699,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_three)
 "wk" = (
@@ -12732,6 +12728,11 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/lightgrey/border,
+/obj/machinery/computer/guestpass{
+	dir = 1;
+	icon_state = "guest";
+	pixel_y = -28
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_three)
 "wm" = (
@@ -18743,6 +18744,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "ED" = (
@@ -19215,24 +19221,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
-/area/hallway/lower/third_south)
-"Fm" = (
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
@@ -20419,12 +20409,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
-"Hv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/outside/outside3)
 "Hw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -21020,6 +21004,16 @@
 /turf/simulated/floor/reinforced,
 /turf/simulated/shuttle/plating/carry,
 /area/shuttle/tether/surface)
+"IF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
 "IH" = (
 /obj/machinery/optable{
 	name = "Robotics Operating Table"
@@ -21858,6 +21852,26 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
+"La" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
 "Lc" = (
 /obj/structure/table/gamblingtable,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -22814,6 +22828,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
+"Rm" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/third_south)
 "Rt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23603,7 +23638,7 @@
 	name = "The Game Den"
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/tether/surfacebase/outside/outside3)
+/area/crew_quarters/bar)
 "Yq" = (
 /obj/structure/closet/toolcloset,
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -23715,6 +23750,20 @@
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/bar)
+"YR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/third_south)
 "YV" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -35297,7 +35346,7 @@ zl
 zl
 Iw
 wO
-Fm
+Ff
 Gb
 wf
 Gj
@@ -35423,8 +35472,8 @@ lY
 lY
 lY
 uI
-vk
-jM
+La
+IF
 wj
 xf
 xT
@@ -35439,8 +35488,8 @@ zQ
 zQ
 zQ
 IC
-DO
-Gb
+Rm
+YR
 GO
 Gj
 Gv
@@ -35582,7 +35631,7 @@ zl
 Ix
 wK
 DW
-Gb
+Fp
 GO
 ts
 Gv
@@ -35724,7 +35773,7 @@ wK
 wK
 wK
 Eu
-Gb
+Fp
 GO
 Gj
 Gv
@@ -35866,7 +35915,7 @@ wK
 tH
 DL
 DO
-Gb
+Fp
 GO
 Gj
 Gv
@@ -38282,7 +38331,7 @@ KW
 sX
 sX
 sX
-Hv
+vK
 ac
 ac
 IR
@@ -38424,7 +38473,7 @@ QG
 NU
 NU
 sX
-Hv
+vK
 ac
 ac
 IR

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -22477,6 +22477,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_three)
+"Pw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "Px" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -32488,7 +32495,7 @@ ac
 ac
 ac
 ac
-ac
+Pw
 tD
 tV
 tY

--- a/maps/tether/tether-04-transit.dmm
+++ b/maps/tether/tether-04-transit.dmm
@@ -19,7 +19,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/substation)
+/area/maintenance/tether_midpoint)
 "c" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -35,7 +35,7 @@
 /obj/structure/disposalpipe/down,
 /obj/effect/ceiling,
 /turf/simulated/open,
-/area/maintenance/substation)
+/area/maintenance/tether_midpoint)
 "d" = (
 /turf/simulated/shuttle/wall/voidcraft/green{
 	hard_corner = 1
@@ -47,7 +47,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/ceiling,
-/obj/structure/disposalpipe/junction,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -58,8 +57,12 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/substation)
+/area/maintenance/tether_midpoint)
 "f" = (
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/tether/midpoint)
@@ -82,16 +85,16 @@
 /obj/structure/cable,
 /obj/effect/ceiling,
 /turf/simulated/floor/plating,
-/area/maintenance/substation)
+/area/maintenance/tether_midpoint)
 "h" = (
 /obj/effect/ceiling,
 /turf/simulated/floor/plating,
-/area/maintenance/substation)
+/area/maintenance/tether_midpoint)
 "i" = (
 /obj/structure/disposalpipe/up,
 /obj/effect/ceiling,
 /turf/simulated/floor/plating,
-/area/maintenance/substation)
+/area/maintenance/tether_midpoint)
 "j" = (
 /obj/structure/disposalpipe/down{
 	dir = 1
@@ -102,7 +105,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/substation)
+/area/maintenance/tether_midpoint)
 "k" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -170,7 +173,7 @@
 /area/tether/midpoint)
 "s" = (
 /turf/simulated/wall/r_wall,
-/area/maintenance/substation)
+/area/maintenance/tether_midpoint)
 "t" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -208,6 +211,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/midpoint)
+"x" = (
+/turf/simulated/floor/plating,
+/area/maintenance/tether_midpoint)
 "y" = (
 /turf/simulated/wall/r_wall,
 /area/tether/midpoint)
@@ -228,12 +234,18 @@
 	icon_state = "intact-scrubbers";
 	dir = 5
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/substation)
+/area/maintenance/tether_midpoint)
 "A" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/maintenance/substation)
+/area/maintenance/tether_midpoint)
 "B" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -250,7 +262,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/substation)
+/area/maintenance/tether_midpoint)
 "C" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -268,12 +280,12 @@
 	},
 /obj/machinery/door/airlock/maintenance/engi,
 /turf/simulated/floor/plating,
-/area/maintenance/substation)
+/area/maintenance/tether_midpoint)
 "D" = (
 /obj/structure/closet,
 /obj/random/plushie,
 /turf/simulated/floor/plating,
-/area/maintenance/substation)
+/area/maintenance/tether_midpoint)
 "E" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -296,8 +308,15 @@
 /turf/simulated/floor/plating,
 /area/tether/midpoint)
 "I" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/substation)
+/area/maintenance/tether_midpoint)
 "K" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -313,6 +332,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/midpoint)
+"M" = (
+/obj/machinery/telecomms/relay/preset/tether/transit,
+/turf/simulated/floor/plating,
+/area/maintenance/tether_midpoint)
 "N" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -384,6 +407,9 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
 	},
+/obj/machinery/camera/network/northern_star{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/midpoint)
 "X" = (
@@ -397,7 +423,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/substation)
+/area/maintenance/tether_midpoint)
 "Y" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -9159,10 +9185,10 @@ b
 X
 z
 I
-I
-I
-I
-I
+x
+x
+x
+M
 s
 u
 u
@@ -9304,7 +9330,7 @@ g
 h
 i
 j
-I
+x
 s
 u
 u
@@ -9446,7 +9472,7 @@ d
 d
 d
 d
-I
+x
 s
 u
 u
@@ -9730,7 +9756,7 @@ f
 f
 f
 d
-I
+x
 s
 u
 u
@@ -9872,7 +9898,7 @@ f
 f
 f
 d
-I
+x
 s
 u
 u

--- a/maps/tether/tether-04-transit.dmm
+++ b/maps/tether/tether-04-transit.dmm
@@ -59,6 +59,7 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
+	dpdir = 11;
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -15,8 +15,9 @@
 /turf/simulated/wall/r_wall,
 /area/tether/station/excursion_dock)
 "aae" = (
-/turf/simulated/wall,
-/area/crew_quarters/freezer)
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/lounge/kitchen_freezer)
 "aaf" = (
 /turf/space,
 /area/shuttle/excursion/tether_nearby)
@@ -203,28 +204,22 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/excursion/tether)
 "aaE" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
-"aaF" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/super;
+/obj/machinery/firealarm{
 	dir = 8;
-	name = "west bump";
-	pixel_x = -30
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "freezer";
-	name = "Freezer shutters";
-	pixel_x = -24;
-	pixel_y = -24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
+/area/crew_quarters/lounge/kitchen_freezer)
+"aaF" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/lounge/kitchen_freezer)
 "aaG" = (
 /obj/machinery/power/smes/buildable/main,
 /obj/structure/cable{
@@ -1067,10 +1062,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "acs" = (
-/obj/structure/closet/crate/freezer,
-/obj/machinery/camera/network/civilian,
 /turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
+/area/crew_quarters/lounge/kitchen_freezer)
 "act" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -1096,13 +1089,27 @@
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "acv" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/freezer{
+	name = "Kitchen cold room";
+	req_access = list(28)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
+/area/crew_quarters/lounge/kitchen)
 "acw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -1198,25 +1205,21 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/engine_smes)
 "acM" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/freezer{
-	name = "Kitchen cold room";
-	req_access = list(28)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/loungekitchen)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/lounge/kitchen)
 "acN" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1486,14 +1489,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
-"adp" = (
-/obj/structure/kitchenspike,
-/obj/machinery/alarm{
-	pixel_y = 22;
-	target_temperature = 293.15
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
 "adq" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -1782,9 +1777,19 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
 "adR" = (
-/obj/structure/kitchenspike,
+/obj/machinery/light_switch{
+	pixel_x = 25
+	},
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/weapon/reagent_containers/food/condiment/flour,
+/obj/item/weapon/reagent_containers/food/condiment/flour,
+/obj/item/weapon/reagent_containers/food/condiment/flour,
+/obj/item/weapon/reagent_containers/food/condiment/flour,
+/obj/item/weapon/reagent_containers/food/condiment/flour,
+/obj/item/weapon/reagent_containers/food/condiment/flour,
+/obj/item/weapon/reagent_containers/food/condiment/flour,
 /turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
+/area/crew_quarters/lounge/kitchen_freezer)
 "adS" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
@@ -1792,12 +1797,15 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/backup)
 "adT" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
+/area/crew_quarters/lounge/kitchen_freezer)
 "adU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1845,8 +1853,14 @@
 /turf/simulated/floor,
 /area/maintenance/substation/engineering)
 "adX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
+/area/crew_quarters/lounge/kitchen_freezer)
 "adY" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
@@ -1872,19 +1886,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_smes)
 "aec" = (
-/obj/machinery/light_switch{
-	pixel_x = 25
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
 	},
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/weapon/reagent_containers/food/condiment/flour,
-/obj/item/weapon/reagent_containers/food/condiment/flour,
-/obj/item/weapon/reagent_containers/food/condiment/flour,
-/obj/item/weapon/reagent_containers/food/condiment/flour,
-/obj/item/weapon/reagent_containers/food/condiment/flour,
-/obj/item/weapon/reagent_containers/food/condiment/flour,
-/obj/item/weapon/reagent_containers/food/condiment/flour,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
+/area/crew_quarters/lounge/kitchen_freezer)
 "aed" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -1898,12 +1908,30 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_prep)
 "aee" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -30
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "freezer";
+	name = "Freezer shutters";
+	pixel_x = -24;
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
+/area/crew_quarters/lounge/kitchen_freezer)
 "aef" = (
 /obj/random/junk,
 /obj/random/trash,
@@ -1933,26 +1961,24 @@
 /turf/simulated/shuttle/wall/voidcraft,
 /area/shuttle/excursion/tether)
 "aek" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
+/obj/machinery/gibber,
 /turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
+/area/crew_quarters/lounge/kitchen_freezer)
 "ael" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
 "aem" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/space_heater,
@@ -2257,9 +2283,9 @@
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "aeF" = (
-/obj/machinery/gibber,
+/obj/machinery/chem_master/condimaster,
 /turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
+/area/crew_quarters/lounge/kitchen_freezer)
 "aeG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2274,13 +2300,6 @@
 	},
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/excursion/tether)
-"aeI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/icecream_vat,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
 "aeJ" = (
 /obj/effect/floor_decal/steeldecal/steel_decals5,
 /obj/machinery/light{
@@ -2360,10 +2379,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
-"aeR" = (
-/obj/machinery/chem_master/condimaster,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
 "aeS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2389,24 +2404,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
-"aeT" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/item/weapon/reagent_containers/food/snacks/mint,
-/obj/item/weapon/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/reagent_containers/glass/beaker{
-	pixel_x = 5
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
 "aeU" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled,
@@ -2454,8 +2451,21 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/excursion/tether)
 "aeZ" = (
-/turf/simulated/wall/r_wall,
-/area/crew_quarters/loungekitchen)
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/alarm{
+	frequency = 1441;
+	pixel_y = 22
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/lounge/kitchen)
 "afa" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -2546,21 +2556,15 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
 "afg" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/machinery/alarm{
-	frequency = 1441;
-	pixel_y = 22
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/camera/network/northern_star{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
 "afh" = (
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -2619,14 +2623,12 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
 "afl" = (
-/obj/structure/table/standard,
-/obj/machinery/microwave,
-/obj/machinery/newscaster{
-	pixel_x = 0;
-	pixel_y = 30
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
 "afm" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2652,18 +2654,6 @@
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
-"afo" = (
-/obj/structure/table/standard,
-/obj/machinery/microwave,
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/firealarm{
-	dir = 2;
-	layer = 3.3;
-	pixel_x = 0;
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
 "afp" = (
 /obj/machinery/light{
 	dir = 8;
@@ -2674,29 +2664,13 @@
 /turf/simulated/floor,
 /area/engineering/storage)
 "afq" = (
-/obj/effect/floor_decal/corner/grey/diagonal{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
-	},
-/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
-	pixel_x = 3
-	},
-/obj/structure/table/standard,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
-"afr" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/table/standard,
-/obj/item/weapon/material/kitchen/rollingpin,
-/obj/item/weapon/material/knife/butch,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
 "afs" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light{
@@ -2708,44 +2682,46 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor,
 /area/engineering/storage)
-"aft" = (
-/obj/machinery/vending/dinnerware,
-/obj/effect/floor_decal/corner/grey/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
 "afu" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
-"afv" = (
-/obj/machinery/appliance/grill,
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 9
+/obj/machinery/camera/network/northern_star{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
+"afv" = (
+/obj/machinery/appliance/mixer/candy,
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/lounge/kitchen)
 "afw" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
 "afx" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
 "afy" = (
 /obj/structure/sign/deck1,
 /turf/simulated/shuttle/wall/voidcraft/green{
@@ -2763,12 +2739,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "afB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/structure/table/standard,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/item/weapon/book/manual/chef_recipes,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
 "afC" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/station/atrium)
@@ -2817,15 +2792,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "afG" = (
-/obj/machinery/appliance/mixer/candy,
+/obj/machinery/appliance/mixer/cereal,
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
 "afH" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2858,12 +2830,22 @@
 /area/hallway/station/atrium)
 "afK" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/closet/chefcloset,
+/obj/item/glass_jar,
+/obj/item/device/retail_scanner/civilian,
+/obj/item/weapon/soap/nanotrasen,
+/obj/item/device/destTagger{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/machinery/light_switch{
+	pixel_x = -25
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
 "afL" = (
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
@@ -2961,19 +2943,17 @@
 /area/engineering/workshop)
 "afV" = (
 /obj/structure/table/standard,
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/item/weapon/book/manual/chef_recipes,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
-"afW" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/item/weapon/reagent_containers/food/condiment/enzyme{
-	layer = 5
+/obj/machinery/reagentgrinder,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
 	},
-/obj/item/weapon/reagent_containers/dropper,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
+"afW" = (
+/turf/simulated/wall,
+/area/crew_quarters/lounge/kitchen)
 "afX" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2997,9 +2977,21 @@
 "afY" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/item/weapon/packageWrap,
+/obj/item/weapon/reagent_containers/food/snacks/mint,
+/obj/item/weapon/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/glass/beaker{
+	pixel_x = 5
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
 "afZ" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 10
@@ -3034,12 +3026,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
 "agd" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -3133,10 +3122,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/door/airlock/freezer{
+	name = "Kitchen";
+	req_access = list(28);
+	req_one_access = newlist()
+	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
+/turf/simulated/floor/tiled,
+/area/crew_quarters/lounge/kitchen)
 "agn" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3192,40 +3185,22 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "agp" = (
-/obj/machinery/appliance/mixer/cereal,
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
+/obj/machinery/appliance/cooker/fryer,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
 "agq" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/closet/chefcloset,
-/obj/item/glass_jar,
-/obj/item/device/retail_scanner/civilian,
-/obj/item/weapon/soap/nanotrasen,
-/obj/item/device/destTagger{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/machinery/light_switch{
-	pixel_x = -25
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
-"agr" = (
-/obj/structure/table/standard,
-/obj/machinery/reagentgrinder,
-/obj/machinery/light{
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/structure/extinguisher_cabinet{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "extinguisher_closed";
+	pixel_x = -30
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
 "ags" = (
 /obj/structure/bed/chair/sofa,
 /turf/simulated/floor/wood,
@@ -3236,37 +3211,11 @@
 /area/crew_quarters/lounge)
 "agu" = (
 /obj/effect/floor_decal/industrial/warning/dust{
-	dir = 8
+	dir = 10
 	},
-/obj/machinery/appliance/cooker/fryer,
+/obj/machinery/appliance/cooker/oven,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
-"agv" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	icon_state = "extinguisher_closed";
-	pixel_x = -30
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
-"agw" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/freezer{
-	name = "Kitchen";
-	req_access = list(28);
-	req_one_access = newlist()
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
 "agx" = (
 /obj/structure/bed/chair/comfy/blue{
 	icon_state = "comfychair_preview";
@@ -3274,23 +3223,13 @@
 	},
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/excursion/tether)
-"agy" = (
+"agA" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
-"agz" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 10
-	},
-/obj/machinery/appliance/cooker/oven,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/loungekitchen)
-"agA" = (
-/turf/simulated/wall,
-/area/crew_quarters/loungekitchen)
+/area/crew_quarters/lounge/kitchen)
 "agB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -17699,6 +17638,13 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor,
 /area/crew_quarters/sleep/cryo)
+"biB" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/table/standard,
+/obj/item/weapon/material/kitchen/rollingpin,
+/obj/item/weapon/material/knife/butch,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/lounge/kitchen)
 "biC" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -22345,6 +22291,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
+"eWV" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/lounge)
 "flX" = (
 /obj/structure/table/woodentable,
 /obj/item/device/universal_translator,
@@ -22441,6 +22396,26 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/station/atrium)
+"hpl" = (
+/obj/effect/floor_decal/corner/grey/diagonal{
+	dir = 4
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = 3
+	},
+/obj/structure/table/standard,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/lounge/kitchen)
+"hry" = (
+/turf/simulated/wall,
+/area/crew_quarters/lounge/kitchen_freezer)
 "hCe" = (
 /turf/simulated/wall/r_wall,
 /area/tether/station/pathfinder_office)
@@ -22471,6 +22446,11 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/excursion/tether)
+"ico" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/lounge)
 "ixk" = (
 /obj/structure/table/woodentable,
 /obj/machinery/photocopier/faxmachine{
@@ -22513,6 +22493,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/excursion_dock)
+"jeb" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/northern_star,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/lounge)
 "jki" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -22538,6 +22536,15 @@
 /obj/item/weapon/paper_bin,
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
+"jzP" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/item/weapon/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/weapon/reagent_containers/dropper,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/lounge/kitchen)
 "jDS" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -22551,6 +22558,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
+"jIu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/lounge/kitchen_freezer)
 "jQQ" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -22721,6 +22734,11 @@
 /obj/item/weapon/folder/yellow,
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
+"myT" = (
+/obj/machinery/vending/dinnerware,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/lounge/kitchen)
 "mCP" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
@@ -22949,6 +22967,19 @@
 /obj/item/clothing/head/helmet/space/void/exploration,
 /turf/simulated/floor/tiled/monotile,
 /area/tether/station/explorer_prep)
+"puj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/lounge/kitchen_freezer)
+"pxY" = (
+/obj/structure/kitchenspike,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/lounge/kitchen_freezer)
 "pAD" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/paper_bin{
@@ -23029,6 +23060,24 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/station/excursion_dock)
+"qun" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/bridge)
+"qxB" = (
+/obj/structure/table/standard,
+/obj/machinery/microwave,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/lounge/kitchen)
 "qzk" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -23068,12 +23117,23 @@
 /obj/machinery/camera/network/northern_star,
 /turf/simulated/floor/tiled,
 /area/tether/station/excursion_dock)
+"rnb" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/lounge/kitchen)
 "rRn" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
+"rYy" = (
+/obj/machinery/appliance/grill,
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/lounge/kitchen)
 "sbI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -23088,6 +23148,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
+"sfY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/camera/network/northern_star{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/lounge)
 "soc" = (
 /obj/machinery/camera/network/northern_star,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -23113,6 +23182,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/station/pathfinder_office)
+"syg" = (
+/turf/simulated/floor/tiled,
+/area/crew_quarters/lounge)
 "sSn" = (
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
@@ -23264,6 +23336,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_prep)
+"uvx" = (
+/obj/structure/closet/crate/freezer,
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/lounge/kitchen_freezer)
+"uzc" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/item/weapon/packageWrap,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/lounge/kitchen)
 "uzS" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/blue,
@@ -23292,6 +23375,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
+"uIy" = (
+/obj/structure/table/standard,
+/obj/machinery/microwave,
+/obj/machinery/newscaster{
+	pixel_x = 0;
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/lounge/kitchen)
+"uRe" = (
+/turf/simulated/wall/r_wall,
+/area/crew_quarters/lounge/kitchen)
 "vrH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23432,6 +23527,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_prep)
+"wfy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/icecream_vat,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/lounge/kitchen_freezer)
 "wmC" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
@@ -23490,6 +23592,10 @@
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
+"wJa" = (
+/obj/machinery/camera/network/northern_star,
+/turf/simulated/floor/wood,
+/area/crew_quarters/lounge)
 "wLj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -23565,6 +23671,18 @@
 /obj/structure/railing,
 /turf/simulated/floor,
 /area/engineering/shaft)
+"xMl" = (
+/obj/structure/kitchenspike,
+/obj/machinery/alarm{
+	pixel_y = 22;
+	target_temperature = 293.15
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/lounge/kitchen_freezer)
+"xQB" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/crew_quarters/lounge)
 "ygn" = (
 /turf/simulated/floor/tiled,
 /area/tether/station/pathfinder_office)
@@ -32685,21 +32803,20 @@ aaa
 aaa
 aaa
 aaa
-abC
-abC
-aae
-aae
-aae
-aae
-aae
-aae
+aaa
+hry
+hry
+hry
+hry
+hry
+hry
+uRe
 aeZ
 afg
 afw
 afK
 agq
-agv
-agA
+afW
 agC
 agt
 ahe
@@ -32713,6 +32830,7 @@ ahg
 ahx
 agj
 aht
+syg
 aik
 aie
 aBH
@@ -32828,7 +32946,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+hry
 aae
 aaE
 adT
@@ -32839,9 +32957,8 @@ acM
 ael
 afx
 agc
+agc
 agm
-agm
-agw
 agB
 agD
 agM
@@ -32855,6 +32972,7 @@ agD
 ahv
 ahE
 ahS
+syg
 aik
 aif
 aBR
@@ -32970,20 +33088,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aae
+hry
+uvx
 acs
 adX
-adX
-adX
-aeI
-aeZ
+puj
+wfy
+uRe
+uIy
 afl
-afB
-afu
-afu
-afu
-agA
+rnb
+rnb
+rnb
+afW
 agG
 agG
 agG
@@ -32997,6 +33114,7 @@ agG
 ahC
 agj
 ahU
+syg
 aik
 aig
 alQ
@@ -33112,33 +33230,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
+hry
+xMl
+acs
+jIu
+acs
 aae
-adp
-adX
-adX
-adX
-aaE
-aeZ
-afo
+uRe
+qxB
+afl
 afB
 afV
-agr
-afu
-agA
+rnb
+afW
 afb
 agG
 agG
 ahk
 agG
-agG
+xQB
 agG
 agG
 agG
 agG
 ahz
 agj
-ahU
+jeb
+syg
 aik
 aig
 alT
@@ -33158,7 +33276,7 @@ agg
 acr
 acp
 beg
-awz
+qun
 axc
 axc
 bkS
@@ -33254,21 +33372,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aae
+hry
+pxY
 adR
 aec
 aek
 aeF
-aeR
-aeZ
+uRe
+hpl
 afq
-afB
+jzP
 afW
 agA
-agy
-agA
-agG
+afW
+wJa
 agS
 ahe
 ahl
@@ -33281,6 +33398,7 @@ agG
 ahz
 agk
 ahX
+eWV
 ahQ
 aih
 alT
@@ -33396,20 +33514,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aae
-aae
-aae
-aae
-aae
-aae
-aeZ
-afr
-afB
+hry
+hry
+hry
+hry
+hry
+hry
+uRe
+biB
+afl
+uzc
 afY
-aeT
-afu
-agA
+rnb
+afW
 afh
 agS
 ahh
@@ -33423,6 +33540,7 @@ agG
 agi
 agj
 ahL
+syg
 abC
 azJ
 alT
@@ -33539,19 +33657,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aac
 aac
 aac
 aac
 aat
-aeZ
-aft
-afB
+uRe
+myT
+afl
+rnb
+rnb
 afu
-afu
-afu
-agA
+afW
 ahp
 agS
 ahh
@@ -33565,6 +33682,7 @@ agG
 ahz
 ain
 ahN
+syg
 aaT
 azI
 alT
@@ -33682,18 +33800,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aat
 aat
 aat
 aat
-aeZ
-afu
-afB
-afu
-afu
-afu
-agA
+uRe
+rnb
+afl
+rnb
+rnb
+rnb
+afW
 agG
 agS
 ahe
@@ -33704,9 +33821,10 @@ ahe
 ahe
 ahi
 agG
-ahk
+sfY
 agk
 ahL
+syg
 aaY
 azX
 aCa
@@ -33824,18 +33942,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aat
 aat
 aat
 aat
-aeZ
+uRe
+rYy
 afv
 afG
 agp
 agu
-agz
-agA
+afW
 agH
 agG
 aga
@@ -33849,6 +33966,7 @@ aga
 ahA
 agj
 ahP
+ico
 agl
 agn
 abX
@@ -33970,7 +34088,7 @@ aaa
 aat
 aat
 aat
-aat
+uRe
 aad
 aad
 aad

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -4018,12 +4018,6 @@
 /turf/space,
 /area/space)
 "ahX" = (
-/obj/structure/cable/pink{
-	icon_state = "16-0"
-	},
-/obj/structure/cable/pink{
-	icon_state = "0-2"
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -4158,6 +4152,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/pink{
+	icon_state = "0-1";
+	dir = 4
+	},
+/obj/structure/cable/pink{
+	icon_state = "16-0"
 	},
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -3564,16 +3564,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/interrogation)
 "gG" = (
-/obj/structure/lattice,
-/obj/structure/cable/pink{
-	icon_state = "32-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/open,
+/obj/structure/cable/pink{
+	icon_state = "2-8";
+	dir = 4
+	},
+/turf/simulated/floor,
 /area/maintenance/station/sec_lower)
 "gH" = (
 /obj/machinery/door/airlock/maintenance/common,
@@ -17608,6 +17607,24 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
+"LE" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/lattice,
+/obj/structure/cable/pink{
+	icon_state = "32-4";
+	dir = 4
+	},
+/turf/simulated/open,
+/area/maintenance/station/sec_lower)
+"LG" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/pink{
+	icon_state = "1-2";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
 "LL" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -29306,8 +29323,8 @@ YU
 fN
 RS
 gG
-SI
-SI
+LG
+LE
 SI
 SI
 SI


### PR DESCRIPTION
Fixes numerous issues with recent map changes.

Adds missing wires, to connect the surface library to the power grid. 
Adds disposal segments to connect library to disposals network
Fixes broken disposals in tether midpoint
Fixed misplaced light and Guest Pass Terminal near surface library
Adds APC and telecomms relay to tether midpoint
Shifts the Asteroid 1 lounge north 1 tile, making the hallway 2 wide.
Redefines the areas for the kitchen and freezer on asteroid 1, making them distinct from surface 3 kitchen (an air alarm in one would trigger both)
Redefines the area in tether midpoint maint, so it's no longer listed as "substation" on power alarms
Slightly adjusts areas in surface bar game room, so the door and windows are powered.
Adds holopads and cameras to Asteroid 1, so the AI can relax too
Moves [this pink cable](https://files.catbox.moe/8fko6t.png) three tiles south, into maint. Adjusts chapel maint slightly as to not break the cable
Closes #1636, Closes #1635, Closes #1634