### PR TITLE
Turns off the two randomly broadcasting intercomms

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -10224,16 +10224,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "asO" = (
-/obj/item/device/radio/intercom{
-	broadcasting = 1;
-	dir = 8;
-	listening = 1;
-	name = "Common Channel";
-	pixel_x = -21;
-	pixel_y = 0
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/pipedispenser,
+/obj/item/device/radio/intercom,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "asP" = (
@@ -11176,7 +11173,7 @@
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/anomaly_lab)
@@ -17859,7 +17856,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/item/device/radio/intercom{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/anomaly_lab)
@@ -18791,7 +18788,7 @@
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
@@ -22905,7 +22902,7 @@
 /obj/structure/table/woodentable,
 /obj/item/device/radio/intercom{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -24
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -313,7 +313,7 @@
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
@@ -2016,7 +2016,7 @@
 "dZ" = (
 /obj/item/device/radio/intercom{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/security/breakroom)
@@ -6697,7 +6697,7 @@
 /obj/item/weapon/material/ashtray/plastic,
 /obj/item/device/radio/intercom{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -24
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/atrium_three)
@@ -10056,7 +10056,7 @@
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
@@ -23065,15 +23065,11 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_three)
 "Yz" = (
-/obj/item/device/radio/intercom{
-	broadcasting = 1;
-	dir = 8;
-	listening = 1;
-	name = "Common Channel";
-	pixel_x = -21;
-	pixel_y = 0
-	},
 /obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
 "YA" = (


### PR DESCRIPTION
Makes it so the intercoms in atmos and the public garden aren't broadcasting at round start