### PR TITLE
Map Changes to Science, Midpoint and Chapel: Also known as, LOL why were air-alarms in the confession booth. 

### DIFF
--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -11606,10 +11606,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/kitchen)
 "up" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether/surface)
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/tiled/steel_grid,
+/area/assembly/robotics)
 "uq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -12422,6 +12422,18 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/bar)
+"vO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/westright{
+	name = "Research Desk";
+	req_access = list(47)
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_grid,
+/area/assembly/robotics)
 "vP" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -12707,6 +12719,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_three)
+"wq" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve/bordercorner2{
+	dir = 4
+	},
+/obj/machinery/media/jukebox,
+/turf/simulated/floor/tiled/steel_grid,
+/area/assembly/robotics)
 "wr" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
@@ -12746,6 +12776,14 @@
 /obj/item/weapon/reagent_containers/food/condiment/sugar,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
+"wv" = (
+/obj/structure/table/marble,
+/obj/machinery/chemical_dispenser/bar_soft/full{
+	icon_state = "soda_dispenser";
+	dir = 8
+	},
+/turf/simulated/floor/lino,
+/area/assembly/robotics)
 "ww" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -13339,6 +13377,25 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"xu" = (
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 4
+	},
+/obj/item/weapon/storage/box/cups,
+/turf/simulated/floor/tiled/steel_grid,
+/area/assembly/robotics)
 "xv" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -13374,6 +13431,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
+"xx" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tether/surface)
 "xy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
@@ -17294,24 +17356,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
-"DD" = (
-/obj/structure/bed/chair,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	icon_state = "borderfloor";
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve/bordercorner2{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/assembly/robotics)
 "DE" = (
 /obj/structure/bed/chair,
 /obj/machinery/firealarm{
@@ -17913,19 +17957,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
-"Es" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/research{
-	id_tag = "researchdoor";
-	name = "Robotics Lab";
-	req_access = list(29,47);
-	req_one_access = list(47)
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/assembly/robotics)
 "Et" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -19971,24 +20002,6 @@
 /obj/machinery/door/airlock/glass_external/public,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
-"HX" = (
-/obj/structure/table/standard,
-/obj/item/weapon/paper_bin{
-	pixel_x = -1;
-	pixel_y = 4
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/assembly/robotics)
 "HY" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/blood,
@@ -21403,14 +21416,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
-"LY" = (
-/obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/bar_soft/full{
-	icon_state = "soda_dispenser";
-	dir = 8
-	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
 "Mf" = (
 /obj/structure/railing{
 	dir = 4
@@ -32877,7 +32882,7 @@ Ba
 BR
 Cx
 Ei
-DD
+wq
 FV
 If
 HJ
@@ -33169,9 +33174,9 @@ Ij
 IB
 LC
 LS
-LY
+wv
 HP
-HX
+xu
 Ik
 Da
 ac
@@ -33587,9 +33592,9 @@ Bf
 BQ
 Bf
 Bf
-Da
-Es
-Da
+up
+vO
+up
 De
 FX
 GC
@@ -37577,7 +37582,7 @@ Jr
 Js
 Jv
 JE
-up
+xx
 IY
 JH
 JJ
@@ -37719,7 +37724,7 @@ Js
 Js
 Jz
 JE
-up
+xx
 IY
 JH
 JJ
@@ -37861,7 +37866,7 @@ Jt
 Js
 Jz
 JE
-up
+xx
 IY
 JH
 JJ

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -5462,6 +5462,11 @@
 "jo" = (
 /obj/structure/reagent_dispensers/cookingoil,
 /obj/effect/floor_decal/corner/black/diagonal,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/kitchen)
 "jp" = (
@@ -7299,7 +7304,6 @@
 	dir = 8
 	},
 /obj/structure/table/standard,
-/obj/machinery/microwave,
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/kitchen)
 "mL" = (
@@ -9663,27 +9667,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "qW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
 /obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/light,
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/kitchen)
 "qX" = (
@@ -11315,7 +11300,8 @@
 	req_access = list(28);
 	req_one_access = newlist()
 	},
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/corner/black/diagonal,
+/turf/simulated/floor/tiled/steel,
 /area/crew_quarters/kitchen)
 "tQ" = (
 /obj/machinery/disposal,
@@ -11583,6 +11569,25 @@
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/kitchen)
 "un" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel,
+/area/crew_quarters/kitchen)
+"uo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chemical_dispenser/bar_soft/full,
 /obj/machinery/door/blast/shutters{
@@ -11592,17 +11597,7 @@
 	name = "Kitchen Shutters"
 	},
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel,
-/area/crew_quarters/kitchen)
-"uo" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "kitchen";
-	layer = 3.3;
-	name = "Kitchen Shutters"
-	},
-/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/kitchen)
 "up" = (
@@ -12406,22 +12401,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "vN" = (
-/obj/effect/floor_decal/corner/beige{
-	dir = 10
-	},
-/obj/effect/floor_decal/spline/plain,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
 /obj/machinery/door/blast/shutters{
-	dir = 8;
-	id = "bar";
+	dir = 2;
+	id = "kitchen";
 	layer = 3.3;
-	name = "Bar Shutters"
+	name = "Kitchen Shutters"
 	},
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/steel,
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "vO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13432,10 +13421,17 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "xx" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether/surface)
+/obj/structure/table/reinforced,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "kitchen";
+	layer = 3.3;
+	name = "Kitchen Shutters"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/corner/black/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/crew_quarters/kitchen)
 "xy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
@@ -13762,6 +13758,33 @@
 	},
 /turf/simulated/floor/carpet,
 /area/library)
+"xY" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	id = "bar";
+	layer = 3.3;
+	name = "Bar Shutters"
+	},
+/obj/effect/floor_decal/borderfloor,
+/turf/simulated/floor/tiled/steel,
+/area/crew_quarters/bar)
+"xZ" = (
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "kitchen";
+	layer = 3.3;
+	name = "Kitchen Shutters"
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/crew_quarters/kitchen)
 "ya" = (
 /turf/simulated/floor/tiled,
 /area/hydroponics)
@@ -13774,6 +13797,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
+"yc" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tether/surface)
 "yd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -37582,7 +37610,7 @@ Jr
 Js
 Jv
 JE
-xx
+yc
 IY
 JH
 JJ
@@ -37724,7 +37752,7 @@ Js
 Js
 Jz
 JE
-xx
+yc
 IY
 JH
 JJ
@@ -37866,7 +37894,7 @@ Jt
 Js
 Jz
 JE
-xx
+yc
 IY
 JH
 JJ
@@ -38967,7 +38995,7 @@ fI
 jq
 kO
 mf
-mi
+qW
 mK
 oN
 um
@@ -39111,8 +39139,8 @@ kP
 fJ
 mj
 fJ
-qW
-ru
+un
+xZ
 nq
 uS
 vq
@@ -39252,9 +39280,9 @@ kb
 kQ
 lu
 mk
+mi
 lu
-lu
-un
+uo
 no
 uR
 vq
@@ -39394,9 +39422,9 @@ kg
 kR
 lu
 lu
+qW
 lu
-lu
-um
+vN
 ns
 uR
 vq
@@ -39536,9 +39564,9 @@ kh
 lt
 lu
 mI
+mi
 lu
-lu
-uo
+xx
 no
 uR
 vq
@@ -39680,7 +39708,7 @@ lu
 lu
 lu
 lu
-uo
+xx
 no
 uR
 uR
@@ -39822,11 +39850,11 @@ mh
 mJ
 oM
 sn
-uo
+xx
 uj
 uT
 no
-vN
+xY
 nu
 rO
 rS

--- a/maps/tether/tether-04-transit.dmm
+++ b/maps/tether/tether-04-transit.dmm
@@ -298,6 +298,11 @@
 /area/tether/midpoint)
 "aG" = (
 /obj/machinery/vending/snack,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	icon_state = "intercom";
+	pixel_x = 24
+	},
 /turf/simulated/floor/wood,
 /area/tether/midpoint)
 "aH" = (
@@ -510,11 +515,8 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/midpoint)
 "bh" = (
-/obj/structure/table/woodentable,
-/obj/machinery/camera/network/northern_star{
-	dir = 5
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
 /area/tether/midpoint)
 "bi" = (
 /obj/structure/table/woodentable,
@@ -534,6 +536,17 @@
 /obj/structure/table/woodentable,
 /obj/machinery/light,
 /obj/structure/flora/pottedplant/small,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/midpoint)
+"bl" = (
+/obj/structure/table/woodentable,
+/obj/machinery/camera/network/northern_star{
+	dir = 5
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/midpoint)
 
@@ -11111,7 +11124,7 @@ aq
 aq
 aO
 bf
-bh
+bl
 bg
 aq
 aq
@@ -11394,7 +11407,7 @@ an
 aq
 aq
 aq
-aq
+bh
 aq
 aq
 aq

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -1,1874 +1,39447 @@
-"aa" = (/turf/space,/area/space)
-"ab" = (/turf/simulated/floor/airless,/area/space)
-"ac" = (/turf/simulated/mineral/vacuum,/area/mine/explored/upper_level)
-"ad" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/light/small{dir = 4},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/security/riot_control)
-"ae" = (/obj/structure/disposalpipe/segment,/turf/simulated/wall/r_wall,/area/security/brig/bathroom)
-"af" = (/turf/simulated/wall/r_wall,/area/security/brig/visitation)
-"ag" = (/obj/effect/floor_decal/steeldecal/steel_decals5,/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 5},/obj/machinery/shower{pixel_y = 16},/obj/structure/curtain/open/shower/security,/turf/simulated/floor/tiled,/area/security/brig/bathroom)
-"ah" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/monotile,/area/security/brig)
-"ai" = (/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/steeldecal/steel_decals5,/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 5},/obj/machinery/shower{pixel_y = 16},/obj/structure/curtain/open/shower/security,/turf/simulated/floor/tiled,/area/security/brig/bathroom)
-"aj" = (/turf/simulated/wall/r_wall,/area/security/security_cell_hallway)
-"ak" = (/obj/effect/floor_decal/corner/white/border{dir = 8},/turf/simulated/floor/tiled/monotile,/area/security/brig)
-"al" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/door/airlock{id_tag = "visitdoor"; name = "Visitation Area"; req_access = list(1)},/turf/simulated/floor/tiled,/area/security/brig)
-"am" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/dark,/area/security/brig)
-"an" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/airlock{name = "Visitation"; req_one_access = list(1,38)},/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"ao" = (/obj/effect/floor_decal/borderfloor/shifted{icon_state = "borderfloor_shifted"; dir = 4},/obj/effect/floor_decal/corner/red/border/shifted{icon_state = "bordercolor_shifted"; dir = 4},/obj/effect/floor_decal/corner/red{icon_state = "corner_white"; dir = 6},/obj/structure/table/reinforced,/obj/machinery/atmospherics/unary/vent_scrubber/on,/obj/machinery/alarm{pixel_y = 22},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"ap" = (/obj/effect/floor_decal/borderfloor/shifted{icon_state = "borderfloor_shifted"; dir = 4},/obj/effect/floor_decal/corner/red/border/shifted{icon_state = "bordercolor_shifted"; dir = 4},/obj/effect/floor_decal/corner/red{icon_state = "corner_white"; dir = 6},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/obj/machinery/button/remote/airlock{id = "visitdoor"; name = "Visitation Access"; pixel_y = -24},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"aq" = (/obj/machinery/light{dir = 4},/obj/structure/table/reinforced,/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"ar" = (/obj/structure/bed/chair,/obj/effect/floor_decal/borderfloor/corner,/obj/machinery/atmospherics/pipe/manifold/hidden/green{icon_state = "map"; dir = 1},/obj/effect/floor_decal/corner/lightorange/bordercorner,/turf/simulated/floor/tiled,/area/security/brig)
-"as" = (/obj/effect/floor_decal/borderfloorblack{dir = 5},/obj/structure/closet/secure_closet/brig,/turf/simulated/floor/tiled/dark,/area/security/recstorage)
-"at" = (/turf/simulated/wall,/area/maintenance/station/sec_lower)
-"au" = (/obj/structure/bed/chair,/obj/effect/floor_decal/borderfloor/corner{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/green{icon_state = "intact"; dir = 4},/obj/effect/floor_decal/corner/lightorange/bordercorner{icon_state = "bordercolorcorner"; dir = 8},/turf/simulated/floor/tiled,/area/security/brig)
-"av" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/turf/simulated/floor/tiled/freezer,/area/security/brig/bathroom)
-"aw" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/freezer,/area/security/brig/bathroom)
-"ax" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled/freezer,/area/security/brig/bathroom)
-"ay" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8},/obj/machinery/light{dir = 4},/obj/machinery/alarm{dir = 8; icon_state = "alarm0"; pixel_x = 24},/turf/simulated/floor/tiled/freezer,/area/security/brig/bathroom)
-"az" = (/obj/effect/floor_decal/borderfloorblack{dir = 4},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8},/obj/structure/closet/secure_closet/brig,/obj/machinery/light/small{dir = 4},/turf/simulated/floor/tiled/dark,/area/security/recstorage)
-"aA" = (/obj/effect/floor_decal/corner/white/border,/obj/effect/floor_decal/corner/white/border{dir = 1},/obj/structure/holohoop{icon_state = "hoop"; dir = 4},/turf/simulated/floor/tiled/monotile,/area/security/brig)
-"aB" = (/obj/effect/floor_decal/corner/white/border{dir = 8},/obj/item/weapon/paper/crumpled{name = "basketball"},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/monotile,/area/security/brig)
-"aC" = (/obj/effect/floor_decal/corner/white/border{icon_state = "bordercolor"; dir = 4},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/monotile,/area/security/brig)
-"aD" = (/obj/effect/floor_decal/corner/white/border{dir = 1},/obj/effect/floor_decal/corner/white/border,/obj/structure/holohoop{icon_state = "hoop"; dir = 8},/turf/simulated/floor/tiled/monotile,/area/security/brig)
-"aE" = (/obj/machinery/atmospherics/portables_connector,/turf/simulated/floor,/area/security/riot_control)
-"aF" = (/obj/effect/decal/cleanable/dirt,/obj/structure/railing{icon_state = "railing0"; dir = 1},/obj/structure/railing{dir = 8},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"aG" = (/obj/machinery/door/airlock/security{name = "The Hole"; req_access = list(2)},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"aH" = (/obj/effect/floor_decal/borderfloor{dir = 5},/obj/effect/floor_decal/corner/red/border{dir = 5},/obj/effect/floor_decal/borderfloor/corner2{dir = 5},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 5},/obj/machinery/camera/network/security,/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"aI" = (/obj/effect/floor_decal/borderfloorblack{dir = 4},/obj/structure/table/steel,/obj/machinery/camera/network/security{icon_state = "camera"; dir = 8},/obj/item/toy/stickhorse,/turf/simulated/floor/tiled/dark,/area/security/recstorage)
-"aJ" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/obj/machinery/atmospherics/pipe/simple/hidden/green,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/security/riot_control)
-"aK" = (/obj/machinery/atmospherics/binary/pump,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/security/riot_control)
-"aL" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"aM" = (/obj/effect/floor_decal/borderfloorblack{dir = 10},/obj/effect/floor_decal/borderfloorblack/corner2{icon_state = "borderfloorcorner2_black"; dir = 8},/obj/structure/disposalpipe/trunk{dir = 1},/obj/machinery/disposal,/turf/simulated/floor/tiled/dark,/area/security/recstorage)
-"aN" = (/obj/effect/decal/cleanable/dirt,/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"aO" = (/obj/effect/decal/cleanable/dirt,/obj/random/trash_pile,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"aP" = (/turf/simulated/mineral/floor/vacuum,/area/mine/explored/upper_level)
-"aQ" = (/obj/machinery/door/firedoor/glass,/obj/machinery/door/airlock{name = "Brig Restroom"},/turf/simulated/floor/tiled/freezer,/area/security/brig/bathroom)
-"aR" = (/obj/effect/floor_decal/borderfloorblack,/obj/structure/table/steel,/obj/item/weapon/deck/cards,/obj/item/toy/nanotrasenballoon,/obj/item/weapon/material/twohanded/fireaxe/foam,/turf/simulated/floor/tiled/dark,/area/security/recstorage)
-"aS" = (/turf/simulated/wall/r_wall,/area/security/brig)
-"aT" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 11; pixel_y = 0},/turf/simulated/floor/tiled/freezer,/area/security/brig/bathroom)
-"aU" = (/obj/structure/railing,/obj/effect/floor_decal/spline/plain,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/monotile,/area/security/brig)
-"aV" = (/obj/structure/railing{dir = 4},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/obj/machinery/light,/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"aW" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/red/border{dir = 8},/obj/effect/floor_decal/borderfloor/corner2{dir = 10; icon_state = "borderfloorcorner2"; pixel_x = 0},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/machinery/button/remote/blast_door{dir = 8; id = "Cell 4"; name = "Cell 4 Door"; pixel_x = -28; req_access = list(1,2)},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"aX" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/red/border{dir = 8},/obj/effect/floor_decal/borderfloor/corner2{dir = 10; icon_state = "borderfloorcorner2"; pixel_x = 0},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/machinery/button/remote/blast_door{dir = 8; id = "Cell 3"; name = "Cell 3 Door"; pixel_x = -28; req_access = list(1,2)},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"aY" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/red/border{dir = 8},/obj/effect/floor_decal/borderfloor/corner2{dir = 10; icon_state = "borderfloorcorner2"; pixel_x = 0},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 10},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/machinery/button/remote/blast_door{dir = 8; id = "Cell 2"; name = "Cell 2 Door"; pixel_x = -28; req_access = list(1,2)},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"aZ" = (/obj/machinery/atmospherics/valve/digital,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/security/riot_control)
-"ba" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/door/airlock/glass_security{name = "Solitary Confinement 1"; req_access = list(2)},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"bb" = (/obj/machinery/atmospherics/pipe/simple/hidden/green,/obj/structure/table/steel,/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/lightorange/border{icon_state = "bordercolor"; dir = 4},/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"bc" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/structure/table/steel,/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/lightorange/border{icon_state = "bordercolor"; dir = 8},/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"bd" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/red/border{dir = 8},/obj/effect/floor_decal/borderfloor/corner2{dir = 10; icon_state = "borderfloorcorner2"; pixel_x = 0},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/machinery/button/remote/blast_door{dir = 8; id = "Cell 1"; name = "Cell 1 Door"; pixel_x = -28; req_access = list(1,2)},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"be" = (/obj/structure/railing{dir = 8},/obj/structure/railing{dir = 1},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"bf" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"bg" = (/turf/simulated/wall,/area/chapel/chapel_morgue)
-"bh" = (/obj/structure/toilet{dir = 1},/obj/machinery/light/small{dir = 4},/turf/simulated/floor/tiled/freezer,/area/security/brig/bathroom)
-"bi" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/light{dir = 1},/obj/machinery/firealarm{dir = 2; layer = 3.3; pixel_x = 0; pixel_y = 26},/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"bj" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/effect/decal/cleanable/dirt,/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/freezer,/area/security/brig/bathroom)
-"bk" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/airlock{name = "Brig Restroom"},/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled/freezer,/area/security/brig)
-"bl" = (/obj/machinery/atmospherics/unary/vent_pump/on,/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"bm" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/spline/plain{icon_state = "spline_plain"; dir = 8},/obj/structure/railing{dir = 8},/obj/effect/floor_decal/borderfloor/shifted,/turf/simulated/floor/tiled,/area/security/brig)
-"bn" = (/obj/machinery/atmospherics/pipe/simple/hidden/green{icon_state = "intact"; dir = 5},/obj/machinery/power/apc{dir = 8; name = "west bump"; pixel_x = -28},/obj/structure/cable/green{icon_state = "0-4"},/turf/simulated/floor,/area/security/riot_control)
-"bo" = (/obj/machinery/atmospherics/pipe/manifold4w/hidden/green,/obj/machinery/meter,/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/security/riot_control)
-"bp" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/green{icon_state = "intact"; dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/security/riot_control)
-"bq" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{icon_state = "0-4"},/obj/machinery/door/blast/regular{density = 0; dir = 1; icon_state = "pdoor0"; id = "brig_lockdown"; name = "Security Blast Doors"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/plating,/area/security/brig)
-"br" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/spline/plain{dir = 4},/obj/structure/railing{dir = 4},/obj/effect/floor_decal/borderfloor/shifted,/turf/simulated/floor/tiled,/area/security/brig)
-"bs" = (/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/red/border{dir = 4},/obj/effect/floor_decal/borderfloor/corner2{dir = 6},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/machinery/computer/cryopod{pixel_x = 32},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"bt" = (/obj/structure/bed/chair{dir = 1},/obj/effect/floor_decal/borderfloor/corner{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/green,/obj/effect/floor_decal/corner/lightorange/bordercorner{icon_state = "bordercolorcorner"; dir = 4},/turf/simulated/floor/tiled,/area/security/brig)
-"bu" = (/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 8},/obj/structure/bed/chair{dir = 1},/obj/effect/floor_decal/borderfloor/corner{dir = 1},/obj/effect/floor_decal/corner/lightorange/bordercorner{icon_state = "bordercolorcorner"; dir = 1},/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"bv" = (/obj/machinery/portable_atmospherics/hydroponics,/obj/effect/floor_decal/borderfloor/corner,/obj/machinery/atmospherics/pipe/manifold4w/hidden/green,/obj/effect/floor_decal/corner/lightorange/bordercorner,/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"bw" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/portable_atmospherics/hydroponics,/obj/effect/floor_decal/borderfloor/corner{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/green{icon_state = "intact"; dir = 4},/obj/effect/floor_decal/corner/lightorange/bordercorner{icon_state = "bordercolorcorner"; dir = 8},/turf/simulated/floor/tiled,/area/security/brig)
-"bx" = (/obj/effect/floor_decal/rust,/obj/random/junk,/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/maintenance/engineering,/turf/simulated/floor/plating,/area/maintenance/station/sec_lower)
-"by" = (/obj/machinery/alarm{pixel_y = 22},/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"bz" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"bA" = (/obj/structure/closet/coffin,/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"bB" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/green,/obj/machinery/computer/arcade/orion_trail,/obj/item/clothing/suit/ianshirt,/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/lightorange/border{icon_state = "bordercolor"; dir = 4},/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"bC" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/red/border{dir = 8},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/obj/machinery/door_timer/cell_3{id = "Cell 4"; name = "Cell 4"; pixel_x = -32},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"bD" = (/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/obj/structure/table/steel,/obj/machinery/microwave,/obj/item/weapon/storage/box/donkpockets,/obj/item/weapon/material/twohanded/fireaxe/foam,/turf/simulated/floor/tiled,/area/security/brig)
-"bE" = (/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/borderfloor/corner{dir = 4},/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/green,/obj/effect/floor_decal/corner/lightorange/bordercorner{icon_state = "bordercolorcorner"; dir = 4},/obj/structure/bed/chair{dir = 1},/turf/simulated/floor/tiled,/area/security/brig)
-"bF" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/structure/table/steel,/obj/item/weapon/paper_bin,/obj/item/weapon/pen/blue{pixel_x = 5; pixel_y = 5},/obj/item/device/taperecorder{pixel_x = -4; pixel_y = 2},/obj/effect/floor_decal/borderfloor/corner{dir = 1},/obj/effect/floor_decal/corner/lightorange/bordercorner{icon_state = "bordercolorcorner"; dir = 1},/turf/simulated/floor/tiled,/area/security/brig)
-"bG" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled,/area/security/brig)
-"bH" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/red/border{dir = 8},/obj/effect/floor_decal/borderfloor/corner2{dir = 8},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 8},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 8},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door_timer/cell_3{id = "Cell 3"; name = "Cell 3"; pixel_x = -32},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"bI" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/obj/structure/mopbucket,/obj/item/weapon/mop,/obj/machinery/button/remote/blast_door{id = "prison_access"; name = "Brig Auxillary Access"; pixel_x = -24; pixel_y = -8; req_access = list(1,2)},/obj/structure/sink{icon_state = "sink"; dir = 8; pixel_x = -12; pixel_y = 2},/turf/simulated/floor/tiled,/area/security/brig)
-"bJ" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/red/border{dir = 8},/obj/effect/floor_decal/borderfloor/corner2{dir = 8},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/firedoor/glass,/obj/machinery/door_timer/cell_3{id = "Cell 2"; name = "Cell 2"; pixel_x = -32},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"bK" = (/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"bL" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/blast/regular{density = 0; dir = 1; icon_state = "pdoor0"; id = "brig_lockdown"; name = "Security Blast Doors"; opacity = 0},/obj/effect/floor_decal/industrial/hatch/yellow,/obj/machinery/door/window/brigdoor/southleft{dir = 4; icon_state = "leftsecure"; id = "Cell 4"; name = "Cell 4"; req_access = list(2)},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"bM" = (/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/red/border{dir = 4},/obj/effect/floor_decal/borderfloor/corner2{dir = 5},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 5},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 8},/obj/machinery/light{dir = 4},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"bN" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/button/remote/blast_door{id = "prison_access"; name = "Brig Auxillary Access"; pixel_x = 8; pixel_y = 24; req_access = list(1,2)},/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"bO" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/airlock/glass_security{name = "Brig Auxillary Access"; req_access = list(2)},/obj/machinery/door/blast/regular{id = "prison_access"; name = "Brig Auxillary Access"},/turf/simulated/floor/tiled,/area/security/brig)
-"bP" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/door/airlock/glass_security{name = "Brig Auxillary Access"; req_access = list(2)},/obj/machinery/door/blast/regular{id = "prison_access"; name = "Brig Auxillary Access"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/security/brig)
-"bQ" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/red/border{dir = 8},/obj/effect/floor_decal/borderfloor/corner2{dir = 8},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 8},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door_timer/cell_3{id = "Cell 1"; name = "Cell 1"; pixel_x = -32},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"bR" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/disposalpipe/segment,/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"bS" = (/obj/effect/decal/cleanable/dirt,/obj/structure/closet,/obj/item/clothing/glasses/sunglasses/blindfold,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"bT" = (/obj/structure/morgue,/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"bU" = (/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"bV" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"bW" = (/turf/simulated/wall/r_wall,/area/engineering/shaft)
-"bX" = (/obj/random/trash,/obj/structure/railing{dir = 8},/obj/structure/railing,/turf/simulated/floor/tiled/dark,/area/security/brig)
-"bY" = (/obj/effect/floor_decal/borderfloor/shifted{icon_state = "borderfloor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange/border/shifted{icon_state = "bordercolor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange{icon_state = "corner_white"; dir = 5},/obj/machinery/light/small{icon_state = "bulb1"; dir = 1},/obj/structure/bed/padded,/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"bZ" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/unary/outlet_injector{dir = 4; frequency = 1442; icon_state = "map_injector"; id = "riot_inject"; req_access = list(3)},/obj/effect/decal/cleanable/dirt,/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled,/area/security/brig)
-"ca" = (/obj/effect/floor_decal/borderfloor/shifted{icon_state = "borderfloor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange/border/shifted{icon_state = "bordercolor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange{icon_state = "corner_white"; dir = 5},/obj/machinery/light/small{icon_state = "bulb1"; dir = 1},/obj/structure/bed/padded,/obj/item/weapon/bedsheet,/obj/item/weapon/pen/crayon/green,/turf/simulated/floor/tiled/dark,/area/security/brig)
-"cb" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/unary/outlet_injector{dir = 8; frequency = 1442; icon_state = "map_injector"; id = "riot_inject"; req_access = list(3)},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"cc" = (/obj/effect/floor_decal/borderfloor/shifted{icon_state = "borderfloor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange/border/shifted{icon_state = "bordercolor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange{icon_state = "corner_white"; dir = 5},/obj/machinery/light/small{icon_state = "bulb1"; dir = 1},/obj/structure/bed/padded,/obj/item/weapon/bedsheet,/turf/simulated/floor/tiled/dark,/area/security/brig)
-"cd" = (/obj/machinery/light{dir = 4},/obj/structure/table/steel,/obj/item/weapon/storage/laundry_basket,/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"ce" = (/obj/machinery/washing_machine,/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"cf" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"cg" = (/obj/machinery/atmospherics/pipe/simple/hidden/green,/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/turf/simulated/floor/tiled,/area/security/brig)
-"ch" = (/turf/simulated/wall/r_wall,/area/security/brig/bathroom)
-"ci" = (/obj/effect/decal/cleanable/dirt,/obj/structure/closet,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"cj" = (/obj/machinery/button/remote/driver{id = "chapelgun"; name = "Chapel Mass Driver"; pixel_x = 32; pixel_y = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/camera/network/civilian{dir = 8},/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"ck" = (/obj/structure/ladder,/turf/simulated/floor/plating,/area/engineering/shaft)
-"cl" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/door/airlock/security{name = "Interrogation"; req_access = newlist(); req_one_access = list(2,4)},/turf/simulated/floor/tiled/dark,/area/security/interrogation)
-"cm" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/blast/regular{density = 0; dir = 4; icon_state = "pdoor0"; id = "brig_lockdown"; name = "Security Blast Doors"; opacity = 0},/obj/machinery/door/airlock/glass_security{id_tag = "briginner"; name = "Brig"; req_access = list(2); req_one_access = newlist()},/turf/simulated/floor/tiled,/area/security/brig)
-"cn" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/green,/obj/machinery/door/blast/regular{density = 0; dir = 4; icon_state = "pdoor0"; id = "brig_lockdown"; name = "Security Blast Doors"; opacity = 0},/obj/structure/disposalpipe/segment,/obj/machinery/door/airlock/glass_security{id_tag = "briginner"; name = "Brig"; req_access = list(2); req_one_access = newlist()},/turf/simulated/floor/tiled,/area/security/brig)
-"co" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/airlock/glass_security{name = "Brig Cells"; req_access = newlist(); req_one_access = list(2,4)},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"cp" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"cq" = (/obj/machinery/door/firedoor/glass,/obj/machinery/door/airlock/glass_security{name = "Brig Cells"; req_access = newlist(); req_one_access = list(2,4)},/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"cr" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled,/area/security/brig)
-"cs" = (/obj/machinery/door/firedoor/glass,/obj/machinery/door/airlock/glass_security{id_tag = "brigouter"; name = "Brig"; req_access = list(2); req_one_access = newlist()},/turf/simulated/floor/tiled,/area/security/brig)
-"ct" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"cu" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/green{icon_state = "intact"; dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/door/airlock/glass_security{id_tag = "brigouter"; name = "Brig"; req_access = list(2); req_one_access = newlist()},/turf/simulated/floor/tiled,/area/security/brig)
-"cv" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/green{icon_state = "intact"; dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/button/remote/airlock{id = "brigouter"; name = "Outer Brig Doors"; pixel_x = 6; pixel_y = -24; req_access = list(2)},/obj/machinery/button/remote/airlock{id = "briginner"; name = "Inner Brig Doors"; pixel_x = -6; pixel_y = -24; req_access = list(2)},/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"cw" = (/obj/effect/floor_decal/borderfloor/shifted{icon_state = "borderfloor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange/border/shifted{icon_state = "bordercolor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange{icon_state = "corner_white"; dir = 5},/obj/machinery/atmospherics/unary/vent_pump/on,/obj/machinery/cryopod{dir = 4},/obj/machinery/alarm{pixel_y = 22},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"cx" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/airlock/security{name = "Observation"; req_one_access = list(1,4)},/turf/simulated/floor/tiled/dark,/area/security/interrogation)
-"cy" = (/obj/effect/floor_decal/borderfloor/shifted{icon_state = "borderfloor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange/border/shifted{icon_state = "bordercolor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange{icon_state = "corner_white"; dir = 5},/obj/machinery/atmospherics/unary/vent_scrubber/on,/obj/structure/table/steel,/obj/item/weapon/paper,/obj/item/weapon/pen/blue{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"cz" = (/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/red/border{dir = 4},/obj/effect/floor_decal/borderfloor/corner2{dir = 6},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 6},/obj/machinery/firealarm{dir = 4; pixel_x = 24},/obj/machinery/hologram/holopad,/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"cA" = (/turf/simulated/wall/r_wall,/area/security/recstorage)
-"cB" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"cC" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"cD" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/structure/bed/chair{dir = 1},/obj/machinery/camera/network/security{icon_state = "camera"; dir = 8},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"cE" = (/obj/machinery/hologram/holopad,/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"cF" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"cG" = (/obj/machinery/door/window{dir = 8; name = "Mass Driver"; req_access = list(22)},/obj/machinery/mass_driver{dir = 4; id = "chapelgun"},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 8},/obj/machinery/airlock_sensor{pixel_y = 25},/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor/plating,/area/chapel/chapel_morgue)
-"cH" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'EXTERNAL AIRLOCK'"; icon_state = "space"; layer = 4; name = "EXTERNAL AIRLOCK"; pixel_x = 0; pixel_y = 32},/obj/effect/floor_decal/industrial/warning{dir = 4},/turf/simulated/floor/plating,/area/chapel/chapel_morgue)
-"cI" = (/obj/machinery/door/blast/regular{id = "chapelgun"; name = "Chapel Launcher Door"},/turf/simulated/floor/plating,/area/chapel/chapel_morgue)
-"cJ" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/engineering/shaft)
-"cK" = (/obj/effect/floor_decal/borderfloor/shifted{icon_state = "borderfloor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange/border/shifted{icon_state = "bordercolor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange{icon_state = "corner_white"; dir = 5},/obj/structure/table/steel,/obj/machinery/alarm{pixel_y = 22},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"cL" = (/turf/space,/obj/structure/shuttle/engine/propulsion{dir = 8; icon_state = "propulsion_l"},/turf/simulated/shuttle/plating/airless/carry,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"cM" = (/obj/effect/floor_decal/borderfloor/shifted{icon_state = "borderfloor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange/border/shifted{icon_state = "bordercolor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange{icon_state = "corner_white"; dir = 5},/obj/machinery/atmospherics/unary/vent_pump/on,/obj/structure/closet/secure_closet/brig{id = "Cell 4"},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"cN" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/disposalpipe/segment,/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"cO" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"cP" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"cQ" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"cR" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"cS" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/blast/regular{density = 0; dir = 1; icon_state = "pdoor0"; id = "brig_lockdown"; name = "Security Blast Doors"; opacity = 0},/obj/effect/floor_decal/industrial/hatch/yellow,/obj/machinery/door/window/brigdoor/southleft{dir = 4; icon_state = "leftsecure"; id = "Cell 3"; name = "Cell 3"; req_access = list(2)},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"cT" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"cU" = (/turf/simulated/wall,/area/security/recstorage)
-"cV" = (/obj/effect/floor_decal/borderfloorblack{dir = 1},/obj/machinery/alarm{pixel_y = 22},/turf/simulated/floor/tiled/dark,/area/security/recstorage)
-"cW" = (/turf/space,/obj/structure/shuttle/engine/propulsion{dir = 8},/turf/simulated/shuttle/plating/airless/carry,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"cX" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/obj/machinery/door/blast/regular{density = 0; dir = 1; icon_state = "pdoor0"; id = "brig_lockdown"; name = "Security Blast Doors"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor,/area/security/brig/visitation)
-"cY" = (/turf/simulated/wall,/area/chapel/office)
-"cZ" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/obj/structure/cable/pink{icon_state = "2-4"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"da" = (/obj/structure/cable/pink{icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"db" = (/obj/structure/cable/pink{icon_state = "4-8"},/obj/machinery/alarm{pixel_y = 22},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"dc" = (/obj/structure/cable/pink{icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/camera/network/civilian{dir = 2},/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"dd" = (/obj/machinery/light{dir = 1},/obj/structure/cable/pink{icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"de" = (/obj/structure/cable/pink{icon_state = "4-8"},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/door/airlock{name = "Chapel Backroom"; req_access = list(27)},/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"df" = (/obj/structure/cable/pink{icon_state = "2-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"dg" = (/obj/structure/extinguisher_cabinet{pixel_x = 25; pixel_y = 0},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"dh" = (/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/plating,/area/engineering/shaft)
-"di" = (/obj/effect/floor_decal/borderfloor/shifted{icon_state = "borderfloor_shifted"; dir = 8},/obj/effect/floor_decal/corner/red/border/shifted{icon_state = "bordercolor_shifted"; dir = 8},/obj/effect/floor_decal/corner/red{icon_state = "corner_white"; dir = 9},/obj/structure/table/reinforced,/obj/machinery/atmospherics/unary/vent_scrubber/on,/obj/machinery/alarm{pixel_y = 22},/obj/machinery/camera/network/security,/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"dj" = (/turf/simulated/wall,/area/security/brig/visitation)
-"dk" = (/obj/effect/floor_decal/borderfloor/shifted{icon_state = "borderfloor_shifted"; dir = 4},/obj/effect/floor_decal/corner/red/border/shifted{icon_state = "bordercolor_shifted"; dir = 4},/obj/effect/floor_decal/corner/red{icon_state = "corner_white"; dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/structure/bed/chair{dir = 4},/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"dl" = (/obj/effect/floor_decal/corner/red{icon_state = "corner_white"; dir = 9},/obj/effect/floor_decal/corner/red{icon_state = "corner_white"; dir = 6},/obj/machinery/door/firedoor/glass,/obj/machinery/door/blast/regular{density = 0; dir = 1; icon_state = "pdoor0"; id = "brig_lockdown"; name = "Security Blast Doors"; opacity = 0},/obj/structure/table/reinforced,/obj/machinery/door/window/brigdoor/westleft{req_access = list(1,2)},/obj/machinery/door/window/brigdoor/eastright,/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"dm" = (/turf/space,/obj/structure/shuttle/engine/propulsion{dir = 8; icon_state = "propulsion_r"},/turf/simulated/shuttle/plating/airless/carry,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"dn" = (/obj/effect/floor_decal/industrial/warning,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"do" = (/obj/effect/floor_decal/borderfloor/shifted{icon_state = "borderfloor_shifted"; dir = 8},/obj/effect/floor_decal/corner/red/border/shifted{icon_state = "bordercolor_shifted"; dir = 8},/obj/effect/floor_decal/corner/red{icon_state = "corner_white"; dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/structure/bed/chair{dir = 8},/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"dp" = (/obj/machinery/vending/hydronutrients,/obj/machinery/alarm{dir = 8; icon_state = "alarm0"; pixel_x = 24},/turf/simulated/floor/tiled,/area/security/brig)
-"dq" = (/obj/effect/floor_decal/borderfloor/shifted{icon_state = "borderfloor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange/border/shifted{icon_state = "bordercolor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange{icon_state = "corner_white"; dir = 5},/obj/machinery/atmospherics/unary/vent_pump/on,/obj/structure/closet/secure_closet/brig{id = "Cell 3"},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"ds" = (/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/red/border{dir = 4},/obj/effect/floor_decal/borderfloor/corner2{dir = 5},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 5},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"dt" = (/obj/effect/floor_decal/borderfloor/shifted{icon_state = "borderfloor_shifted"; dir = 8},/obj/effect/floor_decal/corner/red/border/shifted{icon_state = "bordercolor_shifted"; dir = 8},/obj/effect/floor_decal/corner/red{icon_state = "corner_white"; dir = 9},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"du" = (/obj/effect/floor_decal/borderfloorblack{dir = 8},/obj/effect/floor_decal/borderfloorblack/corner2{icon_state = "borderfloorcorner2_black"; dir = 10},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/obj/machinery/power/apc{dir = 8; name = "west bump"; pixel_x = -28},/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/structure/closet,/obj/item/weapon/material/minihoe,/turf/simulated/floor/tiled/dark,/area/security/recstorage)
-"dv" = (/obj/effect/floor_decal/rust,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/turf/simulated/floor/tiled/dark,/area/security/recstorage)
-"dw" = (/obj/effect/floor_decal/borderfloor/shifted{icon_state = "borderfloor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange/border/shifted{icon_state = "bordercolor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange{icon_state = "corner_white"; dir = 5},/obj/machinery/atmospherics/unary/vent_pump/on,/obj/structure/closet/secure_closet/brig{id = "Cell 2"},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"dx" = (/obj/effect/floor_decal/borderfloor/shifted,/obj/effect/floor_decal/corner/red/border/shifted,/obj/effect/floor_decal/corner/red{icon_state = "corner_white"; dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/machinery/vending/snack,/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"dy" = (/obj/structure/flora/pottedplant/stoutbush,/obj/structure/table/woodentable,/turf/simulated/floor/lino,/area/chapel/office)
-"dz" = (/obj/machinery/newscaster{pixel_y = 32},/obj/machinery/button/windowtint{id = "chapel"; pixel_x = -24; pixel_y = 26},/turf/simulated/floor/lino,/area/chapel/office)
-"dA" = (/obj/machinery/power/apc{dir = 1; name = "north bump"; pixel_x = 0; pixel_y = 24},/obj/structure/cable/pink{icon_state = "0-2"},/turf/simulated/floor/lino,/area/chapel/office)
-"dB" = (/obj/machinery/alarm{pixel_y = 22},/turf/simulated/floor/lino,/area/chapel/office)
-"dC" = (/obj/machinery/photocopier,/obj/machinery/light_switch{dir = 2; name = "light switch "; pixel_x = 0; pixel_y = 26},/turf/simulated/floor/lino,/area/chapel/office)
-"dD" = (/obj/structure/cable/pink{icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"dE" = (/turf/simulated/wall/r_wall,/area/ai_upload)
-"dF" = (/obj/structure/cable/pink{icon_state = "1-2"},/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"dG" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"dH" = (/obj/structure/bed/chair{dir = 4},/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"dI" = (/obj/structure/table/standard,/obj/machinery/firealarm{dir = 2; pixel_y = 24},/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"dJ" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 4},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/chapel/chapel_morgue)
-"dK" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/engineering/shaft)
-"dL" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/hologram/holopad,/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"dM" = (/obj/effect/floor_decal/borderfloor/shifted,/obj/effect/floor_decal/corner/red/border/shifted,/obj/effect/floor_decal/corner/red{icon_state = "corner_white"; dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/machinery/vending/cola,/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"dN" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/unary/outlet_injector{dir = 4; frequency = 1442; icon_state = "map_injector"; id = "riot_inject"; req_access = list(3)},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"dO" = (/obj/effect/floor_decal/borderfloor/shifted{icon_state = "borderfloor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange/border/shifted{icon_state = "bordercolor_shifted"; dir = 1},/obj/effect/floor_decal/corner/lightorange{icon_state = "corner_white"; dir = 5},/obj/machinery/atmospherics/unary/vent_pump/on,/obj/structure/closet/secure_closet/brig{id = "Cell 1"},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"dP" = (/obj/machinery/atmospherics/unary/outlet_injector{dir = 8; frequency = 1442; icon_state = "map_injector"; id = "riot_inject"; req_access = list(3)},/obj/effect/decal/cleanable/dirt,/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"dQ" = (/obj/effect/floor_decal/industrial/warning,/obj/machinery/atmospherics/pipe/simple/hidden/green,/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/turf/simulated/floor/tiled,/area/security/brig)
-"dR" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/blast/regular{density = 0; dir = 4; icon_state = "pdoor0"; id = "security_lockdown"; name = "Security Blast Doors"; opacity = 0},/obj/machinery/door/airlock/maintenance/sec{name = "Riot Control"; req_access = list(1)},/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/pipe/simple/hidden/green,/turf/simulated/floor,/area/security/riot_control)
-"dT" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 1},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"dU" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/door/airlock/security{name = "Brig Recreation Storage"},/turf/simulated/floor/tiled,/area/security/recstorage)
-"dV" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/turf/simulated/floor/tiled/dark,/area/security/recstorage)
-"dY" = (/obj/machinery/light{dir = 8},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor/lino,/area/chapel/office)
-"dZ" = (/obj/structure/bed/chair,/obj/effect/landmark/start{name = "Chaplain"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/lino,/area/chapel/office)
-"ea" = (/obj/structure/cable/pink{icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/turf/simulated/floor/lino,/area/chapel/office)
-"eb" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/lino,/area/chapel/office)
-"ec" = (/obj/structure/table/woodentable,/obj/item/weapon/nullrod,/obj/item/weapon/reagent_containers/food/drinks/bottle/holywater,/obj/machinery/atmospherics/unary/vent_pump/on{dir = 8},/turf/simulated/floor/lino,/area/chapel/office)
-"ek" = (/obj/structure/cable/pink,/obj/machinery/power/apc{cell_type = /obj/item/weapon/cell/super; dir = 8; name = "west bump"; pixel_x = -28},/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"el" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"em" = (/obj/structure/table/standard,/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"en" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/plating,/area/engineering/shaft)
-"eo" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"ep" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"eq" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/disposalpipe/segment,/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/security/brig)
-"es" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/hologram/holopad,/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"ev" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/light,/turf/simulated/floor/carpet/bcarpet,/area/tether/station/public_meeting_room)
-"ew" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/blast/regular{density = 0; dir = 1; icon_state = "pdoor0"; id = "brig_lockdown"; name = "Security Blast Doors"; opacity = 0},/obj/effect/floor_decal/industrial/hatch/yellow,/obj/machinery/door/window/brigdoor/southleft{dir = 4; id = "Cell 2"; name = "Cell 2"; req_access = list(2)},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"ey" = (/obj/structure/table/woodentable,/obj/item/device/flashlight/lamp{pixel_y = 10},/obj/machinery/camera/network/civilian{dir = 4},/turf/simulated/floor/lino,/area/chapel/office)
-"ez" = (/obj/structure/table/woodentable,/obj/item/weapon/paper_bin{pixel_x = 1; pixel_y = 9},/obj/item/weapon/pen/blue{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/lino,/area/chapel/office)
-"eA" = (/obj/structure/table/woodentable,/obj/item/weapon/storage/fancy/crayons,/obj/structure/cable/pink{icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/lino,/area/chapel/office)
-"eB" = (/turf/simulated/floor/lino,/area/chapel/office)
-"eC" = (/obj/structure/closet/wardrobe/chaplain_black,/obj/machinery/light{dir = 4},/turf/simulated/floor/lino,/area/chapel/office)
-"eD" = (/obj/item/toy/figure/mime,/obj/item/clothing/head/soft/mime,/obj/item/clothing/mask/gas/mime,/obj/item/clothing/shoes/mime,/obj/item/clothing/under/mime,/obj/item/weapon/pen/crayon/mime,/obj/effect/decal/cleanable/dirt,/obj/effect/floor_decal/rust,/obj/structure/closet,/obj/random/contraband,/obj/random/maintenance/clean,/obj/random/maintenance/clean,/turf/simulated/floor,/area/chapel/chapel_morgue)
-"eE" = (/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"eF" = (/obj/structure/stairs/north,/turf/simulated/floor/bluegrid,/area/ai_upload)
-"eG" = (/obj/machinery/computer/aiupload,/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"eH" = (/obj/structure/cable/cyan{d1 = 16; d2 = 0; icon_state = "16-0"},/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers,/obj/machinery/atmospherics/pipe/zpipe/up/supply,/obj/machinery/alarm{pixel_y = 22},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"eI" = (/obj/machinery/computer/borgupload,/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"eK" = (/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"eL" = (/obj/structure/bed/chair{dir = 4},/obj/machinery/light,/turf/simulated/floor/tiled/dark,/area/chapel/chapel_morgue)
-"eM" = (/obj/structure/lattice,/turf/space,/area/space)
-"eQ" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/turf/simulated/floor/tiled,/area/security/brig)
-"eS" = (/obj/effect/floor_decal/industrial/warning/corner{icon_state = "warningcorner"; dir = 1},/obj/machinery/disposal,/obj/structure/disposalpipe/trunk{dir = 4},/obj/machinery/light{icon_state = "tube1"; dir = 8},/obj/structure/sign/deathsposal{pixel_x = -32},/turf/simulated/floor/tiled,/area/security/brig)
-"fc" = (/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/red/border{dir = 4},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 8},/obj/structure/disposalpipe/segment,/obj/machinery/alarm{dir = 8; icon_state = "alarm0"; pixel_x = 24},/obj/machinery/camera/network/security{icon_state = "camera"; dir = 8},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"fd" = (/turf/simulated/wall/r_wall,/area/security/interrogation)
-"fi" = (/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"fj" = (/obj/structure/bed/chair{dir = 1},/turf/simulated/floor/lino,/area/chapel/office)
-"fk" = (/obj/structure/cable/pink{icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/lino,/area/chapel/office)
-"fl" = (/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/turf/simulated/floor/lino,/area/chapel/office)
-"fm" = (/obj/machinery/disposal,/obj/structure/disposalpipe/trunk{dir = 8},/obj/machinery/camera/network/civilian{dir = 8},/turf/simulated/floor/lino,/area/chapel/office)
-"fn" = (/obj/structure/cable/pink{icon_state = "1-2"},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/door/airlock{name = "Chapel Backroom Access"; req_access = newlist()},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"fo" = (/turf/simulated/wall,/area/chapel/main)
-"fp" = (/obj/effect/floor_decal/techfloor{dir = 8},/obj/machinery/camera/motion/security{dir = 4},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"fr" = (/obj/effect/floor_decal/industrial/outline/grey,/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"fs" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"ft" = (/obj/effect/floor_decal/industrial/outline/grey,/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"fv" = (/obj/effect/floor_decal/techfloor{dir = 4},/obj/machinery/atmospherics/pipe/zpipe/up/supply{dir = 8},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"fx" = (/obj/effect/decal/cleanable/dirt,/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/maintenance/engineering,/obj/random/maintenance/clean,/turf/simulated/floor/plating,/area/engineering/shaft)
-"fy" = (/obj/structure/grille,/turf/simulated/mineral/floor/vacuum,/area/mine/explored/upper_level)
-"fB" = (/obj/structure/stairs/south,/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"fD" = (/obj/effect/floor_decal/industrial/warning/corner,/obj/machinery/cryopod{dir = 4},/obj/machinery/camera/network/security{icon_state = "camera"; dir = 4},/turf/simulated/floor/tiled,/area/security/brig)
-"fI" = (/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/red/border{dir = 4},/obj/effect/floor_decal/borderfloor/corner2{dir = 5},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 5},/obj/structure/disposalpipe/segment,/obj/machinery/firealarm{dir = 4; pixel_x = 24},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"fK" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/obj/structure/bed/chair,/turf/simulated/floor/tiled/dark,/area/security/interrogation)
-"fL" = (/obj/machinery/camera/network/security{icon_state = "camera"; dir = 8},/turf/simulated/floor/tiled/dark,/area/security/interrogation)
-"fN" = (/obj/random/trash_pile,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"fO" = (/obj/structure/grille,/obj/machinery/door/firedoor/glass,/obj/structure/window/reinforced/polarized{dir = 10; icon_state = "fwindow"; id = "chapel"},/turf/simulated/floor/plating,/area/chapel/office)
-"fP" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/machinery/door/firedoor/glass,/obj/structure/cable/pink{icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/door/airlock{name = "Chapel Office"; req_access = list(27)},/turf/simulated/floor/lino,/area/chapel/office)
-"fQ" = (/obj/structure/grille,/obj/machinery/door/firedoor/glass,/obj/structure/disposalpipe/segment,/obj/structure/window/reinforced/polarized{dir = 10; icon_state = "fwindow"; id = "chapel"},/turf/simulated/floor/plating,/area/chapel/office)
-"fR" = (/obj/structure/cable/pink{icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"fS" = (/obj/machinery/door/morgue{dir = 2; name = "Confession Booth"},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"fT" = (/obj/machinery/alarm{pixel_y = 22},/obj/machinery/light/small{dir = 4; pixel_y = 0},/obj/structure/bed/chair,/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"fU" = (/turf/simulated/floor/bluegrid,/area/ai_upload)
-"fV" = (/obj/machinery/porta_turret/ai_defense,/turf/simulated/floor/bluegrid,/area/ai_upload)
-"fW" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"fX" = (/turf/simulated/wall/r_wall,/area/engineering/locker_room)
-"fY" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/airlock/maintenance/engi{name = "Engineering Electrical Shaft"; req_one_access = list(10)},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/engineering/locker_room)
-"fZ" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/blast/regular{density = 0; dir = 1; icon_state = "pdoor0"; id = "brig_lockdown"; name = "Security Blast Doors"; opacity = 0},/obj/effect/floor_decal/industrial/hatch/yellow,/obj/machinery/door/window/brigdoor/southleft{dir = 4; id = "Cell 1"; name = "Cell 1"; req_access = list(2)},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"ga" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"gb" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/structure/table/steel,/obj/item/device/flashlight/lamp,/turf/simulated/floor/tiled/dark,/area/security/interrogation)
-"gc" = (/obj/machinery/light/small{dir = 4},/obj/machinery/alarm{dir = 8; icon_state = "alarm0"; pixel_x = 24},/turf/simulated/floor/tiled/dark,/area/security/interrogation)
-"ge" = (/obj/effect/floor_decal/chapel{dir = 1},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"gf" = (/obj/effect/floor_decal/chapel{dir = 4},/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"gg" = (/obj/structure/cable/pink{icon_state = "1-2"},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 8},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/carpet,/area/chapel/main)
-"gh" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/disposalpipe/sortjunction{dir = 8; name = "Chapel"; sortType = "Chapel"},/obj/effect/landmark/start{name = "Chaplain"},/turf/simulated/floor/carpet,/area/chapel/main)
-"gi" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/turf/simulated/floor/carpet,/area/chapel/main)
-"gj" = (/obj/effect/floor_decal/chapel{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/light_switch{dir = 2; name = "light switch "; pixel_x = 0; pixel_y = 26},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"gk" = (/obj/effect/floor_decal/chapel{dir = 4},/obj/structure/cable/pink{icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"gl" = (/obj/structure/grille,/obj/structure/window/reinforced/tinted{dir = 1},/obj/structure/window/reinforced/tinted,/obj/structure/window/reinforced/tinted{dir = 4; icon_state = "twindow"},/obj/structure/window/reinforced/tinted{dir = 8; icon_state = "twindow"},/turf/simulated/floor/plating,/area/chapel/main)
-"gm" = (/obj/effect/floor_decal/techfloor{dir = 10},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"gn" = (/obj/effect/floor_decal/techfloor,/obj/machinery/light,/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"go" = (/obj/effect/floor_decal/techfloor,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"gp" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"gq" = (/obj/effect/floor_decal/techfloor,/obj/structure/cable/cyan{d2 = 8; icon_state = "0-8"},/obj/machinery/power/apc{dir = 2; name = "south bump"; pixel_y = -32},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"gr" = (/obj/effect/floor_decal/techfloor{dir = 6},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"gs" = (/obj/effect/floor_decal/borderfloor{dir = 9},/obj/effect/floor_decal/corner/yellow/border{dir = 9},/obj/machinery/cryopod{dir = 4},/obj/structure/window/reinforced,/obj/machinery/computer/cryopod{pixel_x = -32},/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"gt" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/yellow/border{dir = 1},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"gu" = (/obj/effect/floor_decal/borderfloor/corner{dir = 1},/obj/effect/floor_decal/corner/yellow/bordercorner{icon_state = "bordercolorcorner"; dir = 1},/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"gv" = (/obj/structure/railing{dir = 8},/turf/simulated/open,/area/engineering/locker_room)
-"gw" = (/turf/simulated/open,/area/engineering/locker_room)
-"gy" = (/obj/effect/floor_decal/borderfloor{dir = 1; pixel_y = 0},/obj/effect/floor_decal/corner/red/border{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"gE" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/obj/structure/bed/chair{dir = 1},/turf/simulated/floor/tiled/dark,/area/security/interrogation)
-"gG" = (/obj/structure/cable/pink{icon_state = "2-4"},/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"gH" = (/obj/machinery/door/airlock/maintenance/common,/obj/machinery/door/firedoor/glass,/obj/structure/disposalpipe/segment{dir = 4},/obj/structure/cable/pink{icon_state = "4-8"},/turf/simulated/floor,/area/chapel/main)
-"gI" = (/obj/effect/floor_decal/chapel{dir = 8},/obj/structure/cable/pink{icon_state = "4-8"},/obj/structure/cable/pink{icon_state = "2-8"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"gJ" = (/obj/effect/floor_decal/chapel,/obj/structure/cable/pink{icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"gK" = (/obj/structure/table/woodentable,/obj/structure/cable/pink{icon_state = "4-8"},/obj/structure/cable/pink{icon_state = "1-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/carpet,/area/chapel/main)
-"gL" = (/obj/structure/table/woodentable,/obj/structure/cable/pink{icon_state = "4-8"},/turf/simulated/floor/carpet,/area/chapel/main)
-"gM" = (/obj/structure/table/woodentable,/obj/structure/cable/pink{icon_state = "4-8"},/obj/structure/disposalpipe/segment,/turf/simulated/floor/carpet,/area/chapel/main)
-"gN" = (/obj/effect/floor_decal/chapel{dir = 8},/obj/structure/cable/pink{icon_state = "4-8"},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"gO" = (/obj/effect/floor_decal/chapel,/obj/structure/cable/pink{icon_state = "1-8"},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"gP" = (/obj/machinery/door/morgue{dir = 2; name = "Confession Booth (Chaplain)"; req_access = list(22)},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"gQ" = (/obj/machinery/alarm{dir = 1; icon_state = "alarm0"; pixel_y = -22},/obj/machinery/light/small{dir = 4; pixel_y = 0},/obj/structure/bed/chair{dir = 1},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"gR" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/door/airlock/highsecurity{name = "AI Upload"; req_access = list(16); req_one_access = list()},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"gS" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/yellow/border{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/machinery/vending/assist,/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"gT" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"gU" = (/obj/effect/floor_decal/corner_steel_grid,/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"gV" = (/obj/effect/floor_decal/borderfloor{dir = 1; pixel_y = 0},/obj/effect/floor_decal/corner/red/border{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"gW" = (/obj/effect/floor_decal/borderfloor{dir = 1; pixel_y = 0},/obj/effect/floor_decal/corner/red/border{dir = 1},/obj/effect/floor_decal/borderfloor/corner2{dir = 1},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 1},/obj/machinery/hologram/holopad,/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"gX" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"gY" = (/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"ha" = (/obj/machinery/door/firedoor/glass,/obj/structure/grille,/obj/structure/window/reinforced/polarized{dir = 10; icon_state = "fwindow"; id = "chapel"},/obj/structure/window/reinforced/tinted,/obj/structure/window/reinforced/tinted{dir = 1},/obj/structure/window/reinforced/tinted{dir = 4; icon_state = "twindow"},/turf/simulated/floor,/area/security/interrogation)
-"hc" = (/obj/structure/cable/pink{icon_state = "1-2"},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/obj/structure/extinguisher_cabinet{pixel_x = -27},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"hd" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"he" = (/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"hf" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/carpet,/area/chapel/main)
-"hg" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"hh" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"hi" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 8},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"hj" = (/obj/machinery/ai_status_display{pixel_x = -32; pixel_y = 0},/obj/machinery/porta_turret/ai_defense,/turf/simulated/floor/bluegrid,/area/ai_upload)
-"hk" = (/obj/effect/floor_decal/techfloor{dir = 9},/obj/effect/floor_decal/techfloor/hole{dir = 1},/obj/structure/cable/cyan{d2 = 4; icon_state = "0-4"},/obj/machinery/power/apc{dir = 1; name = "north bump"; pixel_x = 0; pixel_y = 28},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"hl" = (/obj/effect/floor_decal/corner_techfloor_grid{dir = 5},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/cyan{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"hm" = (/obj/effect/floor_decal/techfloor{dir = 5},/obj/effect/floor_decal/techfloor/hole/right{dir = 1},/obj/item/device/radio/intercom/locked/ai_private{dir = 1; icon_state = "intercom"; pixel_y = 32},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"hn" = (/obj/machinery/status_display{density = 0; layer = 4; pixel_x = 32; pixel_y = 0},/obj/machinery/porta_turret/ai_defense,/turf/simulated/floor/bluegrid,/area/ai_upload)
-"ho" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/yellow/border{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/table/reinforced,/obj/random/maintenance/engineering,/obj/random/maintenance/engineering,/obj/random/tech_supply,/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"hp" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"hq" = (/obj/effect/floor_decal/corner_steel_grid{dir = 6},/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"hr" = (/turf/simulated/wall,/area/maintenance/station/eng_upper)
-"hs" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/red/border,/obj/structure/railing,/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"ht" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/red/border,/obj/effect/floor_decal/borderfloor/corner2{dir = 9},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 9},/obj/structure/railing,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"hu" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"hv" = (/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/obj/machinery/firealarm{dir = 4; pixel_x = 24},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"hw" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/obj/structure/bed/chair{dir = 1},/obj/machinery/alarm{dir = 8; icon_state = "alarm0"; pixel_x = 24},/turf/simulated/floor/tiled/dark,/area/security/interrogation)
-"hx" = (/obj/effect/floor_decal/chapel{dir = 1},/obj/item/weapon/stool/padded,/obj/structure/cable/pink{icon_state = "1-2"},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"hy" = (/obj/effect/floor_decal/chapel{dir = 4},/obj/item/weapon/stool/padded,/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"hz" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"hA" = (/turf/simulated/floor/carpet,/area/chapel/main)
-"hB" = (/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"hC" = (/obj/effect/floor_decal/chapel{dir = 1},/obj/item/weapon/stool/padded,/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"hD" = (/obj/structure/table/standard,/obj/item/weapon/aiModule/oxygen,/obj/item/weapon/aiModule/oneHuman,/obj/item/weapon/aiModule/purge,/obj/item/weapon/aiModule/antimov,/obj/item/weapon/aiModule/teleporterOffline,/obj/effect/floor_decal/techfloor{dir = 9},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"hE" = (/obj/effect/floor_decal/techfloor{dir = 5},/obj/machinery/alarm{pixel_y = 22},/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor/bluegrid,/area/ai_upload)
-"hF" = (/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"hG" = (/obj/effect/floor_decal/techfloor{dir = 8},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"hH" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"hI" = (/obj/effect/floor_decal/techfloor{dir = 4},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"hJ" = (/obj/effect/floor_decal/techfloor{dir = 9},/obj/machinery/alarm{pixel_y = 22},/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor/bluegrid,/area/ai_upload)
-"hK" = (/obj/structure/table/standard,/obj/item/weapon/aiModule/reset,/obj/effect/floor_decal/techfloor{dir = 5},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"hL" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/yellow/border{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/alarm{dir = 4; pixel_x = -23; pixel_y = 0},/obj/machinery/light{icon_state = "tube1"; dir = 8},/obj/structure/table/reinforced,/obj/random/maintenance/clean,/obj/random/powercell,/obj/item/device/t_scanner,/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"hM" = (/obj/effect/floor_decal/corner_steel_grid{icon_state = "steel_grid"; dir = 4},/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"hN" = (/obj/structure/railing{dir = 8},/obj/structure/railing,/turf/simulated/open,/area/engineering/locker_room)
-"hO" = (/obj/structure/railing,/turf/simulated/open,/area/engineering/locker_room)
-"hP" = (/obj/structure/railing,/obj/machinery/light{icon_state = "tube1"; dir = 4},/turf/simulated/open,/area/engineering/locker_room)
-"hQ" = (/turf/simulated/wall/r_wall,/area/engineering/foyer_mezzenine)
-"hU" = (/obj/structure/stairs/west,/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"hV" = (/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"hW" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"hY" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/dark,/area/security/interrogation)
-"hZ" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/camera/network/security{dir = 1},/turf/simulated/floor/tiled/dark,/area/security/interrogation)
-"ia" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/tiled/dark,/area/security/interrogation)
-"id" = (/obj/effect/floor_decal/chapel{dir = 8},/obj/structure/cable/pink,/obj/machinery/power/apc{cell_type = /obj/item/weapon/cell/super; dir = 8; name = "west bump"; pixel_x = -28},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"ie" = (/obj/effect/floor_decal/chapel,/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"if" = (/obj/effect/floor_decal/chapel{dir = 8},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"ig" = (/obj/effect/floor_decal/chapel,/obj/machinery/camera/network/civilian{dir = 8},/obj/machinery/status_display{pixel_x = 32},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"ih" = (/obj/effect/floor_decal/techfloor{dir = 8},/obj/machinery/light{dir = 8},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"ii" = (/obj/effect/floor_decal/techfloor/corner,/obj/effect/floor_decal/techfloor/corner{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/hologram/holopad,/turf/simulated/floor/bluegrid,/area/ai_upload)
-"ij" = (/obj/effect/floor_decal/techfloor,/obj/effect/floor_decal/techfloor{dir = 1},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/door/airlock/highsecurity{name = "AI Storage"; req_access = list(16); req_one_access = list()},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"ik" = (/obj/effect/floor_decal/techfloor,/obj/effect/floor_decal/techfloor{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"il" = (/obj/effect/floor_decal/corner_techfloor_grid{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"im" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/hologram/holopad,/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"in" = (/obj/effect/floor_decal/corner_techfloor_grid{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"io" = (/obj/effect/floor_decal/techfloor/corner{dir = 1},/obj/effect/floor_decal/techfloor/corner{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/machinery/hologram/holopad,/turf/simulated/floor/bluegrid,/area/ai_upload)
-"ip" = (/obj/structure/table/standard,/obj/item/weapon/aiModule/nanotrasen,/obj/effect/floor_decal/techfloor{dir = 4},/obj/machinery/light{icon_state = "tube1"; dir = 4},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"iq" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/yellow/border{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/table/reinforced,/obj/random/powercell,/obj/random/tech_supply,/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"ir" = (/obj/machinery/atmospherics/unary/vent_pump/on,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"is" = (/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"it" = (/obj/structure/closet/secure_closet/engineering_personal,/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"iu" = (/obj/effect/floor_decal/borderfloor{dir = 9},/obj/effect/floor_decal/corner/yellow/border{dir = 9},/obj/effect/floor_decal/borderfloor/corner2{dir = 10},/obj/effect/floor_decal/corner/yellow/bordercorner2{dir = 10},/obj/machinery/disposal,/obj/structure/disposalpipe/trunk,/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"iv" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/yellow/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/machinery/vending/snack,/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"iw" = (/obj/effect/floor_decal/borderfloor{dir = 5},/obj/effect/floor_decal/corner/yellow/border{dir = 5},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"iz" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/obj/machinery/alarm{pixel_y = 22},/obj/machinery/camera/network/security{icon_state = "camera"; dir = 8},/turf/simulated/floor,/area/security/riot_control)
-"iA" = (/obj/machinery/hologram/holopad,/turf/simulated/floor/carpet,/area/chapel/main)
-"iC" = (/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"iD" = (/obj/machinery/light{dir = 4},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"iH" = (/obj/machinery/hologram/holopad,/turf/simulated/floor/lino,/area/chapel/office)
-"iJ" = (/obj/item/weapon/stool/padded,/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"iK" = (/obj/item/weapon/stool/padded,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"iL" = (/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"iM" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/carpet,/area/chapel/main)
-"iN" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"iO" = (/obj/item/weapon/stool/padded,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"iP" = (/obj/item/weapon/stool/padded,/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"iQ" = (/obj/structure/table/standard,/obj/item/weapon/aiModule/asimov,/obj/item/weapon/aiModule/freeformcore,/obj/item/weapon/aiModule/corp,/obj/item/weapon/aiModule/paladin,/obj/item/weapon/aiModule/robocop,/obj/effect/floor_decal/techfloor{dir = 10},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"iR" = (/obj/effect/floor_decal/techfloor{dir = 6},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/obj/machinery/camera/network/command{dir = 1},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"iS" = (/obj/machinery/light{dir = 8},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"iT" = (/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"iU" = (/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"iV" = (/obj/machinery/light{icon_state = "tube1"; dir = 4},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"iW" = (/obj/effect/floor_decal/techfloor{dir = 10},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/obj/machinery/camera/network/command{dir = 1},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"iX" = (/obj/structure/table/standard,/obj/item/weapon/aiModule/freeform,/obj/effect/floor_decal/techfloor{dir = 6},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"iY" = (/turf/simulated/wall,/area/vacant/vacant_office)
-"iZ" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/yellow/border{dir = 8},/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/structure/table/reinforced,/obj/random/toolbox,/obj/item/device/geiger,/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"ja" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"jb" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"jc" = (/obj/machinery/door/blast/regular{density = 0; dir = 1; icon_state = "pdoor0"; id = "englockdown"; name = "Engineering Lockdown"; opacity = 0},/obj/machinery/door/firedoor/glass,/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/airlock/engineering{name = "Engineering Workshop"; req_one_access = list(10,24)},/turf/simulated/floor/plating,/area/engineering/locker_room)
-"jd" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 1},/obj/structure/disposalpipe/junction{icon_state = "pipe-j2"; dir = 4},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"je" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"jf" = (/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"jg" = (/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/yellow/border{dir = 4},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"jh" = (/obj/machinery/door/firedoor/glass,/obj/machinery/door/blast/regular{density = 0; dir = 1; icon_state = "pdoor0"; id = "englockdown"; name = "Engineering Lockdown"; opacity = 0},/obj/machinery/door/airlock/maintenance/sec{name = "Riot Control"; req_one_access = list(1,10,24)},/turf/simulated/floor/plating,/area/security/riot_control)
-"jj" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"jl" = (/obj/machinery/power/apc{dir = 1; name = "north bump"; pixel_x = 0; pixel_y = 24},/obj/structure/cable/green{icon_state = "0-2"},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"jn" = (/obj/effect/floor_decal/chapel{dir = 1},/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"jo" = (/obj/effect/floor_decal/chapel{dir = 4},/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"jp" = (/obj/effect/floor_decal/techfloor{dir = 10},/obj/effect/floor_decal/techfloor/hole/right,/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"jq" = (/obj/effect/floor_decal/corner_techfloor_grid{dir = 10},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"jr" = (/obj/effect/floor_decal/techfloor{dir = 6},/obj/effect/floor_decal/techfloor/hole,/obj/machinery/camera/network/command{dir = 1},/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"js" = (/turf/simulated/floor,/area/vacant/vacant_office)
-"jt" = (/turf/simulated/floor/tiled/dark,/area/vacant/vacant_office)
-"jx" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/vacant/vacant_office)
-"jA" = (/obj/effect/floor_decal/borderfloor{dir = 10},/obj/effect/floor_decal/corner/yellow/border{dir = 10},/obj/structure/disposalpipe/trunk{dir = 1},/obj/machinery/disposal,/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"jB" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/yellow/border,/obj/structure/cable/green,/obj/machinery/power/apc{dir = 2; name = "south bump"; pixel_y = -32},/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"jC" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/yellow/border,/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"jD" = (/obj/structure/closet/wardrobe/engineering_yellow,/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/yellow/border,/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"jE" = (/obj/structure/closet/wardrobe/atmospherics_yellow,/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/yellow/border,/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"jF" = (/obj/structure/closet/secure_closet/atmos_personal,/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/yellow/border,/turf/simulated/floor/tiled,/area/engineering/locker_room)
-"jG" = (/obj/effect/floor_decal/borderfloor{dir = 10},/obj/effect/floor_decal/corner/yellow/border{dir = 10},/obj/effect/floor_decal/borderfloor/corner2{dir = 9},/obj/effect/floor_decal/borderfloor/corner2{dir = 8},/obj/effect/floor_decal/corner/yellow/bordercorner2{dir = 9},/obj/effect/floor_decal/corner/yellow/bordercorner2{dir = 8},/obj/machinery/alarm{dir = 4; pixel_x = -23; pixel_y = 0},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"jH" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"jI" = (/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 6},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"jJ" = (/obj/effect/floor_decal/borderfloor{dir = 6},/obj/effect/floor_decal/corner/yellow/border{dir = 6},/obj/effect/floor_decal/borderfloor/corner2,/obj/effect/floor_decal/corner/yellow/bordercorner2,/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"jL" = (/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"jM" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/junction/yjunction,/obj/structure/catwalk,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"jN" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/obj/structure/catwalk,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"jO" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/airlock/maintenance/common,/obj/structure/disposalpipe/segment{dir = 4},/obj/structure/catwalk,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"jP" = (/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/disposalpipe/segment{dir = 4},/obj/structure/catwalk,/turf/simulated/floor/plating,/area/maintenance/station/sec_lower)
-"jQ" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/decal/cleanable/dirt,/obj/structure/catwalk,/turf/simulated/floor/plating,/area/maintenance/station/sec_lower)
-"jR" = (/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/decal/cleanable/dirt,/obj/structure/catwalk,/turf/simulated/floor/plating,/area/maintenance/station/sec_lower)
-"jS" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/decal/cleanable/dirt,/obj/structure/catwalk,/turf/simulated/floor/plating,/area/maintenance/station/sec_lower)
-"jV" = (/obj/effect/floor_decal/chapel{dir = 8},/obj/item/weapon/stool/padded,/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"jW" = (/obj/effect/floor_decal/chapel,/obj/item/weapon/stool/padded,/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"jX" = (/turf/simulated/wall/r_wall,/area/ai_server_room)
-"jY" = (/turf/simulated/wall/r_wall,/area/ai_upload_foyer)
-"jZ" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/door/airlock/highsecurity{name = "AI Upload"; req_access = list(16); req_one_access = list()},/turf/simulated/floor/tiled/techfloor,/area/ai_upload_foyer)
-"ka" = (/obj/structure/sign/securearea,/turf/simulated/wall/r_wall,/area/ai_upload_foyer)
-"kb" = (/turf/simulated/wall/r_wall,/area/ai_cyborg_station)
-"kc" = (/obj/effect/floor_decal/rust,/turf/simulated/floor,/area/vacant/vacant_office)
-"kd" = (/obj/random/junk,/turf/simulated/floor,/area/vacant/vacant_office)
-"kf" = (/turf/simulated/wall,/area/engineering/foyer_mezzenine)
-"kg" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"kh" = (/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 5},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 6},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"ki" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/machinery/door/airlock/maintenance/common,/obj/structure/catwalk,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"kj" = (/turf/simulated/wall/r_wall,/area/maintenance/station/eng_upper)
-"kk" = (/turf/simulated/wall/r_wall,/area/maintenance/station/sec_lower)
-"kl" = (/obj/structure/sign/department/chapel,/turf/simulated/wall,/area/chapel/main)
-"km" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/chapel/main)
-"kn" = (/obj/machinery/door/airlock/glass{name = "Chapel"},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"ko" = (/obj/machinery/door/airlock/glass{name = "Chapel"},/obj/machinery/door/firedoor/glass,/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled/dark,/area/chapel/main)
-"kp" = (/obj/machinery/message_server,/turf/simulated/floor/tiled/techfloor,/area/ai_server_room)
-"kq" = (/obj/machinery/alarm{pixel_y = 22},/turf/simulated/floor/tiled/techfloor,/area/ai_server_room)
-"kr" = (/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/machinery/power/apc{dir = 1; name = "north bump"; pixel_x = 0; pixel_y = 28},/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor/tiled/techfloor,/area/ai_server_room)
-"ks" = (/obj/machinery/turretid/stun{control_area = "\improper AI Upload Chamber"; name = "AI Upload turret control"; pixel_x = 0; pixel_y = 30},/obj/machinery/alarm{dir = 4; pixel_x = -23; pixel_y = 0},/turf/simulated/floor/tiled/techfloor,/area/ai_upload_foyer)
-"kt" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/techfloor,/area/ai_upload_foyer)
-"ku" = (/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/obj/structure/cable/cyan{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/tiled/techfloor,/area/ai_upload_foyer)
-"kv" = (/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/machinery/power/apc{dir = 1; name = "north bump"; pixel_x = 0; pixel_y = 28},/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor/tiled/techfloor,/area/ai_cyborg_station)
-"kw" = (/obj/structure/table/standard,/obj/item/weapon/phone,/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled/techfloor,/area/ai_cyborg_station)
-"kx" = (/obj/machinery/computer/aifixer,/turf/simulated/floor/tiled/techfloor,/area/ai_cyborg_station)
-"kz" = (/obj/structure/table,/turf/simulated/floor,/area/vacant/vacant_office)
-"kC" = (/obj/effect/decal/cleanable/dirt,/obj/random/maintenance/engineering,/obj/random/tech_supply,/turf/simulated/floor,/area/vacant/vacant_office)
-"kD" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/pipe/cap/hidden/supply{dir = 4},/turf/simulated/floor,/area/vacant/vacant_office)
-"kF" = (/obj/effect/decal/cleanable/dirt,/obj/structure/table,/turf/simulated/floor,/area/vacant/vacant_office)
-"kG" = (/obj/effect/decal/cleanable/dirt,/obj/structure/table/reinforced,/turf/simulated/floor,/area/vacant/vacant_office)
-"kI" = (/turf/space/cracked_asteroid,/area/mine/explored/upper_level)
-"kJ" = (/turf/simulated/wall,/area/storage/tech)
-"kK" = (/turf/simulated/floor,/area/storage/tech)
-"kL" = (/obj/machinery/disposal,/obj/structure/disposalpipe/trunk,/obj/machinery/light/small{dir = 1},/turf/simulated/floor,/area/storage/tech)
-"kM" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/device/analyzer/plant_analyzer,/obj/item/device/healthanalyzer,/obj/item/device/analyzer,/obj/item/device/analyzer,/turf/simulated/floor/plating,/area/storage/tech)
-"kN" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/stock_parts/matter_bin,/obj/item/weapon/stock_parts/matter_bin,/obj/item/weapon/stock_parts/manipulator,/obj/item/weapon/stock_parts/console_screen,/obj/item/weapon/circuitboard/autolathe,/obj/item/weapon/circuitboard/partslathe,/turf/simulated/floor,/area/storage/tech)
-"kO" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/circuitboard/unary_atmos/heater,/obj/item/weapon/circuitboard/unary_atmos/cooler{pixel_x = 3; pixel_y = -3},/turf/simulated/floor/plating,/area/storage/tech)
-"kP" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/stock_parts/manipulator,/obj/item/weapon/stock_parts/matter_bin,/obj/item/weapon/stock_parts/matter_bin,/obj/item/weapon/stock_parts/capacitor,/obj/item/weapon/stock_parts/capacitor,/obj/machinery/light/small{dir = 1},/turf/simulated/floor/plating,/area/storage/tech)
-"kQ" = (/obj/machinery/vending/assist,/turf/simulated/floor,/area/storage/tech)
-"kS" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"kT" = (/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 5},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 6},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"kU" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/rust,/obj/structure/catwalk,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"kV" = (/obj/machinery/alarm{pixel_y = 22},/obj/machinery/portable_atmospherics/powered/scrubber,/obj/structure/railing{dir = 8},/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"kW" = (/obj/structure/railing{dir = 4},/obj/machinery/portable_atmospherics/powered/pump/filled,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"kX" = (/obj/machinery/light/small{dir = 4; pixel_y = 0},/obj/machinery/atmospherics/pipe/zpipe/down,/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,/obj/machinery/atmospherics/pipe/zpipe/down/supply,/obj/structure/lattice,/obj/structure/cable{icon_state = "32-2"},/obj/machinery/door/firedoor/glass,/turf/simulated/open,/area/maintenance/station/eng_upper)
-"kY" = (/turf/simulated/shuttle/wall/voidcraft/green{hard_corner = 1},/area/hallway/station/starboard)
-"kZ" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/borderfloor/corner2{dir = 4},/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/machinery/station_map{pixel_y = 32},/obj/machinery/status_display{pixel_x = -32},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"la" = (/obj/machinery/camera/network/northern_star,/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"lb" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/borderfloor/corner2{dir = 1},/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"lc" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/carpet,/area/hallway/station/starboard)
-"ld" = (/turf/simulated/floor/carpet,/area/hallway/station/starboard)
-"le" = (/obj/structure/disposalpipe/segment,/turf/simulated/floor/carpet,/area/hallway/station/starboard)
-"lf" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/borderfloor/corner2{dir = 4},/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"lg" = (/obj/effect/floor_decal/borderfloor{dir = 5},/obj/effect/floor_decal/corner/lightgrey/border{dir = 5},/obj/structure/closet/emcloset,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"lh" = (/obj/machinery/computer/message_monitor{dir = 4},/obj/machinery/light{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/ai_server_room)
-"li" = (/obj/machinery/hologram/holopad,/turf/simulated/floor/tiled/techfloor,/area/ai_server_room)
-"lj" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/turf/simulated/floor/tiled/techfloor,/area/ai_server_room)
-"lk" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/door/airlock/highsecurity{name = "Messaging Server"; req_access = list(16); req_one_access = list()},/turf/simulated/floor/tiled/techfloor,/area/ai_server_room)
-"ll" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/ai_upload_foyer)
-"lm" = (/obj/structure/cable/cyan{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/hologram/holopad,/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,/turf/simulated/floor/tiled/techfloor,/area/ai_upload_foyer)
-"ln" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/door/airlock/highsecurity{name = "AI Upload Access"; req_access = list(16); req_one_access = list()},/turf/simulated/floor/tiled/techfloor,/area/ai_cyborg_station)
-"lo" = (/obj/structure/cable/cyan{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/turf/simulated/floor/tiled/techfloor,/area/ai_cyborg_station)
-"lp" = (/obj/machinery/hologram/holopad,/turf/simulated/floor/tiled/techfloor,/area/ai_cyborg_station)
-"lq" = (/obj/machinery/light{icon_state = "tube1"; dir = 4},/turf/simulated/floor/tiled/techfloor,/area/ai_cyborg_station)
-"ls" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor,/area/vacant/vacant_office)
-"lt" = (/obj/structure/grille,/obj/machinery/door/firedoor/glass,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/turf/simulated/floor,/area/storage/tech)
-"lu" = (/obj/structure/grille,/obj/machinery/door/firedoor/glass,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 1},/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/turf/simulated/floor,/area/storage/tech)
-"lv" = (/obj/structure/grille,/obj/machinery/door/firedoor/glass,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 1},/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/turf/simulated/floor,/area/storage/tech)
-"lw" = (/turf/simulated/wall/r_wall,/area/storage/tech)
-"lx" = (/obj/machinery/status_display{layer = 4; pixel_x = -32; pixel_y = 0},/turf/simulated/floor,/area/storage/tech)
-"ly" = (/obj/structure/disposalpipe/segment,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/storage/tech)
-"lz" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/storage/tech)
-"lA" = (/obj/structure/table/steel,/obj/item/weapon/storage/bag/circuits/basic,/turf/simulated/floor,/area/storage/tech)
-"lB" = (/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"lC" = (/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 5},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 6},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"lD" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/structure/disposalpipe/segment,/obj/structure/railing,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"lE" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/effect/decal/cleanable/dirt,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"lF" = (/obj/structure/railing{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 1},/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"lG" = (/obj/machinery/atmospherics/pipe/simple/visible,/obj/structure/cable{icon_state = "1-2"},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/maintenance/clean,/obj/random/maintenance/engineering,/obj/random/maintenance/cargo,/obj/random/junk,/obj/random/maintenance/clean,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"lH" = (/turf/simulated/floor/holofloor/tiled/dark,/area/hallway/station/starboard)
-"lI" = (/obj/machinery/door/firedoor/glass/hidden/steel{dir = 2},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"lJ" = (/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"lK" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"lL" = (/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"lM" = (/obj/machinery/light{icon_state = "tube1"; dir = 4},/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/lightgrey/border{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/obj/item/device/radio/intercom{dir = 4; pixel_x = 24},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"lN" = (/obj/machinery/blackbox_recorder,/turf/simulated/floor/tiled/techfloor,/area/ai_server_room)
-"lO" = (/obj/machinery/camera/network/command{dir = 1},/turf/simulated/floor/tiled/techfloor,/area/ai_server_room)
-"lP" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/techfloor,/area/ai_server_room)
-"lQ" = (/obj/machinery/light,/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/obj/machinery/camera/network/command{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/ai_upload_foyer)
-"lR" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/ai_upload_foyer)
-"lS" = (/obj/machinery/light,/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8},/obj/item/device/radio/intercom/locked/ai_private{dir = 4; icon_state = "intercom"; pixel_x = 32},/turf/simulated/floor/tiled/techfloor,/area/ai_upload_foyer)
-"lT" = (/obj/structure/closet/crate{name = "Camera Assembly Crate"},/obj/item/weapon/camera_assembly,/obj/item/weapon/camera_assembly,/obj/item/weapon/camera_assembly,/obj/item/weapon/camera_assembly,/obj/machinery/alarm{dir = 1; pixel_y = -22},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/techfloor,/area/ai_cyborg_station)
-"lU" = (/obj/machinery/recharge_station,/obj/machinery/camera/network/command{dir = 1},/turf/simulated/floor/tiled/techfloor,/area/ai_cyborg_station)
-"lV" = (/obj/machinery/recharge_station,/turf/simulated/floor/tiled/techfloor,/area/ai_cyborg_station)
-"ma" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/turf/simulated/floor/tiled/dark,/area/vacant/vacant_office)
-"mb" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor,/area/vacant/vacant_office)
-"md" = (/obj/structure/grille,/obj/machinery/door/firedoor/glass,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8},/obj/structure/cable/green,/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/turf/simulated/floor,/area/storage/tech)
-"me" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/circuitboard/robotics{pixel_x = -2; pixel_y = 2},/obj/item/weapon/circuitboard/mecha_control{pixel_x = 1; pixel_y = -1},/turf/simulated/floor/tiled/dark,/area/storage/tech)
-"mf" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/obj/machinery/light/small{dir = 4},/turf/simulated/floor/tiled/dark,/area/storage/tech)
-"mg" = (/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/machinery/power/apc{cell_type = /obj/item/weapon/cell/apc; dir = 8; name = "west bump"; pixel_x = -28},/turf/simulated/floor,/area/storage/tech)
-"mh" = (/obj/structure/disposalpipe/segment,/turf/simulated/floor,/area/storage/tech)
-"mi" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/item/weapon/circuitboard/transhuman_synthprinter{pixel_x = -3; pixel_y = 4},/obj/item/weapon/circuitboard/rdconsole{pixel_x = 0; pixel_y = 2},/obj/item/weapon/circuitboard/destructive_analyzer,/obj/item/weapon/circuitboard/protolathe{pixel_x = 3; pixel_y = -2},/obj/item/weapon/circuitboard/rdserver{pixel_x = 6; pixel_y = -4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/storage/tech)
-"mj" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/circuitboard/security/mining{pixel_x = 1; pixel_y = 3},/obj/item/weapon/circuitboard/autolathe,/obj/item/weapon/circuitboard/scan_consolenew{pixel_x = 6; pixel_y = -3},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/storage/tech)
-"mk" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/circuitboard/arcade/orion_trail{pixel_x = -3; pixel_y = 3},/obj/item/weapon/circuitboard/jukebox{pixel_x = 0; pixel_y = 0},/obj/item/weapon/circuitboard/message_monitor{pixel_x = 3; pixel_y = -3},/obj/item/weapon/circuitboard/arcade/battle{pixel_x = 6; pixel_y = -5},/turf/simulated/floor/plating,/area/storage/tech)
-"ml" = (/obj/structure/table/steel,/obj/item/device/integrated_electronics/debugger{pixel_x = -5; pixel_y = 0},/obj/item/device/integrated_electronics/wirer{pixel_x = 5; pixel_y = 0},/turf/simulated/floor,/area/storage/tech)
-"mm" = (/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"mn" = (/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 5},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 6},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"mo" = (/obj/structure/sign/department/eng,/turf/simulated/wall,/area/engineering/foyer_mezzenine)
-"mp" = (/obj/structure/lattice,/obj/machinery/door/firedoor/glass,/obj/structure/disposalpipe/down{dir = 1},/turf/simulated/open,/area/maintenance/station/eng_upper)
-"mq" = (/obj/structure/railing{dir = 8},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"mr" = (/obj/structure/railing{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/effect/floor_decal/rust,/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"ms" = (/obj/machinery/atmospherics/pipe/zpipe/up/supply{dir = 1},/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/zpipe/up{dir = 1},/obj/structure/cable{icon_state = "16-0"},/obj/structure/cable,/obj/structure/cable{d2 = 2; icon_state = "0-2"; pixel_y = 0},/obj/structure/cable{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"mt" = (/obj/machinery/door/firedoor/glass/hidden/steel,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"mu" = (/obj/item/device/radio/beacon,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"mv" = (/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/lightgrey/border{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"mw" = (/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/door/airlock/highsecurity{name = "AI Upload Access"; req_access = list(16); req_one_access = list()},/turf/simulated/floor/tiled/steel_grid,/area/ai_upload_foyer)
-"mx" = (/obj/structure/sign/department/ai,/turf/simulated/wall/r_wall,/area/ai_upload_foyer)
-"my" = (/obj/machinery/status_display,/turf/simulated/wall,/area/hallway/station/starboard)
-"mz" = (/obj/machinery/door/firedoor/glass,/obj/structure/grille,/obj/structure/disposalpipe/segment,/obj/structure/window/reinforced/polarized{dir = 10; icon_state = "fwindow"; id = "lawyer_blast"},/turf/simulated/floor/plating,/area/hallway/station/starboard)
-"mA" = (/obj/machinery/door/firedoor/glass,/obj/structure/grille,/obj/structure/window/reinforced/polarized{dir = 10; icon_state = "fwindow"; id = "lawyer_blast"},/turf/simulated/floor/plating,/area/hallway/station/starboard)
-"mB" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/door/airlock/glass,/turf/simulated/floor/tiled/steel_grid,/area/hallway/station/starboard)
-"mC" = (/obj/structure/grille,/obj/machinery/door/firedoor/glass,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8},/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/obj/structure/cable/green,/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/turf/simulated/floor,/area/storage/tech)
-"mD" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/circuitboard/crew{pixel_x = -1; pixel_y = 1},/obj/item/weapon/circuitboard/card{pixel_x = 2; pixel_y = -2},/obj/item/weapon/circuitboard/communications{pixel_x = 5; pixel_y = -5},/obj/machinery/light/small{dir = 8},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/dark,/area/storage/tech)
-"mE" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/dark,/area/storage/tech)
-"mF" = (/obj/machinery/door/firedoor/glass,/obj/machinery/door/airlock/highsecurity{name = "Secure Tech Storage"; req_access = list(19,23); req_one_access = newlist()},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/storage/tech)
-"mG" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor,/area/storage/tech)
-"mH" = (/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/storage/tech)
-"mI" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/storage/tech)
-"mJ" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/storage/tech)
-"mK" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/storage/tech)
-"mL" = (/obj/machinery/door/firedoor/glass,/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/airlock/engineering{name = "Tech Storage"; req_access = list(23); req_one_access = newlist()},/turf/simulated/floor/plating,/area/storage/tech)
-"mM" = (/obj/structure/catwalk,/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/open,/area/engineering/foyer_mezzenine)
-"mN" = (/obj/structure/catwalk,/obj/structure/disposalpipe/junction,/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/open,/area/engineering/foyer_mezzenine)
-"mO" = (/obj/structure/catwalk,/turf/simulated/open,/area/engineering/foyer_mezzenine)
-"mP" = (/obj/effect/floor_decal/borderfloor/corner{dir = 4},/obj/effect/floor_decal/corner/yellow/bordercorner{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"mQ" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/yellow/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/machinery/power/apc{dir = 1; name = "north bump"; pixel_x = 0; pixel_y = 24},/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"mR" = (/obj/structure/railing{dir = 1},/obj/structure/reagent_dispensers/watertank,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"mS" = (/obj/random/junk,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"mT" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/railing{dir = 4},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"mU" = (/obj/structure/cable{icon_state = "1-2"},/obj/structure/reagent_dispensers/fueltank,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"mV" = (/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"mW" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"mX" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/floor_decal/borderfloor/corner{dir = 4},/obj/effect/floor_decal/corner/lightgrey/bordercorner{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"mY" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/computer/guestpass{pixel_y = 32},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/machinery/door/firedoor/glass/hidden/steel{dir = 2},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"mZ" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/atm{pixel_y = 30},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"na" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/machinery/firealarm{dir = 2; layer = 3.3; pixel_x = 0; pixel_y = 26},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nb" = (/obj/machinery/alarm{pixel_y = 22},/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nc" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nd" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/status_display{pixel_y = 30},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/borderfloor/corner2{dir = 1},/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"ne" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nf" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/borderfloor/corner2{dir = 4},/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"ng" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/camera/network/northern_star,/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nh" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"ni" = (/obj/structure/disposalpipe/junction{dir = 8; icon_state = "pipe-j2"},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nk" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/machinery/light{dir = 1},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nl" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nm" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nn" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"no" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/borderfloor/corner2{dir = 1},/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"np" = (/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 9},/obj/machinery/atmospherics/pipe/manifold/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nq" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/borderfloor/corner2{dir = 4},/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nr" = (/obj/structure/flora/pottedplant/stoutbush,/obj/effect/floor_decal/borderfloor{dir = 5},/obj/effect/floor_decal/corner/lightgrey/border{dir = 5},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"ns" = (/turf/simulated/wall,/area/hallway/station/starboard)
-"nt" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/circuitboard/borgupload{pixel_x = -1; pixel_y = 1},/obj/item/weapon/circuitboard/aiupload{pixel_x = 2; pixel_y = -2},/obj/item/weapon/circuitboard/transhuman_resleever{pixel_x = 5; pixel_y = -5},/turf/simulated/floor/tiled/dark,/area/storage/tech)
-"nu" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/obj/machinery/camera/network/engineering{dir = 8},/turf/simulated/floor/tiled/dark,/area/storage/tech)
-"nv" = (/obj/machinery/requests_console{department = "Tech storage"; pixel_x = -28; pixel_y = 0},/obj/machinery/camera/network/engineering{dir = 4},/turf/simulated/floor,/area/storage/tech)
-"nw" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/circuitboard/transhuman_clonepod{pixel_x = -2; pixel_y = 3},/obj/item/weapon/circuitboard/resleeving_control{pixel_x = 0; pixel_y = 1},/obj/item/weapon/circuitboard/body_designer{pixel_x = 1; pixel_y = -1},/obj/item/weapon/circuitboard/med_data{pixel_x = 5; pixel_y = -3},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/plating,/area/storage/tech)
-"nx" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/circuitboard/secure_data{pixel_x = -2; pixel_y = 2},/obj/item/weapon/circuitboard/security{pixel_x = 1; pixel_y = -1},/obj/item/weapon/circuitboard/skills{pixel_x = 4; pixel_y = -3},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/storage/tech)
-"ny" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/circuitboard/powermonitor{pixel_x = 0; pixel_y = 3},/obj/item/weapon/circuitboard/stationalert_engineering{pixel_x = 2; pixel_y = 1},/obj/item/weapon/circuitboard/security/engineering{pixel_x = 5; pixel_y = -1},/obj/item/weapon/circuitboard/atmos_alert{pixel_x = 6; pixel_y = -3},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/storage/tech)
-"nz" = (/obj/machinery/light_switch{dir = 8; pixel_x = 24},/turf/simulated/floor,/area/storage/tech)
-"nA" = (/obj/structure/catwalk,/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/open,/area/engineering/foyer_mezzenine)
-"nB" = (/obj/structure/disposalpipe/junction/yjunction,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"nC" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"nD" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/yellow/border{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"nE" = (/obj/machinery/door/firedoor/glass,/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/door/blast/regular{density = 0; dir = 1; icon_state = "pdoor0"; id = "englockdown"; name = "Engineering Lockdown"; opacity = 0},/obj/machinery/door/airlock/maintenance/common,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"nF" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"nG" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment{dir = 4},/obj/structure/railing{dir = 4},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"nH" = (/obj/structure/cable{icon_state = "1-2"},/obj/structure/disposalpipe/up{dir = 8},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"nI" = (/obj/structure/sign/deck2,/turf/simulated/shuttle/wall/voidcraft/green{hard_corner = 1},/area/hallway/station/starboard)
-"nJ" = (/obj/machinery/door/firedoor/glass/hidden/steel{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nK" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nL" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nM" = (/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold/hidden/supply,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nN" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nO" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/door/firedoor/glass/hidden/steel{dir = 8},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nP" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nQ" = (/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nR" = (/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nS" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nT" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9; pixel_y = 0},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nU" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nV" = (/obj/structure/extinguisher_cabinet{pixel_x = 25; pixel_y = 0},/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/lightgrey/border{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"nW" = (/obj/structure/grille,/obj/machinery/door/firedoor/glass,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced,/obj/structure/cable/green,/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/turf/simulated/floor,/area/storage/tech)
-"nX" = (/obj/structure/grille,/obj/machinery/door/firedoor/glass,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced,/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/turf/simulated/floor,/area/storage/tech)
-"nY" = (/obj/structure/grille,/obj/machinery/door/firedoor/glass,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced,/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/turf/simulated/floor,/area/storage/tech)
-"nZ" = (/obj/machinery/status_display{layer = 4; pixel_x = -32; pixel_y = 0},/obj/effect/floor_decal/rust,/turf/simulated/floor,/area/storage/tech)
-"oa" = (/obj/effect/floor_decal/rust,/turf/simulated/floor,/area/storage/tech)
-"ob" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor,/area/storage/tech)
-"oc" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/storage/tech)
-"od" = (/obj/structure/table/steel,/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000},/obj/item/stack/cable_coil,/obj/machinery/camera/network/engineering{dir = 8},/turf/simulated/floor,/area/storage/tech)
-"oe" = (/obj/structure/railing{dir = 1},/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/simulated/open,/area/engineering/foyer_mezzenine)
-"of" = (/obj/structure/railing{dir = 1},/turf/simulated/open,/area/engineering/foyer_mezzenine)
-"og" = (/obj/structure/railing{dir = 1},/obj/structure/railing{dir = 4},/turf/simulated/open,/area/engineering/foyer_mezzenine)
-"oh" = (/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"oi" = (/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"oj" = (/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/yellow/border{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/obj/machinery/light{icon_state = "tube1"; dir = 4},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"ok" = (/obj/structure/railing,/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/maintenance/clean,/obj/random/maintenance/engineering,/obj/random/maintenance/cargo,/obj/random/junk,/obj/random/maintenance/engineering,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"ol" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"om" = (/obj/structure/cable{icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/structure/railing{dir = 1},/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"on" = (/obj/machinery/hologram/holopad,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"oo" = (/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/effect/floor_decal/borderfloor/corner,/obj/effect/floor_decal/corner/lightgrey/bordercorner,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"op" = (/obj/machinery/camera/network/northern_star{dir = 1},/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"oq" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"or" = (/obj/machinery/power/apc{dir = 2; name = "south bump"; pixel_y = -32},/obj/structure/cable{d2 = 8; icon_state = "0-8"},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"os" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/machinery/door/firedoor/glass/hidden/steel{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"ot" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"ou" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/structure/extinguisher_cabinet{dir = 1; icon_state = "extinguisher_closed"; pixel_y = -32},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"ov" = (/obj/machinery/light,/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"ow" = (/obj/machinery/camera/network/northern_star{dir = 1},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"ox" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/disposalpipe/segment,/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"oy" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"oz" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/borderfloor/corner2{dir = 9},/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"oA" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 5},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 8},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"oB" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/borderfloor/corner2{dir = 9},/obj/effect/floor_decal/borderfloor/corner2,/obj/effect/floor_decal/corner/lightgrey/bordercorner2,/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 9},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"oC" = (/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 5},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 8},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"oD" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/borderfloor/corner2,/obj/effect/floor_decal/corner/lightgrey/bordercorner2,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"oE" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"oF" = (/obj/machinery/light,/obj/structure/closet/emcloset,/obj/effect/floor_decal/borderfloor{dir = 6},/obj/effect/floor_decal/corner/lightgrey/border{dir = 6},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"oG" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/storage/toolbox/electrical{pixel_x = 1; pixel_y = -1},/obj/item/device/multitool,/obj/item/clothing/glasses/meson,/obj/machinery/light/small,/turf/simulated/floor/plating,/area/storage/tech)
-"oH" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/storage/toolbox/electrical{pixel_x = 1; pixel_y = -1},/obj/item/clothing/gloves/yellow,/obj/item/device/t_scanner,/obj/item/clothing/glasses/meson,/obj/item/device/multitool,/obj/machinery/ai_status_display{pixel_x = 0; pixel_y = -32},/turf/simulated/floor/plating,/area/storage/tech)
-"oI" = (/obj/item/device/flashlight{pixel_x = 1; pixel_y = 5},/obj/item/device/flashlight{pixel_x = 1; pixel_y = 5},/obj/item/device/flash,/obj/item/device/flash,/obj/structure/table/steel,/obj/machinery/alarm{dir = 1; pixel_y = -25},/turf/simulated/floor/plating,/area/storage/tech)
-"oJ" = (/obj/structure/table/steel,/obj/item/device/aicard,/obj/item/weapon/aiModule/reset,/turf/simulated/floor,/area/storage/tech)
-"oK" = (/obj/structure/table/steel,/obj/item/weapon/module/power_control,/obj/item/weapon/airlock_electronics,/obj/machinery/light/small,/turf/simulated/floor,/area/storage/tech)
-"oL" = (/obj/structure/table/steel,/obj/machinery/cell_charger{pixel_y = 5},/obj/item/device/multitool,/turf/simulated/floor,/area/storage/tech)
-"oM" = (/turf/simulated/open,/area/engineering/foyer_mezzenine)
-"oN" = (/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/yellow/border{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/obj/machinery/alarm{dir = 8; pixel_x = 25; pixel_y = 0},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"oO" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/structure/disposalpipe/up,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"oP" = (/obj/structure/railing{dir = 8},/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"oQ" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable{icon_state = "1-2"},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"oR" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/maintenance/clean,/obj/random/maintenance/engineering,/obj/random/maintenance/clean,/obj/random/junk,/obj/random/maintenance/engineering,/obj/effect/floor_decal/rust,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"oS" = (/obj/structure/closet,/obj/random/maintenance/clean,/obj/random/maintenance/clean,/obj/random/junk,/obj/random/tool,/obj/random/maintenance/security,/obj/random/maintenance/engineering,/obj/effect/decal/cleanable/dirt,/obj/effect/floor_decal/rust,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"oT" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/lightgrey/border{dir = 8},/obj/effect/floor_decal/borderfloor/corner2{dir = 8},/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 5},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 6},/obj/machinery/firealarm{dir = 8; pixel_x = -26},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"oU" = (/obj/machinery/atmospherics/unary/vent_pump/on,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"oV" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"; pixel_y = 0},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/light{dir = 4; icon_state = "tube1"; pixel_x = 0},/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/lightgrey/border{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"oW" = (/turf/simulated/wall/r_wall,/area/medical/virology)
-"oX" = (/obj/machinery/door/firedoor/glass,/obj/machinery/door/airlock/maintenance/command,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/maintenance/evahallway)
-"oY" = (/turf/simulated/wall/r_wall,/area/ai_monitored/storage/eva)
-"oZ" = (/obj/structure/grille,/obj/structure/sign/securearea,/obj/machinery/door/firedoor/border_only,/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/structure/window/reinforced/full,/turf/simulated/floor/plating,/area/ai_monitored/storage/eva)
-"pa" = (/obj/machinery/door/airlock/glass_command{id_tag = "evadoors"; name = "E.V.A."; req_access = list(); req_one_access = list(18,19,43,67)},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled/steel_grid,/area/ai_monitored/storage/eva)
-"pb" = (/obj/structure/grille,/obj/machinery/door/firedoor/border_only,/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/structure/window/reinforced/full,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/plating,/area/ai_monitored/storage/eva)
-"pc" = (/obj/machinery/door/airlock/glass_command{id_tag = "evadoors"; name = "E.V.A."; req_access = list(); req_one_access = list(18,19,43,67)},/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/steel_grid,/area/ai_monitored/storage/eva)
-"pd" = (/turf/simulated/wall,/area/vacant/vacant_restaurant_upper)
-"pe" = (/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 5},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"pf" = (/obj/effect/floor_decal/borderfloor/corner{dir = 4},/obj/effect/floor_decal/corner/yellow/bordercorner{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 5},/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"pg" = (/obj/structure/railing{dir = 8},/obj/structure/closet,/obj/random/maintenance/clean,/obj/random/maintenance/engineering,/obj/random/maintenance/medical,/obj/random/junk,/obj/random/medical/lite,/obj/random/tool,/obj/random/maintenance/security,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"ph" = (/obj/machinery/light/small,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"pi" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable{icon_state = "1-2"},/obj/effect/floor_decal/rust,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"pj" = (/obj/structure/closet/crate,/obj/random/maintenance/clean,/obj/random/maintenance/medical,/obj/random/junk,/obj/random/maintenance/engineering,/obj/random/maintenance/clean,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"pk" = (/obj/structure/extinguisher_cabinet{pixel_x = -27},/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/lightgrey/border{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 5},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 6},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"pl" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"pm" = (/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/lightgrey/border{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"pn" = (/obj/structure/bed/padded,/obj/machinery/camera/network/medbay{c_tag = "MED - Virology Containment One"; dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"po" = (/obj/machinery/atmospherics/unary/vent_pump/on,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"pp" = (/obj/structure/closet/secure_closet/personal/patient,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"pq" = (/obj/random/junk,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/medical/virology)
-"pr" = (/obj/structure/closet/crate,/obj/random/contraband,/obj/random/maintenance/medical,/obj/random/maintenance/medical,/obj/random/maintenance/medical,/obj/effect/decal/cleanable/dirt,/obj/effect/floor_decal/rust,/turf/simulated/floor,/area/medical/virology)
-"ps" = (/obj/random/junk,/obj/effect/decal/cleanable/dirt,/obj/effect/floor_decal/rust,/turf/simulated/floor,/area/medical/virology)
-"pt" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/medical/virology)
-"pu" = (/obj/effect/decal/cleanable/dirt,/obj/random/trash_pile,/turf/simulated/floor,/area/medical/virology)
-"pv" = (/obj/structure/catwalk,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/maintenance/evahallway)
-"pw" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/clothing/mask/breath,/obj/item/clothing/shoes/magboots,/obj/item/clothing/suit/space/void/medical,/obj/item/clothing/head/helmet/space/void/medical,/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"px" = (/obj/machinery/door/firedoor/border_only,/obj/structure/grille,/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/obj/structure/window/reinforced/full,/turf/simulated/floor/plating,/area/ai_monitored/storage/eva)
-"py" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/requests_console{department = "EVA"; pixel_x = -32; pixel_y = 0},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"pz" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"pA" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/button/remote/airlock{desc = "A remote control switch for exiting EVA."; id = "evadoors"; name = "EVA Door Control"; pixel_x = 0; pixel_y = 28},/obj/machinery/camera/network/command{c_tag = "EVA - Fore"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"pB" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"pC" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/machinery/alarm{dir = 8; icon_state = "alarm0"; pixel_x = 24},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"pD" = (/obj/structure/grille,/obj/machinery/door/firedoor/border_only,/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/obj/structure/window/reinforced/full,/turf/simulated/floor/plating,/area/ai_monitored/storage/eva)
-"pE" = (/obj/structure/table/rack,/obj/item/clothing/mask/breath,/obj/item/clothing/shoes/magboots,/obj/item/clothing/suit/space/void/security,/obj/item/clothing/head/helmet/space/void/security,/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"pF" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"pG" = (/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"pH" = (/obj/effect/floor_decal/rust,/obj/item/frame/apc,/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"pI" = (/obj/effect/floor_decal/rust,/obj/random/cigarettes,/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"pJ" = (/obj/machinery/light_switch{dir = 8; pixel_x = 24},/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"pK" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/obj/machinery/door/blast/regular{density = 0; dir = 4; icon_state = "pdoor0"; id = "englockdown"; name = "Engineering Lockdown"; opacity = 0},/turf/simulated/floor/plating,/area/engineering/foyer_mezzenine)
-"pL" = (/obj/structure/disposalpipe/segment,/obj/machinery/door/airlock/glass_engineering{name = "Engineering Mezzenine"; req_one_access = list()},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/blast/regular{density = 0; dir = 4; icon_state = "pdoor0"; id = "englockdown"; name = "Engineering Lockdown"; opacity = 0},/turf/simulated/floor/tiled/steel_grid,/area/engineering/foyer_mezzenine)
-"pM" = (/obj/machinery/door/airlock/glass_engineering{name = "Engineering Mezzenine"; req_one_access = list()},/obj/machinery/door/firedoor/glass,/obj/machinery/door/blast/regular{density = 0; dir = 4; icon_state = "pdoor0"; id = "englockdown"; name = "Engineering Lockdown"; opacity = 0},/turf/simulated/floor/tiled/steel_grid,/area/engineering/foyer_mezzenine)
-"pN" = (/obj/structure/cable{icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/door/firedoor/glass,/obj/machinery/door/airlock/maintenance/common,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"pO" = (/turf/simulated/wall/r_wall,/area/hallway/station/port)
-"pP" = (/obj/machinery/vending/snack,/obj/effect/floor_decal/corner/lightgrey{dir = 9},/obj/effect/floor_decal/corner/lightgrey{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"pQ" = (/obj/effect/floor_decal/corner/lightgrey{dir = 9},/obj/effect/floor_decal/corner/lightgrey{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/obj/machinery/vending/nifsoft_shop,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"pR" = (/obj/machinery/vending/coffee,/obj/effect/floor_decal/corner/lightgrey{dir = 9},/obj/effect/floor_decal/corner/lightgrey{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"pS" = (/turf/simulated/wall/r_wall,/area/hallway/station/starboard)
-"pT" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"; pixel_y = 0},/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/lightgrey/border{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 5},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 6},/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"pU" = (/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/lightgrey/border{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"pV" = (/obj/structure/table/standard,/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"pW" = (/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"pX" = (/turf/simulated/floor/tiled/white,/area/medical/virology)
-"pY" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 10},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"pZ" = (/turf/simulated/wall/r_wall,/area/medical/virologyisolation)
-"qa" = (/obj/structure/catwalk,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/floor_decal/rust,/turf/simulated/floor,/area/maintenance/evahallway)
-"qb" = (/obj/machinery/light/small{dir = 8},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"qc" = (/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"qd" = (/obj/machinery/door/airlock/glass_medical{name = "Medical Hardsuits"; req_one_access = list(5)},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"qe" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"qf" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"qg" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"qh" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"qi" = (/obj/machinery/door/airlock/glass_security{name = "Security Hardsuits"; req_access = list(1)},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"qj" = (/obj/machinery/light/small{dir = 4; pixel_y = 0},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"qk" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"ql" = (/obj/effect/floor_decal/rust,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"qm" = (/obj/effect/floor_decal/rust,/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"qn" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/hallway/station/port)
-"qo" = (/obj/effect/floor_decal/borderfloor{dir = 9},/obj/effect/floor_decal/corner/yellow/border{dir = 9},/obj/effect/floor_decal/borderfloor/corner2{dir = 10},/obj/effect/floor_decal/corner/yellow/bordercorner2{dir = 10},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"qp" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/yellow/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/port)
-"qq" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/yellow/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/machinery/door/firedoor/glass/hidden/steel{dir = 2},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"qr" = (/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 4},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"qs" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/yellow/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/borderfloor/corner2{dir = 1},/obj/effect/floor_decal/borderfloor/corner2{dir = 4},/obj/effect/floor_decal/corner/yellow/bordercorner2{dir = 1},/obj/effect/floor_decal/corner/yellow/bordercorner2{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"qt" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"qu" = (/obj/machinery/alarm{pixel_y = 22},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/yellow/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/borderfloor/corner2{dir = 4},/obj/effect/floor_decal/corner/yellow/bordercorner2{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"qv" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/machinery/computer/guestpass{pixel_y = 32},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"qw" = (/obj/machinery/power/apc{dir = 1; name = "north bump"; pixel_x = 0; pixel_y = 28},/obj/structure/cable{icon_state = "0-4"; d2 = 4},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/port)
-"qx" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/port)
-"qy" = (/obj/structure/cable{icon_state = "1-2"},/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/port)
-"qz" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/obj/machinery/camera/network/northern_star,/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/port)
-"qA" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/obj/machinery/status_display{pixel_y = 30},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/port)
-"qB" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/port)
-"qC" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"qD" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"qE" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/machinery/door/firedoor/glass/hidden/steel{dir = 2},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"qF" = (/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/effect/floor_decal/borderfloor/corner{dir = 1},/obj/effect/floor_decal/corner/lightgrey/bordercorner{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 5},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"qG" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"qH" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/medical/virology)
-"qI" = (/obj/machinery/door/window/westright{name = "Virology Isolation Room One"; icon_state = "right"; dir = 1; req_access = list(39)},/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"qJ" = (/obj/machinery/door/window/westright{dir = 1; icon_state = "right"; name = "Virology Isolation Room Two"; req_access = list(39)},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/black,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"qK" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/green,/obj/machinery/camera/network/medbay{dir = 4},/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"qL" = (/obj/machinery/light_switch{dir = 2; name = "light switch "; pixel_x = 0; pixel_y = 26},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"qM" = (/obj/machinery/alarm{pixel_y = 22},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"qN" = (/obj/machinery/vending/coffee,/obj/machinery/status_display{pixel_y = 30},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"qO" = (/obj/machinery/vending/snack,/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"qP" = (/obj/structure/closet/secure_closet/personal/patient,/obj/item/clothing/under/color/white,/obj/item/clothing/under/color/white,/obj/item/clothing/under/color/white,/obj/item/clothing/under/color/white,/obj/item/clothing/under/color/white,/obj/item/clothing/under/color/white,/obj/item/clothing/under/color/white,/obj/item/clothing/shoes/white,/obj/item/clothing/shoes/white,/obj/item/clothing/shoes/white,/obj/item/clothing/shoes/white,/obj/item/clothing/shoes/white,/obj/item/clothing/shoes/white,/obj/item/clothing/shoes/white,/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"qQ" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/structure/dispenser/oxygen,/obj/machinery/firealarm{dir = 8; pixel_x = -26},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"qR" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"qS" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 8},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"qT" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"qU" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/obj/structure/extinguisher_cabinet{pixel_x = 25; pixel_y = 0},/obj/structure/table/rack,/obj/item/device/suit_cooling_unit,/obj/item/device/suit_cooling_unit,/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"qV" = (/obj/random/junk,/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"qW" = (/obj/random/trash,/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"qX" = (/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"qY" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"qZ" = (/obj/machinery/atmospherics/pipe/cap/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"ra" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/cap/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"rb" = (/obj/structure/disposalpipe/broken{icon_state = "pipe-b"; dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"rc" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"rd" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/door/airlock/glass,/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled/steel_grid,/area/hallway/station/port)
-"re" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rf" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/door/firedoor/glass/hidden/steel,/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/steeldecal/steel_decals5{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rg" = (/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1},/obj/structure/disposalpipe/segment{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rh" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9; pixel_y = 0},/obj/structure/disposalpipe/junction{icon_state = "pipe-j2"; dir = 4},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"ri" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rj" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rk" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rl" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rm" = (/obj/structure/cable{icon_state = "1-2"},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold/hidden/supply,/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rn" = (/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1},/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"ro" = (/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9; pixel_y = 0},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rp" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"rq" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/door/firedoor/glass/hidden/steel,/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"rr" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"rs" = (/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"rt" = (/obj/machinery/atmospherics/pipe/manifold/hidden/black,/obj/machinery/atmospherics/pipe/manifold/hidden/supply,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"ru" = (/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"rv" = (/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/item/weapon/storage/secure/safe{pixel_x = 5; pixel_y = 29},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"rw" = (/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"rx" = (/obj/item/device/radio/intercom{dir = 4; pixel_x = 24},/obj/structure/table/glass,/obj/machinery/computer/med_data/laptop{dir = 8},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"ry" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/green,/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"rz" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"rA" = (/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"rB" = (/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"rC" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 8},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"rD" = (/obj/structure/reagent_dispensers/water_cooler/full,/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"rE" = (/obj/machinery/light/small{dir = 4; pixel_y = 0},/obj/structure/catwalk,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/maintenance/evahallway)
-"rF" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/clothing/mask/breath,/obj/item/weapon/rig/eva/equipped,/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"rG" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/clothing/shoes/magboots,/obj/item/clothing/suit/space/void/atmos,/obj/item/clothing/mask/breath,/obj/item/clothing/head/helmet/space/void/atmos,/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"rH" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/portable_atmospherics/canister/oxygen,/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"rI" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"rJ" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"rK" = (/obj/structure/table/reinforced,/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/effect/floor_decal/industrial/warning{dir = 4},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"rL" = (/obj/machinery/door/firedoor/border_only,/obj/structure/grille,/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/structure/window/reinforced/full,/turf/simulated/floor/plating,/area/ai_monitored/storage/eva)
-"rM" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/clothing/head/helmet/space/skrell/black,/obj/item/clothing/mask/breath,/obj/item/clothing/suit/space/skrell/black,/obj/item/clothing/head/helmet/space/skrell/white,/obj/item/clothing/mask/breath,/obj/item/clothing/suit/space/skrell/white,/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"rN" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/rig/breacher,/obj/item/clothing/mask/breath,/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"rO" = (/obj/effect/floor_decal/borderfloor{dir = 10},/obj/effect/floor_decal/corner/lightgrey/border{dir = 10},/obj/effect/floor_decal/borderfloor/corner2{dir = 8},/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 8},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rP" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rQ" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/machinery/light,/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rR" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/machinery/door/firedoor/glass/hidden/steel{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rS" = (/obj/effect/floor_decal/borderfloor/corner{dir = 8},/obj/effect/floor_decal/corner/lightgrey/bordercorner{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 6},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rT" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rU" = (/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/effect/floor_decal/borderfloor/corner,/obj/effect/floor_decal/corner/lightgrey/bordercorner,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rV" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rW" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/camera/network/northern_star{dir = 1},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rX" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/machinery/firealarm{dir = 1; pixel_x = 0; pixel_y = -25},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rY" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/structure/extinguisher_cabinet{dir = 1; icon_state = "extinguisher_closed"; pixel_y = -32},/obj/effect/floor_decal/borderfloor/corner2{dir = 9},/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 9},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"rZ" = (/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/cable{icon_state = "1-8"},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/borderfloor/corner2,/obj/effect/floor_decal/corner/lightgrey/bordercorner2,/turf/simulated/floor/tiled,/area/hallway/station/port)
-"sa" = (/obj/machinery/light,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"sb" = (/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"sc" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"sd" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/machinery/door/firedoor/glass/hidden/steel{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"se" = (/obj/structure/flora/pottedplant/stoutbush,/obj/effect/floor_decal/borderfloor{dir = 6},/obj/effect/floor_decal/corner/lightgrey/border{dir = 6},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"sf" = (/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/firealarm{dir = 8; pixel_x = -24; pixel_y = 0},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"sg" = (/obj/machinery/disease2/diseaseanalyser,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"sh" = (/obj/machinery/light,/obj/machinery/computer/centrifuge,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"si" = (/obj/machinery/disease2/incubator,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"sj" = (/obj/structure/table/glass,/obj/item/weapon/storage/box/monkeycubes,/obj/item/weapon/extinguisher,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"sk" = (/obj/structure/sink{icon_state = "sink"; dir = 8; pixel_x = -12; pixel_y = 2},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"sl" = (/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"sm" = (/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"sn" = (/obj/item/weapon/stool/padded,/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"so" = (/obj/structure/table/standard,/obj/item/weapon/storage/box/cups,/obj/machinery/firealarm{dir = 4; pixel_x = 24},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"sp" = (/obj/machinery/door/airlock/glass_engineering{name = "Engineering Hardsuits"; req_one_access = list(11,24)},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"sq" = (/obj/machinery/light{icon_state = "tube1"; dir = 4},/obj/structure/table/reinforced,/obj/machinery/camera/network/security{dir = 8},/obj/item/stack/material/glass/reinforced{amount = 50},/obj/item/stack/rods{amount = 50},/obj/effect/floor_decal/industrial/warning{dir = 4},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"sr" = (/obj/machinery/door/firedoor/border_only,/obj/structure/grille,/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/structure/cable/green,/obj/structure/window/reinforced/full,/turf/simulated/floor/plating,/area/ai_monitored/storage/eva)
-"ss" = (/obj/random/junk,/obj/random/maintenance/engineering,/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"st" = (/obj/structure/table/bench/wooden,/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"su" = (/obj/structure/railing{dir = 1},/obj/structure/railing{dir = 8},/turf/simulated/open,/area/vacant/vacant_restaurant_upper)
-"sv" = (/obj/structure/railing{dir = 1},/turf/simulated/open,/area/vacant/vacant_restaurant_upper)
-"sw" = (/turf/simulated/wall,/area/tether/station/stairs_two)
-"sx" = (/obj/structure/sign/directions/engineering{dir = 1; pixel_y = 8},/obj/structure/sign/directions/elevator{dir = 4},/turf/simulated/wall,/area/tether/station/stairs_two)
-"sy" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/lightgrey/border{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 5},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"sz" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"sA" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"; pixel_y = 0},/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/lightgrey/border{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"sB" = (/turf/simulated/wall,/area/maintenance/station/micro)
-"sC" = (/obj/machinery/door/airlock/maintenance/common,/obj/machinery/door/firedoor/glass,/obj/structure/cable{icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/turf/simulated/floor/plating,/area/maintenance/station/micro)
-"sD" = (/turf/simulated/wall,/area/maintenance/substation/medical)
-"sE" = (/turf/simulated/wall,/area/medical/virology)
-"sF" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/obj/machinery/atmospherics/pipe/simple/hidden/black,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"sG" = (/obj/machinery/disposal,/obj/effect/floor_decal/industrial/warning/full,/obj/structure/sign/deathsposal{pixel_x = 32; pixel_y = 0},/obj/structure/disposalpipe/trunk{dir = 8},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"sH" = (/obj/machinery/computer/diseasesplicer{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"sI" = (/obj/structure/bed/chair/office/dark{dir = 8},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"sJ" = (/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals4,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"sK" = (/obj/machinery/door/airlock/glass_medical{name = "Virology Laboratory"; req_access = list(39)},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"sL" = (/obj/machinery/atmospherics/pipe/manifold/hidden/black{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 6},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"sM" = (/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"sN" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/black{dir = 4},/obj/machinery/hologram/holopad,/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"sO" = (/obj/structure/table/standard,/obj/item/weapon/soap/nanotrasen,/obj/machinery/camera/network/medbay{dir = 8},/obj/item/device/radio/intercom{dir = 4; pixel_x = 24},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"sP" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/obj/structure/table/reinforced,/obj/item/weapon/storage/toolbox/electrical{pixel_x = 1; pixel_y = -1},/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/status_display{pixel_x = -32},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"sQ" = (/obj/machinery/hologram/holopad,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"sR" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"sS" = (/obj/structure/table/reinforced,/obj/item/stack/material/plasteel{amount = 10},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/effect/floor_decal/industrial/warning{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"sT" = (/obj/machinery/door/firedoor/border_only,/obj/structure/grille,/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/structure/cable/green,/obj/structure/window/reinforced/full,/turf/simulated/floor/plating,/area/ai_monitored/storage/eva)
-"sU" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 6},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"sV" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/door/airlock/maintenance/common,/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"sW" = (/obj/machinery/light/small{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 1; icon_state = "map"},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"sX" = (/obj/machinery/atmospherics/portables_connector{dir = 8},/obj/machinery/portable_atmospherics/canister/air/airlock,/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"sY" = (/obj/item/stack/material/wood{amount = 10},/obj/structure/table,/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"sZ" = (/obj/effect/floor_decal/rust,/obj/structure/table/woodentable,/obj/random/maintenance/clean,/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"ta" = (/obj/structure/railing{dir = 8},/turf/simulated/open,/area/vacant/vacant_restaurant_upper)
-"tb" = (/turf/simulated/open,/area/vacant/vacant_restaurant_upper)
-"tc" = (/turf/simulated/floor,/area/tether/station/stairs_two)
-"td" = (/obj/machinery/light/small{dir = 1},/turf/simulated/open,/area/tether/station/stairs_two)
-"te" = (/turf/simulated/open,/area/tether/station/stairs_two)
-"tf" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/lightgrey/border{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 5},/obj/machinery/firealarm{dir = 8; pixel_x = -26},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"tg" = (/obj/structure/table/wooden_reinforced,/obj/machinery/photocopier/faxmachine{department = "Public Meeting Room"},/obj/effect/floor_decal/borderfloor{dir = 9},/obj/effect/floor_decal/corner/lightgrey/border{dir = 9},/obj/effect/floor_decal/borderfloor/corner2{dir = 1},/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 1},/turf/simulated/floor/tiled/dark,/area/tether/station/public_meeting_room)
-"th" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/maintenance/station/micro)
-"ti" = (/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"; pixel_y = 0},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/rust,/turf/simulated/floor/plating,/area/maintenance/station/micro)
-"tj" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/firedoor/glass,/obj/machinery/door/airlock/engineering{name = "Medbay Substation"; req_one_access = list(11,24,5)},/turf/simulated/floor/plating,/area/maintenance/substation/medical)
-"tk" = (/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/alarm{pixel_y = 22},/turf/simulated/floor/plating,/area/maintenance/substation/medical)
-"tl" = (/obj/machinery/power/breakerbox/activated{RCon_tag = "Medical Substation Bypass"},/turf/simulated/floor/plating,/area/maintenance/substation/medical)
-"tm" = (/obj/structure/closet,/obj/random/maintenance/medical,/obj/random/contraband,/obj/random/maintenance/research,/obj/random/maintenance/medical,/obj/effect/decal/cleanable/dirt,/obj/effect/floor_decal/rust,/turf/simulated/floor,/area/medical/virology)
-"tn" = (/obj/machinery/smartfridge/secure/virology,/obj/machinery/status_display{density = 0; layer = 4; pixel_x = 0; pixel_y = 32},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"to" = (/obj/machinery/light_switch{dir = 2; name = "light switch "; pixel_x = 0; pixel_y = 26},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"tp" = (/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"tq" = (/obj/machinery/disease2/isolator,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"tr" = (/obj/machinery/light{dir = 1},/obj/machinery/computer/centrifuge,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"ts" = (/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"tt" = (/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/structure/sink{icon_state = "sink"; dir = 8; pixel_x = -12; pixel_y = 2},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"tu" = (/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"tv" = (/obj/item/weapon/stool/padded,/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"tw" = (/obj/structure/table/standard,/obj/item/weapon/storage/box/donkpockets{pixel_x = 3; pixel_y = 3},/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"tx" = (/obj/machinery/suit_cycler/security{req_access = null},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"ty" = (/obj/structure/table/reinforced,/obj/machinery/cell_charger,/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000},/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = -7},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = -7},/obj/item/device/radio/off,/obj/item/device/radio/off,/obj/item/device/radio/off,/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"tz" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"tA" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"tB" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 8},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"tC" = (/obj/item/weapon/storage/briefcase/inflatable{pixel_x = 3; pixel_y = 6},/obj/item/weapon/storage/briefcase/inflatable{pixel_y = 3},/obj/item/weapon/storage/briefcase/inflatable{pixel_x = -3},/obj/structure/table/reinforced,/obj/effect/floor_decal/industrial/warning{dir = 4},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"tD" = (/obj/machinery/door/firedoor/border_only,/obj/structure/grille,/obj/structure/cable/green,/obj/structure/window/reinforced/full,/turf/simulated/floor/plating,/area/ai_monitored/storage/eva)
-"tE" = (/obj/machinery/suit_storage_unit/standard_unit,/obj/machinery/alarm{dir = 8; pixel_x = 25; pixel_y = 0},/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"tF" = (/obj/machinery/meter,/obj/machinery/atmospherics/pipe/simple/hidden{dir = 5; icon_state = "intact"},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"tG" = (/obj/effect/decal/cleanable/dirt,/obj/random/powercell,/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"tH" = (/obj/machinery/light{dir = 4; icon_state = "tube1"; pixel_x = 0},/turf/simulated/open,/area/vacant/vacant_restaurant_upper)
-"tI" = (/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/lightgrey/border{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 5},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"tJ" = (/obj/structure/cable,/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/lightgrey/border{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"tK" = (/obj/structure/cable{icon_state = "0-4"},/obj/machinery/power/apc{cell_type = /obj/item/weapon/cell/super; dir = 8; name = "west bump"; pixel_x = -28},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/maintenance/station/micro)
-"tL" = (/obj/structure/cable{icon_state = "1-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/turf/simulated/floor/plating,/area/maintenance/station/micro)
-"tM" = (/obj/machinery/power/terminal{dir = 4},/obj/structure/cable,/obj/machinery/light/small{dir = 8; pixel_y = 0},/obj/random/junk,/turf/simulated/floor/plating,/area/maintenance/substation/medical)
-"tN" = (/obj/machinery/power/smes/buildable{charge = 0; RCon_tag = "Substation - Medical"},/obj/structure/cable/green,/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/turf/simulated/floor/plating,/area/maintenance/substation/medical)
-"tO" = (/obj/effect/decal/cleanable/dirt,/obj/effect/floor_decal/rust,/turf/simulated/floor,/area/medical/virology)
-"tP" = (/obj/structure/sink{icon_state = "sink"; dir = 8; pixel_x = -12; pixel_y = 2},/obj/machinery/newscaster{pixel_x = -32; pixel_y = 0},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"tQ" = (/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"tR" = (/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/obj/machinery/atmospherics/pipe/manifold/hidden/black,/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"tS" = (/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"tT" = (/obj/structure/bed/chair/office/dark{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden/black{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1},/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"tU" = (/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/hologram/holopad,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"tV" = (/obj/structure/table/glass,/obj/item/weapon/storage/lockbox/vials,/obj/item/weapon/reagent_containers/syringe/antiviral,/obj/item/weapon/reagent_containers/syringe/antiviral,/obj/item/weapon/reagent_containers/syringe/antiviral,/obj/item/weapon/reagent_containers/syringe/antiviral,/obj/machinery/requests_console{department = "Virology"; name = "Virology Requests Console"; pixel_x = 32},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"tW" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/green,/obj/machinery/atmospherics/pipe/simple/hidden/black,/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"tX" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"tY" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"tZ" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/manifold/hidden/black{dir = 8},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"ua" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"ub" = (/obj/structure/table/standard,/obj/machinery/microwave{pixel_x = -3; pixel_y = 6},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"uc" = (/obj/structure/catwalk,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/machinery/alarm{dir = 8; pixel_x = 25; pixel_y = 0},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/floor_decal/rust,/turf/simulated/floor,/area/maintenance/evahallway)
-"ud" = (/obj/machinery/suit_cycler/medical{req_access = null},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"ue" = (/obj/machinery/door/airlock/glass_command{name = "E.V.A. Cycler Access"; req_one_access = list(18)},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"uf" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"ug" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"uh" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"ui" = (/obj/machinery/door/firedoor/glass,/obj/machinery/door/airlock/glass_command{name = "E.V.A."; req_one_access = newlist()},/obj/machinery/atmospherics/pipe/simple/hidden/universal{dir = 4},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"uj" = (/obj/machinery/atmospherics/binary/passive_gate/on{dir = 4},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"uk" = (/obj/machinery/suit_storage_unit/standard_unit,/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 4; icon_state = "map"},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"ul" = (/obj/effect/decal/cleanable/dirt,/obj/random/trash,/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"um" = (/obj/effect/decal/cleanable/dirt,/obj/random/junk,/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"un" = (/obj/structure/stairs/north,/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"uo" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/lightgrey/border{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 5},/obj/item/device/radio/intercom{dir = 8; pixel_x = -24},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"up" = (/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/lightgrey/border{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"uq" = (/obj/machinery/light/small{dir = 8; pixel_y = 0},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/maintenance/station/micro)
-"ur" = (/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/maintenance/station/micro)
-"us" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/firedoor/glass,/obj/machinery/door/airlock/engineering{name = "Medbay Substation"; req_one_access = list(11,24,5)},/turf/simulated/floor/plating,/area/maintenance/substation/medical)
-"ut" = (/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/obj/machinery/power/apc{dir = 2; name = "south bump"; pixel_y = -32},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/maintenance/substation/medical)
-"uu" = (/obj/machinery/power/sensor{name = "Powernet Sensor - Medbay Subgrid"; name_tag = "Medbay Subgrid"},/obj/structure/cable/green,/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/plating,/area/maintenance/substation/medical)
-"uv" = (/obj/structure/closet/crate,/obj/random/maintenance/medical,/obj/random/maintenance/research,/obj/random/maintenance/medical,/obj/effect/decal/cleanable/dirt,/obj/effect/floor_decal/rust,/turf/simulated/floor,/area/medical/virology)
-"uw" = (/obj/structure/table/glass,/obj/item/device/antibody_scanner{pixel_x = 2; pixel_y = 2},/obj/item/device/antibody_scanner,/obj/structure/reagent_dispensers/virusfood{pixel_x = -30},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"ux" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"uy" = (/obj/item/weapon/stool/padded,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"uz" = (/obj/structure/table/glass,/obj/item/weapon/storage/fancy/vials,/obj/machinery/alarm{dir = 8; icon_state = "alarm0"; pixel_x = 24},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"uA" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/green,/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/machinery/camera/network/medbay{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"uB" = (/obj/structure/extinguisher_cabinet{pixel_x = 5; pixel_y = -32},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"uC" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"uD" = (/obj/machinery/computer/arcade,/obj/machinery/light{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"uE" = (/obj/machinery/suit_cycler/engineering{req_access = null},/obj/machinery/light/small{dir = 8},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"uF" = (/obj/machinery/door/firedoor/border_only,/obj/structure/grille,/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/structure/window/reinforced/full,/turf/simulated/floor/plating,/area/ai_monitored/storage/eva)
-"uG" = (/obj/structure/table/reinforced,/obj/item/clothing/head/welding,/obj/item/weapon/storage/belt/utility,/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/camera/network/command{dir = 4},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"uH" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"uI" = (/obj/machinery/door/firedoor/border_only,/obj/structure/grille,/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/structure/window/reinforced/full,/turf/simulated/floor/plating,/area/ai_monitored/storage/eva)
-"uJ" = (/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"uK" = (/obj/machinery/access_button{command = "cycle_interior"; frequency = 1379; master_tag = "eva_port_airlock"; name = "interior access button"; pixel_x = 26; pixel_y = 26; req_one_access = list(18)},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 5; icon_state = "intact"},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"uL" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/effect/floor_decal/industrial/hatch/yellow,/obj/machinery/door/airlock/glass_external{frequency = 1379; icon_state = "door_locked"; id_tag = "eva_port_inner"; locked = 1; name = "EVA Internal Access"; req_access = list(18)},/obj/structure/sign/securearea{desc = "A warning sign which reads 'EXTERNAL AIRLOCK'"; icon_state = "space"; layer = 4; name = "EXTERNAL AIRLOCK"; pixel_x = 0; pixel_y = -32},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"uM" = (/obj/machinery/embedded_controller/radio/airlock/airlock_controller{frequency = 1379; id_tag = "eva_port_airlock"; name = "Airlock Console"; pixel_y = 30; req_access = list(18); tag_airpump = "eva_port_pump"; tag_chamber_sensor = "eva_port_sensor"; tag_exterior_door = "eva_port_outer"; tag_interior_door = "eva_port_inner"},/obj/machinery/light/small,/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"uN" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 8; frequency = 1379; id_tag = "eva_port_pump"},/obj/machinery/airlock_sensor{frequency = 1379; id_tag = "eva_port_sensor"; pixel_x = 0; pixel_y = -25},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"uO" = (/obj/machinery/door/airlock/glass_external{frequency = 1379; icon_state = "door_locked"; id_tag = "eva_port_outer"; locked = 1; name = "EVA External Access"},/obj/effect/floor_decal/industrial/hatch/yellow,/obj/machinery/access_button{command = "cycle_exterior"; frequency = 1379; master_tag = "eva_port_airlock"; name = "exterior access button"; pixel_x = 4; pixel_y = -26; req_access = list(18)},/obj/machinery/shield_diffuser,/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"uP" = (/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"uQ" = (/obj/structure/sign/deck2,/turf/simulated/wall,/area/tether/station/stairs_two)
-"uR" = (/obj/structure/extinguisher_cabinet{pixel_x = -27},/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/lightgrey/border{dir = 8},/obj/effect/floor_decal/borderfloor/corner2{dir = 10},/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 5},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"uS" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"uT" = (/obj/machinery/light{dir = 4; icon_state = "tube1"},/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/lightgrey/border{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 10},/obj/effect/floor_decal/borderfloor/corner2{dir = 5},/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 5},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"uU" = (/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/maintenance/medical,/obj/random/maintenance/medical,/obj/effect/floor_decal/rust,/obj/random/maintenance/clean,/obj/random/maintenance/clean,/turf/simulated/floor/plating,/area/maintenance/station/micro)
-"uV" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/maintenance/station/micro)
-"uW" = (/turf/simulated/wall,/area/medical/morgue)
-"uX" = (/turf/simulated/wall/r_wall,/area/medical/morgue)
-"uY" = (/obj/structure/table/glass,/obj/item/weapon/folder/white,/obj/item/weapon/hand_labeler,/obj/structure/extinguisher_cabinet{pixel_x = -27},/obj/item/device/radio{pixel_x = -4},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"uZ" = (/obj/structure/table/glass,/obj/item/weapon/paper_bin{pixel_x = 1; pixel_y = 8},/obj/item/device/radio{anchored = 1; broadcasting = 0; canhear_range = 7; frequency = 1487; icon = 'icons/obj/items.dmi'; icon_state = "red_phone"; listening = 1; name = "Virology Emergency Phone"; pixel_x = -6; pixel_y = 8},/obj/item/weapon/reagent_containers/spray/cleaner,/obj/machinery/light,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"va" = (/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 5},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"vb" = (/obj/machinery/power/apc{dir = 2; name = "south bump"; pixel_y = -32},/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/obj/structure/closet/crate/freezer,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"vc" = (/obj/structure/table/glass,/obj/item/weapon/storage/box/gloves{pixel_x = 4; pixel_y = 4},/obj/item/weapon/storage/box/masks,/obj/machinery/camera/network/medbay{dir = 1},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"vd" = (/obj/item/weapon/storage/box/syringes{pixel_x = 4; pixel_y = 4},/obj/item/weapon/storage/box/beakers,/obj/item/weapon/reagent_containers/dropper,/obj/structure/table/glass,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"ve" = (/turf/simulated/wall/r_wall,/area/medical/virologyaccess)
-"vf" = (/obj/machinery/atmospherics/pipe/simple/hidden/black,/turf/simulated/wall/r_wall,/area/medical/virologyaccess)
-"vg" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 5},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"vh" = (/obj/machinery/disposal,/obj/effect/floor_decal/industrial/warning/full,/obj/structure/sign/deathsposal{pixel_x = 32; pixel_y = 0},/obj/structure/disposalpipe/trunk{dir = 8},/turf/simulated/floor/tiled/white,/area/medical/virologyisolation)
-"vi" = (/obj/machinery/suit_cycler/mining{req_access = null},/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"vj" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/obj/structure/table/reinforced,/obj/item/weapon/storage/toolbox/mechanical{pixel_x = -2; pixel_y = -1},/obj/item/device/multitool,/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"vk" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/obj/structure/reagent_dispensers/watertank,/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"vl" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/tank/jetpack/carbondioxide,/obj/item/clothing/shoes/magboots,/turf/simulated/floor/tiled/dark,/area/ai_monitored/storage/eva)
-"vm" = (/obj/random/toolbox,/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"vn" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"vo" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"vp" = (/obj/machinery/light/small{dir = 1},/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/door/firedoor/glass/hidden/steel{dir = 2},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"vq" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 1},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"vr" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals6{dir = 10},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"vs" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals_central1{dir = 1},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled/monofloor{dir = 1},/area/tether/station/stairs_two)
-"vt" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals6{dir = 9},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"vu" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9; pixel_y = 0},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"vv" = (/obj/structure/closet/emcloset,/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"vw" = (/obj/structure/closet,/obj/random/maintenance/medical,/obj/random/junk,/obj/random/tool,/obj/random/maintenance/clean,/obj/random/maintenance/clean,/turf/simulated/floor/plating,/area/maintenance/station/micro)
-"vx" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/turf/simulated/floor/plating,/area/maintenance/station/micro)
-"vy" = (/obj/structure/morgue{dir = 2},/obj/effect/floor_decal/techfloor{dir = 4},/obj/effect/floor_decal/techfloor{dir = 8},/turf/unsimulated/floor/techfloor_grid,/area/medical/morgue)
-"vz" = (/obj/structure/morgue{dir = 2},/obj/machinery/camera/network/medbay{c_tag = "MED - Morgue North"},/obj/effect/floor_decal/techfloor{dir = 4},/obj/effect/floor_decal/techfloor{dir = 8},/turf/unsimulated/floor/techfloor_grid,/area/medical/morgue)
-"vA" = (/obj/machinery/door/airlock/glass_medical{name = "Virology Laboratory"; req_access = list(39)},/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled/white,/area/medical/virology)
-"vB" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/obj/machinery/power/apc{dir = 1; name = "north bump"; pixel_x = 0; pixel_y = 28},/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/machinery/atmospherics/pipe/simple/hidden/red{dir = 6; icon_state = "intact"},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"vC" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/atmospherics/tvalve/bypass,/obj/machinery/light{icon_state = "tube1"; dir = 4},/turf/simulated/floor/plating,/area/medical/virologyaccess)
-"vD" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/medical/virologyaccess)
-"vE" = (/obj/machinery/door/airlock/medical{autoclose = 0; frequency = 1379; icon_state = "door_locked"; id_tag = "virologyq_airlock_exterior"; locked = 1; name = "Virology Quarantine Airlock"; req_access = list(39)},/obj/machinery/access_button{command = "cycle_exterior"; frequency = 1379; master_tag = "virologyq_airlock_control"; name = "Virology Quarantine Access Button"; pixel_x = 24; pixel_y = 0; req_access = list(39)},/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"vF" = (/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/structure/catwalk,/obj/machinery/power/apc{dir = 1; name = "north bump"; pixel_x = 0; pixel_y = 28},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor,/area/maintenance/evahallway)
-"vG" = (/obj/structure/catwalk,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor,/area/maintenance/evahallway)
-"vH" = (/obj/structure/table/reinforced,/obj/item/device/assembly/signaler,/obj/item/device/assembly/signaler,/obj/effect/floor_decal/industrial/warning{dir = 10},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"vI" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"vJ" = (/obj/effect/floor_decal/industrial/warning,/obj/machinery/camera/network/command{dir = 1},/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"vK" = (/obj/effect/floor_decal/industrial/warning/corner,/obj/structure/cable/green,/obj/machinery/power/apc{dir = 2; name = "south bump"; pixel_y = -24},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"vL" = (/obj/effect/floor_decal/industrial/warning{dir = 6},/obj/structure/reagent_dispensers/fueltank,/turf/simulated/floor/tiled,/area/ai_monitored/storage/eva)
-"vM" = (/obj/machinery/light,/turf/simulated/open,/area/vacant/vacant_restaurant_upper)
-"vN" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"vO" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 1},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"vP" = (/obj/machinery/door/firedoor/glass/hidden/steel{dir = 1},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"vQ" = (/obj/machinery/camera/network/northern_star{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals6{dir = 5},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"vR" = (/obj/machinery/door/airlock/multi_tile/glass{dir = 2; name = "Stairwell"},/obj/effect/floor_decal/steeldecal/steel_decals_central1,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled/monofloor,/area/tether/station/stairs_two)
-"vS" = (/obj/effect/floor_decal/steeldecal/steel_decals6{dir = 6},/turf/simulated/floor/tiled,/area/tether/station/stairs_two)
-"vT" = (/turf/simulated/wall,/area/medical/biostorage)
-"vU" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/machinery/door/blast/shutters{density = 0; dir = 2; icon_state = "shutter0"; id = "medbayquar"; name = "Medbay Emergency Lockdown Shutters"; opacity = 0},/obj/machinery/door/airlock/maintenance/medical{req_access = list(5)},/turf/simulated/floor/plating,/area/medical/biostorage)
-"vV" = (/obj/item/device/radio/intercom{dir = 8; pixel_x = -24},/obj/effect/floor_decal/techfloor{dir = 9},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"vW" = (/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"vX" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"vY" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"vZ" = (/obj/effect/floor_decal/techfloor{dir = 5},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"wa" = (/obj/machinery/disposal,/obj/structure/disposalpipe/trunk{dir = 8},/turf/unsimulated/floor/techfloor_grid,/area/medical/morgue)
-"wb" = (/obj/structure/sign/nosmoking_1,/turf/simulated/wall/r_wall,/area/medical/virologyaccess)
-"wc" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/obj/structure/closet/l3closet/virology,/obj/item/clothing/mask/gas,/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wd" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/manifold/hidden/black{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"we" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wf" = (/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wg" = (/obj/machinery/atmospherics/unary/vent_pump/on,/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wh" = (/obj/machinery/status_display{density = 0; layer = 4; pixel_x = 0; pixel_y = 32},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wi" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/universal,/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wj" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/machinery/embedded_controller/radio/airlock/access_controller{id_tag = "virologyq_airlock_control"; name = "Virology Quarantine Access Console"; pixel_x = 22; pixel_y = 0; tag_exterior_door = "virologyq_airlock_exterior"; tag_interior_door = "virologyq_airlock_interior"},/obj/effect/floor_decal/industrial/warning/corner,/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wk" = (/obj/machinery/access_button{command = "cycle_interior"; frequency = 1379; master_tag = "virologyq_airlock_control"; name = "Virology Quarantine Access Button"; pixel_x = -28; pixel_y = 0; req_access = list(39)},/obj/structure/sink{icon_state = "sink"; dir = 8; pixel_x = -12; pixel_y = 2},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wl" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wm" = (/obj/effect/floor_decal/industrial/warning{dir = 5},/obj/structure/closet/l3closet/virology,/obj/machinery/camera/network/medbay{dir = 8},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wn" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/catwalk,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/rust,/turf/simulated/floor,/area/maintenance/evahallway)
-"wo" = (/turf/simulated/wall/r_wall,/area/bridge/meeting_room)
-"wp" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced,/turf/simulated/floor/plating,/area/vacant/vacant_restaurant_upper)
-"wq" = (/obj/structure/table/rack,/obj/effect/floor_decal/borderfloor{dir = 9},/obj/effect/floor_decal/corner/paleblue/border{dir = 9},/obj/item/clothing/accessory/stethoscope,/obj/item/clothing/accessory/stethoscope,/obj/structure/extinguisher_cabinet{pixel_x = -27},/obj/item/clothing/accessory/stethoscope,/turf/simulated/floor/tiled,/area/medical/biostorage)
-"wr" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/structure/table/standard,/obj/item/roller,/obj/item/roller{pixel_y = 8},/obj/item/roller{pixel_y = 16},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"ws" = (/obj/structure/sink/kitchen{pixel_y = 28},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"wt" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/borderfloor/corner,/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/effect/floor_decal/corner/paleblue/bordercorner,/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"wu" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/paleblue/border,/obj/effect/floor_decal/borderfloor/corner2{dir = 1},/obj/effect/floor_decal/borderfloor/corner2{dir = 9},/obj/effect/floor_decal/corner/paleblue/bordercorner2{dir = 1},/obj/effect/floor_decal/corner/paleblue/bordercorner2{dir = 9},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"wv" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/firedoor/glass,/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 5},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 6},/obj/machinery/door/airlock/medical{name = "Morgue"; req_access = list(6)},/turf/simulated/floor/tiled/white,/area/medical/morgue)
-"ww" = (/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 1},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/corner_techfloor_grid{dir = 9},/obj/effect/floor_decal/techfloor/corner{dir = 1},/obj/effect/floor_decal/techfloor/corner{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"wx" = (/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"wy" = (/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"wz" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"wA" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"wB" = (/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"wC" = (/obj/structure/morgue{dir = 8},/obj/effect/floor_decal/techfloor,/obj/effect/floor_decal/techfloor{dir = 1},/turf/unsimulated/floor/techfloor_grid,/area/medical/morgue)
-"wD" = (/obj/machinery/camera/network/medbay{dir = 1},/obj/machinery/embedded_controller/radio/airlock/access_controller{id_tag = "virology_airlock_control"; name = "Virology Access Console"; pixel_x = 8; pixel_y = -22; tag_exterior_door = "virology_airlock_exterior"; tag_interior_door = "virology_airlock_interior"},/obj/structure/sink{icon_state = "sink"; dir = 8; pixel_x = -12; pixel_y = 2},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wE" = (/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/structure/disposalpipe/junction{icon_state = "pipe-j2"; dir = 2},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 5},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wF" = (/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for shutters."; id = "virologyquar"; name = "Virology Emergency Lockdown Control"; pixel_x = 0; pixel_y = -28; req_access = list(5)},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 6},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wG" = (/obj/machinery/alarm{dir = 1; icon_state = "alarm0"; pixel_y = -22},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wH" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/obj/item/device/radio/intercom{dir = 2; pixel_y = -24},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wI" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wJ" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/camera/network/medbay{dir = 1},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wK" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 9; icon_state = "intact"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wL" = (/obj/machinery/door/airlock/medical{autoclose = 0; frequency = 1379; icon_state = "door_locked"; id_tag = "virologyq_airlock_interior"; locked = 1; name = "Virology Quarantine Airlock"; req_access = list(39)},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wM" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wN" = (/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wO" = (/obj/structure/closet/secure_closet/personal/patient,/obj/machinery/alarm{dir = 8; pixel_x = 25; pixel_y = 0},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8},/obj/effect/floor_decal/industrial/warning{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"wP" = (/obj/machinery/light/small{dir = 4; pixel_y = 0},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/catwalk,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/turf/simulated/floor,/area/maintenance/evahallway)
-"wQ" = (/obj/structure/table/woodentable,/obj/structure/extinguisher_cabinet{pixel_x = -27},/obj/machinery/computer/guestpass{pixel_y = 32},/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"wR" = (/obj/structure/table/woodentable,/obj/machinery/chemical_dispenser/bar_soft/full,/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"wS" = (/obj/structure/table/woodentable,/obj/machinery/photocopier/faxmachine{department = "Command Conf Room"},/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"wT" = (/obj/machinery/light{dir = 1},/obj/machinery/disposal,/obj/structure/disposalpipe/trunk,/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"wU" = (/obj/machinery/newscaster{pixel_y = 32},/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"wV" = (/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"wW" = (/obj/machinery/atm{pixel_y = 30},/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"wX" = (/obj/structure/flora/pottedplant,/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"wY" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 4},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/bridge/meeting_room)
-"wZ" = (/obj/machinery/atmospherics/unary/freezer{dir = 4},/obj/effect/floor_decal/industrial/hatch/yellow,/turf/simulated/floor/tiled/steel,/area/medical/biostorage)
-"xa" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/effect/floor_decal/borderfloor/corner2{dir = 4},/obj/effect/floor_decal/corner/paleblue/bordercorner2{dir = 4},/obj/machinery/camera/network/medbay,/obj/machinery/alarm{frequency = 1441; pixel_y = 22},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 10; icon_state = "intact"},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"xb" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/structure/table/rack,/obj/item/clothing/suit/radiation,/obj/item/clothing/head/radiation,/obj/item/weapon/storage/toolbox/emergency,/obj/item/bodybag/cryobag{pixel_x = -3},/obj/item/bodybag/cryobag{pixel_x = -3},/obj/item/weapon/storage/toolbox/mechanical,/turf/simulated/floor/tiled,/area/medical/biostorage)
-"xc" = (/obj/structure/table/rack,/obj/item/weapon/storage/belt/medical,/obj/item/weapon/storage/belt/medical,/obj/item/weapon/storage/belt/medical,/obj/effect/floor_decal/borderfloor/corner{dir = 1},/obj/effect/floor_decal/corner/paleblue/bordercorner{dir = 1},/obj/item/weapon/storage/belt/medical,/obj/item/weapon/storage/belt/medical,/turf/simulated/floor/tiled,/area/medical/biostorage)
-"xd" = (/turf/simulated/floor/tiled,/area/medical/biostorage)
-"xe" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled,/area/medical/biostorage)
-"xf" = (/obj/structure/window/basic{dir = 4},/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/paleblue/border{dir = 4},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"xg" = (/obj/structure/sign/department/morgue,/turf/simulated/wall,/area/medical/morgue)
-"xh" = (/obj/structure/filingcabinet/chestdrawer{desc = "A large drawer filled with autopsy reports."; name = "Autopsy Reports"},/obj/machinery/light{dir = 8},/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"xi" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"xj" = (/obj/structure/table/steel,/obj/item/weapon/autopsy_scanner,/obj/item/weapon/surgical/scalpel,/obj/item/weapon/surgical/cautery,/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"xk" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/optable,/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"xl" = (/obj/machinery/hologram/holopad,/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"xm" = (/obj/machinery/door/airlock/medical{autoclose = 0; frequency = 1379; icon_state = "door_locked"; id_tag = "virology_airlock_interior"; locked = 1; name = "Virology Interior Airlock"; req_access = list(39)},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/black,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/disposalpipe/segment,/obj/machinery/door/firedoor/glass,/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals10,/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 1},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"xn" = (/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/turf/simulated/wall/r_wall,/area/medical/virologyaccess)
-"xo" = (/obj/effect/floor_decal/industrial/warning{dir = 10},/obj/structure/closet/l3closet/virology,/obj/machinery/camera/network/medbay{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"xp" = (/obj/structure/closet/secure_closet/personal/patient,/obj/machinery/light,/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"xq" = (/obj/effect/floor_decal/industrial/warning{dir = 6},/obj/structure/closet/secure_closet/personal/patient,/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"xr" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/catwalk,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/turf/simulated/floor,/area/maintenance/evahallway)
-"xs" = (/obj/structure/table/woodentable,/obj/item/weapon/storage/box/cups,/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/machinery/power/apc{cell_type = /obj/item/weapon/cell/super; dir = 8; name = "west bump"; pixel_x = -28},/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"xt" = (/obj/structure/disposalpipe/segment,/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"xu" = (/obj/machinery/atmospherics/portables_connector{dir = 4},/obj/effect/floor_decal/industrial/hatch/yellow,/obj/machinery/portable_atmospherics/canister/oxygen/prechilled,/turf/simulated/floor/tiled/steel,/area/medical/biostorage)
-"xv" = (/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 4; icon_state = "map"},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"xw" = (/obj/structure/stairs/south,/turf/simulated/floor/tiled,/area/medical/biostorage)
-"xx" = (/obj/structure/table/steel,/obj/item/weapon/storage/box/bodybags,/obj/item/weapon/storage/box/bodybags{pixel_x = 4; pixel_y = 4},/obj/machinery/power/apc{dir = 8; name = "west bump"; pixel_x = -28},/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"xy" = (/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"xz" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"xA" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"xB" = (/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"xC" = (/obj/effect/floor_decal/industrial/warning{dir = 5},/obj/structure/closet/wardrobe/virology_white,/obj/machinery/access_button{command = "cycle_interior"; frequency = 1379; master_tag = "virology_airlock_control"; name = "Virology Access Button"; pixel_x = 8; pixel_y = 28; req_access = list(39)},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"xD" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/black{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 6},/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"xE" = (/obj/effect/floor_decal/industrial/warning{dir = 10},/obj/machinery/shower{dir = 8; icon_state = "shower"; pixel_x = -5; pixel_y = 0},/obj/structure/window/reinforced,/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 9; icon_state = "intact"},/turf/simulated/floor/tiled/steel,/area/medical/virologyaccess)
-"xF" = (/turf/simulated/wall/r_wall,/area/maintenance/station/medbay)
-"xG" = (/obj/structure/cable/green{icon_state = "16-0"},/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/medbay)
-"xH" = (/obj/machinery/alarm{pixel_y = 22},/turf/simulated/floor,/area/maintenance/station/medbay)
-"xI" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/maintenance/medical,/obj/random/junk,/obj/random/maintenance/medical,/obj/random/maintenance/clean,/obj/random/maintenance/clean,/turf/simulated/floor,/area/maintenance/station/medbay)
-"xJ" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/airlock/maintenance/command{req_access = list(19)},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/turf/simulated/floor,/area/bridge/meeting_room)
-"xK" = (/obj/structure/table/woodentable,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/camera/network/command{c_tag = "Command Meeting Room West"; dir = 4},/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"xL" = (/obj/machinery/hologram/holopad,/obj/structure/disposalpipe/segment,/turf/simulated/floor/carpet/sblucarpet,/area/bridge/meeting_room)
-"xM" = (/obj/structure/bed/chair/comfy/black,/turf/simulated/floor/carpet/sblucarpet,/area/bridge/meeting_room)
-"xN" = (/turf/simulated/floor/carpet/sblucarpet,/area/bridge/meeting_room)
-"xO" = (/obj/machinery/atmospherics/portables_connector{dir = 4},/obj/effect/floor_decal/industrial/hatch/yellow,/obj/machinery/light{icon_state = "tube1"; dir = 8},/obj/machinery/portable_atmospherics/canister/oxygen/prechilled,/turf/simulated/floor/tiled/steel,/area/medical/biostorage)
-"xP" = (/obj/machinery/atmospherics/pipe/manifold4w/hidden,/turf/simulated/floor/tiled,/area/medical/biostorage)
-"xQ" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"xR" = (/obj/machinery/atmospherics/pipe/zpipe/up{dir = 8},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"xS" = (/obj/structure/table/standard,/obj/item/weapon/storage/firstaid/adv{pixel_x = 5; pixel_y = 5},/obj/item/weapon/storage/firstaid/adv,/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/obj/effect/floor_decal/corner/red/full{dir = 8},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"xT" = (/obj/structure/table/standard,/obj/item/weapon/storage/firstaid/toxin{pixel_x = 5; pixel_y = 5},/obj/item/weapon/storage/firstaid/toxin{pixel_x = 0; pixel_y = 0},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/corner/green/full{dir = 1},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"xU" = (/obj/effect/floor_decal/borderfloor/corner{dir = 4},/obj/effect/floor_decal/corner/paleblue/bordercorner{dir = 4},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"xV" = (/obj/structure/window/basic{dir = 1},/obj/effect/floor_decal/borderfloor{dir = 5},/obj/effect/floor_decal/corner/paleblue/border{dir = 5},/obj/structure/closet/crate{icon_state = "crate"; name = "Grenade Crate"; opened = 0},/obj/item/weapon/grenade/chem_grenade,/obj/item/weapon/grenade/chem_grenade,/obj/item/weapon/grenade/chem_grenade,/obj/item/device/assembly/igniter,/obj/item/device/assembly/igniter,/obj/item/device/assembly/igniter,/obj/item/device/assembly/timer,/obj/item/device/assembly/timer,/obj/item/device/assembly/timer,/turf/simulated/floor/tiled,/area/medical/biostorage)
-"xW" = (/obj/structure/sign/nosmoking_1,/turf/simulated/wall,/area/medical/morgue)
-"xX" = (/obj/structure/table/steel,/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"xY" = (/obj/structure/bed/chair/office/light{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"xZ" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"ya" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"yb" = (/obj/effect/floor_decal/industrial/warning{dir = 4},/obj/structure/closet/l3closet/virology,/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"yc" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"yd" = (/obj/structure/table/steel,/obj/machinery/light_switch{pixel_x = 26; pixel_y = 0},/obj/machinery/camera/network/medbay{dir = 8},/obj/random/medical,/obj/machinery/atmospherics/unary/vent_pump/on{dir = 8},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"ye" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/maintenance/station/medbay)
-"yf" = (/obj/structure/ladder/up,/turf/simulated/floor,/area/maintenance/station/medbay)
-"yg" = (/turf/simulated/floor,/area/maintenance/station/medbay)
-"yh" = (/turf/simulated/open,/area/bridge/meeting_room)
-"yi" = (/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals5,/turf/simulated/floor/tiled,/area/bridge/meeting_room)
-"yj" = (/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals5,/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/turf/simulated/floor/tiled,/area/bridge/meeting_room)
-"yk" = (/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals5,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold/hidden/supply,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/disposalpipe/junction{dir = 1},/turf/simulated/floor/tiled,/area/bridge/meeting_room)
-"yl" = (/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals5,/obj/machinery/door/firedoor/glass/hidden/steel{dir = 2},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/bridge/meeting_room)
-"ym" = (/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"yn" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"yo" = (/obj/structure/bed/chair/comfy/black{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/effect/landmark/start{name = "Command Secretary"},/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/turf/simulated/floor/carpet/sblucarpet,/area/bridge/meeting_room)
-"yp" = (/obj/structure/table/woodentable,/obj/item/weapon/book/manual/security_space_law,/obj/machinery/atmospherics/unary/vent_pump/on{dir = 8},/turf/simulated/floor/carpet/sblucarpet,/area/bridge/meeting_room)
-"yq" = (/obj/structure/table/woodentable,/obj/item/weapon/folder/red,/turf/simulated/floor/carpet/sblucarpet,/area/bridge/meeting_room)
-"yr" = (/obj/structure/bed/chair/comfy/black{dir = 8},/obj/effect/landmark/start{name = "Command Secretary"},/turf/simulated/floor/carpet/sblucarpet,/area/bridge/meeting_room)
-"ys" = (/obj/machinery/camera/network/command{c_tag = "Command Meeting Room East"; dir = 9},/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"yt" = (/obj/machinery/portable_atmospherics/canister/oxygen,/obj/machinery/atmospherics/portables_connector{dir = 4},/obj/effect/floor_decal/industrial/hatch/yellow,/obj/item/weapon/tool/wrench,/turf/simulated/floor/tiled/steel,/area/medical/biostorage)
-"yu" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 9; icon_state = "intact"},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"yv" = (/obj/machinery/hologram/holopad,/turf/simulated/floor/tiled,/area/medical/biostorage)
-"yw" = (/obj/structure/table/standard,/obj/item/weapon/storage/firstaid/o2{pixel_x = 5; pixel_y = 5},/obj/item/weapon/storage/firstaid/o2{pixel_x = 0; pixel_y = 0},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/obj/effect/floor_decal/corner/blue/full,/turf/simulated/floor/tiled,/area/medical/biostorage)
-"yx" = (/obj/structure/table/standard,/obj/item/weapon/storage/firstaid/fire{pixel_x = 5; pixel_y = 5},/obj/item/weapon/storage/firstaid/fire{pixel_x = 0; pixel_y = 0},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/corner/yellow/full{dir = 4},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"yy" = (/obj/structure/closet/secure_closet/medical3,/obj/item/weapon/soap/nanotrasen,/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/paleblue/border{dir = 4},/obj/machinery/light{dir = 4; icon_state = "tube1"; pixel_x = 0},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"yz" = (/obj/structure/table/steel,/obj/item/weapon/paper_bin{pixel_y = 0},/obj/item/weapon/pen/red{pixel_x = -1; pixel_y = -3},/obj/item/weapon/pen/blue{pixel_x = 3; pixel_y = -1},/obj/item/device/camera{name = "Autopsy Camera"; pixel_x = -2; pixel_y = 7},/obj/machinery/firealarm{dir = 8; pixel_x = -24; pixel_y = 0},/obj/effect/floor_decal/techfloor{dir = 10},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"yA" = (/obj/structure/table/steel,/obj/effect/floor_decal/techfloor,/obj/item/device/sleevemate,/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"yB" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 5},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 8},/obj/effect/floor_decal/corner_techfloor_grid{dir = 10},/obj/effect/floor_decal/techfloor/corner,/obj/effect/floor_decal/techfloor/corner{dir = 8},/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"yC" = (/obj/structure/table/steel,/obj/machinery/camera/network/medbay{dir = 1},/obj/effect/floor_decal/techfloor,/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"yD" = (/obj/structure/table/steel,/obj/machinery/alarm{dir = 1; icon_state = "alarm0"; pixel_y = -22},/obj/effect/floor_decal/techfloor,/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"yE" = (/obj/effect/floor_decal/techfloor{dir = 6},/turf/simulated/floor/tiled/techfloor,/area/medical/morgue)
-"yF" = (/obj/effect/floor_decal/industrial/warning{dir = 6},/obj/structure/closet/l3closet/virology,/obj/machinery/light,/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"yG" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 5},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"yH" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 11; pixel_y = 0},/obj/machinery/camera/network/medbay{dir = 1},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"yI" = (/obj/machinery/light/small,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/medbay)
-"yJ" = (/obj/random/trash_pile,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/medbay)
-"yK" = (/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/steeldecal/steel_decals5{dir = 1},/turf/simulated/floor/tiled,/area/bridge/meeting_room)
-"yL" = (/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/steeldecal/steel_decals5{dir = 1},/obj/machinery/light,/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor/tiled,/area/bridge/meeting_room)
-"yM" = (/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/steeldecal/steel_decals5{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled,/area/bridge/meeting_room)
-"yN" = (/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/steeldecal/steel_decals5{dir = 1},/obj/machinery/door/firedoor/glass/hidden/steel{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled,/area/bridge/meeting_room)
-"yO" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"yP" = (/obj/structure/bed/chair/comfy/black{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/carpet/sblucarpet,/area/bridge/meeting_room)
-"yQ" = (/obj/structure/table/woodentable,/obj/item/weapon/paper_bin{pixel_x = -3; pixel_y = 7},/obj/item/weapon/pen,/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8},/turf/simulated/floor/carpet/sblucarpet,/area/bridge/meeting_room)
-"yR" = (/obj/structure/table/woodentable,/obj/item/weapon/folder/blue,/turf/simulated/floor/carpet/sblucarpet,/area/bridge/meeting_room)
-"yS" = (/obj/structure/bed/chair/comfy/black{dir = 8},/turf/simulated/floor/carpet/sblucarpet,/area/bridge/meeting_room)
-"yT" = (/obj/effect/floor_decal/borderfloor{dir = 8},/obj/effect/floor_decal/corner/paleblue/border{dir = 8},/obj/effect/floor_decal/borderfloor/corner2{dir = 8},/obj/effect/floor_decal/corner/paleblue/bordercorner2{dir = 8},/obj/structure/table/standard,/obj/random/firstaid,/obj/random/firstaid,/obj/item/device/radio/intercom{dir = 8; pixel_x = -24},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"yU" = (/obj/structure/closet/secure_closet/medical3,/obj/item/weapon/soap/nanotrasen,/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/paleblue/border{dir = 4},/obj/machinery/camera/network/medbay{dir = 8},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"yV" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/door/firedoor/glass,/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/steeldecal/steel_decals10,/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 1},/obj/machinery/door/airlock/medical{name = "Morgue"; req_access = list(6)},/turf/simulated/floor/tiled/white,/area/medical/morgue)
-"yW" = (/obj/machinery/access_button{command = "cycle_exterior"; frequency = 1379; master_tag = "virology_airlock_control"; name = "Virology Access Button"; pixel_x = -24; pixel_y = 0; req_access = list(39)},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/structure/disposalpipe/segment,/obj/machinery/door/firedoor/glass,/obj/machinery/door/blast/regular{density = 0; dir = 4; icon_state = "pdoor0"; id = "virologyquar"; name = "Virology Emergency Quarantine Blast Doors"; opacity = 0},/obj/machinery/door/airlock/medical{autoclose = 0; frequency = 1379; icon_state = "door_locked"; id_tag = "virology_airlock_exterior"; locked = 1; name = "Virology Exterior Airlock"; req_access = list(39)},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals10,/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 8},/turf/simulated/floor/tiled/white,/area/medical/virologyaccess)
-"yX" = (/obj/structure/sign/department/virology,/turf/simulated/wall/r_wall,/area/medical/virologyaccess)
-"yY" = (/turf/simulated/wall/r_wall,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"yZ" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/firedoor/glass,/obj/machinery/door/blast/shutters{density = 0; dir = 2; icon_state = "shutter0"; id = "medbayquar"; name = "Medbay Emergency Lockdown Shutters"; opacity = 0},/obj/machinery/door/airlock/maintenance/medical,/turf/simulated/floor,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"za" = (/turf/simulated/wall,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zb" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/disposalpipe/segment,/obj/machinery/door/airlock/maintenance/command{req_access = list(19)},/turf/simulated/floor,/area/bridge/meeting_room)
-"zc" = (/obj/structure/bed/chair/comfy/black{dir = 1},/turf/simulated/floor/carpet/sblucarpet,/area/bridge/meeting_room)
-"zd" = (/obj/effect/floor_decal/borderfloor{dir = 10},/obj/effect/floor_decal/corner/paleblue/border{dir = 10},/obj/structure/table/standard,/obj/item/clothing/gloves/sterile/nitrile,/obj/item/clothing/gloves/sterile/nitrile,/obj/item/device/defib_kit/loaded,/turf/simulated/floor/tiled,/area/medical/biostorage)
-"ze" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/paleblue/border,/obj/structure/table/standard,/obj/item/weapon/storage/box/syringes{pixel_x = 4; pixel_y = 4},/obj/item/weapon/storage/box/syringes,/turf/simulated/floor/tiled,/area/medical/biostorage)
-"zf" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/paleblue/border,/obj/structure/table/standard,/obj/structure/bedsheetbin,/obj/item/device/sleevemate,/turf/simulated/floor/tiled,/area/medical/biostorage)
-"zg" = (/obj/structure/table/standard,/obj/item/weapon/storage/box/beakers,/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/paleblue/border,/obj/structure/cable/green{icon_state = "0-4"},/obj/machinery/power/apc{dir = 2; name = "south bump"; pixel_y = -32},/obj/item/weapon/cane,/obj/item/weapon/cane,/turf/simulated/floor/tiled,/area/medical/biostorage)
-"zh" = (/obj/structure/table/standard,/obj/item/weapon/storage/box/gloves{pixel_x = 4; pixel_y = 4},/obj/item/weapon/storage/box/masks{pixel_y = 0},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/paleblue/border,/obj/effect/floor_decal/borderfloor/corner2{dir = 9},/obj/effect/floor_decal/corner/paleblue/bordercorner2{dir = 9},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/light_switch{pixel_y = -26},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"zi" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 5},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 8},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"zj" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/paleblue/border,/obj/structure/table/standard,/obj/random/medical,/obj/random/medical,/obj/item/device/flashlight,/obj/item/weapon/storage/box/lights/mixed,/obj/effect/floor_decal/borderfloor/corner2,/obj/effect/floor_decal/corner/paleblue/bordercorner2,/obj/item/device/radio{pixel_x = -4},/turf/simulated/floor/tiled,/area/medical/biostorage)
-"zk" = (/obj/structure/table/standard,/obj/effect/floor_decal/borderfloor{dir = 6},/obj/effect/floor_decal/corner/paleblue/border{dir = 6},/obj/item/weapon/gun/launcher/syringe,/obj/item/weapon/storage/box/syringegun,/obj/item/clothing/suit/straight_jacket,/obj/item/clothing/mask/muzzle,/turf/simulated/floor/tiled,/area/medical/biostorage)
-"zl" = (/obj/structure/closet/emcloset,/obj/effect/floor_decal/borderfloorwhite{dir = 9},/obj/effect/floor_decal/corner/paleblue/border{dir = 9},/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zm" = (/obj/effect/floor_decal/borderfloorwhite{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/floor_decal/borderfloorwhite/corner2{dir = 1},/obj/effect/floor_decal/corner/paleblue/bordercorner2{dir = 1},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zn" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/sortjunction/flipped{dir = 4; name = "Morgue"; sortType = "Morgue"},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zo" = (/obj/effect/floor_decal/borderfloorwhite{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/floor_decal/borderfloorwhite/corner2{dir = 4},/obj/effect/floor_decal/corner/paleblue/bordercorner2{dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zp" = (/obj/effect/floor_decal/borderfloorwhite{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/door/firedoor/glass/hidden{icon_state = "door_open"; dir = 2},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zq" = (/obj/effect/floor_decal/borderfloorwhite{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zr" = (/obj/effect/floor_decal/borderfloorwhite{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/newscaster{pixel_y = 32},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zs" = (/obj/effect/floor_decal/borderfloorwhite{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/camera/network/medbay,/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zt" = (/obj/effect/floor_decal/borderfloorwhite{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/effect/floor_decal/borderfloorwhite/corner2{dir = 1},/obj/effect/floor_decal/corner/paleblue/bordercorner2{dir = 1},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zu" = (/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 9},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zv" = (/obj/effect/floor_decal/borderfloorwhite{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/effect/floor_decal/borderfloorwhite/corner2{dir = 4},/obj/effect/floor_decal/corner/paleblue/bordercorner2{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zw" = (/obj/effect/floor_decal/borderfloorwhite{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/machinery/light{dir = 1},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zx" = (/obj/effect/floor_decal/borderfloorwhite{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zy" = (/obj/effect/floor_decal/borderfloorwhite{dir = 5},/obj/effect/floor_decal/corner/paleblue/border{dir = 5},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zz" = (/obj/machinery/door/firedoor/glass,/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/door/blast/shutters{density = 0; dir = 8; icon_state = "shutter0"; id = "medbayquar"; name = "Medbay Emergency Lockdown Shutters"; opacity = 0},/obj/machinery/door/airlock/maintenance/medical,/turf/simulated/floor,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zA" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/bridge/meeting_room)
-"zB" = (/obj/structure/lattice,/obj/machinery/door/firedoor/glass,/obj/structure/disposalpipe/segment{dir = 4},/obj/structure/cable/green{icon_state = "32-4"},/turf/simulated/open,/area/bridge/meeting_room)
-"zC" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/floor_decal/rust,/turf/simulated/floor,/area/bridge/meeting_room)
-"zD" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/bridge/meeting_room)
-"zE" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor,/area/bridge/meeting_room)
-"zF" = (/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/turf/simulated/floor,/area/bridge/meeting_room)
-"zG" = (/obj/structure/table/woodentable,/obj/structure/flora/pottedplant/small{pixel_y = 12},/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"zH" = (/obj/machinery/photocopier,/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"zI" = (/obj/machinery/alarm{dir = 1; icon_state = "alarm0"; pixel_y = -22},/obj/structure/table/woodentable,/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"zJ" = (/obj/machinery/light,/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"zK" = (/obj/machinery/light_switch{pixel_y = -26},/turf/simulated/floor/wood,/area/bridge/meeting_room)
-"zL" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/machinery/door/airlock/glass_medical{name = "Medbay Equipment"; req_access = list(5)},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals10,/turf/simulated/floor/tiled/white,/area/medical/biostorage)
-"zM" = (/obj/effect/floor_decal/borderfloorwhite{dir = 8},/obj/effect/floor_decal/corner/paleblue/border{dir = 8},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/disposalpipe/segment,/obj/machinery/firealarm{dir = 8; pixel_x = -24; pixel_y = 0},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zN" = (/obj/effect/floor_decal/borderfloorwhite/corner,/obj/effect/floor_decal/corner/paleblue/bordercorner,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zO" = (/obj/effect/floor_decal/borderfloorwhite,/obj/effect/floor_decal/corner/paleblue/border,/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold/hidden/supply,/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zP" = (/obj/effect/floor_decal/borderfloorwhite,/obj/effect/floor_decal/corner/paleblue/border,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/extinguisher_cabinet{dir = 1; icon_state = "extinguisher_closed"; pixel_y = -32},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zQ" = (/obj/effect/floor_decal/borderfloorwhite,/obj/effect/floor_decal/corner/paleblue/border,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/door/firedoor/glass/hidden{dir = 1},/obj/effect/floor_decal/borderfloorwhite/corner2{dir = 9},/obj/effect/floor_decal/corner/paleblue/bordercorner2{dir = 9},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zR" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 1},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zS" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zT" = (/obj/effect/floor_decal/borderfloorwhite,/obj/effect/floor_decal/corner/paleblue/border,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/light,/obj/effect/floor_decal/borderfloorwhite/corner2,/obj/effect/floor_decal/corner/paleblue/bordercorner2,/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zU" = (/obj/effect/floor_decal/borderfloorwhite,/obj/effect/floor_decal/corner/paleblue/border,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zV" = (/obj/effect/floor_decal/borderfloorwhite,/obj/effect/floor_decal/corner/paleblue/border,/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 5; icon_state = "intact"},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold/hidden/supply,/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zW" = (/obj/effect/floor_decal/borderfloorwhite,/obj/effect/floor_decal/corner/paleblue/border,/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zX" = (/obj/effect/floor_decal/borderfloorwhite/corner{dir = 8},/obj/effect/floor_decal/corner/paleblue/bordercorner{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zY" = (/obj/effect/floor_decal/borderfloorwhite{dir = 4},/obj/effect/floor_decal/corner/paleblue/border{dir = 4},/obj/machinery/alarm{dir = 8; pixel_x = 25; pixel_y = 0},/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"zZ" = (/turf/simulated/wall,/area/bridge/meeting_room)
-"Aa" = (/obj/machinery/vending/coffee,/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/turf/simulated/floor/tiled/monotile,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Ab" = (/obj/effect/floor_decal/borderfloorwhite{dir = 9},/obj/effect/floor_decal/corner/paleblue/border{dir = 9},/obj/effect/floor_decal/borderfloorwhite/corner2{dir = 1},/obj/effect/floor_decal/corner/paleblue/bordercorner2{dir = 1},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Ac" = (/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Ad" = (/obj/effect/floor_decal/borderfloorwhite{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/effect/floor_decal/borderfloorwhite/corner2{dir = 4},/obj/effect/floor_decal/corner/paleblue/bordercorner2{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Ae" = (/obj/effect/floor_decal/borderfloorwhite{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Af" = (/obj/effect/floor_decal/borderfloorwhite{dir = 1},/obj/effect/floor_decal/corner/paleblue/border{dir = 1},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1},/obj/structure/disposalpipe/junction{icon_state = "pipe-j1"; dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Ag" = (/obj/effect/floor_decal/borderfloorwhite/corner{dir = 1},/obj/effect/floor_decal/corner/paleblue/bordercorner{dir = 1},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Ah" = (/obj/effect/floor_decal/borderfloorwhite{dir = 4},/obj/effect/floor_decal/corner/paleblue/border{dir = 4},/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Ai" = (/turf/simulated/wall,/area/medical/medbay_emt_bay)
-"Aj" = (/obj/structure/sign/nosmoking_1,/turf/simulated/wall,/area/medical/medbay_emt_bay)
-"Ak" = (/obj/machinery/door/window/northleft{req_one_access = list(5)},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"Al" = (/obj/machinery/door/window/northright{req_one_access = list(5)},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"Am" = (/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"An" = (/obj/structure/window/basic{dir = 8},/obj/effect/floor_decal/borderfloorwhite{dir = 8},/obj/effect/floor_decal/corner/paleblue/border{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Ao" = (/obj/effect/floor_decal/borderfloorwhite{dir = 4},/obj/effect/floor_decal/corner/paleblue/border{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/machinery/light{dir = 4; icon_state = "tube1"; pixel_x = 0},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Ap" = (/obj/machinery/vending/medical,/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/turf/simulated/floor/tiled/monotile,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Aq" = (/obj/effect/floor_decal/borderfloorwhite{dir = 10},/obj/effect/floor_decal/corner/paleblue/border{dir = 10},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Ar" = (/obj/effect/floor_decal/borderfloorwhite,/obj/effect/floor_decal/corner/paleblue/border,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"As" = (/obj/effect/floor_decal/borderfloorwhite,/obj/effect/floor_decal/corner/paleblue/border,/obj/machinery/camera/network/medbay{dir = 1},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"At" = (/obj/effect/floor_decal/borderfloorwhite,/obj/effect/floor_decal/corner/paleblue/border,/obj/effect/floor_decal/borderfloorwhite/corner2{dir = 9},/obj/effect/floor_decal/corner/paleblue/bordercorner2{dir = 9},/obj/machinery/light,/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Au" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 5},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 8},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Av" = (/obj/effect/floor_decal/borderfloorwhite,/obj/effect/floor_decal/corner/paleblue/border,/obj/effect/floor_decal/borderfloorwhite/corner2,/obj/effect/floor_decal/corner/paleblue/bordercorner2,/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Aw" = (/obj/effect/floor_decal/borderfloorwhite{dir = 6},/obj/effect/floor_decal/corner/paleblue/border{dir = 6},/obj/machinery/alarm{dir = 1; icon_state = "alarm0"; pixel_y = -22},/obj/structure/closet/l3closet/medical,/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Ax" = (/obj/machinery/suit_cycler/medical,/obj/effect/floor_decal/corner/paleblue{dir = 9},/obj/effect/floor_decal/corner/paleblue{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/obj/effect/floor_decal/industrial/outline,/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"Ay" = (/obj/effect/floor_decal/borderfloorblack{dir = 9},/obj/effect/floor_decal/corner/paleblue/border{dir = 9},/obj/effect/floor_decal/borderfloorblack/corner2{dir = 1},/obj/effect/floor_decal/corner/paleblue/bordercorner2{dir = 1},/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"Az" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"AA" = (/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"AB" = (/obj/effect/floor_decal/borderfloorblack{dir = 5},/obj/effect/floor_decal/corner/paleblue/border{dir = 5},/obj/effect/floor_decal/borderfloorblack/corner2{dir = 4},/obj/effect/floor_decal/corner/paleblue/bordercorner2{dir = 4},/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/obj/machinery/power/apc{dir = 1; name = "north bump"; pixel_x = 0; pixel_y = 28},/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"AC" = (/obj/structure/table/rack,/obj/effect/floor_decal/corner/paleblue{dir = 6},/obj/effect/floor_decal/corner/paleblue{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/item/device/multitool,/obj/item/weapon/storage/toolbox/mechanical,/obj/item/device/radio{pixel_x = -4; pixel_y = 1},/obj/item/device/radio{pixel_x = 4; pixel_y = -1},/obj/item/device/defib_kit/compact/loaded,/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"AD" = (/obj/structure/stairs/south,/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"AE" = (/obj/effect/floor_decal/borderfloorwhite{dir = 4},/obj/effect/floor_decal/corner/paleblue/border{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"AF" = (/turf/simulated/floor/airless{icon_state = "asteroidplating2"},/area/medical/virologyaccess)
-"AG" = (/turf/simulated/wall,/area/crew_quarters/medbreak)
-"AH" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/crew_quarters/medbreak)
-"AI" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/steeldecal/steel_decals10,/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 1},/obj/machinery/door/airlock/glass_medical{name = "Staff Room"; req_access = list(5)},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"AJ" = (/obj/structure/table/rack,/obj/item/device/suit_cooling_unit{pixel_y = -5},/obj/item/weapon/tank/oxygen{pixel_y = -4},/obj/item/device/suit_cooling_unit{pixel_y = -5},/obj/item/weapon/tank/oxygen{pixel_y = -4},/obj/effect/floor_decal/corner/paleblue{dir = 9},/obj/effect/floor_decal/corner/paleblue{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"AK" = (/obj/effect/floor_decal/borderfloorblack{dir = 8},/obj/effect/floor_decal/corner/paleblue/border{dir = 8},/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"AL" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"AM" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 1},/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"AN" = (/obj/effect/floor_decal/borderfloorblack{dir = 4},/obj/effect/floor_decal/corner/paleblue/border{dir = 4},/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"AO" = (/obj/structure/table/rack,/obj/item/weapon/rig/medical/equipped,/obj/effect/floor_decal/corner/paleblue{dir = 9},/obj/effect/floor_decal/corner/paleblue{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/obj/machinery/firealarm{dir = 4; layer = 3.3; pixel_x = 26},/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"AP" = (/obj/effect/floor_decal/borderfloorwhite{dir = 8},/obj/effect/floor_decal/corner/paleblue/border{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"AQ" = (/obj/effect/floor_decal/borderfloorwhite{dir = 4},/obj/effect/floor_decal/corner/paleblue/border{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"AR" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 4},/obj/machinery/door/firedoor/glass,/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/plating,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"AS" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/airless{icon_state = "asteroidplating2"},/area/medical/virologyaccess)
-"AT" = (/obj/structure/disposalpipe/trunk{dir = 8},/obj/structure/disposaloutlet{dir = 4},/turf/simulated/floor/airless{icon_state = "asteroidplating2"},/area/medical/virologyaccess)
-"AU" = (/turf/simulated/wall,/area/crew_quarters/medical_restroom)
-"AV" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/structure/flora/pottedplant,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"AW" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/structure/sink{pixel_y = 24},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"AX" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"AY" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/hologram/holopad,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"AZ" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 9},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Ba" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/light_switch{dir = 2; name = "light switch "; pixel_x = 0; pixel_y = 26},/obj/effect/floor_decal/spline/plain{dir = 4},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Bb" = (/obj/machinery/vending/fitness,/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Bc" = (/obj/structure/table/rack,/obj/item/clothing/shoes/magboots,/obj/item/clothing/suit/space/void/medical/emt,/obj/item/clothing/head/helmet/space/void/medical/emt,/obj/effect/floor_decal/corner/paleblue{dir = 9},/obj/effect/floor_decal/corner/paleblue{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/obj/item/clothing/mask/breath,/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"Bd" = (/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"Be" = (/obj/structure/closet/secure_closet/paramedic,/obj/effect/floor_decal/corner/paleblue{dir = 9},/obj/effect/floor_decal/corner/paleblue{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/obj/effect/floor_decal/industrial/outline/blue,/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"Bf" = (/obj/effect/floor_decal/borderfloorwhite{dir = 4},/obj/effect/floor_decal/corner/paleblue/border{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 5; icon_state = "intact"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Bg" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 4},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 4},/turf/simulated/floor/plating,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Bh" = (/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 4},/turf/simulated/floor/airless{icon_state = "asteroidplating2"},/area/medical/virologyaccess)
-"Bi" = (/obj/machinery/atmospherics/unary/vent_pump{dir = 8; external_pressure_bound = 140; external_pressure_bound_default = 140; icon_state = "map_vent_out"; pressure_checks = 1; pressure_checks_default = 1; use_power = 1},/turf/simulated/floor/airless{icon_state = "asteroidplating2"},/area/medical/virologyaccess)
-"Bj" = (/obj/structure/curtain/open/shower,/obj/machinery/shower{pixel_y = 10},/obj/effect/floor_decal/steeldecal/steel_decals5,/obj/effect/floor_decal/steeldecal/steel_decals5{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 5},/obj/effect/floor_decal/steeldecal/steel_decals10{dir = 6},/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"Bk" = (/obj/machinery/light/small{dir = 1},/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"Bl" = (/obj/structure/toilet{dir = 8},/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"Bm" = (/obj/machinery/recharge_station,/turf/simulated/floor/tiled/techfloor,/area/crew_quarters/medical_restroom)
-"Bn" = (/obj/machinery/washing_machine,/obj/effect/floor_decal/corner/paleblue/diagonal,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Bo" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Bp" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Bq" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9; pixel_y = 0},/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Br" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/obj/effect/floor_decal/spline/plain{dir = 4},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Bs" = (/obj/machinery/vending/snack,/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Bt" = (/obj/machinery/light,/obj/effect/floor_decal/borderfloorblack{dir = 10},/obj/effect/floor_decal/corner/paleblue/border{dir = 10},/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"Bu" = (/obj/effect/floor_decal/borderfloorblack,/obj/effect/floor_decal/corner/paleblue/border,/obj/item/device/radio/intercom{dir = 2; pixel_y = -24},/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"Bv" = (/obj/effect/floor_decal/borderfloorblack,/obj/effect/floor_decal/corner/paleblue/border,/obj/structure/closet/fireaxecabinet{pixel_y = -32},/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"Bw" = (/obj/machinery/camera/network/medbay{dir = 1},/obj/effect/floor_decal/borderfloorblack{dir = 6},/obj/effect/floor_decal/corner/paleblue/border{dir = 6},/turf/simulated/floor/tiled/dark,/area/medical/medbay_emt_bay)
-"Bx" = (/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth{frequency = 1380; id_tag = "large_escape_pod_1_berth"; pixel_x = -26; pixel_y = 0; tag_door = "large_escape_pod_1_berth_hatch"},/obj/effect/floor_decal/borderfloorwhite{dir = 8},/obj/effect/floor_decal/corner/paleblue/border{dir = 8},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 1},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"By" = (/obj/effect/floor_decal/borderfloorwhite{dir = 4},/obj/effect/floor_decal/corner/paleblue/border{dir = 4},/obj/machinery/light{icon_state = "tube1"; dir = 4},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/white,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Bz" = (/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"BA" = (/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 5},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 8},/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"BB" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 11; pixel_y = 0},/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"BC" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/machinery/light/small{dir = 8},/turf/simulated/floor/tiled/steel_grid,/area/crew_quarters/medical_restroom)
-"BD" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/camera/network/medbay{c_tag = "MED - Break Room West"; dir = 4},/obj/machinery/washing_machine,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"BE" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"BF" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"BG" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"BH" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"BI" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/spline/plain{dir = 4},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"BJ" = (/obj/machinery/vending/cola,/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/obj/machinery/camera/network/medbay{c_tag = "MED - Break Room East"; dir = 8},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"BK" = (/turf/simulated/wall,/area/mine/explored/upper_level)
-"BL" = (/obj/machinery/door/airlock/glass_external{frequency = 1380; icon_state = "door_locked"; id_tag = "large_escape_pod_1_berth_hatch"; locked = 1; name = "Large Escape Pod 1"},/obj/machinery/door/firedoor/glass,/obj/machinery/shield_diffuser,/turf/simulated/floor,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"BM" = (/obj/machinery/door/firedoor/glass,/obj/machinery/door/airlock/medical{name = "Rest Room"},/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"BN" = (/obj/machinery/door/airlock/medical{name = "Rest Room"},/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"BO" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/light{dir = 8},/obj/structure/reagent_dispensers/water_cooler/full,/obj/machinery/status_display{pixel_x = -32},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"BP" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"BQ" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"BR" = (/obj/structure/bed/chair,/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/effect/landmark/start{name = "Medical Doctor"},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"BS" = (/obj/structure/bed/chair,/obj/effect/floor_decal/corner/paleblue/diagonal,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"BT" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/atmospherics/unary/vent_pump/on,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"BU" = (/obj/machinery/vending/coffee,/obj/machinery/light{icon_state = "tube1"; dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9,/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"BV" = (/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"BW" = (/turf/simulated/shuttle/wall,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"BX" = (/obj/machinery/door/airlock/glass_external{frequency = 1380; icon_state = "door_locked"; id_tag = "large_escape_pod_1_hatch"; locked = 1; name = "Emergency Airlock"},/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"BY" = (/obj/structure/sign/redcross,/turf/simulated/shuttle/wall,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"BZ" = (/turf/simulated/mineral/floor/vacuum,/area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Ca" = (/obj/structure/mirror{pixel_y = 30},/obj/structure/sink{pixel_y = 24},/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"Cb" = (/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 9},/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"Cc" = (/obj/machinery/alarm{pixel_y = 22},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"Cd" = (/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/obj/machinery/power/apc{dir = 1; name = "north bump"; pixel_x = 0; pixel_y = 28},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"Ce" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals4,/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"Cf" = (/obj/machinery/door/airlock/medical{name = "Rest Room"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Cg" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals4{dir = 1},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Ch" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold/hidden/supply,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Ci" = (/obj/structure/bed/chair{dir = 4},/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Cj" = (/obj/structure/table/glass,/obj/item/weapon/deck/cards,/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Ck" = (/obj/structure/table/glass,/obj/machinery/recharger,/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Cl" = (/obj/structure/bed/chair{dir = 8},/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9; pixel_y = 0},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Cm" = (/obj/structure/table/standard,/obj/machinery/microwave,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Co" = (/obj/structure/shuttle/engine/heater{dir = 8},/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/airless,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"Cp" = (/obj/machinery/atmospherics/unary/cryo_cell{layer = 3.3},/obj/structure/window/reinforced{dir = 8},/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"Cq" = (/obj/structure/bed/roller,/obj/structure/closet/walllocker/emerglocker{pixel_x = 0; pixel_y = 32},/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"Cr" = (/obj/structure/bed/roller,/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"Cs" = (/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{frequency = 1380; id_tag = "large_escape_pod_1"; pixel_x = -26; pixel_y = 26; tag_door = "large_escape_pod_1_hatch"},/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"Ct" = (/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"Cu" = (/obj/structure/bed/chair,/obj/machinery/light{dir = 1},/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"Cv" = (/obj/structure/bed/chair,/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"Cw" = (/obj/structure/bed/chair,/obj/machinery/vending/wallmed1{layer = 3.3; name = "Emergency NanoMed"; pixel_x = 28; pixel_y = 0},/obj/structure/closet/walllocker/emerglocker{pixel_x = 0; pixel_y = 32},/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"Cx" = (/turf/simulated/shuttle/wall/hard_corner,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"Cy" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/plating,/area/crew_quarters/medical_restroom)
-"Cz" = (/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"CA" = (/obj/machinery/light/small,/obj/structure/table/standard,/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"CB" = (/obj/structure/table/standard,/obj/random/soap,/obj/random/soap,/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 1},/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"CC" = (/obj/structure/undies_wardrobe,/turf/simulated/floor/tiled/white,/area/crew_quarters/medical_restroom)
-"CD" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/structure/cable/green,/obj/machinery/power/apc{cell_type = /obj/item/weapon/cell/super; dir = 8; name = "west bump"; pixel_x = -28},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"CE" = (/obj/structure/bed/chair{dir = 4},/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/effect/landmark/start{name = "Search and Rescue"},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"CF" = (/obj/structure/table/glass,/obj/item/device/universal_translator,/obj/effect/floor_decal/corner/paleblue/diagonal,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"CG" = (/obj/structure/table/glass,/obj/effect/floor_decal/corner/paleblue/diagonal,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"CH" = (/obj/structure/bed/chair{dir = 8},/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/effect/landmark/start{name = "Medical Doctor"},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"CI" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/obj/effect/floor_decal/spline/plain{dir = 4},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"CJ" = (/obj/machinery/disposal,/obj/structure/disposalpipe/trunk{dir = 8},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"CK" = (/obj/structure/window/reinforced{dir = 8},/obj/machinery/atmospherics/pipe/simple/visible,/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"CL" = (/obj/structure/bed/chair{dir = 4},/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"CM" = (/obj/structure/shuttle/window,/obj/structure/grille,/turf/simulated/shuttle/plating,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"CN" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced,/turf/simulated/floor/plating,/area/crew_quarters/medical_restroom)
-"CO" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/obj/structure/window/reinforced,/turf/simulated/floor/plating,/area/crew_quarters/medical_restroom)
-"CP" = (/obj/structure/flora/skeleton{name = "\proper Wilhelm"},/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/camera/network/medbay{c_tag = "MED - Break Room Southwest"; dir = 4},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"CQ" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"CR" = (/obj/structure/bed/chair{dir = 1},/obj/effect/floor_decal/corner/paleblue/diagonal,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"CS" = (/obj/structure/bed/chair{dir = 1},/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/effect/landmark/start{name = "Search and Rescue"},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"CT" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 1},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"CU" = (/obj/effect/floor_decal/corner/paleblue/diagonal,/obj/effect/floor_decal/spline/plain{dir = 4},/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"CV" = (/obj/structure/table/standard,/obj/item/weapon/storage/box/donkpockets,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"CW" = (/obj/structure/window/reinforced{dir = 8},/obj/machinery/atmospherics/portables_connector{dir = 1},/obj/machinery/portable_atmospherics/canister/oxygen/prechilled,/obj/machinery/light,/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"CX" = (/obj/structure/table/standard,/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{pixel_x = -4; pixel_y = 0},/obj/item/weapon/tool/wrench,/obj/random/medical/lite,/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"CY" = (/obj/structure/closet/crate/medical,/obj/item/weapon/storage/firstaid/regular{pixel_x = -2; pixel_y = 4},/obj/item/weapon/storage/firstaid/regular{pixel_x = -2; pixel_y = 4},/obj/item/bodybag/cryobag{pixel_x = 5},/obj/item/bodybag/cryobag{pixel_x = 5},/obj/item/weapon/storage/firstaid/o2{layer = 2.8; pixel_x = 4; pixel_y = 6},/obj/item/weapon/storage/box/masks{pixel_x = 0; pixel_y = 0},/obj/item/weapon/storage/box/gloves{pixel_x = 3; pixel_y = 4},/obj/item/weapon/storage/firstaid/toxin,/obj/item/weapon/storage/firstaid/fire{layer = 2.9; pixel_x = 2; pixel_y = 3},/obj/item/weapon/storage/firstaid/adv{pixel_x = -2},/obj/item/weapon/reagent_containers/blood/empty,/obj/item/weapon/reagent_containers/blood/empty,/obj/item/weapon/reagent_containers/blood/empty,/obj/item/weapon/reagent_containers/blood/empty,/obj/item/weapon/reagent_containers/blood/empty,/obj/machinery/status_display{density = 0; layer = 4; pixel_x = 0; pixel_y = -32},/obj/item/device/defib_kit/loaded,/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"CZ" = (/obj/machinery/sleeper{dir = 8},/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"Da" = (/obj/machinery/sleep_console,/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"Db" = (/obj/structure/bed/chair{dir = 1},/obj/machinery/light,/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"Dc" = (/obj/structure/bed/chair{dir = 1},/turf/simulated/shuttle/floor,/area/shuttle/large_escape_pod1/station{base_turf = /turf/simulated/mineral/floor/vacuum})
-"Dd" = (/obj/structure/bookcase/manuals/medical,/obj/item/weapon/book/manual/medical_diagnostics_manual{pixel_y = 7},/obj/item/weapon/book/manual/stasis,/obj/item/weapon/book/manual/resleeving,/obj/effect/floor_decal/corner/paleblue/diagonal,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"De" = (/obj/machinery/camera/network/medbay{dir = 1},/obj/effect/floor_decal/corner/paleblue/diagonal,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Df" = (/obj/machinery/alarm{dir = 1; icon_state = "alarm0"; pixel_y = -22},/obj/effect/floor_decal/corner/paleblue/diagonal,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Dg" = (/obj/structure/table/standard,/turf/simulated/floor/tiled/white,/area/crew_quarters/medbreak)
-"Di" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/obj/structure/window/reinforced,/turf/simulated/floor/plating,/area/crew_quarters/medbreak)
-"Dl" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/evahallway)
-"Do" = (/obj/structure/cable{icon_state = "1-2"},/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/lightgrey/border{dir = 4},/obj/effect/floor_decal/borderfloor/corner2{dir = 6},/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 6},/turf/simulated/floor/tiled/dark,/area/tether/station/public_meeting_room)
-"Dq" = (/obj/machinery/camera/network/security{icon_state = "camera"; dir = 4},/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"Ds" = (/obj/effect/floor_decal/borderfloorblack{dir = 9},/obj/structure/closet/wardrobe/orange,/turf/simulated/floor/tiled/dark,/area/security/recstorage)
-"Dy" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"DA" = (/obj/structure/railing{dir = 4},/obj/random/junk,/obj/effect/floor_decal/techfloor{dir = 10},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"DF" = (/turf/simulated/floor/tiled,/area/security/brig)
-"DG" = (/obj/effect/floor_decal/rust,/obj/effect/decal/cleanable/dirt,/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/maintenance/engineering,/obj/random/maintenance/engineering,/obj/random/maintenance/engineering,/turf/simulated/floor/plating,/area/engineering/shaft)
-"DK" = (/obj/effect/floor_decal/rust,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"DN" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/maintenance/cargo,/obj/random/maintenance/clean,/turf/simulated/floor,/area/maintenance/evahallway)
-"DR" = (/obj/random/trash,/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Ej" = (/obj/effect/floor_decal/rust,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Em" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/security/brig)
-"En" = (/obj/machinery/atmospherics/unary/vent_pump/on,/obj/structure/bed/chair{dir = 1},/turf/simulated/floor/tiled/dark,/area/security/interrogation)
-"Er" = (/obj/effect/floor_decal/borderfloor{dir = 5},/obj/effect/floor_decal/corner/yellow/border{dir = 5},/obj/machinery/vending/coffee,/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"Et" = (/obj/structure/railing,/obj/effect/floor_decal/techfloor{dir = 1},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Eu" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/red/border,/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/green{icon_state = "intact"; dir = 10},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/disposalpipe/junction/yjunction,/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"Ev" = (/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Ew" = (/obj/effect/floor_decal/rust,/obj/effect/decal/cleanable/dirt,/obj/machinery/alarm{pixel_y = 22},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"Ey" = (/turf/simulated/floor/reinforced/airless,/area/space)
-"ED" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/maintenance/clean,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"EF" = (/obj/structure/table/steel,/obj/item/weapon/paper_bin{pixel_x = -3; pixel_y = 7},/turf/simulated/floor,/area/maintenance/evahallway)
-"EH" = (/obj/random/junk,/obj/effect/floor_decal/techfloor{dir = 1},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"EJ" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"EZ" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"Fb" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/security/brig)
-"Fe" = (/obj/structure/table/glass,/obj/item/weapon/surgical/scalpel,/obj/random/maintenance/medical,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Ff" = (/obj/structure/bed/chair{dir = 8},/obj/effect/floor_decal/techfloor{dir = 9},/turf/simulated/floor/airless,/area/maintenance/station/sec_lower)
-"Fj" = (/obj/machinery/door/firedoor/glass,/obj/structure/grille,/obj/structure/window/reinforced/polarized{dir = 10; icon_state = "fwindow"; id = "chapel"},/obj/structure/window/reinforced/tinted,/obj/structure/window/reinforced/tinted{dir = 1},/obj/structure/window/reinforced/tinted{dir = 8; icon_state = "twindow"},/turf/simulated/floor,/area/security/interrogation)
-"Fq" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/table/steel,/turf/simulated/floor/tiled/freezer,/area/security/brig/bathroom)
-"Fs" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Ft" = (/obj/structure/closet,/obj/item/clothing/accessory/poncho/roles/medical,/obj/item/clothing/shoes/boots/winter/medical,/obj/item/clothing/shoes/boots/winter/medical,/obj/item/clothing/suit/storage/hooded/wintercoat/medical,/obj/item/clothing/under/rank/medical,/obj/item/clothing/under/seromi/smock/medical,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Fv" = (/obj/machinery/door/airlock/maintenance/common,/obj/machinery/door/firedoor/glass,/obj/structure/disposalpipe/segment,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Fw" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/disposalpipe/segment,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"Fx" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/hologram/holopad,/turf/simulated/floor/tiled/techfloor,/area/ai_upload)
-"FA" = (/obj/structure/railing{dir = 8},/obj/random/junk,/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"FC" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/maintenance/engineering,/obj/random/maintenance/engineering,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"FD" = (/obj/structure/bed/padded,/obj/machinery/camera/network/medbay{c_tag = "MED - Virology Containment Two"; dir = 4},/turf/simulated/floor/tiled/white,/area/medical/virology)
-"FI" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 1},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"FR" = (/obj/effect/floor_decal/rust,/obj/random/junk,/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"FZ" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/maintenance/station/sec_lower)
-"Gd" = (/obj/structure/table/reinforced,/turf/simulated/floor,/area/vacant/vacant_office)
-"Gf" = (/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/obj/structure/cable,/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/lightgrey/border{dir = 4},/turf/simulated/floor/tiled/dark,/area/tether/station/public_meeting_room)
-"Go" = (/obj/effect/floor_decal/rust,/turf/simulated/floor/plating,/area/engineering/shaft)
-"Gw" = (/turf/simulated/floor/tiled/dark,/area/security/brig)
-"GG" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/obj/structure/table/steel,/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"GV" = (/obj/machinery/door/airlock/maintenance/common,/obj/machinery/door/firedoor/glass,/turf/simulated/floor,/area/vacant/vacant_restaurant_upper)
-"GW" = (/obj/structure/table/reinforced,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"GY" = (/obj/effect/floor_decal/techfloor{dir = 4},/obj/structure/stairs/north,/turf/simulated/floor/bluegrid,/area/ai_upload)
-"Ha" = (/obj/structure/bed/chair/office/dark,/obj/machinery/light{dir = 1},/turf/simulated/floor/carpet/bcarpet,/area/tether/station/public_meeting_room)
-"Hb" = (/obj/structure/closet/crate,/obj/random/maintenance/clean,/obj/effect/floor_decal/techfloor{dir = 9},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Hc" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/catwalk,/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Hk" = (/obj/random/junk,/turf/simulated/floor,/area/maintenance/evahallway)
-"Hq" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/tether/station/public_meeting_room)
-"Hx" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled,/area/security/brig)
-"HA" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/borderfloor/corner2{dir = 9},/obj/effect/floor_decal/corner/lightgrey/bordercorner2{dir = 9},/obj/machinery/vending/fitness,/turf/simulated/floor/tiled/dark,/area/tether/station/public_meeting_room)
-"HH" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"HK" = (/obj/structure/railing{dir = 8},/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled,/area/security/brig)
-"HP" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/catwalk,/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Ik" = (/obj/machinery/light/small{dir = 8},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Ip" = (/turf/simulated/mineral/vacuum,/area/chapel/office)
-"Ix" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/machinery/power/apc{dir = 8; name = "west bump"; pixel_x = -28},/obj/structure/cable/green,/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"Iz" = (/obj/effect/floor_decal/rust,/obj/effect/floor_decal/techfloor{dir = 8},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"IB" = (/obj/structure/bed/chair/office/dark{dir = 8},/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/carpet/bcarpet,/area/tether/station/public_meeting_room)
-"IG" = (/obj/machinery/firealarm{dir = 2; layer = 3.3; pixel_x = 0; pixel_y = 26},/turf/simulated/floor/carpet/bcarpet,/area/tether/station/public_meeting_room)
-"IO" = (/obj/structure/disposaloutlet{dir = 1},/obj/structure/disposalpipe/trunk,/turf/simulated/floor/airless,/area/space)
-"IX" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/catwalk,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"IZ" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"Jc" = (/obj/machinery/seed_storage/garden,/turf/simulated/floor/tiled,/area/security/brig)
-"Jh" = (/obj/effect/floor_decal/rust,/obj/structure/catwalk,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Jl" = (/obj/structure/cable/green{icon_state = "32-2"},/obj/structure/lattice,/obj/structure/railing{dir = 4},/obj/structure/railing,/turf/simulated/open,/area/engineering/shaft)
-"Jp" = (/obj/machinery/alarm{dir = 4; pixel_x = -23; pixel_y = 0},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/plating,/area/engineering/shaft)
-"Jq" = (/obj/structure/bed/chair/office/dark{dir = 8},/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/turf/simulated/floor/carpet/bcarpet,/area/tether/station/public_meeting_room)
-"JD" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/red/border,/obj/effect/floor_decal/borderfloor/corner2,/obj/effect/floor_decal/corner/red/bordercorner2,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/green{icon_state = "intact"; dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"JH" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 4},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/maintenance/station/sec_lower)
-"JK" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/evahallway)
-"JL" = (/obj/structure/table/steel,/turf/simulated/floor,/area/maintenance/evahallway)
-"Kg" = (/obj/structure/closet,/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Kv" = (/obj/effect/floor_decal/borderfloorblack{dir = 6},/obj/structure/table/steel,/obj/item/weapon/beach_ball/holoball,/turf/simulated/floor/tiled/dark,/area/security/recstorage)
-"KG" = (/turf/simulated/mineral/floor/cave,/area/maintenance/station/sec_lower)
-"KI" = (/turf/simulated/wall,/area/tether/station/public_meeting_room)
-"KJ" = (/obj/machinery/power/apc{cell_type = /obj/item/weapon/cell/apc; dir = 8; name = "west bump"; pixel_x = -28},/obj/structure/cable{icon_state = "0-4"; d2 = 4},/obj/effect/decal/cleanable/dirt,/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/junk,/obj/random/junk,/obj/random/maintenance/security,/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"KP" = (/obj/machinery/photocopier,/obj/item/device/radio/intercom{dir = 4; pixel_x = -24},/obj/effect/floor_decal/borderfloor{dir = 8; icon_state = "borderfloor"; pixel_x = 0},/obj/effect/floor_decal/corner/lightgrey/border{dir = 8},/turf/simulated/floor/tiled/dark,/area/tether/station/public_meeting_room)
-"KQ" = (/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"KU" = (/obj/structure/table/glass,/obj/item/weapon/storage/box/gloves{pixel_x = 4; pixel_y = 4},/obj/item/roller,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"KV" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/catwalk,/obj/machinery/alarm{dir = 8; icon_state = "alarm0"; pixel_x = 24},/turf/simulated/floor,/area/maintenance/evahallway)
-"KX" = (/obj/structure/ladder/up,/turf/simulated/floor,/area/maintenance/evahallway)
-"Ld" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/plating,/area/security/brig)
-"Lf" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Ll" = (/turf/simulated/floor,/area/maintenance/evahallway)
-"Ln" = (/obj/machinery/door/airlock/maintenance/common,/obj/machinery/door/firedoor/glass,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Lo" = (/obj/effect/floor_decal/rust,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Lr" = (/obj/machinery/shield_diffuser,/turf/simulated/floor/plating,/area/mine/explored/upper_level)
-"Lx" = (/obj/machinery/power/apc{cell_type = /obj/item/weapon/cell/super; dir = 8; name = "west bump"; pixel_x = -28},/obj/structure/cable/green{icon_state = "0-4"},/obj/structure/table/steel,/obj/item/weapon/reagent_containers/glass/bucket,/turf/simulated/floor/tiled,/area/security/brig)
-"Ly" = (/obj/effect/floor_decal/rust,/obj/structure/closet/crate,/obj/random/maintenance/engineering,/turf/simulated/floor/airless,/area/maintenance/station/sec_lower)
-"LB" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/catwalk,/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"LD" = (/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/structure/cable/green{icon_state = "16-0"},/obj/structure/railing,/obj/structure/railing{dir = 4},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"LE" = (/obj/structure/disposalpipe/segment,/obj/machinery/door/firedoor/glass,/obj/structure/lattice,/obj/structure/cable/pink{d1 = 32; dir = 2; icon_state = "32-1"},/turf/simulated/open,/area/maintenance/station/sec_lower)
-"LG" = (/obj/structure/cable/pink{icon_state = "1-2"},/obj/structure/disposalpipe/segment,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"LL" = (/obj/effect/floor_decal/borderfloor{dir = 6},/obj/effect/floor_decal/corner/lightgrey/border{dir = 6},/obj/effect/floor_decal/borderfloor/corner2,/obj/effect/floor_decal/corner/lightgrey/bordercorner2,/turf/simulated/floor/tiled/dark,/area/tether/station/public_meeting_room)
-"LQ" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/firedoor/glass,/obj/machinery/door/airlock/maintenance/common,/turf/simulated/floor,/area/maintenance/evahallway)
-"LT" = (/obj/structure/table/wooden_reinforced,/obj/item/weapon/paper_bin{pixel_x = 1; pixel_y = 8},/obj/item/weapon/pen/blue,/obj/item/weapon/pen,/obj/item/weapon/pen/red,/turf/simulated/floor/carpet/bcarpet,/area/tether/station/public_meeting_room)
-"LW" = (/obj/structure/catwalk,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/airless,/area/maintenance/station/sec_lower)
-"Me" = (/obj/effect/floor_decal/techfloor,/obj/machinery/light,/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8},/turf/simulated/floor/bluegrid,/area/ai_upload)
-"Mn" = (/obj/structure/table/steel,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Mp" = (/turf/simulated/floor/tiled/dark,/area/security/interrogation)
-"Mq" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 1},/obj/structure/disposalpipe/segment,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/maintenance/station/sec_lower)
-"Ms" = (/obj/structure/bed/chair{dir = 8},/obj/effect/floor_decal/techfloor{dir = 10},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/airless,/area/maintenance/station/sec_lower)
-"Mw" = (/obj/machinery/light/small{dir = 4; pixel_y = 0},/obj/structure/closet/crate,/obj/random/junk,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"MC" = (/obj/structure/railing,/obj/effect/floor_decal/spline/plain,/turf/simulated/floor/tiled/monotile,/area/security/brig)
-"MK" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/maintenance/engineering,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"MN" = (/turf/simulated/floor/tiled/white,/area/maintenance/station/sec_lower)
-"MO" = (/obj/effect/floor_decal/rust,/obj/random/junk,/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"MT" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/catwalk,/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"MX" = (/obj/effect/floor_decal/rust,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/catwalk,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Na" = (/obj/structure/table/glass,/obj/item/weapon/book/manual/medical_diagnostics_manual,/turf/simulated/floor/tiled/white,/area/maintenance/station/sec_lower)
-"Nb" = (/obj/structure/table/reinforced,/turf/simulated/floor/tiled/white,/area/maintenance/station/sec_lower)
-"Nc" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/green{icon_state = "intact"; dir = 5},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/turf/simulated/floor/tiled,/area/security/brig)
-"Ng" = (/obj/effect/floor_decal/borderfloor{dir = 1; pixel_y = 0},/obj/effect/floor_decal/corner/red/border{dir = 1},/obj/effect/floor_decal/borderfloor/corner2{dir = 4},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 4},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"Nh" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor,/area/vacant/vacant_office)
-"Nj" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"Nm" = (/obj/structure/bed/chair{dir = 8},/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor/airless,/area/maintenance/station/sec_lower)
-"Ny" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/effect/floor_decal/corner_techfloor_grid{dir = 8},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"NA" = (/obj/effect/floor_decal/rust,/obj/effect/floor_decal/corner_techfloor_grid{dir = 1},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"NJ" = (/obj/effect/decal/cleanable/dirt,/obj/random/tool,/turf/simulated/floor,/area/vacant/vacant_office)
-"NM" = (/obj/structure/lattice,/turf/simulated/mineral/floor/cave,/area/maintenance/station/sec_lower)
-"NN" = (/obj/structure/table/glass,/obj/item/taperoll/medical,/obj/random/maintenance/medical,/obj/random/maintenance/medical,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"NS" = (/obj/structure/lattice,/obj/structure/grille,/turf/space,/area/space)
-"NY" = (/obj/machinery/light/small{dir = 8},/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor/airless,/area/maintenance/station/sec_lower)
-"NZ" = (/obj/random/junk,/obj/random/junk,/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Ob" = (/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor/airless,/area/maintenance/station/sec_lower)
-"Oc" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/red/border,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"Of" = (/obj/machinery/door/firedoor/glass,/obj/structure/grille,/obj/structure/window/reinforced/polarized{dir = 10; icon_state = "fwindow"; id = "chapel"},/obj/structure/window/reinforced/tinted,/obj/structure/window/reinforced/tinted{dir = 1},/turf/simulated/floor,/area/security/interrogation)
-"Oj" = (/obj/machinery/alarm{dir = 8; pixel_x = 25; pixel_y = 0},/obj/structure/table/steel,/obj/random/maintenance/engineering,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Op" = (/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22},/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{scrub_id = "sec_riot_control"},/turf/simulated/floor/plating,/area/security/brig)
-"Or" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Os" = (/obj/structure/table/glass,/obj/item/clothing/accessory/stethoscope,/obj/item/device/healthanalyzer,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/white,/area/maintenance/station/sec_lower)
-"OA" = (/obj/effect/floor_decal/rust,/obj/random/trash,/obj/effect/floor_decal/techfloor{dir = 5},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"OI" = (/obj/structure/closet{name = "Prisoner's Locker"},/obj/item/weapon/flame/lighter/zippo,/obj/item/clothing/head/greenbandana,/obj/machinery/light{dir = 4},/turf/simulated/floor/tiled,/area/security/brig)
-"OJ" = (/turf/simulated/wall,/area/maintenance/evahallway)
-"OQ" = (/turf/simulated/mineral/vacuum,/area/maintenance/evahallway)
-"OY" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Pd" = (/obj/effect/floor_decal/rust,/obj/random/junk,/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/maintenance/engineering,/obj/structure/railing{dir = 4},/turf/simulated/floor/plating,/area/maintenance/station/eng_upper)
-"Ph" = (/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/red/border,/obj/machinery/atmospherics/pipe/manifold/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"Pj" = (/obj/structure/table/wooden_reinforced,/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor/carpet/bcarpet,/area/tether/station/public_meeting_room)
-"Pl" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/evahallway)
-"Pm" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/obj/machinery/recharge_station,/turf/simulated/floor/tiled,/area/security/brig)
-"Py" = (/obj/structure/bed/chair{dir = 4},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"PA" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/catwalk,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"PE" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/catwalk,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"PF" = (/turf/simulated/wall{can_open = 1},/area/maintenance/station/sec_lower)
-"PJ" = (/obj/effect/floor_decal/borderfloor{dir = 1; pixel_y = 0},/obj/effect/floor_decal/corner/red/border{dir = 1},/obj/machinery/atmospherics/unary/vent_pump/on,/obj/machinery/alarm{pixel_y = 22},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"PM" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/disposalpipe/segment,/obj/machinery/light{icon_state = "tube1"; dir = 8},/obj/machinery/light_switch{dir = 4; icon_state = "light1"; pixel_x = -24},/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"PP" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/obj/effect/decal/cleanable/dirt,/obj/machinery/camera/network/security{icon_state = "camera"; dir = 4},/turf/simulated/floor/tiled,/area/security/brig)
-"PR" = (/obj/structure/bed/chair/office/dark{dir = 8},/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/turf/simulated/floor/carpet/bcarpet,/area/tether/station/public_meeting_room)
-"PS" = (/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/turf/simulated/floor/carpet/bcarpet,/area/tether/station/public_meeting_room)
-"PV" = (/obj/effect/floor_decal/rust,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"PW" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/plating,/area/engineering/shaft)
-"PX" = (/obj/structure/closet/emcloset,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Qk" = (/obj/effect/floor_decal/rust,/obj/random/trash,/obj/effect/floor_decal/techfloor{dir = 1},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Ql" = (/obj/structure/disposalpipe/segment,/obj/structure/table/steel,/turf/simulated/floor/airless,/area/maintenance/station/sec_lower)
-"Qn" = (/obj/effect/floor_decal/borderfloor{dir = 9},/obj/effect/floor_decal/corner/red/border{dir = 9},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"Qs" = (/turf/simulated/mineral/vacuum,/area/maintenance/station/sec_lower)
-"Qu" = (/obj/structure/catwalk,/obj/machinery/door/firedoor/glass,/obj/machinery/door/airlock/maintenance/common,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Qv" = (/obj/structure/closet{name = "Prisoner's Locker"},/obj/item/clothing/head/soft/orange,/obj/item/clothing/suit/storage/apron,/obj/item/clothing/shoes/sandal,/turf/simulated/floor/tiled,/area/security/brig)
-"Qy" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/simulated/floor/tiled,/area/security/brig)
-"QD" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/turf/simulated/floor/tiled/dark,/area/security/recstorage)
-"QF" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled,/area/hallway/station/port)
-"QG" = (/obj/structure/railing{dir = 8},/obj/structure/closet/crate,/obj/random/maintenance/engineering,/obj/random/junk,/obj/random/junk,/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"QH" = (/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/red/border{dir = 4},/obj/machinery/alarm{dir = 8; icon_state = "alarm0"; pixel_x = 24},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"QN" = (/obj/structure/closet,/obj/item/clothing/shoes/boots/winter/medical,/obj/item/clothing/suit/storage/hooded/wintercoat/medical,/obj/item/clothing/under/rank/medical,/turf/simulated/floor/tiled/white,/area/maintenance/station/sec_lower)
-"QQ" = (/obj/effect/floor_decal/rust,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/catwalk,/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"QR" = (/obj/structure/table/steel,/obj/random/maintenance/engineering,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"QS" = (/obj/machinery/light/small,/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/maintenance/clean,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"QW" = (/obj/effect/floor_decal/rust,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/catwalk,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"QZ" = (/obj/structure/railing,/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Rb" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/catwalk,/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Rd" = (/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/evahallway)
-"Rf" = (/obj/structure/closet/crate,/obj/random/junk,/obj/random/maintenance/engineering,/obj/structure/lattice,/turf/simulated/mineral/floor/cave,/area/maintenance/station/sec_lower)
-"Rg" = (/obj/effect/floor_decal/corner/white/border{icon_state = "bordercolor"; dir = 4},/turf/simulated/floor/tiled/monotile,/area/security/brig)
-"Rj" = (/obj/machinery/shield_diffuser,/turf/simulated/floor/airless,/area/space)
-"Rl" = (/obj/effect/decal/cleanable/dirt,/obj/item/frame/apc,/turf/simulated/floor,/area/vacant/vacant_office)
-"Rq" = (/obj/structure/sign/electricshock,/turf/simulated/wall/r_wall,/area/security/brig)
-"Rr" = (/obj/machinery/firealarm{dir = 4; pixel_x = 26},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"RA" = (/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/obj/structure/catwalk,/obj/machinery/light/small,/turf/simulated/floor,/area/maintenance/evahallway)
-"RB" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 1},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/maintenance/station/sec_lower)
-"RD" = (/obj/random/maintenance/engineering,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"RE" = (/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/disposalpipe/trunk,/obj/machinery/disposal,/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"RF" = (/obj/structure/closet/emcloset,/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"RJ" = (/obj/structure/table/wooden_reinforced,/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/obj/item/weapon/folder,/turf/simulated/floor/carpet/bcarpet,/area/tether/station/public_meeting_room)
-"RQ" = (/obj/structure/table/steel,/obj/machinery/microwave{pixel_x = -3; pixel_y = 6},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"RR" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/maintenance/station/sec_lower)
-"RS" = (/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"RT" = (/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"RW" = (/obj/effect/floor_decal/techfloor{dir = 8},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Sb" = (/obj/effect/floor_decal/borderfloor{dir = 8; icon_state = "borderfloor"; pixel_x = 0},/obj/effect/floor_decal/corner/lightgrey/border{dir = 8},/turf/simulated/floor/tiled/dark,/area/tether/station/public_meeting_room)
-"Sg" = (/obj/structure/table/steel,/obj/random/maintenance/clean,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Si" = (/obj/effect/floor_decal/rust,/obj/structure/bed/chair{dir = 4},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Sl" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 1},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"Sp" = (/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/obj/effect/floor_decal/borderfloor{dir = 8; icon_state = "borderfloor"; pixel_x = 0},/obj/effect/floor_decal/corner/lightgrey/border{dir = 8},/turf/simulated/floor/tiled/dark,/area/tether/station/public_meeting_room)
-"Sv" = (/obj/structure/table/steel,/obj/machinery/alarm{dir = 8; icon_state = "alarm0"; pixel_x = 24},/turf/simulated/floor,/area/maintenance/evahallway)
-"Sy" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled/dark,/area/security/interrogation)
-"SI" = (/obj/structure/disposalpipe/segment,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"SJ" = (/obj/random/junk,/obj/effect/floor_decal/techfloor{dir = 8},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"SK" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/maintenance/engineering,/obj/random/maintenance/clean,/turf/simulated/floor,/area/maintenance/evahallway)
-"SM" = (/obj/structure/grille,/turf/simulated/floor/plating,/area/mine/explored/upper_level)
-"ST" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/catwalk,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"SV" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/carpet/bcarpet,/area/tether/station/public_meeting_room)
-"SW" = (/obj/machinery/alarm{dir = 4; pixel_x = -23; pixel_y = 0},/obj/effect/floor_decal/borderfloor{dir = 8; icon_state = "borderfloor"; pixel_x = 0},/obj/effect/floor_decal/corner/lightgrey/border{dir = 8},/turf/simulated/floor/tiled/dark,/area/tether/station/public_meeting_room)
-"SY" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/white,/area/maintenance/station/sec_lower)
-"Ta" = (/obj/structure/table/steel,/obj/random/action_figure,/turf/simulated/floor,/area/maintenance/evahallway)
-"Tf" = (/obj/structure/table/steel,/obj/random/maintenance/clean,/obj/random/maintenance/engineering,/turf/simulated/floor,/area/maintenance/evahallway)
-"Tj" = (/obj/effect/decal/cleanable/dirt,/obj/structure/closet,/obj/random/maintenance/security,/obj/random/contraband,/obj/structure/railing{dir = 4},/turf/simulated/floor/plating,/area/maintenance/station/sec_lower)
-"Tk" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"Tl" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"Tm" = (/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"To" = (/obj/effect/floor_decal/techfloor{dir = 8},/obj/structure/stairs/north,/turf/simulated/floor/bluegrid,/area/ai_upload)
-"Tq" = (/obj/item/weapon/surgical/cautery,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Tw" = (/obj/effect/floor_decal/rust,/obj/machinery/light/small{dir = 1},/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Ty" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"TB" = (/obj/machinery/door/firedoor/glass,/obj/machinery/door/airlock/maintenance/common,/turf/simulated/floor,/area/maintenance/evahallway)
-"TO" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable{icon_state = "1-2"},/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/steeldecal/steel_decals_central1{dir = 4},/turf/simulated/floor/tiled,/area/tether/station/public_meeting_room)
-"TW" = (/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"TY" = (/turf/simulated/wall/r_wall,/area/security/riot_control)
-"Uf" = (/obj/structure/railing{dir = 8},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Ug" = (/obj/structure/closet/crate,/obj/random/junk,/obj/random/junk,/turf/simulated/mineral/floor/cave,/area/maintenance/station/sec_lower)
-"Ui" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/door/blast/regular{dir = 1; id = "Cell 1"; name = "Cell 1"},/obj/effect/floor_decal/industrial/loading{dir = 8},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"Uk" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/structure/catwalk,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Uo" = (/obj/structure/table/steel,/obj/machinery/light/small{dir = 8; pixel_y = 0},/turf/simulated/floor,/area/maintenance/evahallway)
-"Up" = (/obj/structure/bed/chair/office/dark{dir = 4},/turf/simulated/floor/carpet/bcarpet,/area/tether/station/public_meeting_room)
-"Us" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{scrub_id = "sec_riot_control"},/turf/simulated/floor/plating,/area/security/brig)
-"Uu" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/lightgrey/border,/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/obj/structure/cable{icon_state = "1-8"},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"UB" = (/obj/structure/cable{d2 = 8; icon_state = "0-8"},/obj/structure/cable{icon_state = "16-0"},/obj/machinery/atmospherics/pipe/zpipe/up/supply{dir = 8},/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{icon_state = "up-scrubbers"; dir = 8},/turf/simulated/floor,/area/maintenance/evahallway)
-"UE" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"UH" = (/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor/airless,/area/maintenance/station/sec_lower)
-"UJ" = (/obj/random/trash,/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"UO" = (/obj/effect/floor_decal/rust,/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"UR" = (/turf/simulated/floor/tiled/monotile,/area/security/brig)
-"UT" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals9{dir = 8},/obj/effect/floor_decal/steeldecal/steel_decals9,/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"UU" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/yellow/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/effect/floor_decal/borderfloor/corner2{dir = 1},/obj/effect/floor_decal/corner/yellow/bordercorner2{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"UV" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/catwalk,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"UX" = (/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/evahallway)
-"Vj" = (/obj/effect/floor_decal/rust,/obj/effect/floor_decal/techfloor{dir = 1},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Vm" = (/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/red/border{dir = 4},/obj/effect/floor_decal/borderfloor/corner2{dir = 6},/obj/effect/floor_decal/corner/red/bordercorner2{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/structure/disposalpipe/segment,/obj/machinery/light{dir = 4},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"Vw" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/disposalpipe/junction{icon_state = "pipe-j1"; dir = 4},/turf/simulated/floor/tiled,/area/hallway/station/port)
-"VA" = (/obj/machinery/door/airlock/multi_tile/glass{name = "Public Meeting Room"},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/effect/floor_decal/steeldecal/steel_decals_central1{dir = 8},/turf/simulated/floor/tiled,/area/tether/station/public_meeting_room)
-"VF" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/door/blast/regular{dir = 1; id = "Cell 3"; name = "Cell 3"},/obj/effect/floor_decal/industrial/loading{dir = 8},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"VH" = (/obj/structure/table/steel,/obj/item/device/radio{pixel_x = -4},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"VJ" = (/obj/structure/disposalpipe/segment,/obj/effect/floor_decal/techfloor{dir = 1},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"VK" = (/obj/structure/cable{icon_state = "1-2"},/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/lightgrey/border{dir = 4},/turf/simulated/floor/tiled/dark,/area/tether/station/public_meeting_room)
-"VL" = (/turf/simulated/mineral/vacuum,/area/chapel/chapel_morgue)
-"VU" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/tiled,/area/security/brig)
-"Wi" = (/obj/machinery/alarm{frequency = 1441; pixel_y = 22},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Wj" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Wk" = (/obj/effect/floor_decal/borderfloor{dir = 1; pixel_y = 0},/obj/effect/floor_decal/corner/red/border{dir = 1},/obj/machinery/camera/network/security,/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"Ww" = (/obj/effect/floor_decal/rust,/obj/structure/closet,/obj/random/maintenance/clean,/obj/random/maintenance/clean,/obj/random/maintenance/engineering,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"WE" = (/obj/structure/sink{dir = 8; icon_state = "sink"; pixel_x = -12; pixel_y = 8},/turf/simulated/floor/tiled/white,/area/maintenance/station/sec_lower)
-"WG" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"WI" = (/obj/structure/cable{icon_state = "2-4"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/evahallway)
-"WJ" = (/obj/structure/catwalk,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"WL" = (/obj/structure/bed/chair{dir = 1},/turf/simulated/floor/tiled/dark,/area/security/interrogation)
-"WS" = (/obj/machinery/light/small{dir = 8},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/engineering/shaft)
-"Xc" = (/obj/structure/table/glass,/obj/item/weapon/storage/box/syringes{pixel_x = 4; pixel_y = 4},/turf/simulated/floor/tiled/white,/area/maintenance/station/sec_lower)
-"Xk" = (/obj/structure/table/steel,/obj/item/device/flashlight/lamp{pixel_y = 10},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Xp" = (/obj/machinery/atmospherics/pipe/tank/nitrous_oxide{icon_state = "n2o_map"; dir = 1},/turf/simulated/floor,/area/security/riot_control)
-"Xq" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable{icon_state = "2-8"},/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled,/area/hallway/station/port)
-"Xs" = (/obj/effect/floor_decal/corner/white/border{dir = 8},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/monotile,/area/security/brig)
-"Xw" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/lightgrey/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled,/area/hallway/station/starboard)
-"Xx" = (/obj/structure/railing{dir = 8},/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/computer/cryopod{pixel_y = -32},/turf/simulated/floor/tiled,/area/security/brig)
-"XA" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"XC" = (/obj/structure/table/steel,/turf/simulated/floor/tiled,/area/security/brig)
-"XG" = (/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled,/area/security/security_cell_hallway)
-"XH" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/catwalk,/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"XJ" = (/obj/random/maintenance/engineering,/obj/structure/table/rack{dir = 8; layer = 2.9},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"XM" = (/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"XR" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/alarm{pixel_y = 22},/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"XT" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/door/blast/regular{dir = 1; id = "Cell 4"; name = "Cell 4"},/obj/effect/floor_decal/industrial/loading{dir = 8},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"XX" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled,/area/security/brig/visitation)
-"Yc" = (/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/lightgrey/border{dir = 4},/turf/simulated/floor/tiled/dark,/area/tether/station/public_meeting_room)
-"Yd" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Ye" = (/obj/machinery/atmospherics/pipe/simple/hidden/green,/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled/steel_dirty,/area/security/brig)
-"Yf" = (/obj/structure/disposalpipe/trunk{dir = 1},/obj/machinery/disposal,/obj/effect/floor_decal/borderfloor{dir = 10},/obj/effect/floor_decal/corner/lightgrey/border{dir = 10},/turf/simulated/floor/tiled/dark,/area/tether/station/public_meeting_room)
-"Yh" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/alarm{breach_detection = 0; dir = 8; pixel_x = 25; pixel_y = 0; report_danger_level = 0},/obj/structure/catwalk,/turf/simulated/floor/airless,/area/maintenance/station/sec_lower)
-"Yq" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/airlock/maintenance/sec{name = "Riot Control"; req_one_access = list(1,10,24)},/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/plating,/area/security/riot_control)
-"Yw" = (/turf/simulated/floor/airless,/area/mine/explored/upper_level)
-"YD" = (/obj/structure/disposalpipe/segment,/obj/machinery/light/small{dir = 8},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"YE" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/structure/cable/green{icon_state = "0-4"},/obj/machinery/door/blast/regular{density = 0; dir = 4; icon_state = "pdoor0"; id = "brig_lockdown"; name = "Security Blast Doors"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/plating,/area/security/brig)
-"YH" = (/obj/machinery/atmospherics/pipe/cap/hidden/scrubbers{dir = 4},/turf/simulated/floor,/area/vacant/vacant_office)
-"YK" = (/obj/machinery/atmospherics/pipe/simple/hidden/green,/obj/structure/disposalpipe/segment,/turf/simulated/floor/tiled,/area/security/brig)
-"YM" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"YN" = (/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/yellow/border{dir = 1},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 4},/obj/effect/floor_decal/steeldecal/steel_decals7,/obj/machinery/vending/cola,/turf/simulated/floor/tiled,/area/engineering/foyer_mezzenine)
-"YU" = (/obj/effect/floor_decal/rust,/obj/random/trash_pile,/turf/simulated/floor/plating,/area/maintenance/station/sec_lower)
-"YW" = (/obj/random/trash,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Za" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/disposalpipe/segment,/obj/effect/decal/cleanable/dirt,/obj/machinery/power/apc{dir = 8; name = "west bump"; pixel_x = -28},/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/structure/table/steel,/obj/item/weapon/soap/nanotrasen,/turf/simulated/floor/tiled/freezer,/area/security/brig/bathroom)
-"Zb" = (/obj/structure/closet/emcloset,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Zl" = (/obj/structure/closet/crate,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Zo" = (/turf/simulated/floor/plating,/area/mine/explored/upper_level)
-"Zr" = (/obj/effect/floor_decal/rust,/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"Zu" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/obj/machinery/door/blast/regular{density = 0; dir = 4; icon_state = "pdoor0"; id = "brig_lockdown"; name = "Security Blast Doors"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/plating,/area/security/brig)
-"Zx" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/plating,/area/maintenance/evahallway)
-"Zy" = (/turf/simulated/floor/plating,/area/engineering/shaft)
-"ZE" = (/obj/structure/table/steel,/obj/random/maintenance/engineering,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"ZH" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/turf/simulated/floor/tiled,/area/security/brig)
-"ZJ" = (/obj/structure/table/steel,/obj/item/weapon/storage/briefcase/inflatable,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"ZK" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/carpet/bcarpet,/area/tether/station/public_meeting_room)
-"ZL" = (/obj/effect/floor_decal/rust,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/catwalk,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"ZR" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/door/blast/regular{dir = 1; id = "Cell 2"; name = "Cell 2"},/obj/effect/floor_decal/industrial/loading{dir = 8},/turf/simulated/floor/tiled/dark,/area/security/brig)
-"ZW" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/effect/floor_decal/techfloor,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/maintenance/station/sec_lower)
-"ZX" = (/obj/structure/table/steel,/obj/item/weapon/pen,/turf/simulated/floor,/area/maintenance/evahallway)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/space,
+/area/space)
+"ab" = (
+/turf/simulated/floor/airless,
+/area/space)
+"ac" = (
+/turf/simulated/mineral/vacuum,
+/area/mine/explored/upper_level)
+"ad" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/security/riot_control)
+"ae" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
+/area/security/brig/bathroom)
+"af" = (
+/turf/simulated/wall/r_wall,
+/area/security/brig/visitation)
+"ag" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/structure/curtain/open/shower/security,
+/turf/simulated/floor/tiled,
+/area/security/brig/bathroom)
+"ah" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/security/brig)
+"ai" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/structure/curtain/open/shower/security,
+/turf/simulated/floor/tiled,
+/area/security/brig/bathroom)
+"aj" = (
+/turf/simulated/wall/r_wall,
+/area/security/security_cell_hallway)
+"ak" = (
+/obj/effect/floor_decal/corner/white/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/security/brig)
+"al" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "visitdoor";
+	name = "Visitation Area";
+	req_access = list(1)
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"am" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"an" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock{
+	name = "Visitation";
+	req_one_access = list(1,38)
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"ao" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"ap" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/button/remote/airlock{
+	id = "visitdoor";
+	name = "Visitation Access";
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"aq" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"ar" = (
+/obj/structure/bed/chair,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/machinery/atmospherics/pipe/manifold/hidden/green{
+	icon_state = "map";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/bordercorner,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"as" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/structure/closet/secure_closet/brig,
+/turf/simulated/floor/tiled/dark,
+/area/security/recstorage)
+"at" = (
+/turf/simulated/wall,
+/area/maintenance/station/sec_lower)
+"au" = (
+/obj/structure/bed/chair,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightorange/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"av" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/security/brig/bathroom)
+"aw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/security/brig/bathroom)
+"ax" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/freezer,
+/area/security/brig/bathroom)
+"ay" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/security/brig/bathroom)
+"az" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/recstorage)
+"aA" = (
+/obj/effect/floor_decal/corner/white/border,
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/obj/structure/holohoop{
+	icon_state = "hoop";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/security/brig)
+"aB" = (
+/obj/effect/floor_decal/corner/white/border{
+	dir = 8
+	},
+/obj/item/weapon/paper/crumpled{
+	name = "basketball"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/security/brig)
+"aC" = (
+/obj/effect/floor_decal/corner/white/border{
+	icon_state = "bordercolor";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/security/brig)
+"aD" = (
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border,
+/obj/structure/holohoop{
+	icon_state = "hoop";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/security/brig)
+"aE" = (
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor,
+/area/security/riot_control)
+"aF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	icon_state = "railing0";
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"aG" = (
+/obj/machinery/door/airlock/security{
+	name = "The Hole";
+	req_access = list(2)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"aH" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 5
+	},
+/obj/machinery/camera/network/security,
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"aI" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/structure/table/steel,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
+	},
+/obj/item/toy/stickhorse,
+/turf/simulated/floor/tiled/dark,
+/area/security/recstorage)
+"aJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/security/riot_control)
+"aK" = (
+/obj/machinery/atmospherics/binary/pump,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/security/riot_control)
+"aL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"aM" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	icon_state = "borderfloorcorner2_black";
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled/dark,
+/area/security/recstorage)
+"aN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"aO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/trash_pile,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"aP" = (
+/turf/simulated/mineral/floor/vacuum,
+/area/mine/explored/upper_level)
+"aQ" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock{
+	name = "Brig Restroom"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/security/brig/bathroom)
+"aR" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/structure/table/steel,
+/obj/item/weapon/deck/cards,
+/obj/item/toy/nanotrasenballoon,
+/obj/item/weapon/material/twohanded/fireaxe/foam,
+/turf/simulated/floor/tiled/dark,
+/area/security/recstorage)
+"aS" = (
+/turf/simulated/wall/r_wall,
+/area/security/brig)
+"aT" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/security/brig/bathroom)
+"aU" = (
+/obj/structure/railing,
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/security/brig)
+"aV" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"aW" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10;
+	icon_state = "borderfloorcorner2";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "Cell 4";
+	name = "Cell 4 Door";
+	pixel_x = -28;
+	req_access = list(1,2)
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"aX" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10;
+	icon_state = "borderfloorcorner2";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "Cell 3";
+	name = "Cell 3 Door";
+	pixel_x = -28;
+	req_access = list(1,2)
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"aY" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10;
+	icon_state = "borderfloorcorner2";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "Cell 2";
+	name = "Cell 2 Door";
+	pixel_x = -28;
+	req_access = list(1,2)
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"aZ" = (
+/obj/machinery/atmospherics/valve/digital,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/security/riot_control)
+"ba" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_security{
+	name = "Solitary Confinement 1";
+	req_access = list(2)
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"bb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/structure/table/steel,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	icon_state = "bordercolor";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"bc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/table/steel,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	icon_state = "bordercolor";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"bd" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10;
+	icon_state = "borderfloorcorner2";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "Cell 1";
+	name = "Cell 1 Door";
+	pixel_x = -28;
+	req_access = list(1,2)
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"be" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"bf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"bg" = (
+/turf/simulated/wall,
+/area/chapel/chapel_morgue)
+"bh" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/security/brig/bathroom)
+"bi" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"bj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/security/brig/bathroom)
+"bk" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	name = "Brig Restroom"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/security/brig)
+"bl" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"bm" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/shifted,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"bn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	icon_state = "intact";
+	dir = 5
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/security/riot_control)
+"bo" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/green,
+/obj/machinery/meter,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/security/riot_control)
+"bp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	icon_state = "intact";
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/security/riot_control)
+"bq" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "brig_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/brig)
+"br" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/shifted,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"bs" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/computer/cryopod{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"bt" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/effect/floor_decal/corner/lightorange/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"bu" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"bv" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/green,
+/obj/effect/floor_decal/corner/lightorange/bordercorner,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"bw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightorange/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"bx" = (
+/obj/effect/floor_decal/rust,
+/obj/random/junk,
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/station/sec_lower)
+"by" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"bz" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"bA" = (
+/obj/structure/closet/coffin,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"bB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/machinery/computer/arcade/orion_trail,
+/obj/item/clothing/suit/ianshirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	icon_state = "bordercolor";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"bC" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/door_timer/cell_3{
+	id = "Cell 4";
+	name = "Cell 4";
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"bD" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/table/steel,
+/obj/machinery/microwave,
+/obj/item/weapon/storage/box/donkpockets,
+/obj/item/weapon/material/twohanded/fireaxe/foam,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"bE" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/effect/floor_decal/corner/lightorange/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 4
+	},
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"bF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/table/steel,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen/blue{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/device/taperecorder{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"bG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"bH" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door_timer/cell_3{
+	id = "Cell 3";
+	name = "Cell 3";
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"bI" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/structure/mopbucket,
+/obj/item/weapon/mop,
+/obj/machinery/button/remote/blast_door{
+	id = "prison_access";
+	name = "Brig Auxillary Access";
+	pixel_x = -24;
+	pixel_y = -8;
+	req_access = list(1,2)
+	},
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"bJ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door_timer/cell_3{
+	id = "Cell 2";
+	name = "Cell 2";
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"bK" = (
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"bL" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "brig_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/window/brigdoor/southleft{
+	dir = 4;
+	icon_state = "leftsecure";
+	id = "Cell 4";
+	name = "Cell 4";
+	req_access = list(2)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"bM" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"bN" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "prison_access";
+	name = "Brig Auxillary Access";
+	pixel_x = 8;
+	pixel_y = 24;
+	req_access = list(1,2)
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"bO" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass_security{
+	name = "Brig Auxillary Access";
+	req_access = list(2)
+	},
+/obj/machinery/door/blast/regular{
+	id = "prison_access";
+	name = "Brig Auxillary Access"
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"bP" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_security{
+	name = "Brig Auxillary Access";
+	req_access = list(2)
+	},
+/obj/machinery/door/blast/regular{
+	id = "prison_access";
+	name = "Brig Auxillary Access"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"bQ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door_timer/cell_3{
+	id = "Cell 1";
+	name = "Cell 1";
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"bR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"bS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"bT" = (
+/obj/structure/morgue,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"bU" = (
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"bV" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"bW" = (
+/turf/simulated/wall/r_wall,
+/area/engineering/shaft)
+"bX" = (
+/obj/random/trash,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"bY" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/light/small{
+	icon_state = "bulb1";
+	dir = 1
+	},
+/obj/structure/bed/padded,
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"bZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 4;
+	frequency = 1442;
+	icon_state = "map_injector";
+	id = "riot_inject";
+	req_access = list(3)
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"ca" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/light/small{
+	icon_state = "bulb1";
+	dir = 1
+	},
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet,
+/obj/item/weapon/pen/crayon/green,
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"cb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8;
+	frequency = 1442;
+	icon_state = "map_injector";
+	id = "riot_inject";
+	req_access = list(3)
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"cc" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/light/small{
+	icon_state = "bulb1";
+	dir = 1
+	},
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet,
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"cd" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/steel,
+/obj/item/weapon/storage/laundry_basket,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"ce" = (
+/obj/machinery/washing_machine,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"cf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"cg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"ch" = (
+/turf/simulated/wall/r_wall,
+/area/security/brig/bathroom)
+"ci" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"cj" = (
+/obj/machinery/button/remote/driver{
+	id = "chapelgun";
+	name = "Chapel Mass Driver";
+	pixel_x = 32;
+	pixel_y = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/camera/network/civilian{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"ck" = (
+/obj/structure/ladder,
+/turf/simulated/floor/plating,
+/area/engineering/shaft)
+"cl" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security{
+	name = "Interrogation";
+	req_access = newlist();
+	req_one_access = list(2,4)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/interrogation)
+"cm" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "brig_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/glass_security{
+	id_tag = "briginner";
+	name = "Brig";
+	req_access = list(2);
+	req_one_access = newlist()
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"cn" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "brig_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/glass_security{
+	id_tag = "briginner";
+	name = "Brig";
+	req_access = list(2);
+	req_one_access = newlist()
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"co" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/glass_security{
+	name = "Brig Cells";
+	req_access = newlist();
+	req_one_access = list(2,4)
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"cp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"cq" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_security{
+	name = "Brig Cells";
+	req_access = newlist();
+	req_one_access = list(2,4)
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"cr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"cs" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_security{
+	id_tag = "brigouter";
+	name = "Brig";
+	req_access = list(2);
+	req_one_access = newlist()
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"ct" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"cu" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_security{
+	id_tag = "brigouter";
+	name = "Brig";
+	req_access = list(2);
+	req_one_access = newlist()
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"cv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/remote/airlock{
+	id = "brigouter";
+	name = "Outer Brig Doors";
+	pixel_x = 6;
+	pixel_y = -24;
+	req_access = list(2)
+	},
+/obj/machinery/button/remote/airlock{
+	id = "briginner";
+	name = "Inner Brig Doors";
+	pixel_x = -6;
+	pixel_y = -24;
+	req_access = list(2)
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"cw" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"cx" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/security{
+	name = "Observation";
+	req_one_access = list(1,4)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/interrogation)
+"cy" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/table/steel,
+/obj/item/weapon/paper,
+/obj/item/weapon/pen/blue{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"cz" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"cA" = (
+/turf/simulated/wall/r_wall,
+/area/security/recstorage)
+"cB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"cC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"cD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"cE" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"cF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"cG" = (
+/obj/machinery/door/window{
+	dir = 8;
+	name = "Mass Driver";
+	req_access = list(22)
+	},
+/obj/machinery/mass_driver{
+	dir = 4;
+	id = "chapelgun"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/airlock_sensor{
+	pixel_y = 25
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/chapel/chapel_morgue)
+"cH" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/chapel/chapel_morgue)
+"cI" = (
+/obj/machinery/door/blast/regular{
+	id = "chapelgun";
+	name = "Chapel Launcher Door"
+	},
+/turf/simulated/floor/plating,
+/area/chapel/chapel_morgue)
+"cJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/engineering/shaft)
+"cK" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/table/steel,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"cL" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/structure/bed/chair,
+/obj/item/device/radio/intercom/locked/confessional{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"cM" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"cN" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"cO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"cP" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"cQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"cR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"cS" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "brig_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/window/brigdoor/southleft{
+	dir = 4;
+	icon_state = "leftsecure";
+	id = "Cell 3";
+	name = "Cell 3";
+	req_access = list(2)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"cT" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"cU" = (
+/turf/simulated/wall,
+/area/security/recstorage)
+"cV" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/recstorage)
+"cW" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/item/device/radio/intercom/locked/confessional{
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"cX" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "brig_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/security/brig/visitation)
+"cY" = (
+/turf/simulated/wall,
+/area/chapel/office)
+"cZ" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/structure/cable/pink{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"da" = (
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"db" = (
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"dc" = (
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"dd" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"de" = (
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Chapel Backroom";
+	req_access = list(27)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"df" = (
+/obj/structure/cable/pink{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"dg" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"dh" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/shaft)
+"di" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/machinery/camera/network/security,
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"dj" = (
+/turf/simulated/wall,
+/area/security/brig/visitation)
+"dk" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"dl" = (
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "brig_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/westleft{
+	req_access = list(1,2)
+	},
+/obj/machinery/door/window/brigdoor/eastright,
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"dm" = (
+/obj/effect/floor_decal/chapel{
+	dir = 1
+	},
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"dn" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"do" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"dp" = (
+/obj/machinery/vending/hydronutrients,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"dq" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 3"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"dr" = (
+/obj/effect/floor_decal/chapel{
+	dir = 4
+	},
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"ds" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 5
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"dt" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"du" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	icon_state = "borderfloorcorner2_black";
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/closet,
+/obj/item/weapon/material/minihoe,
+/turf/simulated/floor/tiled/dark,
+/area/security/recstorage)
+"dv" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/recstorage)
+"dw" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"dx" = (
+/obj/effect/floor_decal/borderfloor/shifted,
+/obj/effect/floor_decal/corner/red/border/shifted,
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"dy" = (
+/obj/structure/flora/pottedplant/stoutbush,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"dz" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/machinery/button/windowtint{
+	id = "chapel";
+	pixel_x = -24;
+	pixel_y = 26
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"dA" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/pink{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"dB" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"dC" = (
+/obj/machinery/photocopier,
+/obj/machinery/light_switch{
+	dir = 2;
+	name = "light switch ";
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"dD" = (
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"dE" = (
+/turf/simulated/wall/r_wall,
+/area/ai_upload)
+"dF" = (
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"dG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"dH" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"dI" = (
+/obj/structure/table/standard,
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"dJ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/chapel/chapel_morgue)
+"dK" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/engineering/shaft)
+"dL" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"dM" = (
+/obj/effect/floor_decal/borderfloor/shifted,
+/obj/effect/floor_decal/corner/red/border/shifted,
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/machinery/vending/cola,
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"dN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 4;
+	frequency = 1442;
+	icon_state = "map_injector";
+	id = "riot_inject";
+	req_access = list(3)
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"dO" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"dP" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8;
+	frequency = 1442;
+	icon_state = "map_injector";
+	id = "riot_inject";
+	req_access = list(3)
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"dQ" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"dR" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance/sec{
+	name = "Riot Control";
+	req_access = list(1)
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/green,
+/turf/simulated/floor,
+/area/security/riot_control)
+"dS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/weapon/flame/candle/candelabra/everburn,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"dT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"dU" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security{
+	name = "Brig Recreation Storage"
+	},
+/turf/simulated/floor/tiled,
+/area/security/recstorage)
+"dV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/recstorage)
+"dW" = (
+/obj/structure/disposalpipe/segment,
+/obj/item/weapon/flame/candle/candelabra/everburn,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"dX" = (
+/obj/effect/floor_decal/chapel{
+	dir = 1
+	},
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"dY" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"dZ" = (
+/obj/structure/bed/chair,
+/obj/effect/landmark/start{
+	name = "Chaplain"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"ea" = (
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"eb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"ec" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/nullrod,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/holywater,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"ed" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"ee" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"ef" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/item/weapon/flame/candle/candelabra/everburn,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"eg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/weapon/flame/candle/candelabra/everburn,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"eh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"ei" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"ej" = (
+/obj/effect/floor_decal/chapel{
+	dir = 8
+	},
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"ek" = (
+/obj/structure/cable/pink,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"el" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"em" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"en" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/shaft)
+"eo" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"ep" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"eq" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"er" = (
+/obj/effect/floor_decal/chapel,
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"es" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"et" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/wall,
+/area/chapel/main)
+"eu" = (
+/obj/machinery/door/airlock/glass{
+	name = "Chapel"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"ev" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/public_meeting_room)
+"ew" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "brig_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/window/brigdoor/southleft{
+	dir = 4;
+	id = "Cell 2";
+	name = "Cell 2";
+	req_access = list(2)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"ex" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/chapel/main)
+"ey" = (
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp{
+	pixel_y = 10
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"ez" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/weapon/pen/blue{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"eA" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/storage/fancy/crayons,
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/weapon/storage/fancy/candle_box,
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"eB" = (
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"eC" = (
+/obj/structure/closet/wardrobe/chaplain_black,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"eD" = (
+/obj/item/toy/figure/mime,
+/obj/item/clothing/head/soft/mime,
+/obj/item/clothing/mask/gas/mime,
+/obj/item/clothing/shoes/mime,
+/obj/item/clothing/under/mime,
+/obj/item/weapon/pen/crayon/mime,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/rust,
+/obj/structure/closet,
+/obj/random/contraband,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor,
+/area/chapel/chapel_morgue)
+"eE" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"eF" = (
+/obj/structure/stairs/north,
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"eG" = (
+/obj/machinery/computer/aiupload,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"eH" = (
+/obj/structure/cable/cyan{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers,
+/obj/machinery/atmospherics/pipe/zpipe/up/supply,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"eI" = (
+/obj/machinery/computer/borgupload,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"eJ" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_l"
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"eK" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"eL" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"eM" = (
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"eN" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"eO" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_r"
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"eQ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"eS" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/structure/sign/deathsposal{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"fc" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"fd" = (
+/turf/simulated/wall/r_wall,
+/area/security/interrogation)
+"fi" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"fj" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"fk" = (
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"fl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"fm" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 8
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"fn" = (
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock{
+	name = "Chapel Backroom Access";
+	req_access = newlist()
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"fo" = (
+/turf/simulated/wall,
+/area/chapel/main)
+"fp" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/machinery/camera/motion/security{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"fr" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"fs" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"ft" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"fv" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/supply{
+	dir = 8
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"fx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/engineering/shaft)
+"fy" = (
+/obj/structure/grille,
+/turf/simulated/mineral/floor/vacuum,
+/area/mine/explored/upper_level)
+"fB" = (
+/obj/structure/stairs/south,
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"fD" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"fI" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"fK" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/bed/chair,
+/turf/simulated/floor/tiled/dark,
+/area/security/interrogation)
+"fL" = (
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/interrogation)
+"fN" = (
+/obj/random/trash_pile,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"fO" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "chapel"
+	},
+/turf/simulated/floor/plating,
+/area/chapel/office)
+"fP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock{
+	name = "Chapel Office";
+	req_access = list(27)
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"fQ" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "chapel"
+	},
+/turf/simulated/floor/plating,
+/area/chapel/office)
+"fR" = (
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"fS" = (
+/obj/machinery/door/morgue{
+	dir = 2;
+	name = "Confession Booth"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"fU" = (
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"fV" = (
+/obj/machinery/porta_turret/ai_defense,
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"fW" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"fX" = (
+/turf/simulated/wall/r_wall,
+/area/engineering/locker_room)
+"fY" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Engineering Electrical Shaft";
+	req_one_access = list(10)
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/engineering/locker_room)
+"fZ" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "brig_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/window/brigdoor/southleft{
+	dir = 4;
+	id = "Cell 1";
+	name = "Cell 1";
+	req_access = list(2)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"ga" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"gb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/table/steel,
+/obj/item/device/flashlight/lamp,
+/turf/simulated/floor/tiled/dark,
+/area/security/interrogation)
+"gc" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/interrogation)
+"ge" = (
+/obj/effect/floor_decal/chapel{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"gf" = (
+/obj/effect/floor_decal/chapel{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"gg" = (
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"gh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	name = "Chapel";
+	sortType = "Chapel"
+	},
+/obj/effect/landmark/start{
+	name = "Chaplain"
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"gi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"gj" = (
+/obj/effect/floor_decal/chapel{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 2;
+	name = "light switch ";
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"gk" = (
+/obj/effect/floor_decal/chapel{
+	dir = 4
+	},
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"gl" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 4;
+	icon_state = "twindow"
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 8;
+	icon_state = "twindow"
+	},
+/turf/simulated/floor/plating,
+/area/chapel/main)
+"gm" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 10
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"gn" = (
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"go" = (
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"gp" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"gq" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"gr" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"gs" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 9
+	},
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/computer/cryopod{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"gt" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"gu" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"gv" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/engineering/locker_room)
+"gw" = (
+/turf/simulated/open,
+/area/engineering/locker_room)
+"gy" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"gE" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/interrogation)
+"gG" = (
+/obj/structure/cable/pink{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"gH" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/chapel/main)
+"gI" = (
+/obj/effect/floor_decal/chapel{
+	dir = 8
+	},
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/pink{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"gJ" = (
+/obj/effect/floor_decal/chapel,
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"gK" = (
+/obj/structure/table/woodentable,
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/pink{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"gL" = (
+/obj/structure/table/woodentable,
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"gM" = (
+/obj/structure/table/woodentable,
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"gN" = (
+/obj/effect/floor_decal/chapel{
+	dir = 8
+	},
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"gO" = (
+/obj/effect/floor_decal/chapel,
+/obj/structure/cable/pink{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"gP" = (
+/obj/machinery/door/morgue{
+	dir = 2;
+	name = "Confession Booth (Chaplain)";
+	req_access = list(22)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"gR" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Upload";
+	req_access = list(16);
+	req_one_access = list()
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"gS" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/vending/assist,
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"gT" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"gU" = (
+/obj/effect/floor_decal/corner_steel_grid,
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"gV" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"gW" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 1
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"gX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"gY" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"ha" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "chapel"
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 4;
+	icon_state = "twindow"
+	},
+/turf/simulated/floor,
+/area/security/interrogation)
+"hc" = (
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"hd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"he" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"hf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"hg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"hh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"hi" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"hj" = (
+/obj/machinery/ai_status_display{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/machinery/porta_turret/ai_defense,
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"hk" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/techfloor/hole{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"hl" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 5
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"hm" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/techfloor/hole/right{
+	dir = 1
+	},
+/obj/item/device/radio/intercom/locked/ai_private{
+	dir = 1;
+	icon_state = "intercom";
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"hn" = (
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/machinery/porta_turret/ai_defense,
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"ho" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table/reinforced,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"hp" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"hq" = (
+/obj/effect/floor_decal/corner_steel_grid{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"hr" = (
+/turf/simulated/wall,
+/area/maintenance/station/eng_upper)
+"hs" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/structure/railing,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"ht" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 9
+	},
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"hu" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"hv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"hw" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/interrogation)
+"hz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"hA" = (
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"hB" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"hD" = (
+/obj/structure/table/standard,
+/obj/item/weapon/aiModule/oxygen,
+/obj/item/weapon/aiModule/oneHuman,
+/obj/item/weapon/aiModule/purge,
+/obj/item/weapon/aiModule/antimov,
+/obj/item/weapon/aiModule/teleporterOffline,
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"hE" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"hF" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"hG" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"hH" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"hI" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"hJ" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"hK" = (
+/obj/structure/table/standard,
+/obj/item/weapon/aiModule/reset,
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"hL" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/random/maintenance/clean,
+/obj/random/powercell,
+/obj/item/device/t_scanner,
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"hM" = (
+/obj/effect/floor_decal/corner_steel_grid{
+	icon_state = "steel_grid";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"hN" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
+/turf/simulated/open,
+/area/engineering/locker_room)
+"hO" = (
+/obj/structure/railing,
+/turf/simulated/open,
+/area/engineering/locker_room)
+"hP" = (
+/obj/structure/railing,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/open,
+/area/engineering/locker_room)
+"hQ" = (
+/turf/simulated/wall/r_wall,
+/area/engineering/foyer_mezzenine)
+"hU" = (
+/obj/structure/stairs/west,
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"hV" = (
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"hW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"hY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/interrogation)
+"hZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/network/security{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/interrogation)
+"ia" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/interrogation)
+"id" = (
+/obj/effect/floor_decal/chapel{
+	dir = 8
+	},
+/obj/structure/cable/pink,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"ie" = (
+/obj/effect/floor_decal/chapel,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"if" = (
+/obj/effect/floor_decal/chapel{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"ig" = (
+/obj/effect/floor_decal/chapel,
+/obj/machinery/camera/network/civilian{
+	dir = 8
+	},
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"ih" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"ii" = (
+/obj/effect/floor_decal/techfloor/corner,
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"ij" = (
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Storage";
+	req_access = list(16);
+	req_one_access = list()
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"ik" = (
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"il" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"im" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"in" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"io" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"ip" = (
+/obj/structure/table/standard,
+/obj/item/weapon/aiModule/nanotrasen,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"iq" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table/reinforced,
+/obj/random/powercell,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"ir" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"is" = (
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"it" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"iu" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 10
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"iv" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"iw" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"iz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/security/riot_control)
+"iA" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"iC" = (
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"iD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"iH" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/lino,
+/area/chapel/office)
+"iM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"iQ" = (
+/obj/structure/table/standard,
+/obj/item/weapon/aiModule/asimov,
+/obj/item/weapon/aiModule/freeformcore,
+/obj/item/weapon/aiModule/corp,
+/obj/item/weapon/aiModule/paladin,
+/obj/item/weapon/aiModule/robocop,
+/obj/effect/floor_decal/techfloor{
+	dir = 10
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"iR" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/camera/network/command{
+	dir = 1
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"iS" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"iT" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"iU" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"iV" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"iW" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/camera/network/command{
+	dir = 1
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"iX" = (
+/obj/structure/table/standard,
+/obj/item/weapon/aiModule/freeform,
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"iY" = (
+/turf/simulated/wall,
+/area/vacant/vacant_office)
+"iZ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/table/reinforced,
+/obj/random/toolbox,
+/obj/item/device/geiger,
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"ja" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"jb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"jc" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Workshop";
+	req_one_access = list(10,24)
+	},
+/turf/simulated/floor/plating,
+/area/engineering/locker_room)
+"jd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"je" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"jf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"jg" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"jh" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance/sec{
+	name = "Riot Control";
+	req_one_access = list(1,10,24)
+	},
+/turf/simulated/floor/plating,
+/area/security/riot_control)
+"jj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"jl" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"jn" = (
+/obj/effect/floor_decal/chapel{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"jo" = (
+/obj/effect/floor_decal/chapel{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"jp" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/techfloor/hole/right,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"jq" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"jr" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/techfloor/hole,
+/obj/machinery/camera/network/command{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"js" = (
+/turf/simulated/floor,
+/area/vacant/vacant_office)
+"jt" = (
+/turf/simulated/floor/tiled/dark,
+/area/vacant/vacant_office)
+"jx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/vacant/vacant_office)
+"jA" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 10
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"jB" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/obj/structure/cable/green,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"jC" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"jD" = (
+/obj/structure/closet/wardrobe/engineering_yellow,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"jE" = (
+/obj/structure/closet/wardrobe/atmospherics_yellow,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"jF" = (
+/obj/structure/closet/secure_closet/atmos_personal,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
+"jG" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"jH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"jI" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"jJ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/yellow/bordercorner2,
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"jL" = (
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"jM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction/yjunction,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"jN" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"jO" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"jP" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/sec_lower)
+"jQ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/sec_lower)
+"jR" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/sec_lower)
+"jS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/sec_lower)
+"jX" = (
+/turf/simulated/wall/r_wall,
+/area/ai_server_room)
+"jY" = (
+/turf/simulated/wall/r_wall,
+/area/ai_upload_foyer)
+"jZ" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Upload";
+	req_access = list(16);
+	req_one_access = list()
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload_foyer)
+"ka" = (
+/obj/structure/sign/securearea,
+/turf/simulated/wall/r_wall,
+/area/ai_upload_foyer)
+"kb" = (
+/turf/simulated/wall/r_wall,
+/area/ai_cyborg_station)
+"kc" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/vacant/vacant_office)
+"kd" = (
+/obj/random/junk,
+/turf/simulated/floor,
+/area/vacant/vacant_office)
+"kf" = (
+/turf/simulated/wall,
+/area/engineering/foyer_mezzenine)
+"kg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"kh" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"ki" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"kj" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/station/eng_upper)
+"kk" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/station/sec_lower)
+"kl" = (
+/obj/structure/sign/department/chapel,
+/turf/simulated/wall,
+/area/chapel/main)
+"km" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/chapel/main)
+"kp" = (
+/obj/machinery/message_server,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_server_room)
+"kq" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_server_room)
+"kr" = (
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_server_room)
+"ks" = (
+/obj/machinery/turretid/stun{
+	control_area = "\improper AI Upload Chamber";
+	name = "AI Upload turret control";
+	pixel_x = 0;
+	pixel_y = 30
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload_foyer)
+"kt" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload_foyer)
+"ku" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload_foyer)
+"kv" = (
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_cyborg_station)
+"kw" = (
+/obj/structure/table/standard,
+/obj/item/weapon/phone,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_cyborg_station)
+"kx" = (
+/obj/machinery/computer/aifixer,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_cyborg_station)
+"kz" = (
+/obj/structure/table,
+/turf/simulated/floor,
+/area/vacant/vacant_office)
+"kC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/maintenance/engineering,
+/obj/random/tech_supply,
+/turf/simulated/floor,
+/area/vacant/vacant_office)
+"kD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/cap/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/vacant/vacant_office)
+"kF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/simulated/floor,
+/area/vacant/vacant_office)
+"kG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/turf/simulated/floor,
+/area/vacant/vacant_office)
+"kI" = (
+/turf/space/cracked_asteroid,
+/area/mine/explored/upper_level)
+"kJ" = (
+/turf/simulated/wall,
+/area/storage/tech)
+"kK" = (
+/turf/simulated/floor,
+/area/storage/tech)
+"kL" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"kM" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/device/analyzer/plant_analyzer,
+/obj/item/device/healthanalyzer,
+/obj/item/device/analyzer,
+/obj/item/device/analyzer,
+/turf/simulated/floor/plating,
+/area/storage/tech)
+"kN" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/circuitboard/autolathe,
+/obj/item/weapon/circuitboard/partslathe,
+/turf/simulated/floor,
+/area/storage/tech)
+"kO" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/unary_atmos/heater,
+/obj/item/weapon/circuitboard/unary_atmos/cooler{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/simulated/floor/plating,
+/area/storage/tech)
+"kP" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/storage/tech)
+"kQ" = (
+/obj/machinery/vending/assist,
+/turf/simulated/floor,
+/area/storage/tech)
+"kS" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"kT" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"kU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/rust,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"kV" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"kW" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"kX" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down,
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
+/obj/machinery/atmospherics/pipe/zpipe/down/supply,
+/obj/structure/lattice,
+/obj/structure/cable{
+	icon_state = "32-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/open,
+/area/maintenance/station/eng_upper)
+"kY" = (
+/turf/simulated/shuttle/wall/voidcraft/green{
+	hard_corner = 1
+	},
+/area/hallway/station/starboard)
+"kZ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/machinery/station_map{
+	pixel_y = 32
+	},
+/obj/machinery/status_display{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"la" = (
+/obj/machinery/camera/network/northern_star,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"lb" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"lc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/hallway/station/starboard)
+"ld" = (
+/turf/simulated/floor/carpet,
+/area/hallway/station/starboard)
+"le" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet,
+/area/hallway/station/starboard)
+"lf" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"lg" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 5
+	},
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"lh" = (
+/obj/machinery/computer/message_monitor{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_server_room)
+"li" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_server_room)
+"lj" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_server_room)
+"lk" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Messaging Server";
+	req_access = list(16);
+	req_one_access = list()
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_server_room)
+"ll" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload_foyer)
+"lm" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload_foyer)
+"ln" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Upload Access";
+	req_access = list(16);
+	req_one_access = list()
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_cyborg_station)
+"lo" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_cyborg_station)
+"lp" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_cyborg_station)
+"lq" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_cyborg_station)
+"ls" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor,
+/area/vacant/vacant_office)
+"lt" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"lu" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"lv" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"lw" = (
+/turf/simulated/wall/r_wall,
+/area/storage/tech)
+"lx" = (
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"ly" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/storage/tech)
+"lz" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/storage/tech)
+"lA" = (
+/obj/structure/table/steel,
+/obj/item/weapon/storage/bag/circuits/basic,
+/turf/simulated/floor,
+/area/storage/tech)
+"lB" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"lC" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"lD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/railing,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"lE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"lF" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"lG" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/maintenance/clean,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/cargo,
+/obj/random/junk,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"lH" = (
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/hallway/station/starboard)
+"lI" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"lJ" = (
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"lK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"lL" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"lM" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"lN" = (
+/obj/machinery/blackbox_recorder,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_server_room)
+"lO" = (
+/obj/machinery/camera/network/command{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_server_room)
+"lP" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_server_room)
+"lQ" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/camera/network/command{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload_foyer)
+"lR" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload_foyer)
+"lS" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/item/device/radio/intercom/locked/ai_private{
+	dir = 4;
+	icon_state = "intercom";
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload_foyer)
+"lT" = (
+/obj/structure/closet/crate{
+	name = "Camera Assembly Crate"
+	},
+/obj/item/weapon/camera_assembly,
+/obj/item/weapon/camera_assembly,
+/obj/item/weapon/camera_assembly,
+/obj/item/weapon/camera_assembly,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_cyborg_station)
+"lU" = (
+/obj/machinery/recharge_station,
+/obj/machinery/camera/network/command{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_cyborg_station)
+"lV" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_cyborg_station)
+"ma" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/vacant/vacant_office)
+"mb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/vacant/vacant_office)
+"md" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"me" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/robotics{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/weapon/circuitboard/mecha_control{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/storage/tech)
+"mf" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/storage/tech)
+"mg" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/apc;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"mh" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/storage/tech)
+"mi" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/weapon/circuitboard/transhuman_synthprinter{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/weapon/circuitboard/rdconsole{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/item/weapon/circuitboard/destructive_analyzer,
+/obj/item/weapon/circuitboard/protolathe{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/weapon/circuitboard/rdserver{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/storage/tech)
+"mj" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/security/mining{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/autolathe,
+/obj/item/weapon/circuitboard/scan_consolenew{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/storage/tech)
+"mk" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/arcade/orion_trail{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/jukebox{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/weapon/circuitboard/message_monitor{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/weapon/circuitboard/arcade/battle{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/turf/simulated/floor/plating,
+/area/storage/tech)
+"ml" = (
+/obj/structure/table/steel,
+/obj/item/device/integrated_electronics/debugger{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/item/device/integrated_electronics/wirer{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"mm" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"mn" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"mo" = (
+/obj/structure/sign/department/eng,
+/turf/simulated/wall,
+/area/engineering/foyer_mezzenine)
+"mp" = (
+/obj/structure/lattice,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/down{
+	dir = 1
+	},
+/turf/simulated/open,
+/area/maintenance/station/eng_upper)
+"mq" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"mr" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/rust,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"ms" = (
+/obj/machinery/atmospherics/pipe/zpipe/up/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "16-0"
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"mt" = (
+/obj/machinery/door/firedoor/glass/hidden/steel,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"mu" = (
+/obj/item/device/radio/beacon,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"mv" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"mw" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Upload Access";
+	req_access = list(16);
+	req_one_access = list()
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/ai_upload_foyer)
+"mx" = (
+/obj/structure/sign/department/ai,
+/turf/simulated/wall/r_wall,
+/area/ai_upload_foyer)
+"my" = (
+/obj/machinery/status_display,
+/turf/simulated/wall,
+/area/hallway/station/starboard)
+"mz" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/disposalpipe/segment,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "lawyer_blast"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/station/starboard)
+"mA" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "lawyer_blast"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/station/starboard)
+"mB" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass,
+/turf/simulated/floor/tiled/steel_grid,
+/area/hallway/station/starboard)
+"mC" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"mD" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/crew{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/weapon/circuitboard/card{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/weapon/circuitboard/communications{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/storage/tech)
+"mE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/storage/tech)
+"mF" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage";
+	req_access = list(19,23);
+	req_one_access = newlist()
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"mG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"mH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"mI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"mJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/storage/tech)
+"mK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"mL" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage";
+	req_access = list(23);
+	req_one_access = newlist()
+	},
+/turf/simulated/floor/plating,
+/area/storage/tech)
+"mM" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/open,
+/area/engineering/foyer_mezzenine)
+"mN" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/open,
+/area/engineering/foyer_mezzenine)
+"mO" = (
+/obj/structure/catwalk,
+/turf/simulated/open,
+/area/engineering/foyer_mezzenine)
+"mP" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"mQ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"mR" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"mS" = (
+/obj/random/junk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"mT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"mU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"mV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"mW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"mX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"mY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/computer/guestpass{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"mZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atm{
+	pixel_y = 30
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"na" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nb" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"ne" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"ng" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/northern_star,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"ni" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nk" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nl" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nm" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nn" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"no" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"np" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nq" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nr" = (
+/obj/structure/flora/pottedplant/stoutbush,
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"ns" = (
+/turf/simulated/wall,
+/area/hallway/station/starboard)
+"nt" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/borgupload{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/weapon/circuitboard/aiupload{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/weapon/circuitboard/transhuman_resleever{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/storage/tech)
+"nu" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/storage/tech)
+"nv" = (
+/obj/machinery/requests_console{
+	department = "Tech storage";
+	pixel_x = -28;
+	pixel_y = 0
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"nw" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/transhuman_clonepod{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/resleeving_control{
+	pixel_x = 0;
+	pixel_y = 1
+	},
+/obj/item/weapon/circuitboard/body_designer{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/weapon/circuitboard/med_data{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/storage/tech)
+"nx" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/secure_data{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/weapon/circuitboard/security{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/weapon/circuitboard/skills{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/storage/tech)
+"ny" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/powermonitor{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/stationalert_engineering{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/weapon/circuitboard/security/engineering{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/weapon/circuitboard/atmos_alert{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/storage/tech)
+"nz" = (
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"nA" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/open,
+/area/engineering/foyer_mezzenine)
+"nB" = (
+/obj/structure/disposalpipe/junction/yjunction,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"nC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"nD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"nE" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"nF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"nG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"nH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/up{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"nI" = (
+/obj/structure/sign/deck2,
+/turf/simulated/shuttle/wall/voidcraft/green{
+	hard_corner = 1
+	},
+/area/hallway/station/starboard)
+"nJ" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nK" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nM" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nR" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nS" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nU" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nV" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"nW" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"nX" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"nY" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"nZ" = (
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/storage/tech)
+"oa" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/storage/tech)
+"ob" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"oc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/storage/tech)
+"od" = (
+/obj/structure/table/steel,
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/stack/cable_coil,
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/storage/tech)
+"oe" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/open,
+/area/engineering/foyer_mezzenine)
+"of" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/open,
+/area/engineering/foyer_mezzenine)
+"og" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/open,
+/area/engineering/foyer_mezzenine)
+"oh" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"oi" = (
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"oj" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"ok" = (
+/obj/structure/railing,
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/maintenance/clean,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/cargo,
+/obj/random/junk,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"ol" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"om" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"on" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"oo" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"op" = (
+/obj/machinery/camera/network/northern_star{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"oq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"or" = (
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -32
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"os" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"ot" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"ou" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	icon_state = "extinguisher_closed";
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"ov" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"ow" = (
+/obj/machinery/camera/network/northern_star{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"ox" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"oy" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"oz" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"oA" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"oB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"oC" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"oD" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"oE" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"oF" = (
+/obj/machinery/light,
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"oG" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/device/multitool,
+/obj/item/clothing/glasses/meson,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/storage/tech)
+"oH" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/clothing/gloves/yellow,
+/obj/item/device/t_scanner,
+/obj/item/clothing/glasses/meson,
+/obj/item/device/multitool,
+/obj/machinery/ai_status_display{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/storage/tech)
+"oI" = (
+/obj/item/device/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/device/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/structure/table/steel,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor/plating,
+/area/storage/tech)
+"oJ" = (
+/obj/structure/table/steel,
+/obj/item/device/aicard,
+/obj/item/weapon/aiModule/reset,
+/turf/simulated/floor,
+/area/storage/tech)
+"oK" = (
+/obj/structure/table/steel,
+/obj/item/weapon/module/power_control,
+/obj/item/weapon/airlock_electronics,
+/obj/machinery/light/small,
+/turf/simulated/floor,
+/area/storage/tech)
+"oL" = (
+/obj/structure/table/steel,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/item/device/multitool,
+/turf/simulated/floor,
+/area/storage/tech)
+"oM" = (
+/turf/simulated/open,
+/area/engineering/foyer_mezzenine)
+"oN" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"oO" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/up,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"oP" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"oQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"oR" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/maintenance/clean,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/clean,
+/obj/random/junk,
+/obj/random/maintenance/engineering,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"oS" = (
+/obj/structure/closet,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/junk,
+/obj/random/tool,
+/obj/random/maintenance/security,
+/obj/random/maintenance/engineering,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"oT" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"oU" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"oV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"oW" = (
+/turf/simulated/wall/r_wall,
+/area/medical/virology)
+"oX" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/command,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"oY" = (
+/turf/simulated/wall/r_wall,
+/area/ai_monitored/storage/eva)
+"oZ" = (
+/obj/structure/grille,
+/obj/structure/sign/securearea,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/ai_monitored/storage/eva)
+"pa" = (
+/obj/machinery/door/airlock/glass_command{
+	id_tag = "evadoors";
+	name = "E.V.A.";
+	req_access = list();
+	req_one_access = list(18,19,43,67)
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_grid,
+/area/ai_monitored/storage/eva)
+"pb" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/window/reinforced/full,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/ai_monitored/storage/eva)
+"pc" = (
+/obj/machinery/door/airlock/glass_command{
+	id_tag = "evadoors";
+	name = "E.V.A.";
+	req_access = list();
+	req_one_access = list(18,19,43,67)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/ai_monitored/storage/eva)
+"pd" = (
+/turf/simulated/wall,
+/area/vacant/vacant_restaurant_upper)
+"pe" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"pf" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"pg" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/closet,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/medical,
+/obj/random/junk,
+/obj/random/medical/lite,
+/obj/random/tool,
+/obj/random/maintenance/security,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"ph" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"pi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"pj" = (
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/medical,
+/obj/random/junk,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"pk" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"pl" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"pm" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"pn" = (
+/obj/structure/bed/padded,
+/obj/machinery/camera/network/medbay{
+	c_tag = "MED - Virology Containment One";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"po" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"pp" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"pq" = (
+/obj/random/junk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/medical/virology)
+"pr" = (
+/obj/structure/closet/crate,
+/obj/random/contraband,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/medical/virology)
+"ps" = (
+/obj/random/junk,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/medical/virology)
+"pt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/medical/virology)
+"pu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/trash_pile,
+/turf/simulated/floor,
+/area/medical/virology)
+"pv" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"pw" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/void/medical,
+/obj/item/clothing/head/helmet/space/void/medical,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"px" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/ai_monitored/storage/eva)
+"py" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/requests_console{
+	department = "EVA";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"pz" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"pA" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control switch for exiting EVA.";
+	id = "evadoors";
+	name = "EVA Door Control";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "EVA - Fore"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"pB" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"pC" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"pD" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/ai_monitored/storage/eva)
+"pE" = (
+/obj/structure/table/rack,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/void/security,
+/obj/item/clothing/head/helmet/space/void/security,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"pF" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"pG" = (
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"pH" = (
+/obj/effect/floor_decal/rust,
+/obj/item/frame/apc,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"pI" = (
+/obj/effect/floor_decal/rust,
+/obj/random/cigarettes,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"pJ" = (
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"pK" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/engineering/foyer_mezzenine)
+"pL" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Engineering Mezzenine";
+	req_one_access = list()
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/foyer_mezzenine)
+"pM" = (
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Engineering Mezzenine";
+	req_one_access = list()
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/foyer_mezzenine)
+"pN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"pO" = (
+/turf/simulated/wall/r_wall,
+/area/hallway/station/port)
+"pP" = (
+/obj/machinery/vending/snack,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"pQ" = (
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/machinery/vending/nifsoft_shop,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"pR" = (
+/obj/machinery/vending/coffee,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"pS" = (
+/turf/simulated/wall/r_wall,
+/area/hallway/station/starboard)
+"pT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"pU" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"pV" = (
+/obj/structure/table/standard,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"pW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"pX" = (
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"pY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"pZ" = (
+/turf/simulated/wall/r_wall,
+/area/medical/virologyisolation)
+"qa" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"qb" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"qc" = (
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"qd" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medical Hardsuits";
+	req_one_access = list(5)
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"qe" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"qf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"qg" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"qh" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"qi" = (
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Hardsuits";
+	req_access = list(1)
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"qj" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"qk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"ql" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"qm" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"qn" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/hallway/station/port)
+"qo" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"qp" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"qq" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"qr" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"qs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"qt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"qu" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"qv" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/computer/guestpass{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"qw" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"qx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"qy" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"qz" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/camera/network/northern_star,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"qA" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"qB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"qC" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"qD" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"qE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"qF" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"qG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"qH" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/medical/virology)
+"qI" = (
+/obj/machinery/door/window/westright{
+	name = "Virology Isolation Room One";
+	icon_state = "right";
+	dir = 1;
+	req_access = list(39)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"qJ" = (
+/obj/machinery/door/window/westright{
+	dir = 1;
+	icon_state = "right";
+	name = "Virology Isolation Room Two";
+	req_access = list(39)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"qK" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/green,
+/obj/machinery/camera/network/medbay{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"qL" = (
+/obj/machinery/light_switch{
+	dir = 2;
+	name = "light switch ";
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"qM" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"qN" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"qO" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"qP" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/shoes/white,
+/obj/item/clothing/shoes/white,
+/obj/item/clothing/shoes/white,
+/obj/item/clothing/shoes/white,
+/obj/item/clothing/shoes/white,
+/obj/item/clothing/shoes/white,
+/obj/item/clothing/shoes/white,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"qQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/dispenser/oxygen,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"qR" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"qS" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"qT" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"qU" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/structure/table/rack,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"qV" = (
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"qW" = (
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"qX" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"qY" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"qZ" = (
+/obj/machinery/atmospherics/pipe/cap/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"ra" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/cap/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"rb" = (
+/obj/structure/disposalpipe/broken{
+	icon_state = "pipe-b";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"rc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"rd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_grid,
+/area/hallway/station/port)
+"re" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rg" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"ri" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rj" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rn" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"ro" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"rq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"rr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"rs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"rt" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"ru" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"rv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/weapon/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = 29
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"rw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"rx" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"ry" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/green,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"rz" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"rA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"rB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"rC" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"rD" = (
+/obj/structure/reagent_dispensers/water_cooler/full,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"rE" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"rF" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/weapon/rig/eva/equipped,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"rG" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/void/atmos,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/head/helmet/space/void/atmos,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"rH" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"rI" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"rJ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"rK" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"rL" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/ai_monitored/storage/eva)
+"rM" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/head/helmet/space/skrell/black,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/suit/space/skrell/black,
+/obj/item/clothing/head/helmet/space/skrell/white,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/suit/space/skrell/white,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"rN" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/rig/breacher,
+/obj/item/clothing/mask/breath,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"rO" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rP" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rQ" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rR" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rS" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rU" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/network/northern_star{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	icon_state = "extinguisher_closed";
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"rZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2,
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"sa" = (
+/obj/machinery/light,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"sb" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"sc" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"sd" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"se" = (
+/obj/structure/flora/pottedplant/stoutbush,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"sf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"sg" = (
+/obj/machinery/disease2/diseaseanalyser,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"sh" = (
+/obj/machinery/light,
+/obj/machinery/computer/centrifuge,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"si" = (
+/obj/machinery/disease2/incubator,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"sj" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/monkeycubes,
+/obj/item/weapon/extinguisher,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"sk" = (
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"sl" = (
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"sm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"sn" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"so" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/cups,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"sp" = (
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Engineering Hardsuits";
+	req_one_access = list(11,24)
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"sq" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/camera/network/security{
+	dir = 8
+	},
+/obj/item/stack/material/glass/reinforced{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"sr" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/ai_monitored/storage/eva)
+"ss" = (
+/obj/random/junk,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"st" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"su" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/vacant/vacant_restaurant_upper)
+"sv" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/open,
+/area/vacant/vacant_restaurant_upper)
+"sw" = (
+/turf/simulated/wall,
+/area/tether/station/stairs_two)
+"sx" = (
+/obj/structure/sign/directions/engineering{
+	dir = 1;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/elevator{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/tether/station/stairs_two)
+"sy" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"sz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"sA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"sB" = (
+/turf/simulated/wall,
+/area/maintenance/station/micro)
+"sC" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/station/micro)
+"sD" = (
+/turf/simulated/wall,
+/area/maintenance/substation/medical)
+"sE" = (
+/turf/simulated/wall,
+/area/medical/virology)
+"sF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"sG" = (
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/structure/sign/deathsposal{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"sH" = (
+/obj/machinery/computer/diseasesplicer{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"sI" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"sJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"sK" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Virology Laboratory";
+	req_access = list(39)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"sL" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"sM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"sN" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"sO" = (
+/obj/structure/table/standard,
+/obj/item/weapon/soap/nanotrasen,
+/obj/machinery/camera/network/medbay{
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"sP" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/status_display{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"sQ" = (
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"sR" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"sS" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/material/plasteel{
+	amount = 10
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"sT" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/ai_monitored/storage/eva)
+"sU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"sV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"sW" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1;
+	icon_state = "map"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"sX" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"sY" = (
+/obj/item/stack/material/wood{
+	amount = 10
+	},
+/obj/structure/table,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"sZ" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/table/woodentable,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"ta" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/vacant/vacant_restaurant_upper)
+"tb" = (
+/turf/simulated/open,
+/area/vacant/vacant_restaurant_upper)
+"tc" = (
+/turf/simulated/floor,
+/area/tether/station/stairs_two)
+"td" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/open,
+/area/tether/station/stairs_two)
+"te" = (
+/turf/simulated/open,
+/area/tether/station/stairs_two)
+"tf" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"tg" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/photocopier/faxmachine{
+	department = "Public Meeting Room"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/public_meeting_room)
+"th" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/station/micro)
+"ti" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/station/micro)
+"tj" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/engineering{
+	name = "Medbay Substation";
+	req_one_access = list(11,24,5)
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/medical)
+"tk" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/medical)
+"tl" = (
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "Medical Substation Bypass"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/medical)
+"tm" = (
+/obj/structure/closet,
+/obj/random/maintenance/medical,
+/obj/random/contraband,
+/obj/random/maintenance/research,
+/obj/random/maintenance/medical,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/medical/virology)
+"tn" = (
+/obj/machinery/smartfridge/secure/virology,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"to" = (
+/obj/machinery/light_switch{
+	dir = 2;
+	name = "light switch ";
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"tp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"tq" = (
+/obj/machinery/disease2/isolator,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"tr" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer/centrifuge,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"ts" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"tt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"tu" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"tv" = (
+/obj/item/weapon/stool/padded,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"tw" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"tx" = (
+/obj/machinery/suit_cycler/security{
+	req_access = null
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"ty" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/device/radio/off,
+/obj/item/device/radio/off,
+/obj/item/device/radio/off,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"tz" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"tA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"tB" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"tC" = (
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_x = -3
+	},
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"tD" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/cable/green,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/ai_monitored/storage/eva)
+"tE" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"tF" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"tG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/powercell,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"tH" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/turf/simulated/open,
+/area/vacant/vacant_restaurant_upper)
+"tI" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"tJ" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"tK" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/station/micro)
+"tL" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/station/micro)
+"tM" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/substation/medical)
+"tN" = (
+/obj/machinery/power/smes/buildable{
+	charge = 0;
+	RCon_tag = "Substation - Medical"
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/medical)
+"tO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/medical/virology)
+"tP" = (
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/newscaster{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"tQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"tR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"tS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"tT" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"tU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"tV" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/lockbox/vials,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/machinery/requests_console{
+	department = "Virology";
+	name = "Virology Requests Console";
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"tW" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"tX" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"tY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"tZ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"ua" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"ub" = (
+/obj/structure/table/standard,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"uc" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"ud" = (
+/obj/machinery/suit_cycler/medical{
+	req_access = null
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"ue" = (
+/obj/machinery/door/airlock/glass_command{
+	name = "E.V.A. Cycler Access";
+	req_one_access = list(18)
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"uf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"ug" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"uh" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"ui" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_command{
+	name = "E.V.A.";
+	req_one_access = newlist()
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"uj" = (
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"uk" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"ul" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"um" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"un" = (
+/obj/structure/stairs/north,
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"uo" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"up" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"uq" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/station/micro)
+"ur" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/station/micro)
+"us" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/engineering{
+	name = "Medbay Substation";
+	req_one_access = list(11,24,5)
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/medical)
+"ut" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/substation/medical)
+"uu" = (
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Medbay Subgrid";
+	name_tag = "Medbay Subgrid"
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/medical)
+"uv" = (
+/obj/structure/closet/crate,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/research,
+/obj/random/maintenance/medical,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/medical/virology)
+"uw" = (
+/obj/structure/table/glass,
+/obj/item/device/antibody_scanner{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/device/antibody_scanner,
+/obj/structure/reagent_dispensers/virusfood{
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"ux" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"uy" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"uz" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/fancy/vials,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"uA" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/camera/network/medbay{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"uB" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 5;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"uC" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"uD" = (
+/obj/machinery/computer/arcade,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"uE" = (
+/obj/machinery/suit_cycler/engineering{
+	req_access = null
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"uF" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/ai_monitored/storage/eva)
+"uG" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/welding,
+/obj/item/weapon/storage/belt/utility,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/camera/network/command{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"uH" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"uI" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/ai_monitored/storage/eva)
+"uJ" = (
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"uK" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "eva_port_airlock";
+	name = "interior access button";
+	pixel_x = 26;
+	pixel_y = 26;
+	req_one_access = list(18)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"uL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "eva_port_inner";
+	locked = 1;
+	name = "EVA Internal Access";
+	req_access = list(18)
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"uM" = (
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	frequency = 1379;
+	id_tag = "eva_port_airlock";
+	name = "Airlock Console";
+	pixel_y = 30;
+	req_access = list(18);
+	tag_airpump = "eva_port_pump";
+	tag_chamber_sensor = "eva_port_sensor";
+	tag_exterior_door = "eva_port_outer";
+	tag_interior_door = "eva_port_inner"
+	},
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"uN" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1379;
+	id_tag = "eva_port_pump"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1379;
+	id_tag = "eva_port_sensor";
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"uO" = (
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "eva_port_outer";
+	locked = 1;
+	name = "EVA External Access"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "eva_port_airlock";
+	name = "exterior access button";
+	pixel_x = 4;
+	pixel_y = -26;
+	req_access = list(18)
+	},
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"uP" = (
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"uQ" = (
+/obj/structure/sign/deck2,
+/turf/simulated/wall,
+/area/tether/station/stairs_two)
+"uR" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"uS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"uT" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"uU" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
+/obj/effect/floor_decal/rust,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/station/micro)
+"uV" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/station/micro)
+"uW" = (
+/turf/simulated/wall,
+/area/medical/morgue)
+"uX" = (
+/turf/simulated/wall/r_wall,
+/area/medical/morgue)
+"uY" = (
+/obj/structure/table/glass,
+/obj/item/weapon/folder/white,
+/obj/item/weapon/hand_labeler,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/obj/item/device/radio{
+	pixel_x = -4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"uZ" = (
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/obj/item/device/radio{
+	anchored = 1;
+	broadcasting = 0;
+	canhear_range = 7;
+	frequency = 1487;
+	icon = 'icons/obj/items.dmi';
+	icon_state = "red_phone";
+	listening = 1;
+	name = "Virology Emergency Phone";
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"va" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"vb" = (
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -32
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/closet/crate/freezer,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"vc" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/masks,
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"vd" = (
+/obj/item/weapon/storage/box/syringes{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/beakers,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/structure/table/glass,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"ve" = (
+/turf/simulated/wall/r_wall,
+/area/medical/virologyaccess)
+"vf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/turf/simulated/wall/r_wall,
+/area/medical/virologyaccess)
+"vg" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"vh" = (
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/structure/sign/deathsposal{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"vi" = (
+/obj/machinery/suit_cycler/mining{
+	req_access = null
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"vj" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/device/multitool,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"vk" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"vl" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/obj/item/clothing/shoes/magboots,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"vm" = (
+/obj/random/toolbox,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"vn" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"vo" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"vp" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"vq" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"vr" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"vs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/monofloor{
+	dir = 1
+	},
+/area/tether/station/stairs_two)
+"vt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"vu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"vv" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"vw" = (
+/obj/structure/closet,
+/obj/random/maintenance/medical,
+/obj/random/junk,
+/obj/random/tool,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/station/micro)
+"vx" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/station/micro)
+"vy" = (
+/obj/structure/morgue{
+	dir = 2
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/unsimulated/floor/techfloor_grid,
+/area/medical/morgue)
+"vz" = (
+/obj/structure/morgue{
+	dir = 2
+	},
+/obj/machinery/camera/network/medbay{
+	c_tag = "MED - Morgue North"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/unsimulated/floor/techfloor_grid,
+/area/medical/morgue)
+"vA" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Virology Laboratory";
+	req_access = list(39)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"vB" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 6;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"vC" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/tvalve/bypass,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/virologyaccess)
+"vD" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/medical/virologyaccess)
+"vE" = (
+/obj/machinery/door/airlock/medical{
+	autoclose = 0;
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "virologyq_airlock_exterior";
+	locked = 1;
+	name = "Virology Quarantine Airlock";
+	req_access = list(39)
+	},
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "virologyq_airlock_control";
+	name = "Virology Quarantine Access Button";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_access = list(39)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"vF" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"vG" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"vH" = (
+/obj/structure/table/reinforced,
+/obj/item/device/assembly/signaler,
+/obj/item/device/assembly/signaler,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"vI" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"vJ" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/camera/network/command{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"vK" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/cable/green,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"vL" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
+"vM" = (
+/obj/machinery/light,
+/turf/simulated/open,
+/area/vacant/vacant_restaurant_upper)
+"vN" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"vO" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"vP" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"vQ" = (
+/obj/machinery/camera/network/northern_star{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"vR" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2;
+	name = "Stairwell"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central1,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/monofloor,
+/area/tether/station/stairs_two)
+"vS" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
+"vT" = (
+/turf/simulated/wall,
+/area/medical/biostorage)
+"vU" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance/medical{
+	req_access = list(5)
+	},
+/turf/simulated/floor/plating,
+/area/medical/biostorage)
+"vV" = (
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"vW" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"vX" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"vY" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"vZ" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"wa" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/unsimulated/floor/techfloor_grid,
+/area/medical/morgue)
+"wb" = (
+/obj/structure/sign/nosmoking_1,
+/turf/simulated/wall/r_wall,
+/area/medical/virologyaccess)
+"wc" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/closet/l3closet/virology,
+/obj/item/clothing/mask/gas,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wd" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"we" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wf" = (
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wg" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wh" = (
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wi" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wj" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	id_tag = "virologyq_airlock_control";
+	name = "Virology Quarantine Access Console";
+	pixel_x = 22;
+	pixel_y = 0;
+	tag_exterior_door = "virologyq_airlock_exterior";
+	tag_interior_door = "virologyq_airlock_interior"
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wk" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "virologyq_airlock_control";
+	name = "Virology Quarantine Access Button";
+	pixel_x = -28;
+	pixel_y = 0;
+	req_access = list(39)
+	},
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wl" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wm" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/structure/closet/l3closet/virology,
+/obj/machinery/camera/network/medbay{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wn" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"wo" = (
+/turf/simulated/wall/r_wall,
+/area/bridge/meeting_room)
+"wp" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_restaurant_upper)
+"wq" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/obj/item/clothing/accessory/stethoscope,
+/obj/item/clothing/accessory/stethoscope,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/obj/item/clothing/accessory/stethoscope,
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"wr" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/roller,
+/obj/item/roller{
+	pixel_y = 8
+	},
+/obj/item/roller{
+	pixel_y = 16
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"ws" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"wt" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"wu" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"wv" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/machinery/door/airlock/medical{
+	name = "Morgue";
+	req_access = list(6)
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/morgue)
+"ww" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 9
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"wx" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"wy" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"wz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"wA" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"wB" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"wC" = (
+/obj/structure/morgue{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/unsimulated/floor/techfloor_grid,
+/area/medical/morgue)
+"wD" = (
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	id_tag = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_x = 8;
+	pixel_y = -22;
+	tag_exterior_door = "virology_airlock_exterior";
+	tag_interior_door = "virology_airlock_interior"
+	},
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wE" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	dir = 2
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wF" = (
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for shutters.";
+	id = "virologyquar";
+	name = "Virology Emergency Lockdown Control";
+	pixel_x = 0;
+	pixel_y = -28;
+	req_access = list(5)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wG" = (
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wH" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wI" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wJ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wK" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wL" = (
+/obj/machinery/door/airlock/medical{
+	autoclose = 0;
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "virologyq_airlock_interior";
+	locked = 1;
+	name = "Virology Quarantine Airlock";
+	req_access = list(39)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wM" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wN" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wO" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"wP" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"wQ" = (
+/obj/structure/table/woodentable,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/obj/machinery/computer/guestpass{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"wR" = (
+/obj/structure/table/woodentable,
+/obj/machinery/chemical_dispenser/bar_soft/full,
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"wS" = (
+/obj/structure/table/woodentable,
+/obj/machinery/photocopier/faxmachine{
+	department = "Command Conf Room"
+	},
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"wT" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"wU" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"wV" = (
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"wW" = (
+/obj/machinery/atm{
+	pixel_y = 30
+	},
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"wX" = (
+/obj/structure/flora/pottedplant,
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"wY" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/bridge/meeting_room)
+"wZ" = (
+/obj/machinery/atmospherics/unary/freezer{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/steel,
+/area/medical/biostorage)
+"xa" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay,
+/obj/machinery/alarm{
+	frequency = 1441;
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"xb" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/structure/table/rack,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/bodybag/cryobag{
+	pixel_x = -3
+	},
+/obj/item/bodybag/cryobag{
+	pixel_x = -3
+	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"xc" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/belt/medical,
+/obj/item/weapon/storage/belt/medical,
+/obj/item/weapon/storage/belt/medical,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 1
+	},
+/obj/item/weapon/storage/belt/medical,
+/obj/item/weapon/storage/belt/medical,
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"xd" = (
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"xe" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"xf" = (
+/obj/structure/window/basic{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"xg" = (
+/obj/structure/sign/department/morgue,
+/turf/simulated/wall,
+/area/medical/morgue)
+"xh" = (
+/obj/structure/filingcabinet/chestdrawer{
+	desc = "A large drawer filled with autopsy reports.";
+	name = "Autopsy Reports"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"xi" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"xj" = (
+/obj/structure/table/steel,
+/obj/item/weapon/autopsy_scanner,
+/obj/item/weapon/surgical/scalpel,
+/obj/item/weapon/surgical/cautery,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"xk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"xl" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"xm" = (
+/obj/machinery/door/airlock/medical{
+	autoclose = 0;
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "virology_airlock_interior";
+	locked = 1;
+	name = "Virology Interior Airlock";
+	req_access = list(39)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"xn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/wall/r_wall,
+/area/medical/virologyaccess)
+"xo" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/structure/closet/l3closet/virology,
+/obj/machinery/camera/network/medbay{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"xp" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"xq" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/structure/closet/secure_closet/personal/patient,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"xr" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"xs" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/storage/box/cups,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"xt" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"xu" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
+/turf/simulated/floor/tiled/steel,
+/area/medical/biostorage)
+"xv" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"xw" = (
+/obj/structure/stairs/south,
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"xx" = (
+/obj/structure/table/steel,
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/storage/box/bodybags{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"xy" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"xz" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"xA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"xB" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"xC" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/structure/closet/wardrobe/virology_white,
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = 8;
+	pixel_y = 28;
+	req_access = list(39)
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"xD" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"xE" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/machinery/shower{
+	dir = 8;
+	icon_state = "shower";
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 9;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/medical/virologyaccess)
+"xF" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/station/medbay)
+"xG" = (
+/obj/structure/cable/green{
+	icon_state = "16-0"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/medbay)
+"xH" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor,
+/area/maintenance/station/medbay)
+"xI" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/maintenance/medical,
+/obj/random/junk,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor,
+/area/maintenance/station/medbay)
+"xJ" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance/command{
+	req_access = list(19)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/bridge/meeting_room)
+"xK" = (
+/obj/structure/table/woodentable,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Command Meeting Room West";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"xL" = (
+/obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/bridge/meeting_room)
+"xM" = (
+/obj/structure/bed/chair/comfy/black,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/bridge/meeting_room)
+"xN" = (
+/turf/simulated/floor/carpet/sblucarpet,
+/area/bridge/meeting_room)
+"xO" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
+/turf/simulated/floor/tiled/steel,
+/area/medical/biostorage)
+"xP" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"xQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"xR" = (
+/obj/machinery/atmospherics/pipe/zpipe/up{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"xS" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/adv{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/firstaid/adv,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"xT" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/green/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"xU" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"xV" = (
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/obj/structure/closet/crate{
+	icon_state = "crate";
+	name = "Grenade Crate";
+	opened = 0
+	},
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/timer,
+/obj/item/device/assembly/timer,
+/obj/item/device/assembly/timer,
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"xW" = (
+/obj/structure/sign/nosmoking_1,
+/turf/simulated/wall,
+/area/medical/morgue)
+"xX" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"xY" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"xZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"ya" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"yb" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/closet/l3closet/virology,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"yc" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"yd" = (
+/obj/structure/table/steel,
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 8
+	},
+/obj/random/medical,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"ye" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/maintenance/station/medbay)
+"yf" = (
+/obj/structure/ladder/up,
+/turf/simulated/floor,
+/area/maintenance/station/medbay)
+"yg" = (
+/turf/simulated/floor,
+/area/maintenance/station/medbay)
+"yh" = (
+/turf/simulated/open,
+/area/bridge/meeting_room)
+"yi" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/turf/simulated/floor/tiled,
+/area/bridge/meeting_room)
+"yj" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/meeting_room)
+"yk" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/meeting_room)
+"yl" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/meeting_room)
+"ym" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"yn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"yo" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Command Secretary"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/bridge/meeting_room)
+"yp" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/book/manual/security_space_law,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/bridge/meeting_room)
+"yq" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/folder/red,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/bridge/meeting_room)
+"yr" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Command Secretary"
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/bridge/meeting_room)
+"ys" = (
+/obj/machinery/camera/network/command{
+	c_tag = "Command Meeting Room East";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"yt" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/item/weapon/tool/wrench,
+/turf/simulated/floor/tiled/steel,
+/area/medical/biostorage)
+"yu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"yv" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"yw" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/o2{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/firstaid/o2{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/full,
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"yx" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/fire{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/firstaid/fire{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/yellow/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"yy" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/weapon/soap/nanotrasen,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"yz" = (
+/obj/structure/table/steel,
+/obj/item/weapon/paper_bin{
+	pixel_y = 0
+	},
+/obj/item/weapon/pen/red{
+	pixel_x = -1;
+	pixel_y = -3
+	},
+/obj/item/weapon/pen/blue{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/item/device/camera{
+	name = "Autopsy Camera";
+	pixel_x = -2;
+	pixel_y = 7
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"yA" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/techfloor,
+/obj/item/device/sleevemate,
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"yB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10
+	},
+/obj/effect/floor_decal/techfloor/corner,
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"yC" = (
+/obj/structure/table/steel,
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"yD" = (
+/obj/structure/table/steel,
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"yE" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
+"yF" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/structure/closet/l3closet/virology,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"yG" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"yH" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"yI" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/medbay)
+"yJ" = (
+/obj/random/trash_pile,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/medbay)
+"yK" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/meeting_room)
+"yL" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/meeting_room)
+"yM" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/bridge/meeting_room)
+"yN" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/meeting_room)
+"yO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"yP" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/bridge/meeting_room)
+"yQ" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/bridge/meeting_room)
+"yR" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/folder/blue,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/bridge/meeting_room)
+"yS" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/bridge/meeting_room)
+"yT" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 8
+	},
+/obj/structure/table/standard,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"yU" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/weapon/soap/nanotrasen,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"yV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 1
+	},
+/obj/machinery/door/airlock/medical{
+	name = "Morgue";
+	req_access = list(6)
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/morgue)
+"yW" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = -24;
+	pixel_y = 0;
+	req_access = list(39)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "virologyquar";
+	name = "Virology Emergency Quarantine Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/medical{
+	autoclose = 0;
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "virology_airlock_exterior";
+	locked = 1;
+	name = "Virology Exterior Airlock";
+	req_access = list(39)
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
+"yX" = (
+/obj/structure/sign/department/virology,
+/turf/simulated/wall/r_wall,
+/area/medical/virologyaccess)
+"yY" = (
+/turf/simulated/wall/r_wall,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"yZ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance/medical,
+/turf/simulated/floor,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"za" = (
+/turf/simulated/wall,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zb" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance/command{
+	req_access = list(19)
+	},
+/turf/simulated/floor,
+/area/bridge/meeting_room)
+"zc" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/bridge/meeting_room)
+"zd" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/structure/table/standard,
+/obj/item/clothing/gloves/sterile/nitrile,
+/obj/item/clothing/gloves/sterile/nitrile,
+/obj/item/device/defib_kit/loaded,
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"ze" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/syringes{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/syringes,
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"zf" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/table/standard,
+/obj/structure/bedsheetbin,
+/obj/item/device/sleevemate,
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"zg" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/beakers,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -32
+	},
+/obj/item/weapon/cane,
+/obj/item/weapon/cane,
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"zh" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/masks{
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"zi" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"zj" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/table/standard,
+/obj/random/medical,
+/obj/random/medical,
+/obj/item/device/flashlight,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/paleblue/bordercorner2,
+/obj/item/device/radio{
+	pixel_x = -4
+	},
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"zk" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/obj/item/weapon/gun/launcher/syringe,
+/obj/item/weapon/storage/box/syringegun,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/turf/simulated/floor/tiled,
+/area/medical/biostorage)
+"zl" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zm" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zn" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 4;
+	name = "Morgue";
+	sortType = "Morgue"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zo" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zp" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/hidden{
+	icon_state = "door_open";
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zq" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zr" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zs" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay,
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zt" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zu" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zv" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zw" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zx" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zy" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zz" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance/medical,
+/turf/simulated/floor,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/bridge/meeting_room)
+"zB" = (
+/obj/structure/lattice,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "32-4"
+	},
+/turf/simulated/open,
+/area/bridge/meeting_room)
+"zC" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/bridge/meeting_room)
+"zD" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/bridge/meeting_room)
+"zE" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/bridge/meeting_room)
+"zF" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/bridge/meeting_room)
+"zG" = (
+/obj/structure/table/woodentable,
+/obj/structure/flora/pottedplant/small{
+	pixel_y = 12
+	},
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"zH" = (
+/obj/machinery/photocopier,
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"zI" = (
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/structure/table/woodentable,
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"zJ" = (
+/obj/machinery/light,
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"zK" = (
+/obj/machinery/light_switch{
+	pixel_y = -26
+	},
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
+"zL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medbay Equipment";
+	req_access = list(5)
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/turf/simulated/floor/tiled/white,
+/area/medical/biostorage)
+"zM" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zN" = (
+/obj/effect/floor_decal/borderfloorwhite/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zO" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zP" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	icon_state = "extinguisher_closed";
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zQ" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/hidden{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zR" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zT" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/paleblue/bordercorner2,
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zU" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zV" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zW" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zX" = (
+/obj/effect/floor_decal/borderfloorwhite/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zY" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"zZ" = (
+/turf/simulated/wall,
+/area/bridge/meeting_room)
+"Aa" = (
+/obj/machinery/vending/coffee,
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Ab" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Ac" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Ad" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Ae" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Af" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Ag" = (
+/obj/effect/floor_decal/borderfloorwhite/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Ah" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Ai" = (
+/turf/simulated/wall,
+/area/medical/medbay_emt_bay)
+"Aj" = (
+/obj/structure/sign/nosmoking_1,
+/turf/simulated/wall,
+/area/medical/medbay_emt_bay)
+"Ak" = (
+/obj/machinery/door/window/northleft{
+	req_one_access = list(5)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"Al" = (
+/obj/machinery/door/window/northright{
+	req_one_access = list(5)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"Am" = (
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"An" = (
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Ao" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Ap" = (
+/obj/machinery/vending/medical,
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Aq" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Ar" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"As" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"At" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 9
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Au" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Av" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/paleblue/bordercorner2,
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Aw" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/structure/closet/l3closet/medical,
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Ax" = (
+/obj/machinery/suit_cycler/medical,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"Ay" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"Az" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"AA" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"AB" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"AC" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/item/device/multitool,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/device/radio{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/item/device/radio{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/item/device/defib_kit/compact/loaded,
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"AD" = (
+/obj/structure/stairs/south,
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"AE" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"AF" = (
+/turf/simulated/floor/airless{
+	icon_state = "asteroidplating2"
+	},
+/area/medical/virologyaccess)
+"AG" = (
+/turf/simulated/wall,
+/area/crew_quarters/medbreak)
+"AH" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/crew_quarters/medbreak)
+"AI" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 1
+	},
+/obj/machinery/door/airlock/glass_medical{
+	name = "Staff Room";
+	req_access = list(5)
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"AJ" = (
+/obj/structure/table/rack,
+/obj/item/device/suit_cooling_unit{
+	pixel_y = -5
+	},
+/obj/item/weapon/tank/oxygen{
+	pixel_y = -4
+	},
+/obj/item/device/suit_cooling_unit{
+	pixel_y = -5
+	},
+/obj/item/weapon/tank/oxygen{
+	pixel_y = -4
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"AK" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"AL" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"AM" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"AN" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"AO" = (
+/obj/structure/table/rack,
+/obj/item/weapon/rig/medical/equipped,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"AP" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"AQ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"AR" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"AS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/airless{
+	icon_state = "asteroidplating2"
+	},
+/area/medical/virologyaccess)
+"AT" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/turf/simulated/floor/airless{
+	icon_state = "asteroidplating2"
+	},
+/area/medical/virologyaccess)
+"AU" = (
+/turf/simulated/wall,
+/area/crew_quarters/medical_restroom)
+"AV" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/flora/pottedplant,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"AW" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/sink{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"AX" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"AY" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"AZ" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Ba" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/light_switch{
+	dir = 2;
+	name = "light switch ";
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Bb" = (
+/obj/machinery/vending/fitness,
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Bc" = (
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/void/medical/emt,
+/obj/item/clothing/head/helmet/space/void/medical/emt,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/item/clothing/mask/breath,
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"Bd" = (
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"Be" = (
+/obj/structure/closet/secure_closet/paramedic,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"Bf" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Bg" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Bh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/airless{
+	icon_state = "asteroidplating2"
+	},
+/area/medical/virologyaccess)
+"Bi" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 140;
+	external_pressure_bound_default = 140;
+	icon_state = "map_vent_out";
+	pressure_checks = 1;
+	pressure_checks_default = 1;
+	use_power = 1
+	},
+/turf/simulated/floor/airless{
+	icon_state = "asteroidplating2"
+	},
+/area/medical/virologyaccess)
+"Bj" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	pixel_y = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"Bk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"Bl" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"Bm" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/medical_restroom)
+"Bn" = (
+/obj/machinery/washing_machine,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Bo" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Bp" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Bq" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Br" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Bs" = (
+/obj/machinery/vending/snack,
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Bt" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"Bu" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"Bv" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/closet/fireaxecabinet{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"Bw" = (
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
+"Bx" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth{
+	frequency = 1380;
+	id_tag = "large_escape_pod_1_berth";
+	pixel_x = -26;
+	pixel_y = 0;
+	tag_door = "large_escape_pod_1_berth_hatch"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"By" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Bz" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"BA" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"BB" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"BC" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/crew_quarters/medical_restroom)
+"BD" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/camera/network/medbay{
+	c_tag = "MED - Break Room West";
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"BE" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"BF" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"BG" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"BH" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"BI" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"BJ" = (
+/obj/machinery/vending/cola,
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/machinery/camera/network/medbay{
+	c_tag = "MED - Break Room East";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"BK" = (
+/turf/simulated/wall,
+/area/mine/explored/upper_level)
+"BL" = (
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "large_escape_pod_1_berth_hatch";
+	locked = 1;
+	name = "Large Escape Pod 1"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"BM" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/medical{
+	name = "Rest Room"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"BN" = (
+/obj/machinery/door/airlock/medical{
+	name = "Rest Room"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"BO" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/water_cooler/full,
+/obj/machinery/status_display{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"BP" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"BQ" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"BR" = (
+/obj/structure/bed/chair,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"BS" = (
+/obj/structure/bed/chair,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"BT" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"BU" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"BV" = (
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"BW" = (
+/turf/simulated/shuttle/wall,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"BX" = (
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "large_escape_pod_1_hatch";
+	locked = 1;
+	name = "Emergency Airlock"
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"BY" = (
+/obj/structure/sign/redcross,
+/turf/simulated/shuttle/wall,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"BZ" = (
+/turf/simulated/mineral/floor/vacuum,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Ca" = (
+/obj/structure/mirror{
+	pixel_y = 30
+	},
+/obj/structure/sink{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"Cb" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"Cc" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"Cd" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"Ce" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"Cf" = (
+/obj/machinery/door/airlock/medical{
+	name = "Rest Room"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Cg" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Ch" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Ci" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Cj" = (
+/obj/structure/table/glass,
+/obj/item/weapon/deck/cards,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Ck" = (
+/obj/structure/table/glass,
+/obj/machinery/recharger,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Cl" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Cm" = (
+/obj/structure/table/standard,
+/obj/machinery/microwave,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Co" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"Cp" = (
+/obj/machinery/atmospherics/unary/cryo_cell{
+	layer = 3.3
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"Cq" = (
+/obj/structure/bed/roller,
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"Cr" = (
+/obj/structure/bed/roller,
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"Cs" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
+	frequency = 1380;
+	id_tag = "large_escape_pod_1";
+	pixel_x = -26;
+	pixel_y = 26;
+	tag_door = "large_escape_pod_1_hatch"
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"Ct" = (
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"Cu" = (
+/obj/structure/bed/chair,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"Cv" = (
+/obj/structure/bed/chair,
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"Cw" = (
+/obj/structure/bed/chair,
+/obj/machinery/vending/wallmed1{
+	layer = 3.3;
+	name = "Emergency NanoMed";
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"Cx" = (
+/turf/simulated/shuttle/wall/hard_corner,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"Cy" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/medical_restroom)
+"Cz" = (
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"CA" = (
+/obj/machinery/light/small,
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"CB" = (
+/obj/structure/table/standard,
+/obj/random/soap,
+/obj/random/soap,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"CC" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"CD" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/cable/green,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"CE" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/landmark/start{
+	name = "Search and Rescue"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"CF" = (
+/obj/structure/table/glass,
+/obj/item/device/universal_translator,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"CG" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"CH" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"CI" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"CJ" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"CK" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"CL" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"CM" = (
+/obj/structure/shuttle/window,
+/obj/structure/grille,
+/turf/simulated/shuttle/plating,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"CN" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/crew_quarters/medical_restroom)
+"CO" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/crew_quarters/medical_restroom)
+"CP" = (
+/obj/structure/flora/skeleton{
+	name = "\proper Wilhelm"
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/camera/network/medbay{
+	c_tag = "MED - Break Room Southwest";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"CQ" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"CR" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"CS" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/effect/landmark/start{
+	name = "Search and Rescue"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"CT" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"CU" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"CV" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/donkpockets,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"CW" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
+/obj/machinery/light,
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"CX" = (
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/obj/item/weapon/tool/wrench,
+/obj/random/medical/lite,
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"CY" = (
+/obj/structure/closet/crate/medical,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/bodybag/cryobag{
+	pixel_x = 5
+	},
+/obj/item/bodybag/cryobag{
+	pixel_x = 5
+	},
+/obj/item/weapon/storage/firstaid/o2{
+	layer = 2.8;
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/box/masks{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/fire{
+	layer = 2.9;
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/firstaid/adv{
+	pixel_x = -2
+	},
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/item/device/defib_kit/loaded,
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"CZ" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"Da" = (
+/obj/machinery/sleep_console,
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"Db" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"Dc" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"Dd" = (
+/obj/structure/bookcase/manuals/medical,
+/obj/item/weapon/book/manual/medical_diagnostics_manual{
+	pixel_y = 7
+	},
+/obj/item/weapon/book/manual/stasis,
+/obj/item/weapon/book/manual/resleeving,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"De" = (
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Df" = (
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Dg" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"Di" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/crew_quarters/medbreak)
+"Dl" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"Do" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/public_meeting_room)
+"Dq" = (
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"Ds" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/structure/closet/wardrobe/orange,
+/turf/simulated/floor/tiled/dark,
+/area/security/recstorage)
+"Dy" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"DA" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/random/junk,
+/obj/effect/floor_decal/techfloor{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"DF" = (
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"DG" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/engineering/shaft)
+"DK" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"DN" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/clean,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"DR" = (
+/obj/random/trash,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Ej" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Em" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"En" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/interrogation)
+"Er" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 5
+	},
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"Et" = (
+/obj/structure/railing,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Eu" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	icon_state = "intact";
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction/yjunction,
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"Ev" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Ew" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"Ey" = (
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"ED" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/maintenance/clean,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"EF" = (
+/obj/structure/table/steel,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"EH" = (
+/obj/random/junk,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"EJ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"EZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"Fb" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"Fe" = (
+/obj/structure/table/glass,
+/obj/item/weapon/surgical/scalpel,
+/obj/random/maintenance/medical,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Ff" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/turf/simulated/floor/airless,
+/area/maintenance/station/sec_lower)
+"Fj" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "chapel"
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 8;
+	icon_state = "twindow"
+	},
+/turf/simulated/floor,
+/area/security/interrogation)
+"Fq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled/freezer,
+/area/security/brig/bathroom)
+"Fs" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Ft" = (
+/obj/structure/closet,
+/obj/item/clothing/accessory/poncho/roles/medical,
+/obj/item/clothing/shoes/boots/winter/medical,
+/obj/item/clothing/shoes/boots/winter/medical,
+/obj/item/clothing/suit/storage/hooded/wintercoat/medical,
+/obj/item/clothing/under/rank/medical,
+/obj/item/clothing/under/seromi/smock/medical,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Fv" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Fw" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"Fx" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload)
+"FA" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/random/junk,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"FC" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"FD" = (
+/obj/structure/bed/padded,
+/obj/machinery/camera/network/medbay{
+	c_tag = "MED - Virology Containment Two";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"FI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"FR" = (
+/obj/effect/floor_decal/rust,
+/obj/random/junk,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"FZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/station/sec_lower)
+"Gd" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor,
+/area/vacant/vacant_office)
+"Gf" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/public_meeting_room)
+"Go" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/engineering/shaft)
+"Gw" = (
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"GG" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"GV" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor,
+/area/vacant/vacant_restaurant_upper)
+"GW" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"GY" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/stairs/north,
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"Ha" = (
+/obj/structure/bed/chair/office/dark,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/public_meeting_room)
+"Hb" = (
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Hc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Hk" = (
+/obj/random/junk,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"Hq" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether/station/public_meeting_room)
+"Hx" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"HA" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 9
+	},
+/obj/machinery/vending/fitness,
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/public_meeting_room)
+"HH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"HK" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"HP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Ik" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Ip" = (
+/turf/simulated/mineral/vacuum,
+/area/chapel/office)
+"Ix" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/cable/green,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"Iz" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"IB" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/public_meeting_room)
+"IG" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/public_meeting_room)
+"IO" = (
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/airless,
+/area/space)
+"IX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"IZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"Jc" = (
+/obj/machinery/seed_storage/garden,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"Jh" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Jl" = (
+/obj/structure/cable/green{
+	icon_state = "32-2"
+	},
+/obj/structure/lattice,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing,
+/turf/simulated/open,
+/area/engineering/shaft)
+"Jp" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/shaft)
+"Jq" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/public_meeting_room)
+"JD" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/red/bordercorner2,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"JH" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/station/sec_lower)
+"JK" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"JL" = (
+/obj/structure/table/steel,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"Kg" = (
+/obj/structure/closet,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Kv" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/structure/table/steel,
+/obj/item/weapon/beach_ball/holoball,
+/turf/simulated/floor/tiled/dark,
+/area/security/recstorage)
+"KG" = (
+/turf/simulated/mineral/floor/cave,
+/area/maintenance/station/sec_lower)
+"KI" = (
+/turf/simulated/wall,
+/area/tether/station/public_meeting_room)
+"KJ" = (
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/apc;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/junk,
+/obj/random/junk,
+/obj/random/maintenance/security,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"KP" = (
+/obj/machinery/photocopier,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8;
+	icon_state = "borderfloor";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/public_meeting_room)
+"KQ" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"KU" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/roller,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"KV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"KX" = (
+/obj/structure/ladder/up,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"Ld" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/brig)
+"Lf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Ll" = (
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"Ln" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Lo" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Lr" = (
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating,
+/area/mine/explored/upper_level)
+"Lx" = (
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/structure/table/steel,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"Ly" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/closet/crate,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/airless,
+/area/maintenance/station/sec_lower)
+"LB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"LD" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "16-0"
+	},
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"LE" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/lattice,
+/obj/structure/cable/pink{
+	d1 = 32;
+	dir = 2;
+	icon_state = "32-1"
+	},
+/turf/simulated/open,
+/area/maintenance/station/sec_lower)
+"LG" = (
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"LL" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2,
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/public_meeting_room)
+"LQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"LT" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/weapon/paper_bin{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/obj/item/weapon/pen/blue,
+/obj/item/weapon/pen,
+/obj/item/weapon/pen/red,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/public_meeting_room)
+"LW" = (
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/airless,
+/area/maintenance/station/sec_lower)
+"Me" = (
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"Mn" = (
+/obj/structure/table/steel,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Mp" = (
+/turf/simulated/floor/tiled/dark,
+/area/security/interrogation)
+"Mq" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/station/sec_lower)
+"Ms" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/airless,
+/area/maintenance/station/sec_lower)
+"Mw" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/structure/closet/crate,
+/obj/random/junk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"MC" = (
+/obj/structure/railing,
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/tiled/monotile,
+/area/security/brig)
+"MK" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/maintenance/engineering,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"MN" = (
+/turf/simulated/floor/tiled/white,
+/area/maintenance/station/sec_lower)
+"MO" = (
+/obj/effect/floor_decal/rust,
+/obj/random/junk,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"MT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"MX" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Na" = (
+/obj/structure/table/glass,
+/obj/item/weapon/book/manual/medical_diagnostics_manual,
+/turf/simulated/floor/tiled/white,
+/area/maintenance/station/sec_lower)
+"Nb" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/white,
+/area/maintenance/station/sec_lower)
+"Nc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	icon_state = "intact";
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"Ng" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"Nh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/vacant/vacant_office)
+"Nj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"Nm" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/maintenance/station/sec_lower)
+"Ny" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"NA" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"NJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/tool,
+/turf/simulated/floor,
+/area/vacant/vacant_office)
+"NM" = (
+/obj/structure/lattice,
+/turf/simulated/mineral/floor/cave,
+/area/maintenance/station/sec_lower)
+"NN" = (
+/obj/structure/table/glass,
+/obj/item/taperoll/medical,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"NS" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/space,
+/area/space)
+"NY" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/maintenance/station/sec_lower)
+"NZ" = (
+/obj/random/junk,
+/obj/random/junk,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Ob" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/maintenance/station/sec_lower)
+"Oc" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"Of" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "chapel"
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/security/interrogation)
+"Oj" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/structure/table/steel,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Op" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
+	scrub_id = "sec_riot_control"
+	},
+/turf/simulated/floor/plating,
+/area/security/brig)
+"Or" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Os" = (
+/obj/structure/table/glass,
+/obj/item/clothing/accessory/stethoscope,
+/obj/item/device/healthanalyzer,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/maintenance/station/sec_lower)
+"OA" = (
+/obj/effect/floor_decal/rust,
+/obj/random/trash,
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"OI" = (
+/obj/structure/closet{
+	name = "Prisoner's Locker"
+	},
+/obj/item/weapon/flame/lighter/zippo,
+/obj/item/clothing/head/greenbandana,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"OJ" = (
+/turf/simulated/wall,
+/area/maintenance/evahallway)
+"OQ" = (
+/turf/simulated/mineral/vacuum,
+/area/maintenance/evahallway)
+"OY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Pd" = (
+/obj/effect/floor_decal/rust,
+/obj/random/junk,
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/maintenance/engineering,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
+"Ph" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"Pj" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/public_meeting_room)
+"Pl" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"Pm" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"Py" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"PA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"PE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"PF" = (
+/turf/simulated/wall{
+	can_open = 1
+	},
+/area/maintenance/station/sec_lower)
+"PJ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"PM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	icon_state = "light1";
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"PP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"PR" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/public_meeting_room)
+"PS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/public_meeting_room)
+"PV" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"PW" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/shaft)
+"PX" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Qk" = (
+/obj/effect/floor_decal/rust,
+/obj/random/trash,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Ql" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/steel,
+/turf/simulated/floor/airless,
+/area/maintenance/station/sec_lower)
+"Qn" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"Qs" = (
+/turf/simulated/mineral/vacuum,
+/area/maintenance/station/sec_lower)
+"Qu" = (
+/obj/structure/catwalk,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Qv" = (
+/obj/structure/closet{
+	name = "Prisoner's Locker"
+	},
+/obj/item/clothing/head/soft/orange,
+/obj/item/clothing/suit/storage/apron,
+/obj/item/clothing/shoes/sandal,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"Qy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"QD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/recstorage)
+"QF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"QG" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/closet/crate,
+/obj/random/maintenance/engineering,
+/obj/random/junk,
+/obj/random/junk,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"QH" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"QN" = (
+/obj/structure/closet,
+/obj/item/clothing/shoes/boots/winter/medical,
+/obj/item/clothing/suit/storage/hooded/wintercoat/medical,
+/obj/item/clothing/under/rank/medical,
+/turf/simulated/floor/tiled/white,
+/area/maintenance/station/sec_lower)
+"QQ" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"QR" = (
+/obj/structure/table/steel,
+/obj/random/maintenance/engineering,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"QS" = (
+/obj/machinery/light/small,
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/maintenance/clean,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"QW" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"QZ" = (
+/obj/structure/railing,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Rb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Rd" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"Rf" = (
+/obj/structure/closet/crate,
+/obj/random/junk,
+/obj/random/maintenance/engineering,
+/obj/structure/lattice,
+/turf/simulated/mineral/floor/cave,
+/area/maintenance/station/sec_lower)
+"Rg" = (
+/obj/effect/floor_decal/corner/white/border{
+	icon_state = "bordercolor";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/security/brig)
+"Rj" = (
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/airless,
+/area/space)
+"Rl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/frame/apc,
+/turf/simulated/floor,
+/area/vacant/vacant_office)
+"Rq" = (
+/obj/structure/sign/electricshock,
+/turf/simulated/wall/r_wall,
+/area/security/brig)
+"Rr" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"RA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"RB" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/station/sec_lower)
+"RD" = (
+/obj/random/maintenance/engineering,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"RE" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"RF" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"RJ" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/item/weapon/folder,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/public_meeting_room)
+"RQ" = (
+/obj/structure/table/steel,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"RR" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/station/sec_lower)
+"RS" = (
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"RT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"RW" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Sb" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8;
+	icon_state = "borderfloor";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/public_meeting_room)
+"Sg" = (
+/obj/structure/table/steel,
+/obj/random/maintenance/clean,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Si" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Sl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"Sp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8;
+	icon_state = "borderfloor";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/public_meeting_room)
+"Sv" = (
+/obj/structure/table/steel,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"Sy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/interrogation)
+"SI" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"SJ" = (
+/obj/random/junk,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"SK" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/clean,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"SM" = (
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/mine/explored/upper_level)
+"ST" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"SV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/public_meeting_room)
+"SW" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8;
+	icon_state = "borderfloor";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/public_meeting_room)
+"SY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/maintenance/station/sec_lower)
+"Ta" = (
+/obj/structure/table/steel,
+/obj/random/action_figure,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"Tf" = (
+/obj/structure/table/steel,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"Tj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/obj/random/maintenance/security,
+/obj/random/contraband,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/sec_lower)
+"Tk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"Tl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"Tm" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"To" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/stairs/north,
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
+"Tq" = (
+/obj/item/weapon/surgical/cautery,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Tw" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Ty" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"TB" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"TO" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/public_meeting_room)
+"TW" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"TY" = (
+/turf/simulated/wall/r_wall,
+/area/security/riot_control)
+"Uf" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Ug" = (
+/obj/structure/closet/crate,
+/obj/random/junk,
+/obj/random/junk,
+/turf/simulated/mineral/floor/cave,
+/area/maintenance/station/sec_lower)
+"Ui" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/door/blast/regular{
+	dir = 1;
+	id = "Cell 1";
+	name = "Cell 1"
+	},
+/obj/effect/floor_decal/industrial/loading{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"Uk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Uo" = (
+/obj/structure/table/steel,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 0
+	},
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"Up" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/public_meeting_room)
+"Us" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
+	scrub_id = "sec_riot_control"
+	},
+/turf/simulated/floor/plating,
+/area/security/brig)
+"Uu" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"UB" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "16-0"
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
+	icon_state = "up-scrubbers";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"UE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"UH" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/maintenance/station/sec_lower)
+"UJ" = (
+/obj/random/trash,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"UO" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"UR" = (
+/turf/simulated/floor/tiled/monotile,
+/area/security/brig)
+"UT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"UU" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"UV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"UX" = (
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"Vj" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Vm" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"Vw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"VA" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Public Meeting Room"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/public_meeting_room)
+"VF" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/door/blast/regular{
+	dir = 1;
+	id = "Cell 3";
+	name = "Cell 3"
+	},
+/obj/effect/floor_decal/industrial/loading{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"VH" = (
+/obj/structure/table/steel,
+/obj/item/device/radio{
+	pixel_x = -4
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"VJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"VK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/public_meeting_room)
+"VL" = (
+/turf/simulated/mineral/vacuum,
+/area/chapel/chapel_morgue)
+"VU" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"Wi" = (
+/obj/machinery/alarm{
+	frequency = 1441;
+	pixel_y = 22
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Wj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Wk" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/camera/network/security,
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"Ww" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/closet,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"WE" = (
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/maintenance/station/sec_lower)
+"WG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"WI" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
+"WJ" = (
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"WL" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/interrogation)
+"WS" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/engineering/shaft)
+"Xc" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/syringes{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/maintenance/station/sec_lower)
+"Xk" = (
+/obj/structure/table/steel,
+/obj/item/device/flashlight/lamp{
+	pixel_y = 10
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Xp" = (
+/obj/machinery/atmospherics/pipe/tank/nitrous_oxide{
+	icon_state = "n2o_map";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/security/riot_control)
+"Xq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"Xs" = (
+/obj/effect/floor_decal/corner/white/border{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/security/brig)
+"Xw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"Xx" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/computer/cryopod{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"XA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"XC" = (
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"XG" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"XH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"XJ" = (
+/obj/random/maintenance/engineering,
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"XM" = (
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"XR" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"XT" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/door/blast/regular{
+	dir = 1;
+	id = "Cell 4";
+	name = "Cell 4"
+	},
+/obj/effect/floor_decal/industrial/loading{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"XX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
+"Yc" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/public_meeting_room)
+"Yd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Ye" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"Yf" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/public_meeting_room)
+"Yh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/alarm{
+	breach_detection = 0;
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0;
+	report_danger_level = 0
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/airless,
+/area/maintenance/station/sec_lower)
+"Yq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance/sec{
+	name = "Riot Control";
+	req_one_access = list(1,10,24)
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/riot_control)
+"Yw" = (
+/turf/simulated/floor/airless,
+/area/mine/explored/upper_level)
+"YD" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"YE" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "brig_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/security/brig)
+"YH" = (
+/obj/machinery/atmospherics/pipe/cap/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/vacant/vacant_office)
+"YK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"YM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"YN" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/vending/cola,
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
+"YU" = (
+/obj/effect/floor_decal/rust,
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/station/sec_lower)
+"YW" = (
+/obj/random/trash,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Za" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/table/steel,
+/obj/item/weapon/soap/nanotrasen,
+/turf/simulated/floor/tiled/freezer,
+/area/security/brig/bathroom)
+"Zb" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Zl" = (
+/obj/structure/closet/crate,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Zo" = (
+/turf/simulated/floor/plating,
+/area/mine/explored/upper_level)
+"Zr" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"Zu" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "brig_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/brig)
+"Zx" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/evahallway)
+"Zy" = (
+/turf/simulated/floor/plating,
+/area/engineering/shaft)
+"ZE" = (
+/obj/structure/table/steel,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"ZH" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"ZJ" = (
+/obj/structure/table/steel,
+/obj/item/weapon/storage/briefcase/inflatable,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"ZK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/public_meeting_room)
+"ZL" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"ZR" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/door/blast/regular{
+	dir = 1;
+	id = "Cell 2";
+	name = "Cell 2"
+	},
+/obj/effect/floor_decal/industrial/loading{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/brig)
+"ZW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/floor_decal/techfloor,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
+"ZX" = (
+/obj/structure/table/steel,
+/obj/item/weapon/pen,
+/turf/simulated/floor,
+/area/maintenance/evahallway)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRjababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNSNSNSNSNSNSNSeMNSNSaaaaacacacaaaaaaaaaaaaacacacacaaaaacacacaaaaabIOabababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNSaaaaaaaaaaaaaaaaNSaaacacacacacacaaaaaaaaacacacacacacacacacacatRBMqatRBRBatababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNSaaaaaaaaaaaaaaabacacacacacacacacacacacacacacacacacacacacacacatLyQlVHZJZlatacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNSaaaaaaaaaaaaaaabacacacacacacacacacacacacacacacacacacacacacacatRSSIRSDKbfatacacacacacacaaaaaaaaaaaaaaacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNSaaaaaaabababacacacacacacacacacacacacacacacacacacacacacacacacatEvRTDKSiOjatacacacacacacacacacacacacacacacacacacacacYwYwYwYwYwYwYwYwYwYwYwYwYwYwYwYwYwYwaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNSaaaaaaabEyEyEyacacacacacacacacacacatatatatatatatatacacacacacatSIbfDKPyXkatacacacacacacacacacacacacacacacacacacacacacacacacacacacYwYwYwYwYwYwYwYwYwYwYwaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNSaaaaaaabEyEyEyatQsatatatatatatatQsatFCRSWibfRSXJatacBKBKBKacatYDbfatatatatBKacacacacacacacacacacacacacacacacacacacacacacacacacacacYwYwYwYwYwYwYwYwYwYwaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMaaaaaaacEyEykkQsQsQsQsQsQsNMNMQsQsatIkRSRSbfRSMwatacaPkIacacatSIDKatacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacYwYwYwYwYwYwYwYwYwYwaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNSaaaaacacQsQsQsRfNMRSRSRSRSRSNMNMUgatZbbfRSRSbfRSataPaPaPaPacatSIRratacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacYwYwYwYwYwYwYwYwYwaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNSNSacacacQsQsUgNMRSRSRSRSRSRSRSNMKGatMKRSRDRSRSDyatackIaPaPacatSIPXatacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacYwYwYwYwYwYwYwYwYwaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacatatatatatatatPFatatatatatatatatatatLnatatatatatatatatFvatatatatatatatatatatatatatQsQsQsQsQsacacacacacacacacacacacacacacacacacacYwYwYwYwYwYwYwaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacatHbDRTwTWTWQZTWQZFsQkFsFsEHVjVjUOTWTWKgUOUOTWTWTWFsEtVJQZUOTWFsFsTWTWTWTWTWMOOAatQsQsQsQsQsacacacacacacacacacacacacacacacacacacacYwYwYwYwYwYwaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacatUJTyZLZLUVUVUVUVUVUVUVUVPEMXPELBHcHcHcXHXHXHXHMTQQHPRbXAPVOYYMYMXMWJPVXAOYEjFAatQsQsQsQsQsacacacacacacacacacacacacacacacacacacacacYwYwYwYwYwaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabacatRWPAatatatatatatatLnatatchchchaechaSaSaSaSaSaSaSaSaSaSaSaSRSRSRSRSRSRSRSRSXMQGatQsQsQsQsQsacacacacacacacacacacacacacacacacacacacacacYwYwYwYwaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabacatRWIXatNaOsNNatMKYWbfRSWwchagagaiagaSahURakRgahahaSaFEwGwaSajajajajajajajatQuatatIpIpIpIpIpacacacacacacacacacacacacacacacacacacacacacaPaPaPYwaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabacatIzYdatMNSYQNatDKRSDKRSRSchavawaxayaSaAXsaBaCaCaDaSbXamamaGQnaHajcwbYcyajRSaNaOatIpIpIpIpIpacacacacacacacacacacacacacacacacacacacacacacaPaPYwaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabacatRWYdatSYTqGWatRSatatatatchaQchZaaTaSMCaUakaCaUMCaSaSaSaSaSbCSlbacBcCcDajRSaNbfatIpIpIpIpIpacacacacacacacacacacacbgbgbgbgbgbgacacacacaPaPaPYwaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabacatTmOratbfbfNbatRSatacacacchbhchFqbjbkHHblbmbrGGXCLdcKcacMbqaWbsajajajajajbfaNbxatIpIpIpIpIpacacacacacacacacacacVLbgbybzbAbAbgacacZoaPaPaPaPZoaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabacatTmXMatWEMNFtatbfatacacafafafafafafaSPPaLDFDFbGbKXTcOcQcRbLXGbMajcwbYcyajbfaNbSatIpIpIpIpIpacacacacacacacacacacbgbgbUbVbAbAbgacaPZoaPaPaPaPZoaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabacatNZWJatKUXcFeatbfkkbWbWafREaocXdiaqaSQybZaraucbOIaSaSaSaSaSbHcfbacBcCcDajbfaNciatIpIpIpIpIpacacacacacacacacacacbgbTbUcjbgbgbgaPfyZofyaPfyaPSMaPfyaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacatZrSTatatatatatbfkkJlckafXXdkdldocpalcrFwbbbcUEQvLdcKccdqbqaXczcAcAcAcAcARSXMciatIpIpIpIpIpVLVLVLVLVLVLVLVLVLVLbgbTcEcFcGcHcIZoZoZoZoZoZoZoZoZoLraaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacatZrIXLnbfbfRSLoRSkkJpcJafPMapcXdtBVaSLxcNbtbucPbKVFcOcQcRcScTQHcUDscVascAaNXMatcYcYcYcYcYcYbgbgbgbgbgbgbgbgbgbgbgbgbUcFbgbgbgaPfyZofyaPfyaPSMaPfyaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacatTmYdatatatatatatkkPWdhafandjafafafaSbIbRcgbGDFdpaSaSaSaSaSbJdscUdudvazcAaNbeatdydzdAdBdCcYcZdadadadbdcdadadddadadedfdgdHdIdJaPaPZoaPaPaPaPZoaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacatRWSTataPacacacacbWWSGoafEZdLbiXRbNbOHxdNbvbwdPJcLdcKccdwbqaYdTdUQDdVaIcAXMUfatdYdZeaebeccYdDbgbgdEdEdEdEdEdEdEdEdEdFdGdHemdJaPaPZoaPaPaPaPZoaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacatRWSTatkIaPacaPaPbWdKZyafIxTkeoUTepbPVUeqbBbDesbKZRcOcQcRewKQVmcUaMaRKvcAQuatateyezeAeBeCcYdDbgeDdEToeFeGeHeIeFGYdEekeleLemdJaPaPZoaPaPaPaPZoaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMeMeMeMatSJSTataPaPacaPaPbWenDGafDqBVaVBVBVaSeSeQbEbFcPcdaSaSaSaSaSbQfcfdfdfdfdfdfiYUatiHfjfkflfmcYfnfofodEfpfUfrfsftfUfvdEbgbgbgbgbgaPaPZoaPaPaPaPZoaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMaaaaeMatZrLfataPaPaPaPkIbWdKfxafdxdMdjfBfBaSfDdndQZHEmceLdcKccdObqbdfIfdMpfKfLfdXMfNatfOfOfPfQfOcYfRfSfTdEeEfUfVFxfVfUeKdEOQUXUXUXOJaPaPZoaPaPaPaPZoaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMaaaaeMatZrQWatatatatatfXfXfYfXfXfXfXfXfXfXfXPmIZYeFbEmbKUicOcQcRfZKQgaclSygbgcfdaNRSfogegfggghgigjgkfogldEgmgngogpgqMegrdEOQKXOQUXOJOJOJOJZxOJZxOJZxOJaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMaaaaeMFZTmJhatRSQRMnSgfXgsgtgugvgwgwgwgwgwfXaScmcnRqYEZuaSaSaSaSaScocqfdMpgEMpfdaNgGgHgIgJgKgLgMgNgOgPgQdEdEdEdEgRdEdEdEdEOQOQOQUXOQHkLlOJLlDNLlSKTaOJaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMaaaaeMFZRWIXatRSbfbfZlfXgSgTgUgvgwgwgwgwgwfXUsHKYKcsctNgWkPJgygVgWgXgYfdFjOfhafdXMLGfohchdhehfhghhhidEdEdEdEhjhkhlhmhndEdEdEdEOQWIUBLlLlOJLlLlLlLlJLOJacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMeMeMeMFZRWYdLnRSRSbfZEfXhohphqgwgwgwgwgwgwfXOpXxNccucvJDEuPhOchshthuhvfdEnWLhwfdXMLEfohxhyhzhAhBhChydEhDhEdEhFhGhHhIfUdEhJhKdEOQJKOQOQOQOJUoEFZXLlSvOJacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMatRBatRFYdatbfbfRSRQfXhLhphMhNhOhOhOhOhPfXhQhQhQhQTYTYdRTYTYhUhVFIhWcxhYhZiafdaNSIfoidiehziAhBifigdEihiiijikiliminikijioipdEOQJKLlLlLlTBLlLlLlLlTfOJacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMFZFfObNAYdatbfbfRSPXfXiqirisisitititititfXiuivYNErTYaEaJizTYhUhViCiDfdfdfdfdfdaNSIfoiJiKiLiMiNiOiPdEiQiRdEiSiTfWiUiVdEiWiXdERdRAiYiYiYiYiYiYiYiYiYiYiYacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMFZNmLWJhWjatRSMnQSEDfXiZjajbjbjbjbjbjbjbjcjdjejfjgjhaKaZadTYajajajajajLDfNjlTjXMSIfojnjohzhAhBgejodEdEdEdEfVjpjqjrfVdEdEdEdEJKiYiYjsjtjtjtjsjxjxjxjtiYiYacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMFZUHYhatatatatatatatfXjAjBjCjCjDjEjFjFjFfXjGjHjIjJTYbnbobpYqNjjMjNjNjOjPjQjRjSjSRTfojVjWhzhAhBjVjWjXjXjXjXjXjYjZkakbkbkbkbkbDliYjskcjsjtjtRljxjskdjtjtiYacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMatNYIXatQsQsacaPaPaPfXfXfXfXfXfXfXfXfXfXfXkfkgkhkfTYTYXpXpTYkjkihrkjkjkkkkkkkkkkkkfoklkmknkmkokmkljXkpkqkrjXksktkukbkvkwkxkbKViYjskzkzjxkCkDjskFkGGdjtiYacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMFZUHIXatatatkIaPaPaPkJkKkLkMkNkOkPkQkJacackfkSkTkfacTYTYTYTYPdkUkVkWkXkYkYkYkYkYkYkZlalblcldlelflgjXlhliljlklllmlllnlolplqkbPliYjskdjsjskclsjtjxjxjsjsiYacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMFZNmOrXMWJJHaPltlulvlwlxlylzkKkKkKlAkJacackflBlCkfacacacackjKJlDlElFlGkYlHlHlHlHkYlIlJlJlKlJlLlJlMjXlNlOlPjXlQlRlSkblTlUlVkbPliYjsjxjxNJjtmambNhYHjsjsiYacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMFZMsZWNyUkJHaPmdmemflwmgmhmimjmkkKmlkJkfkfkfmmmnmokfkfkfkfkfkjmpmqmrmskYlHlHlHlHlHmtlJlJlKmulLlJmvjXjXjXjXjXjYmwmxkbkbkbkbkbLQnsnsmymzmAnsmBnsmAmAnsiYiYacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMatRRatZrIXataPmCmDmEmFmGmHmImJmKmKmKmLmMmMmMmMmNmOmOmOmPmQiwkjmRmSmTmUkYlHlHlHlHlHmtlJlJlKlJmVmWmXmYmZnanbncndnenfngWGnhninhXwnhnkEJnmnnnonpnqnlnrnsacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMeMeMFZZrYdJHaPmdntnulwnvkKnwnxnykKnzkJmOmOmOmOnAmMmMmMnBnCnDnEnFnFnGnHkYlHlHlHlHnInJnKnLnMnNnNnNnNnOnNnNnNnNnNnMnPnPnPnPnQnPTlnPnPnPnPnRlJnSnTnUnVnsacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMaaaaFZFROrJHaPnWnXnYlwnZoaobkKococodkJoeofofofofofofogohoiojhrokjLolomkYkYkYkYkYkYonlJooopoqoqoqorosotouovowototototototoxoyUuoyoyozoAoBoCoDoEotoFnsacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMaaaaFZDAXMataPaPaPaPkJoaoGoHoIoJoKoLkJoMoMoMoMoMoMoMoMohoioNhroOoPmSoQjjjjjLoRoSkjoToUoVoWoWoWoWoWoWoWoWoWoWoWoWoWoWoWoWoXoYoYoYoYoZpapbpcoZoYoYoYoYacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMaaaapdpdGVpdpdpdpdpdkJkJkJkJkJkJkJkJkJoMoMoMoMoMoMoMoMpeoipfhrmppgphpipjkjkjkjkjkjpkplpmoWpnpoppoWFDpoppoWpqprpsptpspuoWpvoYpwpwpxpypzpApBpCpDpEpEoYacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeMeMeMpFpGpGpGpGpGpGpGpGpGpGpGpGpHpIpJkfpKpKpKpKpKpKpKpKpLpKpMhrhrhrhrpNkjpOpPpQpRpSpTlKpUoWpVpWpXoWpVpYpXoWpZpZpZpZpZpZpZqaoYqbqcqdqeqcqfqgqhqiqcqjoYacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaapFpGqkqkpGpGpGqkpGpGqkqkqlqmpGpGqnqoqpqpqpqpqqqpUUqrqsqtquqvqwqxqyqzqAqBqCqDqEqFqGpUoWqHqIqHoWqHqJqHoWqKqLqMqNqOqPpZpvoYoYoYoYqQqRqSqTqUoYoYoYoYacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaapdpGpGqkqVqWqkqkpGpGqXqYqZrarbrcrdrerererererfrergrhrirjrkrkrlVwrmrkrnronUrprqnPrrpUoWrsrtrurvrurwrxoWryrzrArBrCrDpZrEoYrFrGpxrHpzrIrJrKrLrMrNoYacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaapFpGpGqkqmqkqkpGpGpGpGpGpGpGpGpGqnrOrPrQrPrPrRrSrTrUrVrWrXrYQFXqrZsasbrPscscsdscscseoWsfsgshsipXpXsjqHskslslsmsnsopZpvoYqbqcspqeqcqfqgsqsrqcqcoYoYoYoYaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaapFpGsspGqlqkststsusvsvsvsvsvsvsvswswswswswswsxsyszsAKIKIKIKIVATOKIsBsCsDsDsDsEsEoWoWoWsFsGoWsHsIrssJsKsLsMsMsNsnsOpZpvoYoYoYoYsPqcsQsRsSsTqcsUsVsWsXoYaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaapFpGpGqmqlpGsYsZtatbtbtbtbtbtbtbswtctcswtdteswtfszsAHqtgIGHaZKDoKIthtitjtktlsEtmoWtntotptqtrsipXtspXqHttslsltutvtwpZpvoYtxqcpxtytztAtBtCtDqctEoYtFsXoYaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaapdpGpGqkqkqktGqmtatbtbtbtbtbtbtHswswswswteteswtIsztJKIKPUpRJJqVKKItKtLsDtMtNsEtOoWtPtQtRtStTrutUrwtVoWtWtXtYtZuaubpZucoYudqcueqeqcufuguhuiujukoYoYoYoYaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaapFpGpGulpGumpGqmtatbtbtbtbtbtbtbswununswteteswuoszupHqSbUpLTIBGfKIuqurusutuusEuvoWuwpXuxpXtppXpXuyuzoWuAuBsluCsnuDpZpvoYuEqcuFuGpzpzpBuHuIuJuKuLuMuNuOaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaapFpGqkqkqkqkpGqmtatbtbtbtbtbtbtbswuPuPuQteteswuRuSuTKISWUpPjPRYcKIuUuVuWuWuWuWuWuXuXuXuYuZvavbvcvdoWvevfveslvgvhpZpZpvoYviqctDvjqcqcqgvktDvlvloYoYoYoYaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaapdpdpdvmpGpGsvsvtbtbtbtbtbtbtbtbswvnvovpvqvrvsvtvuvvHqSpSVevPSLLKIvwvxuWvyvyvyvzvyvyuXoWoWvAoWqHqHoWvBvCvevDvEvevevFvGoYoYoYoYvHvIvJvKvLoYoYoYoYaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPpdqkpGpGvMtbtbtbtbvMtbtbtbtbswvNvOvPvOvQvRvSuPvvKIYfHAvTvTvTvTvTvUuWvVvWvXvYvYvZwawbwcwdwewfwgwhwiwjvewkwlwmvewnwowowowowowowowowowooYoYoYaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPpdwpwpwppdwpwpwpwppdwpwpwpwpswswswswswswswswswswswvTvTvTwqwrwswtwuwvwwwxwywzwAwBwCvewDwEwFwGwHwIwJwKwLwMwNwOvewPwowQwRwSwTwUwVwWwXwYaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPacacacacacacacacacacvTwZxaxbxcxdxexfxdxgxhxixjxkxlwBwCuXvexmxnvevevevevevexoxpxqvexrwoxswVwVxtwVwVwVwVwYaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPacacacacacacacacacacvTxuxvxdxdxdxexfxwuWxxxyxzxAxBwBwCuXxCxDxExFxGxHxIwowowowowowoxJwoxKwVwVxLxMxMxNwVwYaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacaPaPkIaPaPaPaPaPaPaPaPaPacacacacacacacacacacvTxOxPxQxRxSxTxUxVxWxXxYxZyaxBwBwCuXybycydxFyeyfygwoyhyhyiyiyjykylymynynyoypyqyryswYaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacaPaPaPaPaPaPaPaPaPaPaPaPacacacacacacacacacacvTytyuyvxdywyxxdyyuWyzyAyByCyDyEwCuXyFyGyHxFyeyIyJwoyhyhyKyKyLyMyNyOyOyOyPyQyRySwVwYaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaPaPaPaPaPaPacaPkIaPaPaPaPacacacacacacacacacacvTyTxdxdxdxdxexdyUuWuWuWyVxguWuWuWuXveyWyXyYyZzazawowowowowowozbwowVwVwVxNzczcxNwVwYaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPacacaPaPaPaPaPacacacacacacacacacacvTzdzezfzgzhzizjzkvTzlzmznzozpzqzrzsztzuzvzwzxzyzzzAzBzCzDzDzEzFwozGzHzIzJzKwVwVwVwYaPaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababaPacaPaPaPaPaPaPacacacacacacacacacacvTvTvTvTvTvTzLvTvTvTzMzNzOzPzQzRzSzTzUzVzWzWzXzYzazZzZzZzZzZzZzZwowowowowowowowowowoaPaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababaPaPaPaPaPaPaPaPacacacacacacacacacacacacaczaAaAbAcAdAeAfAgAhzaAiAjAkAlAiAiAiAmAmAnAozaaPacacacacacacacacacacacacacacacacacacaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababaPaPaPaPaPaPacacacacacacacacacacacacaczaApAqArAsAtAuAvAwzaAxAyAzAAABACAiADADAnAEzaAFaPaPaPacacacacacacacacacacacacacacacacaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababaPaPaPaPaPaPacacacacacacacacacacacacacAGAGAGAHAHAHAIAGAGAGAJAKALAMANAOAizazaAPAQARASATaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababaPaPaPaPaPacacacacacacacacAUAUAUAUAUAUAGAVAWAXAYAXAZBaBbAGBcAKBdBdANBeAiaczaAPBfBgBhBiaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababaaaaaaaaacacacacacacacacAUBjBkBlAUBmAGBnBoBpBpBpBqBrBsAGBcBtBuBvBwBeAiaczaBxByzaAFaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababaaaaaaaaaaaaaaaaaaacacacAUBzBABBAUBCAGBDBEBFBGBGBHBIBJAGBKBKBKyYyYyYyYyYyYBLBLyYyYyYyYyYaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababaaaaaaaaaaaaaaaaaaacacacAUAUBMAUAUBNAGBOBPBQBRBSBTBIBUAGacacacyYcLBWBWBWBWBXBXBYBWBWBWBZaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababaaaaaaaaaaaaaaaaaaacacacAUCaCbCcCdCeCfCgChCiCjCkClBICmAGacacacyYcWCoCpCqCrCsCtCuCvCwCxBWaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababaaaaaaaaaaaaaaaaaaaaaaaaCyCzCzCACBCCAGCDAXCECFCGCHCICJAGacacacyYcWCoCKCtCtCtCtCtCtCtCLCMaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababaaaaaaaaaaaaaaaaaaaaaaaaCNCOCOAUAUAUAGCPAXCQCRCSCTCUCVAGacacacyYcWCoCWCXCYCZDaDbDcDcCxBWaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPacacacAGDdAXAXDeDfAXCUDgAGacacacyYdmBWBWBWBWBWBWBYBWBWBWBZaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPacacAGDiDiDiAGAGDiDiDiAGacacacyYyYyYyYyYyYyYyYyYyYyYyYyYaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPacacacacacacacacacacacacacaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPacacacacacacacacacacacacacacacacaPaPaPaPaPaPaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababaPaPaPaPaPaPaPaPaPaPaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababaaaPaPaPaPaPaPaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(2,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(3,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(4,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(5,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(6,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(7,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(8,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(9,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(10,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(11,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(12,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(13,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(14,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(15,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(16,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(17,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(18,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(19,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(20,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(21,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(22,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(23,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(24,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(25,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(26,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NS
+NS
+NS
+NS
+NS
+NS
+NS
+eM
+NS
+NS
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(27,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NS
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NS
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eM
+eM
+eM
+eM
+eM
+eM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(28,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NS
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+aa
+aa
+eM
+aa
+aa
+aa
+aa
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(29,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NS
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+ac
+ac
+aa
+aa
+eM
+aa
+aa
+aa
+aa
+eM
+at
+FZ
+FZ
+FZ
+at
+FZ
+FZ
+FZ
+at
+eM
+aa
+aa
+aa
+eM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(30,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NS
+aa
+aa
+aa
+ab
+ab
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+eM
+eM
+eM
+eM
+eM
+eM
+RB
+Ff
+Nm
+UH
+NY
+UH
+Nm
+Ms
+RR
+eM
+aa
+aa
+aa
+eM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(31,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NS
+aa
+aa
+aa
+ab
+Ey
+Ey
+Ey
+Qs
+Qs
+at
+at
+at
+at
+at
+at
+at
+at
+at
+at
+at
+at
+at
+at
+at
+at
+at
+at
+FZ
+FZ
+FZ
+at
+Ob
+LW
+Yh
+IX
+IX
+Or
+ZW
+at
+FZ
+FZ
+FZ
+pd
+pF
+pF
+pd
+pF
+pF
+pF
+pd
+pF
+pF
+pd
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(32,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NS
+aa
+aa
+aa
+ab
+Ey
+Ey
+Ey
+Qs
+Qs
+at
+Hb
+UJ
+RW
+RW
+Iz
+RW
+Tm
+Tm
+NZ
+Zr
+Zr
+Tm
+RW
+RW
+SJ
+Zr
+Zr
+Tm
+RW
+RW
+RF
+NA
+Jh
+at
+at
+at
+XM
+Ny
+Zr
+Zr
+FR
+DA
+pd
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pd
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(33,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eM
+aa
+aa
+aa
+ac
+Ey
+Ey
+kk
+Qs
+Ug
+at
+DR
+Ty
+PA
+IX
+Yd
+Yd
+Or
+XM
+WJ
+ST
+IX
+Yd
+ST
+ST
+ST
+Lf
+QW
+Jh
+IX
+Yd
+Yd
+Yd
+Wj
+at
+Qs
+at
+WJ
+Uk
+IX
+Yd
+Or
+XM
+GV
+pG
+qk
+pG
+pG
+ss
+pG
+pG
+pG
+qk
+pd
+pd
+pd
+aP
+aP
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(34,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NS
+aa
+ab
+ab
+ac
+ac
+at
+Qs
+Rf
+NM
+at
+Tw
+ZL
+at
+at
+at
+at
+at
+at
+at
+at
+Ln
+at
+at
+at
+at
+at
+at
+at
+at
+Ln
+at
+at
+at
+at
+Qs
+at
+JH
+JH
+at
+JH
+JH
+at
+pd
+pG
+qk
+qk
+qk
+pG
+qm
+qk
+ul
+qk
+vm
+qk
+wp
+aP
+aP
+ac
+ac
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(35,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NS
+NS
+ac
+ac
+ac
+ac
+Qs
+Qs
+NM
+RS
+at
+TW
+ZL
+at
+Na
+MN
+SY
+bf
+WE
+KU
+at
+bf
+at
+aP
+kI
+aP
+aP
+at
+RS
+RS
+RS
+bf
+bf
+RS
+at
+ac
+kI
+aP
+aP
+aP
+aP
+aP
+aP
+pd
+pG
+pG
+qV
+qm
+ql
+ql
+qk
+pG
+qk
+pG
+pG
+wp
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(36,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+at
+Qs
+RS
+RS
+at
+TW
+UV
+at
+Os
+SY
+Tq
+bf
+MN
+Xc
+at
+bf
+at
+ac
+aP
+aP
+aP
+at
+QR
+bf
+RS
+bf
+bf
+Mn
+at
+aP
+aP
+lt
+md
+mC
+md
+nW
+aP
+pd
+pG
+pG
+qW
+qk
+qk
+pG
+qk
+um
+qk
+pG
+pG
+wp
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(37,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+at
+Qs
+RS
+RS
+at
+QZ
+UV
+at
+NN
+QN
+GW
+Nb
+Ft
+Fe
+at
+RS
+at
+ac
+ac
+ac
+aP
+at
+Mn
+bf
+bf
+RS
+RS
+QS
+at
+aP
+aP
+lu
+me
+mD
+nt
+nX
+aP
+pd
+pG
+pG
+qk
+qk
+st
+sY
+tG
+pG
+pG
+sv
+vM
+pd
+aP
+aP
+kI
+aP
+aP
+aP
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(38,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+at
+Qs
+RS
+RS
+PF
+TW
+UV
+at
+at
+at
+at
+at
+at
+at
+at
+Lo
+at
+ac
+aP
+aP
+aP
+at
+Sg
+Zl
+ZE
+RQ
+PX
+ED
+at
+aP
+aP
+lv
+mf
+mE
+nu
+nY
+aP
+pd
+pG
+qk
+qk
+pG
+st
+sZ
+qm
+qm
+qm
+sv
+tb
+wp
+aP
+aP
+aP
+aP
+aP
+aP
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(39,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+at
+Qs
+RS
+RS
+at
+QZ
+UV
+at
+MK
+DK
+RS
+RS
+bf
+bf
+bf
+RS
+at
+ac
+aP
+aP
+kI
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+kJ
+lw
+lw
+mF
+lw
+lw
+kJ
+kJ
+pG
+pG
+pG
+pG
+su
+ta
+ta
+ta
+ta
+tb
+tb
+wp
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(40,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+at
+NM
+RS
+RS
+at
+Fs
+UV
+at
+YW
+RS
+at
+at
+at
+kk
+kk
+kk
+kk
+bW
+bW
+bW
+bW
+fX
+gs
+gS
+ho
+hL
+iq
+iZ
+jA
+fX
+kK
+lx
+mg
+mG
+nv
+nZ
+oa
+kJ
+pG
+pG
+pG
+pG
+sv
+tb
+tb
+tb
+tb
+tb
+tb
+wp
+aP
+aP
+aP
+aP
+ac
+ac
+ac
+aP
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(41,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+at
+NM
+NM
+RS
+at
+Qk
+UV
+Ln
+bf
+DK
+at
+ac
+ac
+bW
+Jl
+Jp
+PW
+WS
+dK
+en
+dK
+fY
+gt
+gT
+hp
+hp
+ir
+ja
+jB
+fX
+kL
+ly
+mh
+mH
+kK
+oa
+oG
+kJ
+pG
+qk
+qX
+pG
+sv
+tb
+tb
+tb
+tb
+tb
+tb
+wp
+aP
+aP
+aP
+aP
+aP
+ac
+aP
+aP
+aP
+aP
+aP
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(42,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+at
+Qs
+NM
+NM
+at
+Fs
+UV
+at
+RS
+RS
+at
+ac
+ac
+bW
+ck
+cJ
+dh
+Go
+Zy
+DG
+fx
+fX
+gu
+gU
+hq
+hM
+is
+jb
+jC
+fX
+kM
+lz
+mi
+mI
+nw
+ob
+oH
+kJ
+pG
+qk
+qY
+pG
+sv
+tb
+tb
+tb
+tb
+tb
+vM
+pd
+aP
+aP
+aP
+aP
+kI
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(43,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+Qs
+Qs
+Ug
+KG
+at
+Fs
+UV
+at
+Ww
+RS
+at
+ac
+af
+af
+af
+af
+af
+af
+af
+af
+af
+fX
+gv
+gv
+gw
+hN
+is
+jb
+jC
+fX
+kN
+kK
+mj
+mJ
+nx
+kK
+oI
+kJ
+pG
+ql
+qZ
+pG
+sv
+tb
+tb
+tb
+tb
+tb
+tb
+wp
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(44,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+at
+at
+at
+at
+at
+at
+EH
+PE
+ch
+ch
+ch
+ch
+ch
+af
+RE
+XX
+PM
+an
+EZ
+Ix
+Dq
+dx
+fX
+gw
+gw
+gw
+hO
+it
+jb
+jD
+fX
+kO
+kK
+mk
+mK
+ny
+oc
+oJ
+kJ
+pH
+qm
+ra
+pG
+sv
+tb
+tb
+tb
+tb
+tb
+tb
+wp
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(45,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+at
+FC
+Ik
+Zb
+MK
+at
+Vj
+MX
+ch
+ag
+av
+aQ
+bh
+af
+ao
+dk
+ap
+dj
+dL
+Tk
+BV
+dM
+fX
+gw
+gw
+gw
+hO
+it
+jb
+jE
+fX
+kP
+kK
+kK
+mK
+kK
+oc
+oK
+kJ
+pI
+pG
+rb
+pG
+sv
+tb
+tb
+tb
+tb
+tb
+tb
+wp
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(46,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+at
+RS
+RS
+bf
+RS
+at
+Vj
+PE
+ch
+ag
+aw
+ch
+ch
+af
+cX
+dl
+cX
+af
+bi
+eo
+aV
+dj
+fX
+gw
+gw
+gw
+hO
+it
+jb
+jF
+fX
+kQ
+lA
+ml
+mK
+nz
+od
+oL
+kJ
+pJ
+pG
+rc
+pG
+sv
+tb
+tH
+tb
+tb
+tb
+tb
+wp
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(47,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+at
+Wi
+RS
+RS
+RD
+at
+UO
+LB
+ae
+ai
+ax
+Za
+Fq
+af
+di
+do
+dt
+af
+XR
+UT
+BV
+fB
+fX
+gw
+gw
+gw
+hO
+it
+jb
+jF
+fX
+kJ
+kJ
+kJ
+mL
+kJ
+kJ
+kJ
+kJ
+kf
+qn
+rd
+qn
+sw
+sw
+sw
+sw
+sw
+sw
+sw
+sw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(48,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+at
+bf
+bf
+RS
+RS
+at
+TW
+Hc
+ch
+ag
+ay
+aT
+bj
+af
+aq
+cp
+BV
+af
+bN
+ep
+BV
+fB
+fX
+gw
+gw
+gw
+hP
+it
+jb
+jF
+fX
+ac
+ac
+kf
+mM
+mO
+oe
+oM
+oM
+pK
+qo
+re
+rO
+sw
+tc
+sw
+un
+uP
+vn
+vN
+sw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(49,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+at
+RS
+RS
+bf
+RS
+Ln
+TW
+Hc
+aS
+aS
+aS
+aS
+bk
+aS
+aS
+al
+aS
+aS
+bO
+bP
+aS
+aS
+fX
+fX
+fX
+fX
+fX
+fX
+jc
+fX
+fX
+ac
+ac
+kf
+mM
+mO
+of
+oM
+oM
+pK
+qp
+re
+rP
+sw
+tc
+sw
+un
+uP
+vo
+vO
+sw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(50,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+at
+XJ
+Mw
+RS
+Dy
+at
+Kg
+Hc
+aS
+ah
+aA
+MC
+HH
+PP
+Qy
+cr
+Lx
+bI
+Hx
+VU
+eS
+fD
+Pm
+aS
+Us
+Op
+hQ
+iu
+jd
+jG
+kf
+kf
+kf
+kf
+mM
+mO
+of
+oM
+oM
+pK
+qp
+re
+rQ
+sw
+sw
+sw
+sw
+uQ
+vp
+vP
+sw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(51,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+at
+at
+at
+at
+at
+at
+UO
+XH
+aS
+UR
+Xs
+aU
+bl
+aL
+bZ
+Fw
+cN
+bR
+dN
+eq
+eQ
+dn
+IZ
+cm
+HK
+Xx
+hQ
+iv
+je
+jH
+kg
+kS
+lB
+mm
+mM
+mO
+of
+oM
+oM
+pK
+qp
+re
+rP
+sw
+td
+te
+te
+te
+vq
+vO
+sw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(52,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aP
+ac
+at
+UO
+XH
+aS
+ak
+aB
+ak
+bm
+DF
+ar
+bb
+bt
+cg
+bv
+bB
+bE
+dQ
+Ye
+cn
+YK
+Nc
+hQ
+YN
+jf
+jI
+kh
+kT
+lC
+mn
+mN
+nA
+of
+oM
+oM
+pK
+qp
+re
+rP
+sw
+te
+te
+te
+te
+vr
+vQ
+sw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(53,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+BK
+aP
+aP
+kI
+at
+TW
+XH
+aS
+Rg
+aC
+aC
+br
+DF
+au
+bc
+bu
+bG
+bw
+bD
+bF
+ZH
+Fb
+Rq
+cs
+cu
+hQ
+Er
+jg
+jJ
+kf
+kf
+kf
+mo
+mO
+mM
+of
+oM
+oM
+pK
+qq
+rf
+rR
+sx
+sw
+sw
+sw
+sw
+vs
+vR
+sw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(54,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+BK
+kI
+aP
+aP
+at
+TW
+XH
+aS
+ah
+aC
+aU
+GG
+bG
+cb
+UE
+cP
+DF
+dP
+es
+cP
+Em
+Em
+YE
+ct
+cv
+TY
+TY
+jh
+TY
+TY
+ac
+ac
+kf
+mO
+mM
+of
+oM
+oM
+pK
+qp
+re
+rS
+sy
+tf
+tI
+uo
+uR
+vt
+vS
+sw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+AU
+AU
+AU
+AU
+AU
+Cy
+CN
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(55,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+BK
+ac
+aP
+aP
+at
+TW
+MT
+aS
+ah
+aD
+MC
+XC
+bK
+OI
+Qv
+bK
+dp
+Jc
+bK
+cd
+ce
+bK
+Zu
+Ng
+JD
+TY
+aE
+aK
+bn
+TY
+TY
+ac
+kf
+mO
+mM
+og
+oM
+oM
+pK
+UU
+rg
+rT
+sz
+sz
+sz
+sz
+uS
+vu
+uP
+sw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+AU
+Bj
+Bz
+AU
+Ca
+Cz
+CO
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(56,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+at
+Fs
+QQ
+aS
+aS
+aS
+aS
+Ld
+XT
+aS
+Ld
+VF
+aS
+Ld
+ZR
+aS
+Ld
+Ui
+aS
+Wk
+Eu
+dR
+aJ
+aZ
+bo
+Xp
+TY
+ac
+kf
+mP
+nB
+oh
+oh
+pe
+pL
+qr
+rh
+rU
+sA
+sA
+tJ
+up
+uT
+vv
+vv
+sw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+AU
+Bk
+BA
+BM
+Cb
+Cz
+CO
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(57,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+at
+at
+at
+at
+at
+at
+at
+at
+at
+at
+Et
+HP
+aS
+aF
+bX
+aS
+cK
+cO
+aS
+cK
+cO
+aS
+cK
+cO
+aS
+cK
+cO
+aS
+PJ
+Ph
+TY
+iz
+ad
+bp
+Xp
+TY
+ac
+kf
+mQ
+nC
+oi
+oi
+oi
+pK
+qs
+ri
+rV
+KI
+Hq
+KI
+Hq
+KI
+Hq
+KI
+sw
+vT
+vT
+vT
+vT
+vT
+vT
+vT
+ac
+ac
+ac
+AU
+Bl
+BB
+AU
+Cc
+CA
+AU
+ac
+aP
+aP
+aP
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(58,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+RB
+Ly
+RS
+Ev
+SI
+YD
+SI
+SI
+SI
+Fv
+VJ
+Rb
+aS
+Ew
+am
+aS
+ca
+cQ
+aS
+cc
+cQ
+aS
+cc
+cQ
+aS
+cc
+cQ
+aS
+gy
+Oc
+TY
+TY
+TY
+Yq
+TY
+TY
+kj
+kf
+iw
+nD
+oj
+oN
+pf
+pM
+qt
+rj
+rW
+KI
+tg
+KP
+Sb
+SW
+Sp
+Yf
+vT
+wZ
+xu
+xO
+yt
+yT
+zd
+vT
+ac
+ac
+ac
+AU
+AU
+AU
+AU
+Cd
+CB
+AU
+ac
+ac
+aP
+aP
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(59,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Rj
+ab
+IO
+Mq
+Ql
+SI
+RT
+bf
+bf
+DK
+Rr
+PX
+at
+QZ
+XA
+aS
+Gw
+am
+aS
+cM
+cR
+aS
+dq
+cR
+aS
+dw
+cR
+aS
+dO
+cR
+aS
+gV
+hs
+hU
+hU
+aj
+Nj
+kj
+Pd
+KJ
+kj
+kj
+nE
+hr
+hr
+hr
+hr
+qu
+rk
+rX
+KI
+IG
+Up
+Up
+Up
+SV
+HA
+vT
+xa
+xv
+xP
+yu
+xd
+ze
+vT
+ac
+ac
+ac
+AU
+Bm
+BC
+BN
+Ce
+CC
+AU
+ac
+ac
+aP
+aP
+aP
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(60,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+at
+VH
+RS
+DK
+DK
+at
+at
+at
+at
+at
+UO
+PV
+aS
+aS
+aG
+aS
+bq
+bL
+aS
+bq
+cS
+aS
+bq
+ew
+aS
+bq
+fZ
+aS
+gW
+ht
+hV
+hV
+aj
+jM
+ki
+kU
+lD
+mp
+mR
+nF
+ok
+oO
+mp
+hr
+qv
+rk
+rY
+KI
+Ha
+RJ
+LT
+Pj
+ev
+vT
+vT
+xb
+xd
+xQ
+yv
+xd
+zf
+vT
+za
+za
+AG
+AG
+AG
+AG
+AG
+Cf
+AG
+AG
+AG
+AG
+aP
+aP
+aP
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(61,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+RB
+ZJ
+DK
+Si
+Py
+at
+ac
+ac
+ac
+at
+TW
+OY
+RS
+aj
+Qn
+bC
+aW
+XG
+bH
+aX
+cT
+bJ
+aY
+KQ
+bQ
+bd
+KQ
+co
+gX
+hu
+FI
+iC
+aj
+jN
+hr
+kV
+lE
+mq
+mS
+nF
+jL
+oP
+pg
+hr
+qw
+rl
+QF
+VA
+ZK
+Jq
+IB
+PR
+PS
+vT
+wq
+xc
+xd
+xR
+xd
+xd
+zg
+vT
+Aa
+Ap
+AG
+AV
+Bn
+BD
+BO
+Cg
+CD
+CP
+Dd
+Di
+aP
+aP
+aP
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(62,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+RB
+Zl
+bf
+Oj
+Xk
+at
+ac
+ac
+ac
+at
+Fs
+YM
+RS
+aj
+aH
+Sl
+bs
+bM
+cf
+cz
+QH
+ds
+dT
+Vm
+fc
+fI
+ga
+cq
+gY
+hv
+hW
+iD
+aj
+jN
+kj
+kW
+lF
+mr
+mT
+nG
+ol
+mS
+ph
+hr
+qx
+Vw
+Xq
+TO
+Do
+VK
+Gf
+Yc
+LL
+vT
+wr
+xd
+xd
+xS
+yw
+xd
+zh
+vT
+Ab
+Aq
+AG
+AW
+Bo
+BE
+BP
+Ch
+AX
+AX
+AX
+Di
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(63,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+at
+at
+at
+at
+at
+at
+ac
+ac
+ac
+at
+Fs
+YM
+RS
+aj
+aj
+ba
+aj
+aj
+ba
+cA
+cU
+cU
+dU
+cU
+fd
+fd
+cl
+fd
+fd
+fd
+cx
+fd
+aj
+jO
+kj
+kX
+lG
+ms
+mU
+nH
+om
+oQ
+pi
+pN
+qy
+rm
+rZ
+KI
+KI
+KI
+KI
+KI
+KI
+vT
+ws
+xe
+xe
+xT
+yx
+xe
+zi
+zL
+Ac
+Ar
+AH
+AX
+Bp
+BF
+BQ
+Ci
+CE
+CQ
+AX
+Di
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(64,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ac
+ac
+ac
+ac
+BK
+ac
+ac
+ac
+at
+TW
+XM
+RS
+aj
+cw
+cB
+aj
+cw
+cB
+cA
+Ds
+du
+QD
+aM
+fd
+Mp
+Sy
+Mp
+Fj
+En
+hY
+fd
+LD
+jP
+kk
+kY
+kY
+kY
+kY
+kY
+kY
+jj
+pj
+kj
+qz
+rk
+sa
+sB
+th
+tK
+uq
+uU
+vw
+vT
+wt
+xf
+xf
+xU
+xd
+xd
+zj
+vT
+Ad
+As
+AH
+AY
+Bp
+BG
+BR
+Cj
+CF
+CR
+De
+AG
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(65,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+at
+TW
+WJ
+RS
+aj
+bY
+cC
+aj
+bY
+cC
+cA
+cV
+dv
+dV
+aR
+fd
+fK
+gb
+gE
+Of
+WL
+hZ
+fd
+fN
+jQ
+kk
+kY
+lH
+lH
+lH
+lH
+kY
+jj
+kj
+pO
+qA
+rn
+sb
+sC
+ti
+tL
+ur
+uV
+vx
+vU
+wu
+xd
+xw
+xV
+yy
+yU
+zk
+vT
+Ae
+At
+AH
+AX
+Bp
+BG
+BS
+Ck
+CG
+CS
+Df
+AG
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(66,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+at
+TW
+PV
+RS
+aj
+cy
+cD
+aj
+cy
+cD
+cA
+as
+az
+aI
+Kv
+fd
+fL
+gc
+Mp
+ha
+hw
+ia
+fd
+jl
+jR
+kk
+kY
+lH
+lH
+lH
+lH
+kY
+jL
+kj
+pP
+qB
+ro
+rP
+sD
+tj
+sD
+us
+uW
+uW
+uW
+wv
+xg
+uW
+xW
+uW
+uW
+vT
+vT
+Af
+Au
+AI
+AZ
+Bq
+BH
+BT
+Cl
+CH
+CT
+AX
+Di
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(67,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+at
+TW
+XA
+RS
+aj
+aj
+aj
+aj
+aj
+aj
+cA
+cA
+cA
+cA
+cA
+fd
+fd
+fd
+fd
+fd
+fd
+fd
+fd
+Tj
+jS
+kk
+kY
+lH
+lH
+lH
+lH
+kY
+oR
+kj
+pQ
+qC
+nU
+sc
+sD
+tk
+tM
+ut
+uW
+vy
+vV
+ww
+xh
+xx
+xX
+yz
+uW
+zl
+zM
+Ag
+Av
+AG
+Ba
+Br
+BI
+BI
+BI
+CI
+CU
+CU
+Di
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(68,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+at
+TW
+OY
+RS
+at
+RS
+RS
+bf
+bf
+bf
+RS
+aN
+aN
+XM
+Qu
+fi
+XM
+aN
+aN
+XM
+XM
+aN
+aN
+XM
+jS
+kk
+kY
+lH
+lH
+lH
+lH
+kY
+oS
+kj
+pR
+qD
+rp
+sc
+sD
+tl
+tN
+uu
+uW
+vy
+vW
+wx
+xi
+xy
+xY
+yA
+uW
+zm
+zN
+Ah
+Aw
+AG
+Bb
+Bs
+BJ
+BU
+Cm
+CJ
+CV
+Dg
+Di
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(69,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+at
+MO
+Ej
+XM
+Qu
+aN
+aN
+aN
+aN
+aN
+XM
+XM
+be
+Uf
+at
+YU
+fN
+RS
+gG
+LG
+LE
+SI
+SI
+SI
+RT
+kk
+kY
+kY
+lH
+lH
+nI
+kY
+kj
+kj
+pS
+qE
+rq
+sd
+sE
+sE
+sE
+sE
+uW
+vy
+vX
+wy
+xj
+xz
+xZ
+yB
+yV
+zn
+zO
+za
+za
+AG
+AG
+AG
+AG
+AG
+AG
+AG
+AG
+AG
+AG
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(70,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+at
+OA
+FA
+QG
+at
+aO
+bf
+bx
+bS
+ci
+ci
+at
+at
+at
+at
+at
+at
+fo
+gH
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+kZ
+lI
+mt
+mt
+nJ
+on
+oT
+pk
+pT
+qF
+nP
+sc
+sE
+tm
+tO
+uv
+uW
+vz
+vY
+wz
+xk
+xA
+ya
+yC
+xg
+zo
+zP
+Ai
+Ax
+AJ
+Bc
+Bc
+BK
+ac
+ac
+ac
+ac
+ac
+ac
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(71,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+at
+at
+at
+at
+at
+at
+at
+at
+at
+at
+at
+cY
+dy
+dY
+ey
+iH
+fO
+ge
+gI
+hc
+dm
+id
+ed
+jn
+ej
+kl
+la
+lJ
+lJ
+lJ
+nK
+lJ
+oU
+pl
+lK
+qG
+rr
+sc
+oW
+oW
+oW
+oW
+uX
+vy
+vY
+wA
+xl
+xB
+xB
+yD
+uW
+zp
+zQ
+Aj
+Ay
+AK
+AK
+Bt
+BK
+ac
+ac
+ac
+ac
+ac
+ac
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(72,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+Qs
+Qs
+Qs
+Qs
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
+cY
+dz
+dZ
+ez
+fj
+fO
+gf
+gJ
+hd
+dr
+ie
+ee
+jo
+er
+km
+lb
+lJ
+lJ
+lJ
+nL
+oo
+oV
+pm
+pU
+pU
+pU
+se
+oW
+tn
+tP
+uw
+uX
+vy
+vZ
+wB
+wB
+wB
+wB
+yE
+uW
+zq
+zR
+Ak
+Az
+AL
+Bd
+Bu
+BK
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(73,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+Qs
+Qs
+Qs
+Qs
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
+cY
+dA
+ea
+eA
+fk
+fP
+gg
+gK
+he
+dS
+hz
+ef
+hz
+dS
+et
+lc
+lK
+lK
+lK
+nM
+op
+oW
+oW
+oW
+oW
+oW
+oW
+oW
+to
+tQ
+pX
+uX
+uX
+wa
+wC
+wC
+wC
+wC
+wC
+uW
+zr
+zS
+Al
+AA
+AM
+Bd
+Bv
+yY
+yY
+yY
+yY
+yY
+yY
+yY
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(74,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+Qs
+Qs
+Qs
+Qs
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
+cY
+dB
+eb
+eB
+fl
+fQ
+gh
+gL
+hf
+hA
+iA
+iM
+hA
+hA
+eu
+ld
+lJ
+mu
+lJ
+nN
+oq
+oW
+pn
+pV
+qH
+rs
+sf
+sF
+tp
+tR
+ux
+uY
+oW
+wb
+ve
+uX
+uX
+uX
+uX
+uX
+zs
+zT
+Ai
+AB
+AN
+AN
+Bw
+yY
+eJ
+eN
+eN
+eN
+eO
+yY
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(75,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+Qs
+Qs
+Qs
+Qs
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
+cY
+dC
+ec
+eC
+fm
+fO
+gi
+gM
+hg
+dW
+hB
+eg
+hB
+dW
+ex
+le
+lL
+lL
+mV
+nN
+oq
+oW
+po
+pW
+qI
+rt
+sg
+sG
+tq
+tS
+pX
+uZ
+oW
+wc
+wD
+ve
+xC
+yb
+yF
+ve
+zt
+zU
+Ai
+AC
+AO
+Be
+Be
+yY
+BW
+Co
+Co
+Co
+BW
+yY
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(76,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+Qs
+Qs
+Qs
+Qs
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
+cY
+cY
+cY
+cY
+cY
+cY
+gj
+gN
+hh
+dX
+if
+eh
+ge
+ej
+km
+lf
+lJ
+lJ
+mW
+nN
+oq
+oW
+pp
+pX
+qH
+ru
+sh
+oW
+tr
+tT
+tp
+va
+vA
+wd
+wE
+xm
+xD
+yc
+yG
+yW
+zu
+zV
+Ai
+Ai
+Ai
+Ai
+Ai
+yY
+BW
+Cp
+CK
+CW
+BW
+yY
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(77,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+VL
+bg
+cZ
+dD
+dD
+fn
+fR
+gk
+gO
+hi
+dr
+ig
+ei
+jo
+er
+kl
+lg
+lM
+mv
+mX
+nN
+or
+oW
+oW
+oW
+oW
+rv
+si
+sH
+si
+ru
+pX
+vb
+oW
+we
+wF
+xn
+xE
+yd
+yH
+yX
+zv
+zW
+Am
+AD
+za
+ac
+ac
+yY
+BW
+Cq
+Ct
+CX
+BW
+yY
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(78,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+VL
+bg
+da
+bg
+bg
+fo
+fS
+fo
+gP
+dE
+dE
+dE
+dE
+dE
+jX
+jX
+jX
+jX
+jX
+mY
+nO
+os
+oW
+FD
+pV
+qH
+ru
+pX
+sI
+pX
+tU
+pX
+vc
+qH
+wf
+wG
+ve
+xF
+xF
+xF
+yY
+zw
+zW
+Am
+AD
+za
+za
+za
+yY
+BW
+Cr
+Ct
+CY
+BW
+yY
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(79,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+VL
+bg
+da
+bg
+eD
+fo
+cL
+gl
+cW
+dE
+hD
+ih
+iQ
+dE
+jX
+kp
+lh
+lN
+jX
+mZ
+nN
+ot
+oW
+po
+pY
+qJ
+rw
+pX
+rs
+ts
+rw
+uy
+vd
+qH
+wg
+wH
+ve
+xG
+ye
+ye
+yZ
+zx
+zX
+An
+An
+AP
+AP
+Bx
+BL
+BX
+Cs
+Ct
+CZ
+BW
+yY
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(80,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+VL
+bg
+da
+dE
+dE
+dE
+dE
+dE
+dE
+dE
+hE
+ii
+iR
+dE
+jX
+kq
+li
+lO
+jX
+na
+nN
+ou
+oW
+pp
+pX
+qH
+rx
+sj
+sJ
+pX
+tV
+uz
+oW
+oW
+wh
+wI
+ve
+xH
+yf
+yI
+za
+zy
+zY
+Ao
+AE
+AQ
+Bf
+By
+BL
+BX
+Ct
+Ct
+Da
+BW
+yY
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(81,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+VL
+bg
+db
+dE
+To
+fp
+eE
+gm
+dE
+dE
+dE
+ij
+dE
+dE
+jX
+kr
+lj
+lP
+jX
+nb
+nN
+ov
+oW
+oW
+oW
+oW
+oW
+qH
+sK
+qH
+oW
+oW
+ve
+vB
+wi
+wJ
+ve
+xI
+yg
+yJ
+za
+zz
+za
+za
+za
+AR
+Bg
+za
+yY
+BY
+Cu
+Ct
+Db
+BY
+yY
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(82,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+VL
+bg
+dc
+dE
+eF
+fU
+fU
+gn
+dE
+hj
+hF
+ik
+iS
+fV
+jX
+jX
+lk
+jX
+jX
+nc
+nN
+ow
+oW
+pq
+pZ
+qK
+ry
+sk
+sL
+tt
+tW
+uA
+vf
+vC
+wj
+wK
+ve
+wo
+wo
+wo
+wo
+zA
+zZ
+aP
+AF
+AS
+Bh
+AF
+yY
+BW
+Cv
+Ct
+Dc
+BW
+yY
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(83,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+VL
+bg
+da
+dE
+eG
+fr
+fV
+go
+dE
+hk
+hG
+il
+iT
+jp
+jY
+ks
+ll
+lQ
+jY
+nd
+nN
+ot
+oW
+pr
+pZ
+qL
+rz
+sl
+sM
+sl
+tX
+uB
+ve
+ve
+ve
+wL
+ve
+wo
+yh
+yh
+wo
+zB
+zZ
+ac
+aP
+AT
+Bi
+aP
+yY
+BW
+Cw
+Ct
+Dc
+BW
+yY
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(84,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+VL
+bg
+da
+dE
+eH
+fs
+Fx
+gp
+gR
+hl
+hH
+im
+fW
+jq
+jZ
+kt
+lm
+lR
+mw
+ne
+nM
+ot
+oW
+ps
+pZ
+qM
+rA
+sl
+sM
+sl
+tY
+sl
+sl
+vD
+wk
+wM
+xo
+wo
+yh
+yh
+wo
+zC
+zZ
+ac
+aP
+aP
+aP
+aP
+yY
+BW
+Cx
+CL
+Cx
+BW
+yY
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(85,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+VL
+bg
+dd
+dE
+eI
+ft
+fV
+gq
+dE
+hm
+hI
+in
+iU
+jr
+ka
+ku
+ll
+lS
+mx
+nf
+nP
+ot
+oW
+pt
+pZ
+qN
+rB
+sm
+sN
+tu
+tZ
+uC
+vg
+vE
+wl
+wN
+xp
+wo
+yi
+yK
+wo
+zD
+zZ
+ac
+aP
+aP
+aP
+aP
+yY
+BZ
+BW
+CM
+BW
+BZ
+yY
+aP
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(86,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+VL
+bg
+da
+dE
+eF
+fU
+fU
+Me
+dE
+hn
+fU
+ik
+iV
+fV
+kb
+kb
+ln
+kb
+kb
+ng
+nP
+ot
+oW
+ps
+pZ
+qO
+rC
+sn
+sn
+tv
+ua
+sn
+vh
+ve
+wm
+wO
+xq
+wo
+yi
+yK
+wo
+zD
+zZ
+ac
+ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(87,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+VL
+bg
+bg
+bg
+bg
+da
+dE
+GY
+fv
+eK
+gr
+dE
+dE
+dE
+ij
+dE
+dE
+kb
+kv
+lo
+lT
+kb
+WG
+nP
+ot
+oW
+pu
+pZ
+qP
+rD
+so
+sO
+tw
+ub
+uD
+pZ
+ve
+ve
+ve
+ve
+wo
+yj
+yL
+wo
+zE
+zZ
+ac
+ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(88,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+bg
+bg
+bg
+bT
+bT
+bg
+de
+dE
+dE
+dE
+dE
+dE
+dE
+dE
+hJ
+io
+iW
+dE
+kb
+kw
+lp
+lU
+kb
+nh
+nP
+ot
+oW
+oW
+pZ
+pZ
+pZ
+pZ
+pZ
+pZ
+pZ
+pZ
+pZ
+vF
+wn
+wP
+xr
+xJ
+yk
+yM
+zb
+zF
+zZ
+ac
+ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(89,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+bg
+by
+bU
+bU
+cE
+bU
+df
+dF
+ek
+bg
+OQ
+OQ
+OQ
+dE
+hK
+ip
+iX
+dE
+kb
+kx
+lq
+lV
+kb
+ni
+nQ
+ox
+oX
+pv
+qa
+pv
+rE
+pv
+pv
+pv
+uc
+pv
+pv
+vG
+wo
+wo
+wo
+wo
+yl
+yN
+wo
+wo
+wo
+ac
+ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(90,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+bg
+bz
+bV
+cj
+cF
+cF
+dg
+dG
+el
+bg
+UX
+KX
+OQ
+dE
+dE
+dE
+dE
+dE
+kb
+kb
+kb
+kb
+kb
+nh
+nP
+oy
+oY
+oY
+oY
+oY
+oY
+oY
+oY
+oY
+oY
+oY
+oY
+oY
+wo
+wQ
+xs
+xK
+ym
+yO
+wV
+zG
+wo
+ac
+ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(91,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+Yw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+bg
+bA
+bA
+bg
+cG
+bg
+dH
+dH
+eL
+bg
+UX
+OQ
+OQ
+OQ
+OQ
+OQ
+Rd
+JK
+Dl
+KV
+Pl
+Pl
+LQ
+Xw
+Tl
+Uu
+oY
+pw
+qb
+oY
+rF
+qb
+oY
+tx
+ud
+uE
+vi
+oY
+wo
+wR
+wV
+wV
+yn
+yO
+wV
+zH
+wo
+ac
+ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(92,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+Yw
+Yw
+Yw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+bg
+bA
+bA
+bg
+cH
+bg
+dI
+em
+em
+bg
+UX
+UX
+UX
+WI
+JK
+JK
+RA
+iY
+iY
+iY
+iY
+iY
+ns
+nh
+nP
+oy
+oY
+pw
+qc
+oY
+rG
+qc
+oY
+qc
+qc
+qc
+qc
+oY
+wo
+wS
+wV
+wV
+yn
+yO
+wV
+zI
+wo
+ac
+ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(93,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+ac
+ac
+ac
+ac
+ac
+ac
+bg
+bg
+bg
+bg
+cI
+bg
+dJ
+dJ
+dJ
+bg
+OJ
+OJ
+OQ
+UB
+OQ
+Ll
+iY
+iY
+js
+js
+js
+js
+ns
+nk
+nP
+oy
+oY
+px
+qd
+oY
+px
+sp
+oY
+px
+ue
+uF
+tD
+oY
+wo
+wT
+xt
+xL
+yo
+yP
+xN
+zJ
+wo
+ac
+ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(94,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aP
+Zo
+aP
+aP
+aP
+aP
+aP
+aP
+OJ
+Hk
+Ll
+OQ
+Ll
+iY
+js
+kc
+kz
+kd
+jx
+my
+EJ
+nP
+oz
+oZ
+py
+qe
+qQ
+rH
+qe
+sP
+ty
+qe
+uG
+vj
+vH
+wo
+wU
+wV
+xM
+yp
+yQ
+zc
+zK
+wo
+ac
+ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(95,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aP
+fy
+Zo
+fy
+aP
+aP
+aP
+aP
+aP
+OJ
+Ll
+Ll
+OQ
+Ll
+iY
+jt
+js
+kz
+js
+jx
+mz
+nm
+nP
+oA
+pa
+pz
+qc
+qR
+pz
+qc
+qc
+tz
+qc
+pz
+qc
+vI
+wo
+wV
+wV
+xM
+yq
+yR
+zc
+wV
+wo
+ac
+ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(96,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+ac
+ac
+ac
+ac
+ac
+Zo
+Zo
+Zo
+Zo
+Zo
+Zo
+Zo
+Zo
+Zo
+Zo
+OJ
+OJ
+OJ
+OJ
+TB
+iY
+jt
+jt
+jx
+js
+NJ
+mA
+nn
+nR
+oB
+pb
+pA
+qf
+qS
+rI
+qf
+sQ
+tA
+uf
+pz
+qc
+vJ
+wo
+wW
+wV
+xN
+yr
+yS
+xN
+wV
+wo
+ac
+ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(97,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+ac
+ac
+ac
+ac
+aP
+aP
+fy
+Zo
+fy
+aP
+aP
+aP
+aP
+aP
+Zx
+Ll
+Ll
+Uo
+Ll
+iY
+jt
+jt
+kC
+kc
+jt
+ns
+no
+lJ
+oC
+pc
+pB
+qg
+qT
+rJ
+qg
+sR
+tB
+ug
+pB
+qg
+vK
+wo
+wX
+wV
+wV
+ys
+wV
+wV
+wV
+wo
+ac
+ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(98,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+aP
+ac
+aP
+aP
+aP
+aP
+Zo
+aP
+aP
+aP
+aP
+aP
+aP
+OJ
+DN
+Ll
+EF
+Ll
+iY
+js
+Rl
+kD
+ls
+ma
+mB
+np
+nS
+oD
+oZ
+pC
+qh
+qU
+rK
+sq
+sS
+tC
+uh
+uH
+vk
+vL
+wo
+wY
+wY
+wY
+wY
+wY
+wY
+wY
+wo
+ac
+ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(99,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+aP
+aP
+aP
+aP
+aP
+fy
+Zo
+fy
+aP
+aP
+aP
+aP
+aP
+Zx
+Ll
+Ll
+ZX
+Ll
+iY
+jx
+jx
+js
+jt
+mb
+ns
+nq
+nT
+oE
+oY
+pD
+qi
+oY
+rL
+sr
+sT
+tD
+ui
+uI
+tD
+oY
+oY
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+ac
+ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(100,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+aP
+aP
+aP
+aP
+aP
+aP
+Zo
+aP
+aP
+aP
+aP
+aP
+aP
+OJ
+SK
+Ll
+Ll
+Ll
+iY
+jx
+js
+kF
+jx
+Nh
+mA
+nl
+nU
+ot
+oY
+pE
+qc
+oY
+rM
+qc
+qc
+qc
+uj
+uJ
+vl
+oY
+oY
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+ac
+ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(101,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Zo
+Zo
+SM
+Zo
+SM
+Zo
+Zo
+Zo
+Zo
+Zo
+Zx
+Ta
+JL
+Sv
+Tf
+iY
+jx
+kd
+kG
+jx
+YH
+mA
+nr
+nV
+oF
+oY
+pE
+qj
+oY
+rN
+qc
+sU
+tE
+uk
+uK
+vl
+oY
+oY
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(102,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aP
+aP
+aP
+Zo
+aP
+aP
+aP
+aP
+aP
+aP
+OJ
+OJ
+OJ
+OJ
+OJ
+iY
+jt
+jt
+Gd
+js
+js
+ns
+ns
+ns
+ns
+oY
+oY
+oY
+oY
+oY
+oY
+sV
+oY
+oY
+uL
+oY
+oY
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(103,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fy
+Lr
+fy
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+iY
+iY
+jt
+jt
+js
+js
+iY
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+oY
+sW
+tF
+oY
+uM
+oY
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(104,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+iY
+iY
+iY
+iY
+iY
+iY
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+oY
+sX
+sX
+oY
+uN
+oY
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aP
+aP
+aP
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(105,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+oY
+oY
+oY
+oY
+uO
+oY
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(106,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(107,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(108,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(109,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(110,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(111,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(112,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(113,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(114,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(115,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(116,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(117,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(118,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(119,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(120,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(121,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(122,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(123,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(124,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(125,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(126,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(127,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(128,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(129,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(130,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(131,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(132,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(133,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(134,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(135,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(136,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(137,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(138,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(139,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(140,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changing up the layout of robotics but giving them a jukebox, putting a service window for crew to easily ask for help for them like they can for general R&D. Adds an AI holopad, and intercoms to the mid-point tether. Finally, replaces the excess air alarms in the confession booth, adds more lighting AND also replaces the stools with benches.

## Why It's Good For The Game

QOL love, and suggestions from the community.
Sci Change - https://cdn.discordapp.com/attachments/686476138901667895/696228083639910480/RoboticsChanges.png
Chapel Change - https://cdn.discordapp.com/attachments/686476138901667895/696228086743826533/ChapelChanges.png

## Changelog
:cl:
add: Added holopad and intercomms in parts of the station as stated above
tweak: Service desk added to Robotics original side entrance.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
