### PR TITLE
Update tether_defines.dm

### DIFF
--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -143,13 +143,14 @@
 /datum/map/tether/get_map_levels(var/srcz, var/long_range = TRUE)
 	if (long_range && (srcz in map_levels))
 		return map_levels
-	else if (srcz == Z_LEVEL_TRANSIT)
-		return list() // Nothing on transit!
+	else if (srcz == Z_LEVEL_SHIPS || srcz == Z_LEVEL_MISC)
+		return list() //no longer return signals in key transit levels, this means some runtimes from CWCs but 
 	else if (srcz >= Z_LEVEL_SURFACE_LOW && srcz <= Z_LEVEL_SPACE_HIGH)
 		return list(
 			Z_LEVEL_SURFACE_LOW,
 			Z_LEVEL_SURFACE_MID,
 			Z_LEVEL_SURFACE_HIGH,
+			Z_LEVEL_TRANSIT,
 			Z_LEVEL_SPACE_LOW,
 			Z_LEVEL_SPACE_MID,
 			Z_LEVEL_SPACE_HIGH)
@@ -194,8 +195,8 @@
 
 /datum/map_z_level/tether/transit
 	z = Z_LEVEL_TRANSIT
-	name = "Transit"
-	flags = MAP_LEVEL_SEALED|MAP_LEVEL_PLAYER|MAP_LEVEL_CONTACT|MAP_LEVEL_XENOARCH_EXEMPT
+	name = "Midpoint"
+	flags = MAP_LEVEL_STATION|MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER|MAP_LEVEL_CONSOLES|MAP_LEVEL_SEALED|MAP_LEVEL_XENOARCH_EXEMPT
 
 /datum/map_z_level/tether/station/space_low
 	z = Z_LEVEL_SPACE_LOW
@@ -237,6 +238,11 @@
 	z = Z_LEVEL_CENTCOM
 	name = "Colony"
 	flags = MAP_LEVEL_ADMIN|MAP_LEVEL_CONTACT|MAP_LEVEL_XENOARCH_EXEMPT
+
+/datum/map_z_level/tether/ships
+	z = Z_LEVEL_SHIPS
+	name = "Misc"
+	flags = MAP_LEVEL_ADMIN|MAP_LEVEL_XENOARCH_EXEMPT
 
 /datum/map_z_level/tether/misc
 	z = Z_LEVEL_MISC


### PR DESCRIPTION
## About The Pull Request

Updates the tether defines to add the midpoint to crew/gps tracking now that it's an actual, relayed, usable level after #1621 

Also defines the ships zlevel as an admin zlevel like the misc zlevel, as it was previously undefined for some reason.

## Why It's Good For The Game

Pretty self-explanatory. Crew monitors and GPS units can see suit sensors and GPS units on the midlevel.

In exchange crew monitors and gps trackers can't see signals on the misc and ship zlevels any more. This is probably unnecessary? Not sure.

## Changelog
:cl:
tweak: updates tether defines so the crew monitor and gps units can track into the midpoint
/:cl: