### PR TITLE
a nitpicking pr about uniforms

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -488,37 +488,36 @@
 // NEW UNIFORMS BEGIN HERE
 /datum/gear/uniform/sifguard
 	display_name = "uniform, crew"
-	path = /obj/item/clothing/under/solgov/utility/sifguard
+	path = /obj/item/clothing/under/solgov/utility/sifguard/crew
 
 /datum/gear/uniform/sifguard/medical
 	display_name = "uniform, crew (medical)"
-	path = /obj/item/clothing/under/solgov/utility/sifguard/medical
+	path = /obj/item/clothing/under/solgov/utility/sifguard/crew/medical
 	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Field Medic")
 
 /datum/gear/uniform/sifguard/science
 	display_name = "uniform, crew (science)"
-	path = /obj/item/clothing/under/solgov/utility/sifguard/research
+	path = /obj/item/clothing/under/solgov/utility/sifguard/crew/research
 	allowed_roles = list("Research Director","Scientist","Roboticist","Xenobiologist")
 
 /datum/gear/uniform/sifguard/engineering
 	display_name = "uniform, crew (engineering)"
-	path = /obj/item/clothing/under/solgov/utility/sifguard/engineering
+	path = /obj/item/clothing/under/solgov/utility/sifguard/crew/engineering
 	allowed_roles = list("Chief Engineer","Atmospheric Technician","Station Engineer")
 
 /datum/gear/uniform/sifguard/supply
 	display_name = "uniform, crew (supply)"
-	path = /obj/item/clothing/under/solgov/utility/sifguard/supply
+	path = /obj/item/clothing/under/solgov/utility/sifguard/crew/supply
 	allowed_roles = list("Quartermaster","Cargo Technician","Shaft Miner")
 
 /datum/gear/uniform/sifguard/security
 	display_name = "uniform, crew (security)"
-	path = /obj/item/clothing/under/solgov/utility/sifguard/security
-	cost = 2
+	path = /obj/item/clothing/under/solgov/utility/sifguard/crew/security
 	allowed_roles = list("Security Officer","Head of Security","Warden","Detective")
 
 /datum/gear/uniform/sifguard/command
 	display_name = "uniform, crew (command)"
-	path = /obj/item/clothing/under/solgov/utility/sifguard/command
+	path = /obj/item/clothing/under/solgov/utility/sifguard/officer/crew
 	allowed_roles = list("Head of Security","Colony Director","Head of Personnel","Chief Engineer","Research Director","Chief Medical Officer")
 
 /datum/gear/uniform/fleet/medical

--- a/code/modules/clothing/under/solgov.dm
+++ b/code/modules/clothing/under/solgov.dm
@@ -93,7 +93,7 @@
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/research)
 
 /obj/item/clothing/under/solgov/utility/sifguard/officer
-	name = "\improper Sifuard officer's uniform"
+	name = "\improper SifGuard officer's uniform"
 	desc = "The utility uniform of the Sif Defense Force, made from biohazard resistant material. This one has gold trim."
 	icon_state = "blackutility_com"
 	worn_state = "blackutility_com"

--- a/code/modules/clothing/under/solgov_cit.dm
+++ b/code/modules/clothing/under/solgov_cit.dm
@@ -1,0 +1,79 @@
+/obj/item/clothing/under/solgov/utility/sifguard/crew
+	name = "crew uniform"
+	desc = "A comfortable turtleneck and black utility trousers, made from biohazard resistant material. This one has silver trim."
+
+/obj/item/clothing/under/solgov/utility/sifguard/crew/command
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/command/crew)
+
+/obj/item/clothing/under/solgov/utility/sifguard/crew/engineering
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/engineering/crew)
+
+/obj/item/clothing/under/solgov/utility/sifguard/crew/security
+	desc = "A comfortable turtleneck and black utility trousers, made from a slightly sturdy, biohazard resistant material. This one has silver trim."
+	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 10, rad = 10)
+	siemens_coefficient = 0.9
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/security/crew)
+
+/obj/item/clothing/under/solgov/utility/sifguard/crew/medical
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/medical/crew)
+
+/obj/item/clothing/under/solgov/utility/sifguard/crew/supply
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/supply/crew)
+
+/obj/item/clothing/under/solgov/utility/sifguard/crew/exploration
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/exploration/crew)
+
+/obj/item/clothing/under/solgov/utility/sifguard/crew/research
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/research/crew)
+
+/obj/item/clothing/under/solgov/utility/sifguard/officer/crew
+	name = "command crew uniform"
+	desc = "A comfortable turtleneck and black utility trousers, made from biohazard resistant material. This one has gold trim."
+
+/obj/item/clothing/under/solgov/utility/sifguard/officer/crew/command
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/command/crew)
+
+/obj/item/clothing/under/solgov/utility/sifguard/officer/crew/engineering
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/engineering/crew)
+
+/obj/item/clothing/under/solgov/utility/sifguard/officer/crew/security
+	desc = "A comfortable turtleneck and black utility trousers, made from a slightly sturdy, biohazard resistant material. This one has gold trim."
+	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 10, rad = 10)
+	siemens_coefficient = 0.9
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/security/crew)
+
+/obj/item/clothing/under/solgov/utility/sifguard/officer/crew/medical
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/medical/crew)
+
+/obj/item/clothing/under/solgov/utility/sifguard/officer/crew/supply
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/supply/crew)
+
+/obj/item/clothing/under/solgov/utility/sifguard/officer/crew/exploration
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/exploration/crew)
+
+/obj/item/clothing/under/solgov/utility/sifguard/officer/crew/research
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/research/crew)
+
+/obj/item/clothing/accessory/solgov/department/command/crew
+	desc = "An insignia denoting assignment to the command department. These fit crew uniforms."
+
+/obj/item/clothing/accessory/solgov/department/engineering/crew
+	desc = "An insignia denoting assignment to the engineering department. These fit crew uniforms."
+
+/obj/item/clothing/accessory/solgov/department/security/crew
+	desc = "An insignia denoting assignment to the security department. These fit crew uniforms."
+
+/obj/item/clothing/accessory/solgov/department/medical/crew
+	desc = "An insignia denoting assignment to the medical department. These fit crew uniforms."
+
+/obj/item/clothing/accessory/solgov/department/supply/crew
+	desc = "An insignia denoting assignment to the supply department. These fit crew uniforms."
+
+/obj/item/clothing/accessory/solgov/department/exploration/crew
+	desc = "An insignia denoting assignment to the exploration department. These fit crew uniforms."
+
+/obj/item/clothing/accessory/solgov/department/research/crew
+	desc = "An insignia denoting assignment to the research department. These fit crew uniforms."
+
+/obj/item/clothing/accessory/solgov/department/service/crew
+	desc = "An insignia denoting assignment to the service department. These fit crew uniforms."

--- a/code/modules/clothing/under/solgov_vr.dm
+++ b/code/modules/clothing/under/solgov_vr.dm
@@ -28,7 +28,6 @@
 	name = "explorer's officer uniform"
 	desc = "The utility uniform of the Society of Universal Cartographers, made from biohazard resistant material. This one has gold trim."
 
-
 /obj/item/clothing/under/solgov/utility/fleet
 	name = "fleet coveralls"
 	desc = "The utility uniform of the USDF Fleet, made from an insulated material."

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1819,6 +1819,7 @@
 #include "code\modules\clothing\under\pants.dm"
 #include "code\modules\clothing\under\shorts.dm"
 #include "code\modules\clothing\under\solgov.dm"
+#include "code\modules\clothing\under\solgov_cit.dm"
 #include "code\modules\clothing\under\solgov_vr.dm"
 #include "code\modules\clothing\under\syndicate.dm"
 #include "code\modules\clothing\under\accessories\accessory.dm"


### PR DESCRIPTION
## About The Pull Request
- crew uniforms are now named crew uniforms and not explorer's uniforms (subtypes)
- security crew uniforms have armor consistent with the standard variants (10 melee thats about it)
- thats probably it
## Why It's Good For The Game
nitpicking
## Changelog
:cl:
tweak: Crew uniform stuff. You probably won't notice too much.
/:cl: