### PR TITLE
Miscellaneous fixes, resolves issues #1512, #1667

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -873,6 +873,11 @@ FIRE ALARM
 /obj/machinery/firealarm/attackby(obj/item/W as obj, mob/user as mob)
 	add_fingerprint(user)
 
+	if(alarm_deconstruction_screwdriver(user, W))
+		return
+	if(alarm_deconstruction_wirecutters(user, W))
+		return
+
 	if(panel_open)
 		if(istype(W, /obj/item/device/multitool))
 			detecting = !(detecting)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -37,11 +37,14 @@
 	var/obj/item/weapon/airlock_electronics/ae
 	if(!electronics)
 		ae = new/obj/item/weapon/airlock_electronics( src.loc )
-		if(!src.req_access)
-			src.check_access()
-		if(src.req_access.len)
+
+		if(!src.req_access)    //This apparently has side effects that might
+			src.check_access() //update null r_a's? Leaving it just in case.
+
+		if(src.req_access)
 			ae.conf_access = src.req_access
-		else if (src.req_one_access.len)
+
+		else if(src.req_one_access)
 			ae.conf_access = src.req_one_access
 			ae.one_access = 1
 	else

--- a/code/modules/food/kitchen/cooking_machines/container.dm
+++ b/code/modules/food/kitchen/cooking_machines/container.dm
@@ -45,7 +45,7 @@
 			return
 
 /obj/item/weapon/reagent_containers/cooking_container/verb/empty()
-	set src in oview(1)
+	set src in view(1)
 	set name = "Empty Container"
 	set category = "Object"
 	set desc = "Removes items from the container, excluding reagents."

--- a/code/modules/food/kitchen/cooking_machines/grill.dm
+++ b/code/modules/food/kitchen/cooking_machines/grill.dm
@@ -47,26 +47,27 @@
 
 //Container is not removable
 /obj/machinery/appliance/grill/removal_menu(var/mob/user)
-	if (can_remove_items(user))
-		var/list/menuoptions = list()
-		for (var/a in cooking_objs)
-			var/datum/cooking_item/CI = a
-			if (CI.container)
-				if (!CI.container.check_contents())
-					user << "There's nothing in the [src] you can remove!"
-					return
+	if (!can_remove_items(user)) return 0
 
-				for (var/obj/item/I in CI.container)
-					menuoptions[I.name] = I
+	var/datum/cooking_item/CI = cooking_objs[1]
 
-		var/selection = input(user, "Which item would you like to remove? If you want to remove chemicals, use an empty beaker.", "Remove ingredients") as null|anything in menuoptions
-		if (selection)
-			var/obj/item/I = menuoptions[selection]
-			if (!user || !user.put_in_hands(I))
-				I.forceMove(get_turf(src))
-			update_icon()
-		return 1
-	return 0
+	var/list/menuoptions = list()
+	if (CI.container)
+		if (!CI.container.check_contents())
+			user << "There's nothing in the [src] you can remove!"
+			return
+
+		for (var/obj/item/I in CI.container)
+			menuoptions[I.name] = I
+
+	var/selection = input(user, "Which item would you like to remove? If you want to remove chemicals, use an empty beaker.", "Remove ingredients") as null|anything in menuoptions
+	if (selection)
+		var/obj/item/I = menuoptions[selection]
+		if (!user || !user.put_in_hands(I))
+			I.forceMove(get_turf(src))
+		if (cooking_objs[1].container.check_contents() == 0) //Are we empty now? Can we stop doing cooking ticks?
+			cooking_objs[1].reset()							 //Great, we are. Let's reset the container.
+	return 1
 
 /obj/machinery/appliance/grill/update_icon()
 	if (!stat)

--- a/code/modules/mob/living/simple_animal/vore/solargrub_larva.dm
+++ b/code/modules/mob/living/simple_animal/vore/solargrub_larva.dm
@@ -159,6 +159,8 @@ var/global/list/grub_machine_overlays = list()
 	forceMove(get_turf(M))
 	sparks.start()
 	if(machine_effect)
+		for(var/mob/L in player_list)
+			L.client.images -= machine_effect
 		QDEL_NULL(machine_effect)
 	forced_out += rand(5,15)
 	powermachine.draining = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR addresses various various unexpected behaviors encountered while playing the last couple days, and in itemized list form:

- Makes kitchen grill no longer break after a single cooking cycle
- Makes the oven tray empty contents verb usable while holding it
- Addresses a runtime that results in some windoors not breaking #1667 
- Addresses solar grub infestation effects persisting after ejection #1512 
- Allows fire alarms to be deconstructed (again?)

## Why It's Good For The Game

This is nothing but bugfixes and addressing erroneous behavior.

## Changelog
:cl:
fix: Kitchen grills no longer break after a single cooking job
tweak: The oven tray emptying verb can now be accessed while holding it
fix: Fixes certain windoors dropping materials without breaking.
fix: Hopefully prevents solargrub infestation glow from showing up after evicting them
fix: Fire alarms now able to be deconstructed again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
