### PR TITLE
field medics are infact part of medical (all exploration roles now appear in their respective 'master' departments on manifest as well)

### DIFF
--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -73,7 +73,8 @@ var/list/medical_positions = list(
 	"Geneticist",
 	"Psychiatrist",
 	"Chemist",
-	"Paramedic"
+	"Paramedic",
+	"Field Medic"
 )
 
 
@@ -82,7 +83,9 @@ var/list/science_positions = list(
 	"Scientist",
 	"Geneticist",	//Part of both medical and science
 	"Roboticist",
-	"Xenobiologist"
+	"Xenobiologist",
+	"Explorer",
+	"Pathfinder"
 )
 
 //BS12 EDIT
@@ -101,6 +104,7 @@ var/list/civilian_positions = list(
 	"Librarian",
 	"Lawyer",
 	"Chaplain",
+	"Pilot",
 	USELESS_JOB, //VOREStation Edit - Visitor not Assistant
 	"Intern" //VOREStation Edit - Intern
 )


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

someone asked me to and I think this is pretty sensical.
Exploration is meant to work as a unit, but on station, they're still part of their host departments, even if they can be pulled at times to do exploring.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: exploration roles now appear in their host department too, meaning sars/fms are also in med, explorers/pathfinders sci, and pilots civ
/:cl:


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
