### PR TITLE
Adds two new crates, the Jukebox crate, and Jukebox Circuit Board crate.

### DIFF
--- a/code/datums/supplypacks/misc_vr.dm
+++ b/code/datums/supplypacks/misc_vr.dm
@@ -45,7 +45,7 @@
 	contains = list(
 	/obj/item/weapon/reagent_containers/food/snacks/liquidfood = 10
 	)
-	cost = 5
+	cost = 10
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "emergency rations"
 

--- a/code/datums/supplypacks/recreation.dm
+++ b/code/datums/supplypacks/recreation.dm
@@ -68,3 +68,10 @@
 			/obj/item/device/floor_painter = 2,
 			/obj/item/device/closet_painter = 2
 			)
+
+/datum/supply_pack/recreation/jukebox
+	name = "Jukebox crate"
+	cost = 50
+	containername = "Jukebox crate"
+	containertype = /obj/structure/closet/crate
+	contains = list (/obj/machinery/media/jukebox = 1)

--- a/code/datums/supplypacks/science.dm
+++ b/code/datums/supplypacks/science.dm
@@ -1,6 +1,6 @@
 /*
 *	Here is where any supply packs
-*	related to security tasks live
+*	related to science tasks live
 */
 /datum/supply_pack/sci
 	group = "Science"
@@ -64,3 +64,10 @@
 	cost = 30
 	containertype = /obj/structure/closet/crate
 	containername = "Integrated circuit crate"
+
+/datum/supply_pack/sci/jukebox_circuitboard
+	name = "Jukebox Circuit Board crate"
+	contains = list(/obj/item/weapon/circuitboard/jukebox = 2)
+	cost = 25
+	containertype = /obj/structure/closet/crate
+	containername = "Jukebox Circuit Board crate"


### PR DESCRIPTION
Finally, people can get a jukebox of their own.

## About The Pull Request

Adds one crate to the "Recreation" category, the Jukebox crate, and another to the "Science" category, the Jukebox Circuit Board crate. 

Edit: Now also bumps the price up of liquidfood ration crates as requested, to prevent an exploit having to do with infinite cargo points... I think.

## Why It's Good For The Game

Now people can create their own cozy dens and enjoy music with friends in them. Additionally, it gives players more autonomy in the case of player-driven events, and circumvents the need to beg an admin for a jukebox for whatever plans they may have.

## Changelog
:cl:
add: Added two new crates to Cargo's consoles, one under Recreation, the Jukebox crate, and the other under Science, the Jukebox Circuit Board crate.
/:cl: