### PR TITLE
Adds Shield Diffusers around most EVA exits

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -33,7 +33,8 @@
 		/obj/item/weapon/tank/emergency/oxygen/engi,
 		/obj/item/device/gps/engineering/ce,
 		/obj/item/weapon/reagent_containers/spray/windowsealant,//VOREStation Add
-		/obj/item/weapon/pipe_dispenser)
+		/obj/item/weapon/pipe_dispenser, //Citadel Addition
+		/obj/item/weapon/shield_diffuser) //Citadel Addition
 
 /obj/structure/closet/secure_closet/engineering_chief/Initialize()
 	if(prob(50))
@@ -101,7 +102,8 @@
 		/obj/item/clothing/shoes/boots/winter/engineering,
 		/obj/item/weapon/tank/emergency/oxygen/engi,
 		/obj/item/device/gps/engineering,
-		/obj/item/weapon/reagent_containers/spray/windowsealant) //VOREStation Add
+		/obj/item/weapon/reagent_containers/spray/windowsealant, //VOREStation Add
+		/obj/item/weapon/shield_diffuser) //Citadel Addition
 
 /obj/structure/closet/secure_closet/engineering_personal/Initialize()
 	if(prob(50))
@@ -138,7 +140,8 @@
 		/obj/item/clothing/shoes/boots/winter/atmos,
 		/obj/item/weapon/tank/emergency/oxygen/engi,
 		/obj/item/device/gps/engineering/atmos,
-		/obj/item/weapon/pipe_dispenser)
+		/obj/item/weapon/pipe_dispenser,
+		/obj/item/weapon/shield_diffuser) //Citadel Addition
 
 /obj/structure/closet/secure_closet/atmos_personal/Initialize()
 	if(prob(50))

--- a/maps/submaps/engine_submaps/engine_sme.dmm
+++ b/maps/submaps/engine_submaps/engine_sme.dmm
@@ -1660,6 +1660,16 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/template_noop)
+"wm" = (
+/obj/effect/floor_decal/industrial/warning/cee{
+	icon_state = "warningcee";
+	dir = 1
+	},
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/space)
 
 (1,1,1) = {"
 aa
@@ -2088,7 +2098,7 @@ ab
 ab
 ab
 ab
-ab
+wm
 aF
 aM
 aX

--- a/maps/submaps/engine_submaps/engine_sme.dmm
+++ b/maps/submaps/engine_submaps/engine_sme.dmm
@@ -1666,10 +1666,8 @@
 	dir = 1
 	},
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced/nitrogen{
-	nitrogen = 82.1472
-	},
-/area/space)
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/engine_room)
 
 (1,1,1) = {"
 aa

--- a/maps/submaps/engine_submaps/engine_tesla.dmm
+++ b/maps/submaps/engine_submaps/engine_tesla.dmm
@@ -153,6 +153,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_room)
 "au" = (
@@ -1419,6 +1420,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_room)
 "cu" = (
@@ -1746,9 +1748,9 @@ ab
 ab
 ab
 ab
-ad
+aj
 ab
-ad
+aj
 ab
 ab
 ab
@@ -1778,9 +1780,9 @@ ab
 ab
 ab
 ab
-ad
+aj
 ab
-ad
+aj
 ab
 ab
 ab
@@ -1810,9 +1812,9 @@ ab
 ab
 ab
 ab
-ad
+aj
 ab
-ad
+aj
 ab
 ab
 ab
@@ -1842,9 +1844,9 @@ ab
 ab
 ab
 ab
-ad
+aj
 ab
-ad
+aj
 ab
 ab
 ab
@@ -1874,9 +1876,9 @@ ab
 ab
 zh
 ad
+aj
 ad
-ad
-ad
+aj
 ad
 zh
 ab
@@ -1906,9 +1908,9 @@ ab
 ab
 aj
 co
+aj
 ad
-ad
-ad
+aj
 co
 aj
 ab
@@ -1932,21 +1934,21 @@ ab
 ac
 ak
 cF
-ad
-ad
-ad
-ad
-ad
+aj
+aj
+aj
+aj
+aj
 cK
 aX
 aj
 aX
 cK
-ad
-ad
-ad
-ad
-ad
+aj
+aj
+aj
+aj
+aj
 cs
 cy
 cC
@@ -1996,21 +1998,21 @@ ab
 ac
 am
 ar
-ad
-ad
-ad
-ad
-ad
+aj
+aj
+aj
+aj
+aj
 cK
 aX
 aj
 aX
 cK
-ad
-ad
-ad
-ad
-ad
+aj
+aj
+aj
+aj
+aj
 cs
 cz
 cC

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -34,6 +34,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/mining_main/external)
 "aaj" = (
@@ -430,6 +431,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/mining_main/external)
 "aaX" = (
@@ -2862,6 +2864,7 @@
 /area/tether/surfacebase/tram)
 "afq" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/virgo3b,
 /area/tether/surfacebase/outside/outside1)
 "afr" = (
@@ -17500,10 +17503,6 @@
 /obj/effect/step_trigger/teleporter/to_solars,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside1)
-"aFC" = (
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/outside/outside1)
 "aFD" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -19377,6 +19376,7 @@
 	frequency = 1441;
 	id_tag = "atmos_intake"
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/engineering/atmos/intake)
 "aJB" = (
@@ -22886,10 +22886,6 @@
 /area/tether/surfacebase/atrium_one)
 "baY" = (
 /obj/structure/table/woodentable,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
@@ -31390,6 +31386,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"cAR" = (
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/engineering/atmos/intake)
 "cBB" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -31741,6 +31741,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_one)
+"fGy" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "fKN" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/engineering,
@@ -31754,6 +31759,10 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
+"fOF" = (
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/mining_main/external)
 "fUw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -32520,6 +32529,10 @@
 /obj/effect/floor_decal/techfloor/corner,
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/public_garden_one)
+"orR" = (
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "osI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -32613,6 +32626,10 @@
 "pCg" = (
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/public_garden_one)
+"pLu" = (
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "pZF" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -33749,18 +33766,18 @@ frA
 frA
 frA
 abf
-aad
-aFC
-aFC
-aFC
-aFC
-aFC
-aFC
-aad
-aFC
-aFC
-aad
-aFC
+fGy
+fGy
+fGy
+fGy
+fGy
+fGy
+fGy
+fGy
+fGy
+fGy
+fGy
+fGy
 aad
 aad
 aad
@@ -33899,8 +33916,8 @@ aad
 aad
 aad
 aad
-aFC
-aFC
+aad
+aad
 aad
 aad
 aad
@@ -34042,7 +34059,7 @@ aad
 aad
 aad
 aad
-aFC
+aad
 aad
 aad
 aad
@@ -34315,8 +34332,9 @@ aad
 aad
 aad
 aad
-aad
+pLu
 aEv
+pLu
 aad
 aad
 aad
@@ -34327,7 +34345,6 @@ aad
 aad
 aad
 aad
-aFC
 aad
 aad
 aad
@@ -34457,9 +34474,9 @@ aad
 aad
 aad
 aad
-aad
+pLu
 aEw
-aad
+pLu
 aad
 aad
 aad
@@ -34599,8 +34616,9 @@ aad
 aad
 aad
 aad
-aad
+pLu
 aEw
+pLu
 aad
 aad
 aad
@@ -34611,7 +34629,6 @@ aad
 aad
 aad
 aad
-aFC
 aad
 aad
 aad
@@ -34741,9 +34758,9 @@ aad
 aad
 aad
 aad
-aad
+pLu
 aEw
-aad
+pLu
 aad
 aad
 aad
@@ -34883,9 +34900,9 @@ aad
 aad
 aad
 aad
-aad
+pLu
 aEw
-aad
+pLu
 aad
 aad
 aad
@@ -35025,9 +35042,9 @@ aad
 aad
 aad
 aad
-aad
+pLu
 aEw
-aad
+pLu
 aad
 aad
 aad
@@ -35167,9 +35184,9 @@ aad
 aad
 aad
 aad
-aad
+pLu
 aEw
-aad
+pLu
 aad
 aad
 aad
@@ -35309,9 +35326,9 @@ aad
 aad
 aad
 aad
-aad
+pLu
 aEx
-aad
+pLu
 aad
 aad
 aad
@@ -36545,9 +36562,9 @@ aah
 aah
 aah
 adK
-aeo
-aeo
-aeo
+orR
+orR
+orR
 afq
 afq
 adK
@@ -36842,10 +36859,10 @@ aah
 aah
 aah
 aah
-akb
-akb
-akb
-akb
+pLu
+pLu
+pLu
+pLu
 aah
 aah
 aah
@@ -39155,7 +39172,7 @@ bOI
 bQT
 aHh
 aIp
-akb
+pLu
 aad
 aad
 aad
@@ -39297,7 +39314,7 @@ bOt
 bQL
 bSJ
 aIq
-akb
+pLu
 aad
 aad
 aad
@@ -39439,7 +39456,7 @@ bON
 bQV
 bSK
 aIq
-akb
+pLu
 aad
 aad
 aad
@@ -39581,7 +39598,7 @@ bOL
 bQU
 aHh
 aIr
-akb
+pLu
 aad
 aad
 aad
@@ -41297,16 +41314,16 @@ aIv
 aIv
 aIv
 aIv
-aJt
-aJt
-aJt
-aJt
+cAR
+cAR
+cAR
+cAR
 aJA
-aJt
-aJt
-aJt
-aJt
-aJt
+cAR
+cAR
+cAR
+cAR
+cAR
 aad
 aad
 aad
@@ -41449,7 +41466,7 @@ aJS
 aJJ
 aJS
 aJt
-aJt
+cAR
 aad
 aad
 aad
@@ -41591,7 +41608,7 @@ aIM
 aIM
 aIM
 aJS
-aJt
+cAR
 aad
 aad
 aad
@@ -41733,7 +41750,7 @@ aJK
 aJW
 aKl
 aKl
-aJt
+cAR
 aad
 aad
 aad
@@ -41875,7 +41892,7 @@ aJJ
 aJS
 aKl
 aKl
-aJt
+cAR
 aad
 aad
 aad
@@ -42017,7 +42034,7 @@ aIM
 aIM
 aIM
 aJW
-aJt
+cAR
 aad
 aad
 aad
@@ -44056,7 +44073,7 @@ aae
 aae
 aae
 aae
-aaf
+fOF
 aaf
 aao
 aau
@@ -44181,7 +44198,7 @@ clb
 "}
 (76,1,1) = {"
 aac
-aaf
+fOF
 aae
 aae
 aae
@@ -44325,10 +44342,10 @@ aaa
 aac
 aaf
 aaf
-aaf
-aaf
-aaf
-aaf
+fOF
+fOF
+fOF
+fOF
 aae
 aae
 aae
@@ -44471,10 +44488,10 @@ aaf
 aaf
 aaf
 aaf
-aaf
-aaf
-aaf
-aaf
+fOF
+fOF
+fOF
+fOF
 aae
 aae
 aae
@@ -44618,12 +44635,12 @@ aaf
 aaf
 aaf
 aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+fOF
+fOF
+fOF
+fOF
+fOF
+fOF
 aaf
 aak
 aar
@@ -45035,19 +45052,19 @@ aaa
 aac
 aaf
 aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+fOF
+fOF
+fOF
+fOF
+fOF
+fOF
+fOF
+fOF
+fOF
+fOF
+fOF
+fOF
+fOF
 aaf
 aaf
 aaf
@@ -45175,7 +45192,7 @@ aaa
 "}
 (83,1,1) = {"
 aac
-aaf
+fOF
 aae
 aae
 aae
@@ -45332,9 +45349,9 @@ aae
 aae
 aae
 aae
-aaf
-aaf
-aaf
+fOF
+fOF
+fOF
 aaf
 aah
 aah

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -1845,6 +1845,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/rust,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "dI" = (
@@ -1852,6 +1853,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/rust,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "dJ" = (
@@ -1859,6 +1861,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/rust,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "dK" = (
@@ -2158,6 +2161,7 @@
 /obj/effect/floor_decal/corner_oldtile/green{
 	dir = 9
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "em" = (
@@ -2170,6 +2174,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/rust,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "eo" = (
@@ -2592,6 +2597,7 @@
 /obj/effect/floor_decal/corner_oldtile/green{
 	dir = 9
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "eY" = (
@@ -2601,6 +2607,7 @@
 /obj/effect/floor_decal/corner_oldtile/green{
 	dir = 6
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "eZ" = (
@@ -3409,6 +3416,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner_oldtile/green/full,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "gu" = (
@@ -3418,6 +3426,7 @@
 /obj/effect/floor_decal/corner_oldtile/green{
 	dir = 10
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "gv" = (
@@ -3427,6 +3436,7 @@
 /obj/effect/floor_decal/corner_oldtile/green/full{
 	dir = 4
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "gw" = (
@@ -20778,6 +20788,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/atrium_three)
+"KL" = (
+/obj/structure/catwalk,
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/outside/outside3)
 "KM" = (
 /obj/item/weapon/stool/padded,
 /obj/structure/disposalpipe/segment{
@@ -21227,8 +21242,7 @@
 /obj/machinery/camera/network/mining{
 	dir = 8
 	},
-/obj/structure/lattice,
-/turf/simulated/open/virgo3b,
+/turf/simulated/floor/plating,
 /area/tether/surfacebase/outside/outside3)
 "MB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -21249,11 +21263,14 @@
 /obj/machinery/camera/network/mining,
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/tether/surfacebase/outside/outside3)
+"MJ" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/outside/outside3)
 "MK" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/mining,
-/obj/structure/lattice,
-/turf/simulated/open/virgo3b,
+/turf/simulated/floor/plating,
 /area/tether/surfacebase/outside/outside3)
 "MO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -21789,8 +21806,8 @@
 /area/tether/surfacebase/bar_backroom)
 "Pz" = (
 /obj/structure/catwalk,
-/obj/structure/lattice,
-/turf/simulated/open/virgo3b,
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating,
 /area/maintenance/bar/catwalk)
 "PA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -21995,8 +22012,7 @@
 	icon_state = "tube1";
 	dir = 1
 	},
-/obj/structure/lattice,
-/turf/simulated/open/virgo3b,
+/turf/simulated/floor/plating,
 /area/maintenance/bar/catwalk)
 "Qu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -22272,7 +22288,6 @@
 /obj/structure/cable/green{
 	icon_state = "0-8"
 	},
-/obj/structure/lattice,
 /turf/simulated/floor/plating,
 /area/maintenance/bar/catwalk)
 "Rz" = (
@@ -22979,8 +22994,7 @@
 	icon_state = "tube1";
 	dir = 8
 	},
-/obj/structure/lattice,
-/turf/simulated/open/virgo3b,
+/turf/simulated/floor/plating,
 /area/maintenance/bar/catwalk)
 "VF" = (
 /obj/machinery/light{
@@ -23192,6 +23206,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/reading_room)
+"WR" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/bar/catwalk)
 "WS" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
@@ -23231,8 +23249,7 @@
 "Xh" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/northern_star,
-/obj/structure/lattice,
-/turf/simulated/open/virgo3b,
+/turf/simulated/floor/plating,
 /area/maintenance/bar/catwalk)
 "Xk" = (
 /obj/structure/railing,
@@ -23360,11 +23377,6 @@
 /obj/machinery/light/flamp,
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/atrium_three)
-"XM" = (
-/obj/structure/catwalk,
-/obj/structure/lattice,
-/turf/simulated/open/virgo3b,
-/area/tether/surfacebase/outside/outside3)
 "XQ" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
 	frequency = 1380;
@@ -30416,14 +30428,14 @@ ac
 ac
 ac
 ac
-XM
-XM
+KL
+MJ
 Mw
-XM
-XM
-XM
-XM
-XM
+MJ
+MJ
+MJ
+MJ
+MJ
 Pi
 ab
 ab
@@ -30565,7 +30577,7 @@ Dx
 Dx
 Dx
 Dx
-XM
+MJ
 Pi
 ab
 ab
@@ -30707,7 +30719,7 @@ Hk
 Dx
 Dx
 Dx
-XM
+MJ
 Pi
 ab
 ab
@@ -30849,7 +30861,7 @@ Hk
 Dx
 Dx
 Dx
-XM
+MJ
 Pi
 ab
 ab
@@ -30991,7 +31003,7 @@ Il
 Dx
 Dx
 Dx
-XM
+MJ
 Pi
 ab
 ab
@@ -31133,7 +31145,7 @@ Hk
 Dx
 Dx
 Dx
-XM
+MJ
 Pi
 ab
 ab
@@ -31417,7 +31429,7 @@ Hk
 Dx
 Dx
 Dx
-XM
+KL
 Pi
 ab
 ab
@@ -40158,12 +40170,12 @@ ac
 ac
 ac
 ac
-ab
-ab
-ab
-ab
-ab
-ab
+ac
+KL
+MJ
+MJ
+MJ
+KL
 ac
 ac
 kk
@@ -40301,11 +40313,11 @@ ac
 ac
 ac
 ab
-ab
-ab
-ab
-ab
-ab
+Vm
+Vm
+Vm
+Vm
+Vm
 ab
 ab
 ab
@@ -40761,13 +40773,13 @@ Rt
 Ok
 RB
 Ry
-Pz
-Pz
-Pz
-Pz
+WR
+WR
+WR
+WR
 VE
-Pz
-Pz
+WR
+WR
 Pz
 Pi
 ab
@@ -41185,8 +41197,8 @@ ac
 RB
 RB
 RB
-Pz
-Pz
+WR
+WR
 Pi
 ab
 ab
@@ -41324,10 +41336,10 @@ ab
 ab
 Qh
 Pz
-Pz
+WR
 VE
-Pz
-Pz
+WR
+WR
 TB
 ab
 ab

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -11490,6 +11490,7 @@
 	name = "Engineering Starboard External Access"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor,
 /area/engineering/engineering_airlock)
 "aCC" = (
@@ -20613,6 +20614,7 @@
 	locked = 1;
 	name = "Docking Port Airlock"
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "bHu" = (
@@ -20700,6 +20702,7 @@
 	pixel_y = -26;
 	req_one_access = list(13)
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
 "bHN" = (
@@ -21096,6 +21099,7 @@
 	locked = 1;
 	name = "Docking Port Airlock"
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "bPq" = (
@@ -21173,6 +21177,7 @@
 	locked = 1;
 	name = "Docking Port Airlock"
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_two)
 "bPx" = (
@@ -21523,6 +21528,7 @@
 	locked = 1;
 	name = "Dock One External Access"
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "bQz" = (
@@ -21533,6 +21539,7 @@
 	locked = 1;
 	name = "Dock One External Access"
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "bQC" = (
@@ -21552,6 +21559,7 @@
 	pixel_y = -6;
 	req_one_access = list(13)
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
 "bQD" = (
@@ -21579,6 +21587,7 @@
 	locked = 1;
 	name = "Docking Port Airlock"
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
 "bVu" = (

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -3109,6 +3109,10 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/engineering/shaft)
+"fy" = (
+/obj/structure/grille,
+/turf/simulated/mineral/floor/vacuum,
+/area/mine/explored/upper_level)
 "fB" = (
 /obj/structure/stairs/south,
 /turf/simulated/floor/tiled,
@@ -11465,6 +11469,7 @@
 	pixel_y = -26;
 	req_access = list(18)
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
 "uP" = (
@@ -15954,6 +15959,7 @@
 	name = "Large Escape Pod 1"
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor,
 /area/hallway/secondary/escape/medical_escape_pod_hallway)
 "BM" = (
@@ -17540,6 +17546,10 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
+"Lr" = (
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating,
+/area/mine/explored/upper_level)
 "Lx" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/weapon/cell/super;
@@ -18351,6 +18361,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/brig)
+"Rj" = (
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/airless,
+/area/space)
 "Rl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/frame/apc,
@@ -18539,6 +18553,10 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor,
 /area/maintenance/evahallway)
+"SM" = (
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/mine/explored/upper_level)
 "ST" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
@@ -19432,6 +19450,9 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
+"Zo" = (
+/turf/simulated/floor/plating,
+/area/mine/explored/upper_level)
 "Zr" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/techfloor{
@@ -27800,7 +27821,7 @@ aa
 aa
 aa
 aa
-ab
+Rj
 ab
 IO
 Mq
@@ -32792,7 +32813,7 @@ ac
 ac
 ac
 aP
-aP
+Zo
 aP
 aP
 aP
@@ -32933,9 +32954,9 @@ ac
 ac
 ac
 aP
-aP
-aP
-aP
+fy
+Zo
+fy
 aP
 aP
 aP
@@ -33073,16 +33094,16 @@ ac
 ac
 ac
 ac
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
+Zo
+Zo
+Zo
+Zo
+Zo
+Zo
+Zo
+Zo
+Zo
+Zo
 OJ
 OJ
 OJ
@@ -33217,9 +33238,9 @@ ac
 ac
 aP
 aP
-aP
-aP
-aP
+fy
+Zo
+fy
 aP
 aP
 aP
@@ -33360,7 +33381,7 @@ aP
 aP
 aP
 aP
-aP
+Zo
 aP
 aP
 aP
@@ -33501,9 +33522,9 @@ aP
 aP
 aP
 aP
-aP
-aP
-aP
+fy
+Zo
+fy
 aP
 aP
 aP
@@ -33644,7 +33665,7 @@ aP
 aP
 aP
 aP
-aP
+Zo
 aP
 aP
 aP
@@ -33783,16 +33804,16 @@ Yw
 Yw
 Yw
 Yw
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
+Zo
+Zo
+SM
+Zo
+SM
+Zo
+Zo
+Zo
+Zo
+Zo
 Zx
 Ta
 JL
@@ -33928,7 +33949,7 @@ aa
 aP
 aP
 aP
-aP
+Zo
 aP
 aP
 aP
@@ -34069,9 +34090,9 @@ aa
 aa
 aa
 aa
-aP
-aP
-aP
+fy
+Lr
+fy
 aP
 aP
 aP

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -6895,6 +6895,7 @@
 /obj/machinery/door/airlock/external{
 	locked = 1
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor,
 /area/maintenance/station/ai)
 "lu" = (
@@ -12702,24 +12703,7 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "uv" = (
-/obj/structure/table/steel,
-/obj/item/weapon/wrapping_paper,
-/obj/item/weapon/wrapping_paper,
-/obj/item/weapon/wrapping_paper,
-/obj/item/device/destTagger{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "uw" = (
@@ -13257,22 +13241,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
-"vi" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Mailing-Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/delivery)
 "vj" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -13756,24 +13724,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
-/turf/simulated/floor/tiled,
-/area/quartermaster/delivery)
-"vY" = (
-/obj/structure/table/steel,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/machinery/camera/network/cargo{
-	dir = 1;
-	name = "security camera"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 6
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "vZ" = (
@@ -27631,6 +27581,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
+"RC" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "cargo_bay_door";
+	locked = 1;
+	name = "Cargo Docking Hatch"
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad2"
+	},
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating,
+/area/quartermaster/storage)
 "RU" = (
 /obj/machinery/suit_cycler/headofsecurity,
 /turf/simulated/floor/wood,
@@ -27642,6 +27608,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/eva)
+"Sp" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "cargo_bay_door";
+	locked = 1;
+	name = "Cargo Docking Hatch"
+	},
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/tiled,
+/area/quartermaster/storage)
 "SD" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -27651,6 +27629,14 @@
 /area/ai/foyer)
 "SW" = (
 /turf/simulated/mineral/vacuum,
+/area/space)
+"Tv" = (
+/obj/machinery/shield_diffuser,
+/turf/simulated/wall,
+/area/quartermaster/delivery)
+"TE" = (
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/airless,
 /area/space)
 "TL" = (
 /obj/machinery/ai_slipper{
@@ -27709,6 +27695,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/eva)
+"UJ" = (
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "UK" = (
 /obj/random/trash_pile,
 /obj/structure/railing{
@@ -27765,6 +27755,22 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence_storage)
+"Xg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "cargo_bay_door";
+	locked = 1;
+	name = "Cargo Docking Hatch"
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad"
+	},
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating,
+/area/quartermaster/storage)
 "Xv" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -27824,6 +27830,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
+"ZH" = (
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating,
+/area/quartermaster/delivery)
 "ZO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
@@ -37087,7 +37097,7 @@ aa
 aa
 aa
 ed
-gg
+TE
 gg
 aU
 aU
@@ -37229,7 +37239,7 @@ aa
 aa
 aa
 ed
-gg
+TE
 gj
 gl
 gx
@@ -37371,7 +37381,7 @@ aa
 aa
 aa
 ed
-gg
+TE
 gg
 ac
 ag
@@ -37513,8 +37523,8 @@ aa
 aa
 aa
 ed
-gg
-gg
+TE
+TE
 aU
 aU
 aU
@@ -40106,9 +40116,9 @@ rN
 sz
 ty
 uv
-vi
-vY
-wD
+uv
+uv
+ZH
 xm
 ya
 yS
@@ -40250,8 +40260,8 @@ qr
 uw
 uw
 uw
-qr
-xm
+Tv
+UJ
 ya
 yT
 zL
@@ -42388,11 +42398,11 @@ vt
 vt
 vt
 CR
-DD
-Ez
+RC
+Sp
 Fn
-Ez
-GQ
+Sp
+Xg
 HH
 ae
 ae


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds Shield diffusers around most paths outside the station that normally had to be bashed through. Also adds handheld diffusers to engineering lockers

## Why It's Good For The Game
Diffusers have been in the game and code since pre-polaris baycode, and really should have been mapped into the tether initially.

## Changelog
:cl:
add: Shield Diffusers are now mapped in, meaning shields won't form on certain access paths.
add: Engineers now get handheld diffusers in their lockers, to instantly break shields (No more crowbar bashing)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
