### PR TITLE
Sky Triggers Shield

### DIFF
--- a/code/modules/shieldgen/shield_gen_external.dm
+++ b/code/modules/shieldgen/shield_gen_external.dm
@@ -6,6 +6,7 @@
 	var/global/list/blockedturfs =  list(
 		/turf/space,
 		/turf/simulated/floor/outdoors,
+		/turf/simulated/sky,
 	)
 
 /obj/machinery/shield_gen/external/advanced


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds sky to the list of blocked turf to hull shield gen so that if a shield passes through the midpoint layer it generates a hull shield. Mostly cosmetic as nothing actually causes danger to the midpoint.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Minor tweak so things look consistent
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
