### PR TITLE
Medical Changes. Otherwise known as, WHY wasn't there a chemfridge there already??? :agony:

### DIFF
--- a/code/modules/food/drinkingglass/metaglass.dm
+++ b/code/modules/food/drinkingglass/metaglass.dm
@@ -564,9 +564,8 @@ Drinks Data
 /datum/reagent/ethanol/planters_punch
 	glass_icon_state = "planterspunch"
 
-/datum/reagent/ethanol/olympus_mons
+/datum/reagent/ethanol/olympusmons
 	glass_icon_state = "olympusmons"
-	glass_center_of_mass = list("x"=16, "y"=8)
 
 /datum/reagent/ethanol/sazerac
 	glass_icon_state = "sazerac"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -3206,7 +3206,7 @@ End Citadel Change */
 	taste_description = "happy plants"
 	strength = 85
 
-/datum/reagent/ethanol/olympus_mons
+/datum/reagent/ethanol/olympusmons
 	name = "Olympus Mons"
 	id = "olympusmons"
 	description = "For those that need the extra kick."

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2317,7 +2317,7 @@
 	required_reagents = list("rum" = 2, "orangejuice" = 2, "grenadine" = 1)
 	result_amount = 5
 
-/datum/chemical_reaction/drinks/olympus_mons
+/datum/chemical_reaction/drinks/olympusmons
 	name = "Olympus Mons"
 	id = "olympusmons"
 	result = "olympusmons"

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -7889,6 +7889,28 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/blue)
+"nc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/obj/structure/closet/wardrobe/chemistry_white{
+	step_x = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "nd" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13253,6 +13275,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
+"vi" = (
+/obj/machinery/smartfridge/chemistry/chemvator,
+/turf/simulated/floor/plating,
+/area/medical/chemistry)
 "vj" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -13738,6 +13764,21 @@
 /obj/effect/floor_decal/corner/brown/border,
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
+"vY" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "vZ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
@@ -20143,25 +20184,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
-"Gx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
 "Gy" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -20481,22 +20503,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
-"Hc" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/structure/closet/wardrobe/chemistry_white,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
 "Hd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -36335,7 +36341,7 @@ Dp
 EP
 FE
 Gu
-EP
+vi
 Dp
 ID
 Jr
@@ -36477,7 +36483,7 @@ DV
 EQ
 FF
 Gv
-Hc
+vY
 HV
 ID
 Js
@@ -36760,7 +36766,7 @@ Dq
 DX
 ES
 FH
-Gx
+nc
 Hd
 HX
 IF

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -13277,7 +13277,7 @@
 /area/quartermaster/delivery)
 "vi" = (
 /obj/machinery/smartfridge/chemistry/chemvator,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/medical/chemistry)
 "vj" = (
 /obj/effect/floor_decal/borderfloor{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a second chemfridge for the chemistry lab. This will be accessible to the public for when medical is MIA.

## Why It's Good For The Game

This will serve as a good way for a director, or other person doing quick basic chems to place them in a place that won't be a target of greytiding to get to it for supplies.

## Changelog
:cl:
add: Second chemfridge in medical bay up on station-3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
