### PR TITLE
Implements sanity checks for loadout spawning, resolves #1693

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -471,12 +471,30 @@ var/global/datum/controller/occupations/job_master
 
 				if(!isnull(B))
 					for(var/thing in spawn_in_storage)
-						H << "<span class='notice'>Placing \the [thing] in your [B.name]!</span>"
 						var/datum/gear/G = gear_datums[thing]
-						var/metadata = H.client.prefs.gear[G.display_name]
-						G.spawn_item(B, metadata)
+						var/obj/item/I = G.spawn_item(H, H.client.prefs.gear[G.display_name]) //Create the item...
+						if(B.can_be_inserted(I, 1)) //Try putting it in their backpack.
+							H << "<span class='notice'>Placing \the [I] in your [B.name]!</span>"
+							I.forceMove(B)
+							continue
+						if(H.equip_to_appropriate_slot(I)) //Other slots?
+							H << "<span class='notice'>Equipping you with \the [I]!</span>"
+							continue
+						if(H.put_in_hands(I)) //Well, hands?
+							H << "<span class='notice'>Placing \the [I] in your hand!</span>"
+							continue
+						//Throw a tantrum, having exhausted all other options.
+						H << "<span class='danger'>Inventory space exhausted. Putting \the [I] on the ground!</span>"
+						I.forceMove(get_turf(H))
+
 				else
-					H << "<span class='danger'>Failed to locate a storage object on your mob, either you spawned with no arms and no backpack or this is a bug.</span>"
+					H << "<span class='warning'>Failed to locate storage on your mob. Please report this at our Github. Dumping your loadout at your feet...</span>"
+					for(var/thing in spawn_in_storage)
+						var/datum/gear/G = gear_datums[thing]
+						var/obj/item/I = G.spawn_item(H, H.client.prefs.gear[G.display_name])
+						I.forceMove(get_turf(H))
+						H << "<span class='notice'>Putting \the [I] on the ground!</span>"
+
 
 		if(istype(H)) //give humans wheelchairs, if they need them.
 			var/obj/item/organ/external/l_foot = H.get_organ("l_foot")

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -50,7 +50,7 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/equip_to_slot_if_possible(obj/item/W as obj, slot, del_on_fail = 0, disable_warning = 0, redraw_mob = 1)
 	if(!W)
 		return 0
-	if(!W.mob_can_equip(src, slot))
+	if(!W.mob_can_equip(src, slot, disable_warning)) //Previously did not propagate disable_warning. I can't imagine why not.
 		if(del_on_fail)
 			qdel(W)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes inexplicably janky behavior I would've sworn was fixed before Polaris forked off, let alone Vore

## Why It's Good For The Game

See #1693, also changelog

Before:
![75311320-ff5f0500-581b-11ea-8f0e-4d6db6175990 1](https://user-images.githubusercontent.com/22850697/75420170-686e7780-5905-11ea-8ac3-e5da2b2379fe.png)

After:
![OHieYbb](https://user-images.githubusercontent.com/22850697/75420204-820fbf00-5905-11ea-98db-e0e8185806e4.png)
![isdnD45](https://user-images.githubusercontent.com/22850697/75420213-86d47300-5905-11ea-9d35-a1098cc97717.png)


## Changelog
:cl:
fix: Loadout now respects capacity and size rules when spawning into backpack; will not nest duffelbags.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
