### PR TITLE
fixes translocators not teleporting to mining

### DIFF
--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -1418,7 +1418,7 @@
 	var/turf/uT = get_turf(user)
 	var/turf/dT = get_turf(destination)
 	var/list/dat = list()
-	dat["z_level_detection"] = GLOB.using_map.get_map_levels(uT.z)
+	dat["z_level_detection"] = GLOB.using_map.get_map_levels(uT.z, TRUE)
 
 	if(!uT || !dT)
 		return FALSE


### PR DESCRIPTION
I don't particularly like translocators (hinting to that they'll die someday by my hands :^)) but until we rip off the bandaid this is convenient.