### PR TITLE
Fixes Phantom Jukebox Problem, Resolves #1735

### DIFF
--- a/code/modules/media/media_machinery.dm
+++ b/code/modules/media/media_machinery.dm
@@ -54,6 +54,7 @@
 	master_area = null
 
 /obj/machinery/media/Move()
+	disconnect_media_source() // This line is imperative because it prevents a bug wherein multiple areas that *once* but *no longer* have a jukebox in them still hear whatever the original jukebox is now playing, regardless of area. -Drofoljaelisglis
 	..()
 	if(anchored)
 		update_music()


### PR DESCRIPTION
## About The Pull Request

See title. Fixes #1735 

## Why It's Good For The Game

I've heard people worry that the bug, if left unresolved, could be a possible avenue to use to try and bring the server to a crashing fire. So we should probably fix that.

## Changelog
:cl:
fix: Fixed the "Phantom Jukebox" issue, wherein jukeboxes that once were in an area but since have been moved still played whatever new song the jukebox is playing, regardless of whether or not a jukebox is currently in said area.
/:cl: