### PR TITLE
Minor map fixing on Surface-3

### DIFF
--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -10101,7 +10101,7 @@
 	},
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
-	dir = 8;
+	dir = 2;
 	id = "bar";
 	layer = 3.3;
 	name = "Bar Shutters"
@@ -11617,6 +11617,7 @@
 "up" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
 "uq" = (
@@ -12777,10 +12778,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "wv" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether/surface)
+/obj/structure/table/marble,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "bar";
+	layer = 3.3;
+	name = "Bar Shutters"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "ww" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -13805,6 +13811,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
+"yc" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tether/surface)
 "yd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -37613,7 +37624,7 @@ Jr
 Js
 Jv
 JE
-wv
+yc
 IY
 JH
 JJ
@@ -37755,7 +37766,7 @@ Js
 Js
 Jz
 JE
-wv
+yc
 IY
 JH
 JJ
@@ -37897,7 +37908,7 @@ Jt
 Js
 Jz
 JE
-wv
+yc
 IY
 JH
 JJ
@@ -39859,7 +39870,7 @@ uT
 no
 xY
 nu
-rO
+wv
 rS
 rS
 rS
@@ -40001,7 +40012,7 @@ RB
 RB
 Ys
 nu
-rO
+wv
 rO
 sp
 rO


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Non major map changes. Fixing rotation of bar shutters, and adding atmos firedoors on the newly added glass windows for robotics.

## Why It's Good For The Game

QOL and improving safety of station.

## Changelog
:cl:
add: emergency atmos shutters for robotics glass windows
fix: adjusted rotation of some bar shutters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
