### PR TITLE
Changes Compliance disk description, removes it from trash piles, adds to l…

### DIFF
--- a/code/game/objects/structures/trash_pile.dm
+++ b/code/game/objects/structures/trash_pile.dm
@@ -215,7 +215,7 @@
 	return I
 
 /obj/structure/trash_pile/proc/produce_beta_item()
-	var/path = pick(prob(10);/obj/item/weapon/disk/nifsoft/compliance, //Citadel Override probability, 3.6%
+	var/path = pick( //prob(10);/obj/item/weapon/disk/nifsoft/compliance, Citadel Override probability, disabled
 					prob(6);/obj/item/weapon/storage/pill_bottle/tramadol,
 					prob(4);/obj/item/weapon/storage/pill_bottle/happy,
 					prob(4);/obj/item/weapon/storage/pill_bottle/zoom,

--- a/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
@@ -55,3 +55,8 @@
     display_name = "science dufflebag"
     path = /obj/item/weapon/storage/backpack/dufflebag/sci
     allowed_roles = list("Research Director","Scientist","Roboticist","Xenobiologist","Explorer")
+
+/datum/gear/utility/compliance
+	display_name = "NIFSoft Disk(Compliance)" //CITADEL CHANGE: Adds Compliance Disk to loadout
+	path = /obj/item/weapon/disk/nifsoft/compliance
+	cost = 2

--- a/code/modules/nifsoft/nifsoft.dm
+++ b/code/modules/nifsoft/nifsoft.dm
@@ -209,7 +209,7 @@
 // Compliance Disk //
 /obj/item/weapon/disk/nifsoft/compliance
 	name = "NIFSoft Disk (Compliance)"
-	desc = "Wow, adding laws to people? That seems illegal. It probably is. Okay, it really is."
+	desc = "A Compliance NIFSoft disk from Naughty Succubus which entered the market after winning a long and grueling lawsuit about it's legality, which installs custom directives into a user with a NIF, though it can't be used to make the user do something they find utterly unacceptable." //CITADEL CHANGE: Changing description to make it legal instead of illegal
 	stored = /datum/nifsoft/compliance
 	var/laws
 

--- a/code/modules/nifsoft/software/15_misc.dm
+++ b/code/modules/nifsoft/software/15_misc.dm
@@ -90,7 +90,7 @@
 
 /datum/nifsoft/compliance
 	name = "Compliance Module"
-	desc = "A system that allows one to apply 'laws' to sapient life. Extremely illegal, of course."
+	desc = "A system that allows one to apply 'directives' to sapient life, though, it can't be used to order someone to do something they find unacceptable." //CITADEL CHANGE: Changing description to make it legal instead of illegal
 	list_pos = NIF_COMPLIANCE
 	cost = 8200
 	wear = 4


### PR DESCRIPTION
…oadout

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the Compliance disk's description to make it not illegal, removes it from trash spawns, and adds it to the Loadout for 2 points

## Why It's Good For The Game

Right now, these are a inconsistent scene tool, and treated as illegal IC for a reputation it can't manage due to IC and OOC rules. This allows them to be much easier to get for scenes, and not a giant headache for everyone if caught with one by sec.

## Changelog
:cl:
add: Added compliance disks to loadout for 2 points
del: Removed discs spawning in the trash piles
tweak: Compliance disk description
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
