### PR TITLE
Fixes missing docking controller

### DIFF
--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -23638,6 +23638,16 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
+"XQ" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "expshuttle_surface3pad";
+	pixel_x = 0;
+	pixel_y = 28;
+	tag_door = "tether_pad_hatch"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/shuttle_pad)
 "Ya" = (
 /obj/structure/railing{
 	dir = 4
@@ -36510,7 +36520,7 @@ ts
 GP
 GP
 IR
-GR
+XQ
 GN
 IR
 GN

--- a/maps/tether/tether_shuttles.dm
+++ b/maps/tether/tether_shuttles.dm
@@ -266,6 +266,7 @@
 	name = "NSB Adephagia Surface Landing Pad"
 	my_area = /area/shuttle/excursion/tether_surface
 
+	dock_target = "expshuttle_surface3pad"
 	radio_announce = 1
 	announcer = "Excursion Shuttle"
 


### PR DESCRIPTION
## About The Pull Request

Addon to #1601: fixes the lack of a docking controller for the excursion shuttle on the surface 3 pad.

## Why It's Good For The Game

Mostly just fixing things I forgot to do before. The shuttle can now actually be ordered to dock when landed.

## Changelog
:cl:
fix: fixed lack of docking controller for s3 landing pad
/:cl: