### PR TITLE
Removes the Foam Fireaxe from the brig (Temp Fix)

### DIFF
--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -422,7 +422,6 @@
 /obj/structure/table/steel,
 /obj/item/weapon/deck/cards,
 /obj/item/toy/nanotrasenballoon,
-/obj/item/weapon/material/twohanded/fireaxe/foam,
 /turf/simulated/floor/tiled/dark,
 /area/security/recstorage)
 "aS" = (


### PR DESCRIPTION
## Changelog
:cl:
tweak: Removes Steel/Foam Fireaxe from brig until it's spawning properly.
/:cl:
