### PR TITLE
Changes Firing range doors to have same access as research door

### DIFF
--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -19859,7 +19859,12 @@
 /area/crew_quarters/bar)
 "Gq" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/door/window/brigdoor/southleft,
+/obj/machinery/door/window/brigdoor/westright{
+	dir = 2;
+	icon_state = "rightsecure";
+	name = "Firing Range Door";
+	req_access = list(47)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/testingrange)
 "Gr" = (


### PR DESCRIPTION
Closes #1642 
Changes doors in the firing range to have reqaccess(47), which is the same as the research front desk.