### PR TITLE
Food & Drink Balance Pt 3: Otherwise known as, LOL sushi took steak meat and not fish meat

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -802,6 +802,7 @@
 					/obj/item/reagent_containers/food/drinks/glass2/fitnessflask = 8,
 					/obj/item/reagent_containers/food/snacks/candy/proteinbar = 8,
 					/obj/item/reagent_containers/food/snacks/liquidfood = 10,
+					/obj/item/reagent_containers/food/snacks/liquidprotein = 10,
 					/obj/item/reagent_containers/pill/diet = 8,
 					///obj/item/reagent_containers/hypospray/autoinjector/biginjector/glucose = 5,	//VOREStation Removal,
 					/obj/item/towel/random = 8)
@@ -812,6 +813,7 @@
 					/obj/item/reagent_containers/food/drinks/glass2/fitnessflask = 5,
 					/obj/item/reagent_containers/food/snacks/candy/proteinbar = 5,
 					/obj/item/reagent_containers/food/snacks/liquidfood = 10,
+					/obj/item/reagent_containers/food/snacks/liquidprotein = 10,
 					/obj/item/reagent_containers/pill/diet = 25,
 					///obj/item/reagent_containers/hypospray/autoinjector/biginjector/glucose = 5,	//VOREStation Removal,
 					/obj/item/towel/random = 40)

--- a/code/modules/food/drinkingglass/metaglass.dm
+++ b/code/modules/food/drinkingglass/metaglass.dm
@@ -556,7 +556,7 @@ Drinks Data
 	glass_center_of_mass = list("x"=16, "y"=8)
 
 /datum/reagent/ethanol/mintjulep
-	glass_icon_state = "mintjulep"
+	glass_icon_state = "mint_julep"
 	glass_center_of_mass = list("x"=16, "y"=16)
 
 /datum/reagent/ethanol/oldfashioned
@@ -567,7 +567,7 @@ Drinks Data
 	glass_icon_state = "bittersglass"
 
 /datum/reagent/ethanol/planterspunch
-	glass_icon_state = "planterspunch"
+	glass_icon_state = "junglejuice"
 
 /datum/reagent/ethanol/olympusmons
 	glass_icon_state = "olympusmons"

--- a/code/modules/food/drinkingglass/shaker.dm
+++ b/code/modules/food/drinkingglass/shaker.dm
@@ -1,12 +1,12 @@
-/obj/item/reagent_containers/food/drinks/glass2/fitnessflask
+/obj/item/reagent_containers/food/drinks/glass2/fitnessflask // Balance work
 	name = "fitness shaker"
 	base_name = "shaker"
 	desc = "Big enough to contain enough protein to get perfectly swole. Don't mind the bits."
 	icon_state = "fitness-cup_black"
 	base_icon = "fitness-cup"
-	volume = 100
+	volume = 50
 	matter = list("plastic" = 2000)
-	filling_states = list(10,20,30,40,50,60,70,80,90,100)
+	filling_states = list(5,10,15,20,25,30,35,40,45,50)
 	possible_transfer_amounts = list(5, 10, 15, 25)
 	rim_pos = null // no fruit slices
 	var/lid_color = "black"
@@ -28,4 +28,3 @@
 	reagents.add_reagent("nutriment", 10)
 	reagents.add_reagent("iron", 10)
 	reagents.add_reagent("protein", 30)
-	reagents.add_reagent("water", 50)

--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -727,10 +727,14 @@
 /obj/item/reagent_containers/food/snacks/carpmeat/sif/murkfish
 	toxin_type = "murk_protein"
 
-/obj/item/reagent_containers/food/snacks/carpmeat/fish
+/obj/item/reagent_containers/food/snacks/carpmeat/fish // Removed toxin and added a bit more oomph
 	desc = "A fillet of fish meat."
-	toxin_type = "neurotoxic_protein"
-	toxin_amount = 1
+	nutriment_amt = 2
+
+/obj/item/reagent_containers/food/snacks/carpmeat/fish/Initialize()
+	. = ..()
+	reagents.add_reagent("protein", 4)
+	bitesize = 3
 
 /obj/item/reagent_containers/food/snacks/fishfingers
 	name = "Fish Fingers"
@@ -3400,7 +3404,7 @@ END CITADEL CHANGE */
 /obj/item/reagent_containers/food/snacks/rawsticks/Initialize()
 	. = ..()
 
-/obj/item/reagent_containers/food/snacks/liquidfood
+/obj/item/reagent_containers/food/snacks/liquidfood // Buff back to 30 from 20
 	name = "\improper LiquidFood Ration"
 	desc = "A prepackaged grey slurry of all the essential nutrients for a spacefarer on the go. Should this be crunchy?"
 	icon_state = "liquidfood"
@@ -3408,7 +3412,7 @@ END CITADEL CHANGE */
 	filling_color = "#A8A8A8"
 	survivalfood = TRUE
 	center_of_mass = list("x"=16, "y"=15)
-	nutriment_amt = 20
+	nutriment_amt = 30
 	bitesize = 4
 	nutriment_desc = list("chalk" = 6)
 

--- a/code/modules/food/food/snacks_vr.dm
+++ b/code/modules/food/food/snacks_vr.dm
@@ -16,7 +16,7 @@
 	bitesize = 3 //How many reagents to transfer per bite?
 */
 
-/obj/item/reagent_containers/food/snacks/sliceable/sushi
+/obj/item/reagent_containers/food/snacks/sliceable/sushi // Buff 25 >> 35
 	name = "sushi roll"
 	desc = "A whole sushi roll! Slice it up and enjoy with some soy sauce and wasabi."
 	icon = 'icons/obj/food_vr.dmi'
@@ -24,11 +24,11 @@
 	slice_path = /obj/item/reagent_containers/food/snacks/slice/sushi/filled
 	slices_num = 5
 	nutriment_desc = list("rice" = 5, "fish" = 5)
-	nutriment_amt = 15
+	nutriment_amt = 20
 
 /obj/item/reagent_containers/food/snacks/sliceable/sushi/Initialize()
 	..()
-	reagents.add_reagent("protein", 10)
+	reagents.add_reagent("protein", 15)
 	bitesize = 5
 
 /obj/item/reagent_containers/food/snacks/slice/sushi/filled

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -1172,13 +1172,12 @@ I said no!
 
 //BEGIN CITADEL CHANGES
 
-/datum/recipe/sushi
+/datum/recipe/sushi // Changed to take fish and not steak meat OMEGALUL
 	fruit = list("cabbage" = 1)
 	reagents = list("rice" = 20)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/meat,
-		/obj/item/reagent_containers/food/snacks/meat,
-		/obj/item/reagent_containers/food/snacks/meat
+		/obj/item/reagent_containers/food/snacks/carpmeat/fish,
+		/obj/item/reagent_containers/food/snacks/carpmeat/fish
 	)
 	result = /obj/item/reagent_containers/food/snacks/sliceable/sushi
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -2190,6 +2190,13 @@ End Citadel Change */
 	glass_desc = "The second most Irish drink."
 	glass_special = list(DRINK_FIZZ)
 
+/datum/reagent/ethanol/peppermintschnapps
+	name = "Peppermint Schnapps"
+	id = "schnapps_pep"
+	description = "A flavoured grain liqueur with a fresh, minty taste."
+	taste_description = "peachy"
+	strength = 90
+
 // Cocktails
 
 

--- a/code/modules/security levels/security levels.dm
+++ b/code/modules/security levels/security levels.dm
@@ -61,6 +61,7 @@
 			if(SEC_LEVEL_RED)
 				if(security_level < SEC_LEVEL_RED)
 					security_announcement_up.Announce("[config_legacy.alert_desc_red_upto]", "Attention! Code red!")
+					security_announcement_up.Announce(new_sound = 'sound/effects/carter_alarm_cut.ogg')
 				else
 					security_announcement_down.Announce("[config_legacy.alert_desc_red_downto]", "Attention! Code red!")
 				security_level = SEC_LEVEL_RED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixing up missing items in the drinks list, and sweatmax vendor. Did minor food tweaking and re-buffed liquidfood to 30 instead of 20. Removed the water from the shakers and lowers their volume to 50 from 100

## Why It's Good For The Game

QOL

## Changelog
:cl:
tweak: Shakers no longer have water. Drink up
tweak: Sushi now takes fish instead of steak meat LUL
tweak: Minor food value changes
fix: Re-added LiquidProtein to SweatMAX
fix: fixed missing sprites for a few drinks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
