### PR TITLE
More Minor Map Fixing, Also Round-Start Spawn Locations for Science Team

### DIFF
--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -3050,6 +3050,32 @@
 /obj/random/trash_pile,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/lower/bar)
+"gK" = (
+/obj/structure/railing{
+	icon_state = "railing0";
+	dir = 1
+	},
+/turf/simulated/floor/water/deep,
+/area/tether/surfacebase/fishing_garden)
+"gL" = (
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/railing{
+	icon_state = "railing0";
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/water/deep,
+/area/tether/surfacebase/fishing_garden)
+"gM" = (
+/mob/living/simple_mob/animal/passive/fish/bass,
+/turf/simulated/floor/water/deep,
+/area/tether/surfacebase/fishing_garden)
+"gN" = (
+/mob/living/simple_mob/animal/passive/fish/rockfish,
+/turf/simulated/floor/water/deep,
+/area/tether/surfacebase/fishing_garden)
 "gO" = (
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/fishing_garden)
@@ -5274,6 +5300,9 @@
 	name = "RD Office Door Control";
 	pixel_x = -30;
 	pixel_y = -18
+	},
+/obj/effect/landmark/start{
+	name = "Research Director"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/rdoffice)
@@ -11070,10 +11099,10 @@
 /area/maintenance/lower/atmos)
 "vY" = (
 /obj/structure/railing{
-	icon_state = "railing0";
-	dir = 1
+	dir = 4
 	},
-/turf/simulated/floor/water/indoors,
+/mob/living/simple_mob/animal/passive/fish/koi,
+/turf/simulated/floor/water/deep,
 /area/tether/surfacebase/fishing_garden)
 "vZ" = (
 /obj/structure/cable/green{
@@ -11360,19 +11389,11 @@
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/fishing_garden)
 "wB" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/railing{
-	icon_state = "railing0";
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/simulated/floor/water/indoors,
+/turf/simulated/floor/water/deep,
 /area/tether/surfacebase/fishing_garden)
 "wC" = (
-/mob/living/simple_mob/animal/passive/fish/bass,
-/turf/simulated/floor/water/indoors,
+/mob/living/simple_mob/animal/passive/fish/koi,
+/turf/simulated/floor/water/deep,
 /area/tether/surfacebase/fishing_garden)
 "wD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -11382,8 +11403,10 @@
 /turf/simulated/floor/plating,
 /area/tcommsat/computer)
 "wE" = (
-/mob/living/simple_mob/animal/passive/fish/rockfish,
-/turf/simulated/floor/water/indoors,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/water/deep,
 /area/tether/surfacebase/fishing_garden)
 "wF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -12045,11 +12068,8 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/fishing_garden)
 "xr" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/mob/living/simple_mob/animal/passive/fish/koi,
-/turf/simulated/floor/water/indoors,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/simulated/floor/water/deep,
 /area/tether/surfacebase/fishing_garden)
 "xs" = (
 /obj/effect/floor_decal/borderfloor{
@@ -17878,28 +17898,29 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
 "IO" = (
-/turf/simulated/floor/water/indoors,
-/area/tether/surfacebase/fishing_garden)
-"IP" = (
-/mob/living/simple_mob/animal/passive/fish/koi,
-/turf/simulated/floor/water/indoors,
-/area/tether/surfacebase/fishing_garden)
-"IQ" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/simulated/floor/water/indoors,
-/area/tether/surfacebase/fishing_garden)
-"IR" = (
-/obj/structure/flora/ausbushes/reedbush,
-/turf/simulated/floor/water/indoors,
-/area/tether/surfacebase/fishing_garden)
-"IS" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /mob/living/simple_mob/animal/passive/fish/bass,
-/turf/simulated/floor/water/indoors,
+/turf/simulated/floor/water/deep,
+/area/tether/surfacebase/fishing_garden)
+"IP" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/water/deep,
+/area/tether/surfacebase/fishing_garden)
+"IQ" = (
+/mob/living/simple_mob/animal/passive/fish/solarfish,
+/turf/simulated/floor/water/deep,
+/area/tether/surfacebase/fishing_garden)
+"IR" = (
+/mob/living/simple_mob/animal/passive/fish/trout,
+/turf/simulated/floor/water/deep,
+/area/tether/surfacebase/fishing_garden)
+"IS" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/water/deep,
 /area/tether/surfacebase/fishing_garden)
 "IT" = (
 /obj/effect/floor_decal/borderfloor{
@@ -17916,10 +17937,10 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
 "IU" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/water/indoors,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/turf/simulated/floor/water/deep,
 /area/tether/surfacebase/fishing_garden)
 "IV" = (
 /obj/structure/closet,
@@ -18310,14 +18331,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/fishing_garden)
-"JT" = (
-/mob/living/simple_mob/animal/passive/fish/solarfish,
-/turf/simulated/floor/water/indoors,
-/area/tether/surfacebase/fishing_garden)
-"JU" = (
-/mob/living/simple_mob/animal/passive/fish/trout,
-/turf/simulated/floor/water/indoors,
-/area/tether/surfacebase/fishing_garden)
 "JV" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled,
@@ -18439,10 +18452,6 @@
 /obj/structure/railing,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
-/area/tether/surfacebase/fishing_garden)
-"Km" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/water/indoors,
 /area/tether/surfacebase/fishing_garden)
 "Kn" = (
 /obj/structure/cable{
@@ -26949,11 +26958,11 @@ cW
 hb
 xP
 vl
-vY
-wC
-IO
-IR
-IO
+gK
+gM
+wB
+xr
+wB
 Kw
 vn
 hb
@@ -27091,11 +27100,11 @@ ap
 hb
 xP
 vl
-vY
-wE
-IP
-wE
-JU
+gK
+gN
+wC
+gN
+IR
 Kq
 gO
 hb
@@ -27233,11 +27242,11 @@ cW
 hb
 vj
 vl
-wB
-xr
-IQ
-IS
-IQ
+gL
+vY
+wE
+IO
+wE
 Kq
 Kc
 hb
@@ -27378,8 +27387,8 @@ hr
 wF
 JX
 Ks
-JX
-JX
+IU
+IU
 JX
 Kv
 hb
@@ -27520,8 +27529,8 @@ wu
 Jp
 Cs
 xp
-IU
-IU
+IP
+IP
 Kq
 Ke
 hb
@@ -27662,8 +27671,8 @@ CB
 Jp
 vn
 Kl
-IO
-JU
+wB
+IR
 Kq
 xO
 hb
@@ -27804,8 +27813,8 @@ hE
 JS
 gO
 Kl
-JT
-Km
+IQ
+IS
 Bo
 xO
 hb
@@ -27946,8 +27955,8 @@ xR
 Jp
 vn
 Ky
-IO
-IP
+wB
+wC
 ww
 Kg
 hb

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -11652,7 +11652,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
 "uu" = (
-/obj/machinery/media/jukebox,
 /obj/machinery/firealarm{
 	dir = 2;
 	layer = 3.3;
@@ -12275,6 +12274,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
 "vw" = (
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
 "vx" = (
@@ -12451,6 +12453,9 @@
 "vR" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Scientist"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
@@ -13812,10 +13817,23 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "yc" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether/surface)
+/obj/effect/floor_decal/borderfloor{
+	dir = 8;
+	icon_state = "borderfloor";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/medical_wall/synth_anesthetics{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/assembly/robotics)
 "yd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -13846,6 +13864,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
+"yf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/reception_desk)
 "yg" = (
 /obj/structure/table/marble,
 /obj/item/reagent_containers/food/condiment/small/saltshaker{
@@ -14012,10 +14039,17 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/reception_desk)
 "yp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/rnd/reception_desk)
 "yq" = (
 /obj/structure/disposalpipe/segment{
@@ -14204,6 +14238,14 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atrium)
+"yC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/research/testingrange)
 "yD" = (
 /obj/structure/window/basic{
 	dir = 8
@@ -14214,6 +14256,22 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/atrium_three)
+"yE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Roboticist"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/assembly/robotics)
+"yF" = (
+/obj/structure/bed/chair/office/dark,
+/obj/effect/landmark/start{
+	name = "Roboticist"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/assembly/robotics)
 "yG" = (
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
@@ -14673,6 +14731,11 @@
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atrium)
+"zr" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tether/surface)
 "zt" = (
 /obj/structure/window/reinforced/full,
 /obj/structure/grille,
@@ -14793,16 +14856,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/rnd/reception_desk)
-"zE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -18202,11 +18255,6 @@
 "ED" = (
 /turf/simulated/floor/tiled,
 /area/rnd/research/testingrange)
-"EE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/rnd/research/testingrange)
 "EF" = (
 /obj/item/stool/padded,
 /turf/simulated/floor/carpet/bcarpet,
@@ -19981,32 +20029,10 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
-"HQ" = (
-/obj/structure/closet/secure_closet/medical_wall/anesthetics{
-	pixel_x = -32
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8;
-	icon_state = "borderfloor";
-	pixel_x = 0
-	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/assembly/robotics)
 "HR" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/assembly/robotics)
-"HS" = (
-/obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
 "HT" = (
@@ -31222,7 +31248,7 @@ BY
 CX
 Dy
 Ed
-EE
+yC
 EV
 FJ
 Gw
@@ -32650,7 +32676,7 @@ IU
 LM
 IH
 HM
-HQ
+yc
 Ia
 Da
 ac
@@ -32915,7 +32941,7 @@ ud
 xa
 xB
 xL
-yp
+yf
 yV
 zD
 zB
@@ -32926,7 +32952,7 @@ Cx
 Ei
 wq
 FV
-If
+yE
 HJ
 FV
 IA
@@ -33059,7 +33085,7 @@ xC
 xM
 yq
 yW
-zE
+yp
 zI
 xb
 Bf
@@ -33076,7 +33102,7 @@ LB
 LR
 Ih
 En
-HS
+yF
 Id
 Im
 ac
@@ -37624,7 +37650,7 @@ Jr
 Js
 Jv
 JE
-yc
+zr
 IY
 JH
 JJ
@@ -37766,7 +37792,7 @@ Js
 Js
 Jz
 JE
-yc
+zr
 IY
 JH
 JJ
@@ -37908,7 +37934,7 @@ Jt
 Js
 Jz
 JE
-yc
+zr
 IY
 JH
 JJ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

More minor fixing to level 2 and 3 of surface maps (Deep water, ensured alarms and other room critical supplies are for sure in, and a robotics anesthesia locker)

## Why It's Good For The Game

QOL love

## Changelog
:cl:
add: Spawn locations for Science Team
tweak: minor map tile fixing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
