### PR TITLE
Virology crates now stocked, plus new BENEFICIAL symptoms. Otherwise known as, "lol lynch viro anyways."

### DIFF
--- a/code/datums/supplypacks/medical_vr.dm
+++ b/code/datums/supplypacks/medical_vr.dm
@@ -28,3 +28,12 @@
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Virology biohazard equipment"
 	access = access_medical_equip
+
+
+/datum/supply_pack/med/virus
+    name = "Virus sample crate"
+    contains = list(/obj/item/weapon/virusdish/random = 4)
+    cost = 25
+    containertype = "/obj/structure/closet/crate/secure"
+    containername = "Virus sample crate"
+    access = access_medical_equip

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -321,7 +321,7 @@
 
 /datum/disease2/effect/organ_repair/activate(var/mob/living/carbon/mob,var/multiplier)
 	if (mob.reagents.get_reagent_amount(data) < 8)
-		mob << "<span class='notice'>You feel like you rinsides relaxed and you feel healthier after.</span>"
+		mob << "<span class='notice'>You feel like your insides relaxed and you feel healthier after.</span>"
 		mob.reagents.add_reagent(data, 3)
 
 /datum/disease2/effect/toxins

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -79,20 +79,21 @@
 /datum/disease2/effect/gibbingtons/activate(var/mob/living/carbon/mob,var/multiplier)
 	// Probabilities have been tweaked to kill in ~2-3 minutes, giving 5-10 messages.
 	// Probably needs more balancing, but it's better than LOL U GIBBED NOW, especially now that viruses can potentially have no signs up until Gibbingtons.
+	// Tweaking this further cause WTF for a "~2-3 minutes" window god damn holy hell.
 	mob.adjustBruteLoss(10*multiplier)
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
 		var/obj/item/organ/external/O = pick(H.organs)
 		if(prob(25))
 			mob << "<span class='warning'>Your [O.name] feels as if it might burst!</span>"
-		if(prob(10))
+		if(prob(3))
 			spawn(50)
 				if(O)
 					O.droplimb(0,DROPLIMB_BLUNT)
 	else
 		if(prob(75))
 			mob << "<span class='warning'>Your whole body feels like it might fall apart!</span>"
-		if(prob(10))
+		if(prob(3))
 			mob.adjustBruteLoss(25*multiplier)
 
 /datum/disease2/effect/radian
@@ -101,8 +102,9 @@
 	maxm = 3
 	badness = 2
 
+// Nerfing the value of the base rad to adjust and not cause immediate rad poisoning to a crew member.
 /datum/disease2/effect/radian/activate(var/mob/living/carbon/mob,var/multiplier)
-	mob.apply_effect(2*multiplier, IRRADIATE, check_protection = 0)
+	mob.apply_effect(1.10*multiplier, IRRADIATE, check_protection = 0)
 
 /datum/disease2/effect/deaf
 	name = "Deafness"
@@ -112,6 +114,8 @@
 /datum/disease2/effect/deaf/activate(var/mob/living/carbon/mob,var/multiplier)
 	mob.ear_deaf += 20
 
+// This will either be removed cause, god damn why do we need to have stuff that changes a person's model to something.
+// Going to make this similar to gibbingtons' to make sure it's not an instant monkifying
 /datum/disease2/effect/monkey
 	name = "Genome Regression"
 	stage = 4
@@ -120,8 +124,16 @@
 /datum/disease2/effect/monkey/activate(var/mob/living/carbon/mob,var/multiplier)
 	if(istype(mob,/mob/living/carbon/human))
 		var/mob/living/carbon/human/h = mob
-		h.monkeyize()
+		if(prob(25))
+			mob << "<span class='warning'> You feel as if your body is trying to rapidly regress...</span>"
+		if(prob(3))
+			h.monkeyize()
+	else
+		mob << "<span class='warning'>You feel an odd attraction to consume banana's...</span>"
 
+
+
+// Yeah no just turning this to constant ticking oxyloss from a dying windpipe with the name
 /datum/disease2/effect/suicide
 	name = "Windpipe Contraction"
 	stage = 4
@@ -129,20 +141,20 @@
 
 /datum/disease2/effect/suicide/activate(var/mob/living/carbon/mob,var/multiplier)
 	var/datum/gender/TM = gender_datums[mob.get_visible_gender()]
-	mob.suiciding = 30
-	//instead of killing them instantly, just put them at -175 health and let 'em gasp for a while
-	viewers(mob) << "<font color='red'><b>[mob.name] is holding [TM.his] breath. It looks like [TM.he] [TM.is] trying to commit suicide.</b></font>"
-	mob.adjustOxyLoss(175 - mob.getToxLoss() - mob.getFireLoss() - mob.getBruteLoss() - mob.getOxyLoss())
-	mob.updatehealth()
+	if(prob(25))
+		viewers(mob) << "<font color='red'><b>[mob.name] is holding [TM.his] breath. It looks like [TM.his] ability to breath [TM.is] constricted!</b></font>"
+		mob.apply_damage(15, OXY)
 
+// Nerfing from 15 to 10
 /datum/disease2/effect/killertoxins
 	name = "Autoimmune Reponse"
 	stage = 4
 	badness = 2
 
 /datum/disease2/effect/killertoxins/activate(var/mob/living/carbon/mob,var/multiplier)
-	mob.adjustToxLoss(15*multiplier)
+	mob.adjustToxLoss(10*multiplier)
 
+// DNA Damage
 /datum/disease2/effect/dna
 	name = "Catastrophic DNA Degeneration"
 	stage = 4
@@ -180,6 +192,7 @@
 				C.status &= ~ORGAN_DEAD
 		H.update_icons_body()
 
+// Added a delay into how fast this will act
 /datum/disease2/effect/internalorgan
 	name = "Organ Shutdown"
 	stage = 4
@@ -191,8 +204,11 @@
 		var/organ = pick(list("heart","kidney","liver", "lungs"))
 		var/obj/item/organ/internal/O = H.organs_by_name[organ]
 		if (O.robotic != ORGAN_ROBOT)
-			O.damage += (5*multiplier)
-			H << "<span class='notice'>You feel a cramp in your guts.</span>"
+			if(prob(15))
+				O.damage += (5*multiplier)
+				H << "<span class='notice'>You feel a cramp in your guts.</span>"
+			else
+				H << "<span class='warning'>You feel like doom is coming.. you should head to medical!</span>"
 
 /datum/disease2/effect/immortal
 	name = "Hyperaccelerated Aging"
@@ -216,10 +232,28 @@
 	var/backlash_amt = 5*multiplier
 	mob.apply_damages(backlash_amt,backlash_amt,backlash_amt,backlash_amt)
 
+/datum/disease2/effect/better_bones
+	name = "Better Bones"
+	stage = 4
+	chance_maxm = 10
+
+/datum/disease2/effect/better_bones/activate(var/mob/living/carbon/mob,var/multiplier)
+	if(istype(mob, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = mob
+		for (var/obj/item/organ/external/E in H.organs)
+			E.min_broken_damage = max(5, E.min_broken_damage + 30)
+
+/datum/disease2/effect/better_bones/deactivate(var/mob/living/carbon/mob,var/multiplier)
+	if(istype(mob, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = mob
+		for (var/obj/item/organ/external/E in H.organs)
+			E.min_broken_damage = initial(E.min_broken_damage)
+
 /datum/disease2/effect/bones
 	name = "Brittle Bones"
 	stage = 4
 	badness = 2
+
 /datum/disease2/effect/bones/activate(var/mob/living/carbon/mob,var/multiplier)
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
@@ -249,8 +283,46 @@
 			H.adjust_fire_stacks(2)
 			H.IgniteMob()
 
+// Upgraded Chem Synth. Provided only good meds to heal a patient
+/datum/disease2/effect/improved_chem_synthesis
+	name = "Improved Chemical Synthesis"
+	stage = 4
+	chance_maxm = 45
+
+/datum/disease2/effect/improved_chem_synthesis/generate(c_data)
+	if(c_data)
+		data = c_data
+	else
+		data = pick("bicaridine", "kelotane", "anti_toxin", "tricordrazine")
+	var/datum/reagent/R = chemical_reagents_list[data]
+	name = "[initial(name)] ([initial(R.name)])"
+
+/datum/disease2/effect/improved_chem_synthesis/activate(var/mob/living/carbon/mob,var/multiplier)
+	if (mob.reagents.get_reagent_amount(data) < 5)
+		mob.reagents.add_reagent(data, 4)
+
+
 
 ////////////////////////STAGE 3/////////////////////////////////
+
+// Organ Repair
+/datum/disease2/effect/organ_repair
+	name = "Minor Organ Repair"
+	stage = 3
+	chance_maxm = 20
+
+/datum/disease2/effect/organ_repair/generate(c_data)
+	if(c_data)
+		data = c_data
+	else
+		data = "peridaxon"
+	var/datum/reagent/R = data
+	name = "[initial(name)] ([initial(R.name)])"
+
+/datum/disease2/effect/organ_repair/activate(var/mob/living/carbon/mob,var/multiplier)
+	if (mob.reagents.get_reagent_amount(data) < 8)
+		mob << "<span class='notice'>You feel like you rinsides relaxed and you feel healthier after.</span>"
+		mob.reagents.add_reagent(data, 3)
 
 /datum/disease2/effect/toxins
 	name = "Hyperacidity"
@@ -384,6 +456,19 @@
 /datum/disease2/effect/scream/activate(var/mob/living/carbon/mob,var/multiplier)
 	mob.say("*scream")
 
+// Will provide energy to the user
+/datum/disease2/effect/energy_boost
+	name = "Increased Energy"
+	stage = 2
+	chance_maxm = 30
+
+/datum/disease2/effect/energy_boost/activate(var/mob/living/carbon/mob,var/multiplier)
+	if(prob(30))
+		if(mob.drowsyness < 10)
+			mob.drowsyness = 0
+		else
+			mob.drowsyness -= 8
+
 /datum/disease2/effect/drowsness
 	name = "Excessive Sleepiness"
 	stage = 2
@@ -479,7 +564,61 @@
 	if (prob(50))
 		mob.say("*vomit")
 
+// Feeds protein slowly over time.
+/datum/disease2/effect/protein_synthesis
+	name = "Protein Synthesis"
+	stage = 2
+	chance_maxm = 15
+
+/datum/disease2/effect/protein_synthesis/generate(c_data)
+	if(c_data)
+		data = c_data
+	else
+		data = "protein"
+	var/datum/reagent/R = data
+	name = "[initial(name)] ([initial(R.name)])"
+
+/datum/disease2/effect/protein_synthesis/activate(var/mob/living/carbon/mob,var/multiplier)
+	if (mob.reagents.get_reagent_amount(data) < 30)
+		mob.reagents.add_reagent(data, 5)
+
+// Feeds nutriment slowly over time.
+/datum/disease2/effect/nutriment_synthesis
+	name = "Nutriment Synthesis"
+	stage = 2
+	chance_maxm = 15
+
+/datum/disease2/effect/nutriment_synthesis/generate(c_data)
+	if(c_data)
+		data = c_data
+	else
+		data = "protein"
+	var/datum/reagent/R = data
+	name = "[initial(name)] ([initial(R.name)])"
+
+/datum/disease2/effect/nutriment_synthesis/activate(var/mob/living/carbon/mob,var/multiplier)
+	if (mob.reagents.get_reagent_amount(data) < 30)
+		mob.reagents.add_reagent(data, 5)
+
 ////////////////////////STAGE 1/////////////////////////////////
+
+// Feeds sugar VERY slowly over time.
+/datum/disease2/effect/sugar_synthesis
+	name = "Sugar Synthesis"
+	stage = 1
+	chance_maxm = 5
+
+/datum/disease2/effect/sugar_synthesis/generate(c_data)
+	if(c_data)
+		data = c_data
+	else
+		data = "sugar"
+	var/datum/reagent/R = data
+	name = "[initial(name)] ([initial(R.name)])"
+
+/datum/disease2/effect/sugar_synthesis/activate(var/mob/living/carbon/mob,var/multiplier)
+	if (mob.reagents.get_reagent_amount(data) < 30)
+		mob.reagents.add_reagent(data, 5)
 
 /datum/disease2/effect/sneeze
 	name = "Sneezing"

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -3023,15 +3023,22 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload)
 "eJ" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_l"
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -32
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station{
-	base_turf = /turf/simulated/mineral/floor/vacuum
-	})
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/virusdish/random,
+/obj/item/weapon/virusdish/random,
+/obj/item/weapon/virusdish/random,
+/obj/item/weapon/virusdish/random,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
 "eK" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -3051,7 +3058,8 @@
 /area/space)
 "eN" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8
+	dir = 8;
+	icon_state = "propulsion_l"
 	},
 /turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
@@ -3059,6 +3067,15 @@
 	base_turf = /turf/simulated/mineral/floor/vacuum
 	})
 "eO" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"eP" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
 	icon_state = "propulsion_r"
@@ -11623,19 +11640,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"vb" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -32
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/closet/crate/freezer,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "vc" = (
@@ -30027,11 +30031,11 @@ AN
 AN
 Bw
 yY
-eJ
-eN
-eN
 eN
 eO
+eO
+eO
+eP
 yY
 ac
 ac
@@ -30436,7 +30440,7 @@ sH
 si
 ru
 pX
-vb
+eJ
 oW
 we
 wF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Virology has been a quiet/empty spot for the server since before I got here that's for sure, and even if it was accessible it had almost no benefit for players except antags. This is set to be a series of changes to bring Virology into a spot that is fitting for the server and community, and provide exploration and others some bonuses in their rounds.

(Re-did this since the previous one failed and needed Nicc to re-review this)

## Why It's Good For The Game

Bringing in more things for medical to do in their shifts, and provide some possibly fun RP situations. Eventually we will have a less RNG heavy method of virology, and a much larger swath of positive, and neutral, symptoms for the medical team to find.



## Changelog
:cl:
add: Virology crate now comes stocked with 4 random virus samples
add: new possible symptoms to get.
balance: nerfed the stage 4 viruses to not be as round-ruining as they were currently.
code: New symptoms added, basic stuff for now. Will be adding much more better symptoms if we proceed with this.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
