### PR TITLE
Un-Hugboxes Space Vines. Makes them an actual Level 7 threat now!

### DIFF
--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -1,7 +1,7 @@
 #define DEFAULT_SEED "glowshroom"
 #define VINE_GROWTH_STAGES 5
 
-/proc/spacevine_infestation(var/potency_min=85, var/potency_max=100, var/maturation_min=5, var/maturation_max=15)
+/proc/spacevine_infestation(var/potency_min=80, var/potency_max=100, var/maturation_min=5, var/maturation_max=15)
 	spawn() //to stop the secrets panel hanging
 		var/list/turf/simulated/floor/turfs = list() //list of all the empty floor turfs in the hallway areas
 		for(var/areapath in typesof(/area/hallway))
@@ -16,7 +16,7 @@
 			seed.set_trait(TRAIT_SPREAD,2)             // So it will function properly as vines.
 			seed.set_trait(TRAIT_POTENCY,rand(potency_min, potency_max)) // 70-100 potency will help guarantee a wide spread and powerful effects.
 			seed.set_trait(TRAIT_MATURATION,rand(maturation_min, maturation_max))
-			seed.set_trait(TRAIT_CARNIVOROUS,rand(30, 50)) // VINES WERE A BIT TOO MURDERHAPPY AT 80~100!!
+			seed.set_trait(TRAIT_CARNIVOROUS,rand(15, 25)) // VINES WERE A BIT TOO MURDERHAPPY AT 80~100!!
 			seed.display_name = "strange plants" //more thematic for the vine infestation event
 
 			//make vine zero start off fully matured
@@ -55,10 +55,10 @@
 	pass_flags = PASSTABLE
 	mouse_opacity = 2
 
-	var/health = 25
-	var/max_health = 100
+	var/health = 15
+	var/max_health = 50
 	var/growth_threshold = 0
-	var/growth_type = 0
+	var/growth_type = 1
 	var/max_growth = 0
 	var/list/neighbors = list()
 	var/obj/effect/plant/parent
@@ -110,7 +110,6 @@
 		max_growth = VINE_GROWTH_STAGES
 		growth_threshold = max_health/VINE_GROWTH_STAGES
 		icon = 'icons/obj/hydroponics_vines.dmi'
-		growth_type = rand(1,4) // Allows any vine type to show up now. All are bitey
 	else
 		max_growth = seed.growth_stages
 		growth_threshold = max_health/seed.growth_stages
@@ -118,9 +117,9 @@
 	if(max_growth > 2 && prob(50))
 		max_growth-- //Ensure some variation in final sprite, makes the carpet of crap look less wonky.
 
-	mature_time = world.time + seed.get_trait(TRAIT_MATURATION) + 20 //prevent vines from maturing until at least a few seconds after they've been created.
+	mature_time = world.time + seed.get_trait(TRAIT_MATURATION) + 25 //prevent vines from maturing until at least a few seconds after they've been created.
 	spread_chance = seed.get_trait(TRAIT_POTENCY)
-	spread_distance = ((growth_type>0) ? round(spread_chance*1.3) : round(spread_chance*0.85))
+	spread_distance = ((growth_type>0) ? round(spread_chance*0.925) : round(spread_chance*0.75))
 	update_icon()
 
 // Plants will sometimes be spawned in the turf adjacent to the one they need to end up in, for the sake of correct dir/etc being set.
@@ -172,15 +171,14 @@
 			max_growth--
 	max_growth = max(1,max_growth)
 	if(growth_type > 0)
-		switch(growth_type)
-			if(1)
-				icon_state = "worms"
-			if(2)
-				icon_state = "vines-[growth]"
-			if(3)
-				icon_state = "mass-[growth]"
-			if(4)
-				icon_state = "mold-[growth]"
+		if(TRAIT_POTENCY >= 80 && TRAIT_POTENCY < 85)
+			icon_state = "worms"
+		else if(TRAIT_POTENCY >= 85 && TRAIT_POTENCY < 90)
+			icon_state = "vines-[growth]"
+		else if(TRAIT_POTENCY >= 90 && TRAIT_POTENCY < 95)
+			icon_state = "mass-[growth]"
+		else
+			icon_state = "mold-[growth]"
 	else
 		icon_state = "[seed.get_trait(TRAIT_PLANT_ICON)]-[growth]"
 

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -16,7 +16,7 @@
 			seed.set_trait(TRAIT_SPREAD,2)             // So it will function properly as vines.
 			seed.set_trait(TRAIT_POTENCY,rand(potency_min, potency_max)) // 70-100 potency will help guarantee a wide spread and powerful effects.
 			seed.set_trait(TRAIT_MATURATION,rand(maturation_min, maturation_max))
-			seed.set_trait(TRAIT_CARNIVOROUS,rand(30, 50)) // VINES WERE A BIT TOO MURDERHAPPY AT 80~100!!
+			seed.set_trait(TRAIT_CARNIVOROUS,rand(40, 65)) // VINES WERE A BIT TOO MURDERHAPPY AT 80~100!!
 			seed.display_name = "strange plants" //more thematic for the vine infestation event
 
 			//make vine zero start off fully matured

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -1,7 +1,7 @@
 #define DEFAULT_SEED "glowshroom"
 #define VINE_GROWTH_STAGES 5
 
-/proc/spacevine_infestation(var/potency_min=80, var/potency_max=100, var/maturation_min=5, var/maturation_max=15)
+/proc/spacevine_infestation(var/potency_min=40, var/potency_max=80, var/maturation_min=5, var/maturation_max=15)
 	spawn() //to stop the secrets panel hanging
 		var/list/turf/simulated/floor/turfs = list() //list of all the empty floor turfs in the hallway areas
 		for(var/areapath in typesof(/area/hallway))
@@ -171,11 +171,11 @@
 			max_growth--
 	max_growth = max(1,max_growth)
 	if(growth_type > 0)
-		if(TRAIT_POTENCY >= 80 && TRAIT_POTENCY < 85)
+		if(TRAIT_POTENCY >= 40 && TRAIT_POTENCY < 50)
 			icon_state = "vines-[growth]"
-		else if(TRAIT_POTENCY >= 85 && TRAIT_POTENCY < 90)
+		else if(TRAIT_POTENCY >= 50 && TRAIT_POTENCY < 60)
 			icon_state = "mass-[growth]"
-		else if(TRAIT_POTENCY >= 90 && TRAIT_POTENCY < 95)
+		else if(TRAIT_POTENCY >= 60 && TRAIT_POTENCY < 70)
 			icon_state = "worms"
 		else
 			icon_state = "mold-[growth]"

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -16,7 +16,7 @@
 			seed.set_trait(TRAIT_SPREAD,2)             // So it will function properly as vines.
 			seed.set_trait(TRAIT_POTENCY,rand(potency_min, potency_max)) // 70-100 potency will help guarantee a wide spread and powerful effects.
 			seed.set_trait(TRAIT_MATURATION,rand(maturation_min, maturation_max))
-			seed.set_trait(TRAIT_CARNIVOROUS,rand(15, 25)) // VINES WERE A BIT TOO MURDERHAPPY AT 80~100!!
+			seed.set_trait(TRAIT_CARNIVOROUS,rand(5, 20)) // VINES WERE A BIT TOO MURDERHAPPY AT 80~100!!
 			seed.display_name = "strange plants" //more thematic for the vine infestation event
 
 			//make vine zero start off fully matured
@@ -119,7 +119,7 @@
 
 	mature_time = world.time + seed.get_trait(TRAIT_MATURATION) + 25 //prevent vines from maturing until at least a few seconds after they've been created.
 	spread_chance = seed.get_trait(TRAIT_POTENCY)
-	spread_distance = ((growth_type>0) ? round(spread_chance*0.925) : round(spread_chance*0.75))
+	spread_distance = ((growth_type>0) ? round(spread_chance*0.72) : round(spread_chance*0.50))
 	update_icon()
 
 // Plants will sometimes be spawned in the turf adjacent to the one they need to end up in, for the sake of correct dir/etc being set.
@@ -172,11 +172,11 @@
 	max_growth = max(1,max_growth)
 	if(growth_type > 0)
 		if(TRAIT_POTENCY >= 80 && TRAIT_POTENCY < 85)
-			icon_state = "worms"
-		else if(TRAIT_POTENCY >= 85 && TRAIT_POTENCY < 90)
 			icon_state = "vines-[growth]"
-		else if(TRAIT_POTENCY >= 90 && TRAIT_POTENCY < 95)
+		else if(TRAIT_POTENCY >= 85 && TRAIT_POTENCY < 90)
 			icon_state = "mass-[growth]"
+		else if(TRAIT_POTENCY >= 90 && TRAIT_POTENCY < 95)
+			icon_state = "worms"
 		else
 			icon_state = "mold-[growth]"
 	else

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -125,9 +125,9 @@
 	if(max_growth > 2 && prob(50))
 		max_growth-- //Ensure some variation in final sprite, makes the carpet of crap look less wonky.
 
-	mature_time = world.time + seed.get_trait(TRAIT_MATURATION) + 15 //prevent vines from maturing until at least a few seconds after they've been created.
+	mature_time = world.time + seed.get_trait(TRAIT_MATURATION) + 20 //prevent vines from maturing until at least a few seconds after they've been created.
 	spread_chance = seed.get_trait(TRAIT_POTENCY)
-	spread_distance = ((growth_type>0) ? round(spread_chance*1.3) : round(spread_chance*1.1))
+	spread_distance = ((growth_type>0) ? round(spread_chance*1.3) : round(spread_chance*0.85))
 	update_icon()
 
 // Plants will sometimes be spawned in the turf adjacent to the one they need to end up in, for the sake of correct dir/etc being set.

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -1,7 +1,7 @@
 #define DEFAULT_SEED "glowshroom"
 #define VINE_GROWTH_STAGES 5
 
-/proc/spacevine_infestation(var/potency_min=70, var/potency_max=100, var/maturation_min=5, var/maturation_max=15)
+/proc/spacevine_infestation(var/potency_min=90, var/potency_max=100, var/maturation_min=5, var/maturation_max=15)
 	spawn() //to stop the secrets panel hanging
 		var/list/turf/simulated/floor/turfs = list() //list of all the empty floor turfs in the hallway areas
 		for(var/areapath in typesof(/area/hallway))
@@ -16,6 +16,7 @@
 			seed.set_trait(TRAIT_SPREAD,2)             // So it will function properly as vines.
 			seed.set_trait(TRAIT_POTENCY,rand(potency_min, potency_max)) // 70-100 potency will help guarantee a wide spread and powerful effects.
 			seed.set_trait(TRAIT_MATURATION,rand(maturation_min, maturation_max))
+			seed.set_trait(TRAIT_CARNIVOROUS,rand(potency_min, potency_max))
 			seed.display_name = "strange plants" //more thematic for the vine infestation event
 
 			//make vine zero start off fully matured
@@ -54,7 +55,7 @@
 	pass_flags = PASSTABLE
 	mouse_opacity = 2
 
-	var/health = 10
+	var/health = 30
 	var/max_health = 100
 	var/growth_threshold = 0
 	var/growth_type = 0
@@ -126,7 +127,7 @@
 
 	mature_time = world.time + seed.get_trait(TRAIT_MATURATION) + 15 //prevent vines from maturing until at least a few seconds after they've been created.
 	spread_chance = seed.get_trait(TRAIT_POTENCY)
-	spread_distance = ((growth_type>0) ? round(spread_chance*0.6) : round(spread_chance*0.3))
+	spread_distance = ((growth_type>0) ? round(spread_chance*1.3) : round(spread_chance*1.1))
 	update_icon()
 
 // Plants will sometimes be spawned in the turf adjacent to the one they need to end up in, for the sake of correct dir/etc being set.

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -1,7 +1,7 @@
 #define DEFAULT_SEED "glowshroom"
 #define VINE_GROWTH_STAGES 5
 
-/proc/spacevine_infestation(var/potency_min=90, var/potency_max=100, var/maturation_min=5, var/maturation_max=15)
+/proc/spacevine_infestation(var/potency_min=85, var/potency_max=100, var/maturation_min=5, var/maturation_max=15)
 	spawn() //to stop the secrets panel hanging
 		var/list/turf/simulated/floor/turfs = list() //list of all the empty floor turfs in the hallway areas
 		for(var/areapath in typesof(/area/hallway))
@@ -16,7 +16,7 @@
 			seed.set_trait(TRAIT_SPREAD,2)             // So it will function properly as vines.
 			seed.set_trait(TRAIT_POTENCY,rand(potency_min, potency_max)) // 70-100 potency will help guarantee a wide spread and powerful effects.
 			seed.set_trait(TRAIT_MATURATION,rand(maturation_min, maturation_max))
-			seed.set_trait(TRAIT_CARNIVOROUS,rand(potency_min, potency_max))
+			seed.set_trait(TRAIT_CARNIVOROUS,rand(30, 50)) // VINES WERE A BIT TOO MURDERHAPPY AT 80~100!!
 			seed.display_name = "strange plants" //more thematic for the vine infestation event
 
 			//make vine zero start off fully matured
@@ -55,7 +55,7 @@
 	pass_flags = PASSTABLE
 	mouse_opacity = 2
 
-	var/health = 30
+	var/health = 25
 	var/max_health = 100
 	var/growth_threshold = 0
 	var/growth_type = 0

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -16,7 +16,7 @@
 			seed.set_trait(TRAIT_SPREAD,2)             // So it will function properly as vines.
 			seed.set_trait(TRAIT_POTENCY,rand(potency_min, potency_max)) // 70-100 potency will help guarantee a wide spread and powerful effects.
 			seed.set_trait(TRAIT_MATURATION,rand(maturation_min, maturation_max))
-			seed.set_trait(TRAIT_CARNIVOROUS,rand(40, 65)) // VINES WERE A BIT TOO MURDERHAPPY AT 80~100!!
+			seed.set_trait(TRAIT_CARNIVOROUS,rand(30, 50)) // VINES WERE A BIT TOO MURDERHAPPY AT 80~100!!
 			seed.display_name = "strange plants" //more thematic for the vine infestation event
 
 			//make vine zero start off fully matured
@@ -110,14 +110,7 @@
 		max_growth = VINE_GROWTH_STAGES
 		growth_threshold = max_health/VINE_GROWTH_STAGES
 		icon = 'icons/obj/hydroponics_vines.dmi'
-		growth_type = 2 // Vines by default.
-		if(seed.get_trait(TRAIT_CARNIVOROUS) >= 2)
-			growth_type = 1 // WOOOORMS.
-		else if(!(seed.seed_noun in list("seeds","pits")))
-			if(seed.seed_noun == "nodes")
-				growth_type = 3 // Biomass
-			else
-				growth_type = 4 // Mold
+		growth_type = rand(1,4) // Allows any vine type to show up now. All are bitey
 	else
 		max_growth = seed.growth_stages
 		growth_threshold = max_health/seed.growth_stages

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -102,7 +102,7 @@
 
 		for(var/i in 1 to max_spread)
 			if(prob(spread_chance))
-				sleep(rand(3,5))
+				sleep(rand(1,2)) // Adjusting Sleep timer to be lower.
 				if(!neighbors.len)
 					break
 				spread_to(pick(neighbors))

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -1,4 +1,4 @@
-#define NEIGHBOR_REFRESH_TIME 100
+#define NEIGHBOR_REFRESH_TIME 50
 
 /obj/effect/plant/proc/get_cardinal_neighbors()
 	var/list/cardinal_neighbors = list()

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -35,7 +35,7 @@
 		to_chat(victim, "<span class='danger'>You push through the vines and feel some of the thorns rip through your clothing!</span>")
 		victim.adjustToxLoss(rand(2,4))
 		victim.adjustBruteLoss(rand(3,5))
-	if(prob(95))
+	else
 		to_chat(victim, "<span class='danger'>You push through the mess of vines and feel a bit of numbness in your body!</span>")
 		victim.adjustToxLoss(rand(1,2))
 		victim.adjustBruteLoss(rand(2,3),pick("r_foot","l_foot","r_leg","l_leg"))

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -25,7 +25,7 @@
 
 /obj/effect/plant/proc/trodden_on(var/mob/living/victim)
 	if(!is_mature())
-		victim << "<span class='danger'>You push through the vines and feel some minor numbess in your body!</span>"
+		victim << "<span class='danger'>You push through the vines and feel some minor numbness in your body!</span>"
 		victim.adjustToxLoss(1)
 		victim.adjustBruteLoss(2,pick("r_foot","l_foot","r_leg","l_leg"))
 	entangle(victim)
@@ -36,7 +36,7 @@
 		victim.adjustToxLoss(rand(2,4))
 		victim.adjustBruteLoss(rand(3,5))
 	if(prob(95))
-		victim << "<span class='danger'>You push through the mess of vines and feel a bit of numbess in your body!</span>"
+		victim << "<span class='danger'>You push through the mess of vines and feel a bit of numbness in your body!</span>"
 		victim.adjustToxLoss(rand(1,2))
 		victim.adjustBruteLoss(rand(2,3),pick("r_foot","l_foot","r_leg","l_leg"))
 

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -24,14 +24,16 @@
 		trodden_on(O)
 
 /obj/effect/plant/proc/trodden_on(var/mob/living/victim)
-	if(!is_mature())
+	if(has_buckled_mobs())
+		return
+	else if(!is_mature())
 		to_chat(victim, "<span class='danger'>You push through the vines and feel some minor numbness in your body!</span>")
 		victim.adjustToxLoss(1)
 		victim.adjustBruteLoss(1,pick("r_foot","l_foot","r_leg","l_leg"))
-	entangle(victim)
-	seed.do_thorns(victim,src)
-	seed.do_sting(victim,src,pick("r_foot","l_foot","r_leg","l_leg"))
 	else
+		entangle(victim)
+		seed.do_thorns(victim,src)
+		seed.do_sting(victim,src,pick("r_foot","l_foot","r_leg","l_leg"))
 		if(prob(25))
 			to_chat(victim, "<span class='danger'>You push through the vines and feel some of the thorns rip through your clothing!</span>")
 			victim.adjustToxLoss(rand(2,3))

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -108,10 +108,10 @@
 				victim.setDir(pick(cardinal))
 				victim << "<span class='danger'>Tendrils [pick("wind", "tangle", "tighten")] around you!</span>"
 				victim.Weaken(1.5) // Powering up weaken power from .5 (Testing)
-				victim.adjustToxLoss(rand(1,3.25))
+				victim.adjustToxLoss(rand(0.5,1.25))
 				seed.do_thorns(victim,src)
 			else // Adding a non-grab attack chance since we will be increasing the rate at which the vines check for nearby targets
 				src.visible_message("<span class='danger'>Tendrils lash out from \the [src] and swipe across [victim]!</span>")
 				victim.Weaken(3)
-				victim.adjustToxLoss(rand(2,4.5))
-				victim.adjustBruteLoss(rand(0.5,2.5))
+				victim.adjustToxLoss(rand(1,3.5))
+				victim.adjustBruteLoss(rand(0.5,1.5))

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -25,14 +25,20 @@
 
 /obj/effect/plant/proc/trodden_on(var/mob/living/victim)
 	if(!is_mature())
-		return
-	var/mob/living/carbon/human/H = victim
-	if(prob(round(seed.get_trait(TRAIT_POTENCY)/3)))
-		entangle(victim)
-	if(istype(H) && H.shoes)
-		return
+		victim << "<span class='danger'>You push through the vines and feel some minor numbess in your body!</span>"
+		victim.adjustToxLoss(1)
+		victim.adjustBruteLoss(2,pick("r_foot","l_foot","r_leg","l_leg"))
+	entangle(victim)
 	seed.do_thorns(victim,src)
 	seed.do_sting(victim,src,pick("r_foot","l_foot","r_leg","l_leg"))
+	if(prob(25))
+		victim << "<span class='danger'>You push through the vines and feel some of the thorns rip through your clothing!</span>"
+		victim.adjustToxLoss(rand(2,4))
+		victim.adjustBruteLoss(rand(3,5))
+	if(prob(95))
+		victim << "<span class='danger'>You push through the mess of vines and feel a bit of numbess in your body!</span>"
+		victim.adjustToxLoss(rand(1,2))
+		victim.adjustBruteLoss(rand(2,3),pick("r_foot","l_foot","r_leg","l_leg"))
 
 /obj/effect/plant/proc/unbuckle()
 	if(has_buckled_mobs())
@@ -91,10 +97,17 @@
 			if(istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.item_flags & NOSLIP))
 				can_grab = 0
 		if(can_grab)
-			src.visible_message("<span class='danger'>Tendrils lash out from \the [src] and drag \the [victim] in!</span>")
-			victim.forceMove(src.loc)
-			buckle_mob(victim)
-			victim.setDir(pick(cardinal))
-			victim << "<span class='danger'>Tendrils [pick("wind", "tangle", "tighten")] around you!</span>"
-			victim.Weaken(0.5)
-			seed.do_thorns(victim,src)
+			if(prob(85))
+				src.visible_message("<span class='danger'>Tendrils lash out from \the [src] and drag \the [victim] in!</span>")
+				victim.forceMove(src.loc)
+				buckle_mob(victim)
+				victim.setDir(pick(cardinal))
+				victim << "<span class='danger'>Tendrils [pick("wind", "tangle", "tighten")] around you!</span>"
+				victim.Weaken(1.5) // Powering up weaken power from .5 (Testing)
+				victim.adjustToxLoss(rand(1,3))
+				seed.do_thorns(victim,src)
+			else // Adding a non-grab attack chance since we will be increasing the rate at which the vines check for nearby targets
+				src.visible_message("<span class='danger'>Tendrils lash out from \the [src] and swipe across [victim]!</span>")
+				victim.Weaken(3)
+				victim.adjustToxLoss(rand(3,5))
+				victim.adjustBruteLoss(rand(1,2))

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -25,20 +25,21 @@
 
 /obj/effect/plant/proc/trodden_on(var/mob/living/victim)
 	if(!is_mature())
-		victim << "<span class='danger'>You push through the vines and feel some minor numbness in your body!</span>"
+		to_chat(victim, "<span class='danger'>You push through the vines and feel some minor numbness in your body!</span>")
 		victim.adjustToxLoss(1)
 		victim.adjustBruteLoss(2,pick("r_foot","l_foot","r_leg","l_leg"))
 	entangle(victim)
 	seed.do_thorns(victim,src)
 	seed.do_sting(victim,src,pick("r_foot","l_foot","r_leg","l_leg"))
 	if(prob(25))
-		victim << "<span class='danger'>You push through the vines and feel some of the thorns rip through your clothing!</span>"
+		to_chat(victim, "<span class='danger'>You push through the vines and feel some of the thorns rip through your clothing!</span>")
 		victim.adjustToxLoss(rand(2,4))
 		victim.adjustBruteLoss(rand(3,5))
 	if(prob(95))
-		victim << "<span class='danger'>You push through the mess of vines and feel a bit of numbness in your body!</span>"
+		to_chat(victim, "<span class='danger'>You push through the mess of vines and feel a bit of numbness in your body!</span>")
 		victim.adjustToxLoss(rand(1,2))
 		victim.adjustBruteLoss(rand(2,3),pick("r_foot","l_foot","r_leg","l_leg"))
+
 
 /obj/effect/plant/proc/unbuckle()
 	if(has_buckled_mobs())

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -13,6 +13,27 @@
 		spawn(1)
 			entangle(M)
 
+
+/obj/effect/plant/proc/attack_mob(mob/living/M,base_damage)
+	var/target_zone
+	if(M.lying)
+		target_zone = ran_zone()
+	else
+		target_zone = pick("l_foot", "r_foot", "l_leg", "r_leg")
+
+	//armour
+	var/blocked = M.run_armor_check(target_zone, "melee")
+	var/soaked = M.get_armor_soak(target_zone, "melee")
+
+	if(blocked >= 100)
+		return
+
+	if(soaked >= 30)
+		return
+
+	if(!M.apply_damage(base_damage, BRUTE, target_zone, blocked, soaked, used_weapon=src))
+		return 0
+
 /obj/effect/plant/attack_hand(var/mob/user)
 	manual_unbuckle(user)
 
@@ -29,19 +50,19 @@
 	else if(!is_mature())
 		to_chat(victim, "<span class='danger'>You push through the vines and feel some minor numbness in your body!</span>")
 		victim.adjustToxLoss(1)
-		victim.adjustBruteLoss(1,pick("r_foot","l_foot","r_leg","l_leg"))
+		attack_mob(victim,1.5)
 	else
 		entangle(victim)
 		seed.do_thorns(victim,src)
-		seed.do_sting(victim,src,pick("r_foot","l_foot","r_leg","l_leg"))
+		seed.do_sting(victim,pick("r_foot","l_foot","r_leg","l_leg"))
 		if(prob(25))
 			to_chat(victim, "<span class='danger'>You push through the vines and feel some of the thorns rip through your clothing!</span>")
 			victim.adjustToxLoss(rand(2,3))
-			victim.adjustBruteLoss(rand(2,4))
+			attack_mob(victim,rand(4,7))
 		else
 			to_chat(victim, "<span class='danger'>You push through the mess of vines and feel a bit of numbness in your body!</span>")
 			victim.adjustToxLoss(rand(1,2))
-			victim.adjustBruteLoss(2,pick("r_foot","l_foot","r_leg","l_leg"))
+			attack_mob(victim,rand(2,4))
 
 
 /obj/effect/plant/proc/unbuckle()
@@ -114,4 +135,4 @@
 				src.visible_message("<span class='danger'>Tendrils lash out from \the [src] and swipe across [victim]!</span>")
 				victim.Weaken(3)
 				victim.adjustToxLoss(rand(1,3.5))
-				victim.adjustBruteLoss(rand(0.5,1.5))
+				attack_mob(victim,rand(2,3.5))

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -27,18 +27,19 @@
 	if(!is_mature())
 		to_chat(victim, "<span class='danger'>You push through the vines and feel some minor numbness in your body!</span>")
 		victim.adjustToxLoss(1)
-		victim.adjustBruteLoss(2,pick("r_foot","l_foot","r_leg","l_leg"))
+		victim.adjustBruteLoss(1,pick("r_foot","l_foot","r_leg","l_leg"))
 	entangle(victim)
 	seed.do_thorns(victim,src)
 	seed.do_sting(victim,src,pick("r_foot","l_foot","r_leg","l_leg"))
-	if(prob(25))
-		to_chat(victim, "<span class='danger'>You push through the vines and feel some of the thorns rip through your clothing!</span>")
-		victim.adjustToxLoss(rand(2,4))
-		victim.adjustBruteLoss(rand(3,5))
 	else
-		to_chat(victim, "<span class='danger'>You push through the mess of vines and feel a bit of numbness in your body!</span>")
-		victim.adjustToxLoss(rand(1,2))
-		victim.adjustBruteLoss(rand(2,3),pick("r_foot","l_foot","r_leg","l_leg"))
+		if(prob(25))
+			to_chat(victim, "<span class='danger'>You push through the vines and feel some of the thorns rip through your clothing!</span>")
+			victim.adjustToxLoss(rand(2,3))
+			victim.adjustBruteLoss(rand(2,4))
+		else
+			to_chat(victim, "<span class='danger'>You push through the mess of vines and feel a bit of numbness in your body!</span>")
+			victim.adjustToxLoss(rand(1,2))
+			victim.adjustBruteLoss(2,pick("r_foot","l_foot","r_leg","l_leg"))
 
 
 /obj/effect/plant/proc/unbuckle()

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -106,10 +106,10 @@
 				victim.setDir(pick(cardinal))
 				victim << "<span class='danger'>Tendrils [pick("wind", "tangle", "tighten")] around you!</span>"
 				victim.Weaken(1.5) // Powering up weaken power from .5 (Testing)
-				victim.adjustToxLoss(rand(1,3))
+				victim.adjustToxLoss(rand(1,3.25))
 				seed.do_thorns(victim,src)
 			else // Adding a non-grab attack chance since we will be increasing the rate at which the vines check for nearby targets
 				src.visible_message("<span class='danger'>Tendrils lash out from \the [src] and swipe across [victim]!</span>")
 				victim.Weaken(3)
-				victim.adjustToxLoss(rand(3,5))
-				victim.adjustBruteLoss(rand(1,2))
+				victim.adjustToxLoss(rand(2,4.5))
+				victim.adjustBruteLoss(rand(0.5,2.5))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Space Vines were a pretty low threat event to take place on the station. Yeah, nah that isn't the case anymore. Vines will now do damage if you run across them, and will also lash out at players instead of grabbing and doing nothing. However, they will STILL grab and do extra damage on top. Damage types are ONLY Brute & Toxin for now to ensure crew doesn't just 100% die trying to contain angry plants.

Space Vines still won't go through airlocks (for now), and they can not travel up or down a z-level.

## Why It's Good For The Game

QOL change and gives more of a challenge for crew to deal with a major threat.

## Changelog
:cl:
balance: Space Vines are now dangerous, and an actual threat to the station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
