### PR TITLE
Roundstart implants now work. Also known as: wow tracking implants ACTUALLY track you? Cool!

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -387,9 +387,6 @@ var/global/datum/controller/occupations/job_master
 							H << "<span class='warning'>Your current species, job or whitelist status does not permit you to spawn with [thing]!</span>"
 							continue
 
-						if(G.exploitable)
-							H.amend_exploitable(G.path)
-
 						if(G.slot == "implant")
 							var/obj/item/weapon/implant/I = G.spawn_item(H)
 							I.implant_loadout(H)

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -13,6 +13,7 @@
 	var/implant_color = "b"
 	var/allow_reagents = 0
 	var/malfunction = 0
+	var/initialize_loc = BP_TORSO
 	show_messages = 1
 
 /obj/item/weapon/implant/proc/trigger(emote, source as mob)
@@ -65,8 +66,8 @@
 
 /obj/item/weapon/implant/proc/implant_loadout(var/mob/living/carbon/human/H)
 	if(H)
-		var/obj/item/organ/external/affected = H.organs_by_name[BP_HEAD]
-		if(handle_implant(H, affected))
+		if(handle_implant(H, initialize_loc))
+			invisibility = initial(invisibility)
 			post_implant(H)
 
 /obj/item/weapon/implant/Destroy()

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -268,4 +268,7 @@ var/list/gear_datums = list()
 	var/item = new gd.path(gd.location)
 	for(var/datum/gear_tweak/gt in gear_tweaks)
 		gt.tweak_item(item, metadata["[gt]"])
+	var/mob/M = location
+	if(istype(M) && exploitable) //Update exploitable info records for the mob without creating a duplicate object at their feet.
+		M.amend_exploitable(item)
 	return item

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -117,10 +117,17 @@
 
 /datum/gear/utility/implant
 	slot = "implant"
-	exploitable = 1
+	exploitable = 0
+
+/datum/gear/utility/implant/backup
+	slot = "implant"
+	display_name= "implant, mind backup"
+	cost = 2
+	path = /obj/item/weapon/implant/backup
 
 /datum/gear/utility/implant/tracking
 	display_name = "implant, tracking"
+	slot = "implant"
 	path = /obj/item/weapon/implant/tracking/weak
 	cost = 0 //VOREStation Edit. Changed cost to 0
 /* VOREStation Edit - Make languages great again

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1147,10 +1147,10 @@ mob/proc/yank_out_object()
 //Exploitable Info Update
 
 /mob/proc/amend_exploitable(var/obj/item/I)
-	var/obj/item/exploit_item = new I(src.loc)
-	exploit_addons |= exploit_item
-	var/exploitmsg = html_decode("\n" + "Has " + exploit_item.name + ".")
-	exploit_record += exploitmsg
+	if(istype(I))
+		exploit_addons |= I
+		var/exploitmsg = html_decode("\n" + "Has " + I.name + ".")
+		exploit_record += exploitmsg
 
 /client/proc/check_has_body_select()
 	return mob && mob.hud_used && istype(mob.zone_sel, /obj/screen/zone_sel)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the issue with implants starting not inside the player, but in their hands and/or bag.

## Why It's Good For The Game

Just another good QOL change that lets their loadout properly load.

## Changelog
:cl:
add: Mind backup implant is now a loadout item for cost 2
fix: tracking implant now actually tracks
fix: implants now start INSIDE the person
code: adjusted the way implants get handled roundstart to properly load in and work.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
