### PR TITLE
Glide size tweaks

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -145,7 +145,10 @@
 	#define HEARING_SPANS 6
 	#define HEARING_MESSAGE_MODE 7 */
 #define COMSIG_MOVABLE_DISPOSING "movable_disposing"			//called when the movable is added to a disposal holder object for disposal movement: (obj/structure/disposalholder/holder, obj/machinery/disposal/source)
+*/
+#define COMSIG_MOVABLE_CHANGE_GLIDE_SIZE "glide_size_changed"	//from base of atom/movable/set_glide_size(new_glide_size, old_glide_size)
 
+/*
 // /mob signals
 #define COMSIG_MOB_DEATH "mob_death"							//from base of mob/death(): (gibbed)
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1,6 +1,9 @@
 /atom/movable
 	layer = OBJ_LAYER
 	appearance_flags = TILE_BOUND|PIXEL_SCALE|KEEP_TOGETHER
+	/// Our default glide_size.
+	var/default_glide_size = 0
+
 	var/last_move = null
 	var/anchored = 0
 	// var/elevation = 2    - not used anywhere

--- a/code/game/atoms_movable_movement.dm
+++ b/code/game/atoms_movable_movement.dm
@@ -275,3 +275,17 @@
 	for(var/item in src) // Notify contents of Z-transition. This can be overridden IF we know the items contents do not care.
 		var/atom/movable/AM = item
 		AM.onTransitZ(old_z,new_z)
+
+/**
+  * Sets our glide size
+  */
+/atom/movable/proc/set_glide_size(new_glide_size)
+	SEND_SIGNAL(src, COMSIG_MOVABLE_CHANGE_GLIDE_SIZE, new_glide_size, glide_size)
+	glide_size = new_glide_size
+
+/**
+  * Sets our glide size back to our standard glide size.
+  */
+
+/atom/movable/proc/reset_glide_size()
+	set_glide_size(default_glide_size)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -577,14 +577,19 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 	show_inv(usr)
 
 
-/mob/verb/stop_pulling()
-
+/mob/verb/stop_pulling_verb()
 	set name = "Stop Pulling"
 	set category = "IC"
 
+	stop_pulling()
+
+/// to be moved to atom/movable later.
+/mob/proc/stop_pulling()
+	. = ..()
 	if(pulling)
 		pulling.pulledby = null
 		pulling = null
+		pulling.reset_glide_size()
 		if(pullin)
 			pullin.icon_state = "pull0"
 
@@ -648,6 +653,7 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 
 	src.pulling = AM
 	AM.pulledby = src
+	AM.set_glide_size(glide_size)
 
 	if(pullin)
 		pullin.icon_state = "pull1"

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -15,6 +15,9 @@
 	anchored = 1
 	circuit = /obj/item/circuitboard/conveyor
 	speed_process = TRUE
+	/// What we set things to glide size to when they are being moved by us
+	var/conveyor_glide_size = 8
+
 	var/operating = OFF	// 1 if running forward, -1 if backwards, 0 if off
 	var/operable = 1	// true if can operate (no broken segments in this belt run)
 	var/forwards		// this is the default (forward) direction, set by the map dir
@@ -60,6 +63,16 @@
 	. =..()
 	update_dir()
 
+/obj/machinery/conveyor/Crossed(atom/movable/AM)
+	. = ..()
+	if(operating)
+		AM.set_glide_size(conveyor_glide_size)
+
+/obj/machinery/conveyor/Uncrossed(atom/movable/AM)
+	. = ..()
+	if(operating)
+		AM.reset_glide_size()
+
 /obj/machinery/conveyor/proc/update_dir()
 	if(!(dir in cardinal)) // Diagonal. Forwards is *away* from dir, curving to the right.
 		forwards = turn(dir, 135)
@@ -77,6 +90,9 @@
 		operating = OFF
 	if(stat & NOPOWER)
 		operating = OFF
+	if(operating)
+		for(var/atom/movable/AM in loc)
+			AM.set_glide_size(conveyor_glide_size)
 	icon_state = "conveyor[operating]"
 
 	// machine process


### PR DESCRIPTION
Made conveyors and pulling things update their glide size to the host's glide size.
Conveyors now glide things at a size of 8.

Makes conveyors prettier since they're fast now.