### PR TITLE
Fixes Airlock Electronic Access Settings not Applying

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -181,6 +181,14 @@
 	icon = 'icons/obj/doors/Doorext.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_ext
 
+/obj/machinery/door/airlock/external/glass/bolted
+	icon_state = "door_locked" // So it looks visibly bolted in map editor
+	locked = 1
+
+// For convenience in making docking ports: one that is pre-bolted with frequency set!
+/obj/machinery/door/airlock/external/glass/bolted/cycling
+	frequency = 1379
+
 /obj/machinery/door/airlock/glass_external
 	name = "External Airlock"
 	icon = 'icons/obj/doors/Doorextglass.dmi'
@@ -385,7 +393,8 @@
 	else if(electrified_until > 0 && world.time >= electrified_until)
 		electrify(0)
 
-	..()
+	if (..() == PROCESS_KILL && !(main_power_lost_until > 0 || backup_power_lost_until > 0 || electrified_until > 0))
+		. = PROCESS_KILL
 
 /obj/machinery/door/airlock/uranium/process()
 	if(world.time > last_event+20)
@@ -526,7 +535,7 @@ About the new airlock wires panel:
 			else /*if(src.justzap)*/
 				return
 		else if(user.hallucination > 50 && prob(10) && src.operating == 0)
-			to_chat(user,"<span class='danger'>You feel a powerful shock course through your body!</span>")
+			to_chat(user, "<span class='danger'>You feel a powerful shock course through your body!</span>")
 			user.halloss += 10
 			user.stunned += 10
 			return
@@ -575,6 +584,9 @@ About the new airlock wires panel:
 	if(backup_power_lost_until == -1 && !backupPowerCablesCut())
 		backup_power_lost_until = world.time + SecondsToTicks(10)
 
+	if(main_power_lost_until > 0 || backup_power_lost_until > 0)
+		START_MACHINE_PROCESSING(src)
+
 	// Disable electricity if required
 	if(electrified_until && isAllPowerLoss())
 		electrify(0)
@@ -583,6 +595,9 @@ About the new airlock wires panel:
 
 /obj/machinery/door/airlock/proc/loseBackupPower()
 	backup_power_lost_until = backupPowerCablesCut() ? -1 : world.time + SecondsToTicks(60)
+
+	if(backup_power_lost_until > 0)
+		START_MACHINE_PROCESSING(src)
 
 	// Disable electricity if required
 	if(electrified_until && isAllPowerLoss())
@@ -625,6 +640,9 @@ About the new airlock wires panel:
 			shockedby += text("\[[time_stamp()]\] - EMP)")
 		message = "The door is now electrified [duration == -1 ? "permanently" : "for [duration] second\s"]."
 		src.electrified_until = duration == -1 ? -1 : world.time + SecondsToTicks(duration)
+
+	if(electrified_until > 0)
+		START_MACHINE_PROCESSING(src)
 
 	if(feedback && message)
 		to_chat(usr,message)
@@ -761,56 +779,56 @@ About the new airlock wires panel:
 		src.aiHacking=1
 		spawn(20)
 			//TODO: Make this take a minute
-			to_chat(user,"Airlock AI control has been blocked. Beginning fault-detection.")
+			to_chat(user, "Airlock AI control has been blocked. Beginning fault-detection.")
 			sleep(50)
 			if(src.canAIControl())
-				to_chat(user,"Alert cancelled. Airlock control has been restored without our assistance.")
+				to_chat(user, "Alert cancelled. Airlock control has been restored without our assistance.")
 				src.aiHacking=0
 				return
 			else if(!src.canAIHack(user))
-				to_chat(user,"We've lost our connection! Unable to hack airlock.")
+				to_chat(user, "We've lost our connection! Unable to hack airlock.")
 				src.aiHacking=0
 				return
-			to_chat(user,"Fault confirmed: airlock control wire disabled or cut.")
+			to_chat(user, "Fault confirmed: airlock control wire disabled or cut.")
 			sleep(20)
-			to_chat(user,"Attempting to hack into airlock. This may take some time.")
+			to_chat(user, "Attempting to hack into airlock. This may take some time.")
 			sleep(200)
 			if(src.canAIControl())
-				to_chat(user,"Alert cancelled. Airlock control has been restored without our assistance.")
+				to_chat(user, "Alert cancelled. Airlock control has been restored without our assistance.")
 				src.aiHacking=0
 				return
 			else if(!src.canAIHack(user))
-				to_chat(user,"We've lost our connection! Unable to hack airlock.")
+				to_chat(user, "We've lost our connection! Unable to hack airlock.")
 				src.aiHacking=0
 				return
-			to_chat(user,"Upload access confirmed. Loading control program into airlock software.")
+			to_chat(user, "Upload access confirmed. Loading control program into airlock software.")
 			sleep(170)
 			if(src.canAIControl())
-				to_chat(user,"Alert cancelled. Airlock control has been restored without our assistance.")
+				to_chat(user, "Alert cancelled. Airlock control has been restored without our assistance.")
 				src.aiHacking=0
 				return
 			else if(!src.canAIHack(user))
-				to_chat(user,"We've lost our connection! Unable to hack airlock.")
+				to_chat(user, "We've lost our connection! Unable to hack airlock.")
 				src.aiHacking=0
 				return
-			to_chat(user,"Transfer complete. Forcing airlock to execute program.")
+			to_chat(user, "Transfer complete. Forcing airlock to execute program.")
 			sleep(50)
 			//disable blocked control
 			src.aiControlDisabled = 2
-			to_chat(user,"Receiving control information from airlock.")
+			to_chat(user, "Receiving control information from airlock.")
 			sleep(10)
 			//bring up airlock dialog
 			src.aiHacking = 0
 			if (user)
 				src.attack_ai(user)
 
-/obj/machinery/door/airlock/CanAllowThrough(atom/movable/mover, turf/target)
+/obj/machinery/door/airlock/CanPass(atom/movable/mover, turf/target)
 	if (src.isElectrified())
 		if (istype(mover, /obj/item))
 			var/obj/item/i = mover
 			if(world.time > last_spark + 2 SECONDS)
 				if (i.matter && (DEFAULT_WALL_MATERIAL in i.matter) && i.matter[DEFAULT_WALL_MATERIAL] > 0)
-					var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
+					var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread()
 					s.set_up(5, 1, src)
 					s.start()
 					last_spark = world.time
@@ -837,16 +855,16 @@ About the new airlock wires panel:
 
 /obj/machinery/door/airlock/CanUseTopic(var/mob/user)
 	if(operating < 0) //emagged
-		to_chat(user,"<span class='warning'>Unable to interface: Internal error.</span>")
+		to_chat(user, "<span class='warning'>Unable to interface: Internal error.</span>")
 		return STATUS_CLOSE
 	if(issilicon(user) && !src.canAIControl())
 		if(src.canAIHack(user))
 			src.hack(user)
 		else
 			if (src.isAllPowerLoss()) //don't really like how this gets checked a second time, but not sure how else to do it.
-				to_chat(user,"<span class='warning'>Unable to interface: Connection timed out.</span>")
+				to_chat(user, "<span class='warning'>Unable to interface: Connection timed out.</span>")
 			else
-				to_chat(user,"<span class='warning'>Unable to interface: Connection refused.</span>")
+				to_chat(user, "<span class='warning'>Unable to interface: Connection refused.</span>")
 		return STATUS_CLOSE
 
 	return ..()
@@ -867,20 +885,20 @@ About the new airlock wires panel:
 				src.loseBackupPower()
 		if("bolts")
 			if(src.isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
-				to_chat(usr,"The door bolt control wire is cut - Door bolts permanently dropped.")
+				to_chat(usr, "The door bolt control wire is cut - Door bolts permanently dropped.")
 			else if(activate && src.lock())
-				to_chat(usr,"The door bolts have been dropped.")
+				to_chat(usr, "The door bolts have been dropped.")
 			else if(!activate && src.unlock())
-				to_chat(usr,"The door bolts have been raised.")
+				to_chat(usr, "The door bolts have been raised.")
 		if("electrify_temporary")
 			electrify(30 * activate, 1)
 		if("electrify_permanently")
 			electrify(-1 * activate, 1)
 		if("open")
 			if(src.welded)
-				to_chat(usr,text("The airlock has been welded shut!"))
+				to_chat(usr, "The airlock has been welded shut!")
 			else if(src.locked)
-				to_chat(usr,text("The door bolts are down!"))
+				to_chat(usr, "The door bolts are down!")
 			else if(activate && density)
 				open()
 			else if(!activate && !density)
@@ -890,7 +908,7 @@ About the new airlock wires panel:
 		if("timing")
 			// Door speed control
 			if(src.isWireCut(AIRLOCK_WIRE_SPEED))
-				to_chat(usr,text("The timing wire is cut - Cannot alter timing."))
+				to_chat(usr, "The timing wire is cut - Cannot alter timing.")
 			else if (activate && src.normalspeed)
 				normalspeed = 0
 			else if (!activate && !src.normalspeed)
@@ -898,13 +916,13 @@ About the new airlock wires panel:
 		if("lights")
 			// Bolt lights
 			if(src.isWireCut(AIRLOCK_WIRE_LIGHT))
-				to_chat(usr,"The bolt lights wire is cut - The door bolt lights are permanently disabled.")
+				to_chat(usr, "The bolt lights wire is cut - The door bolt lights are permanently disabled.")
 			else if (!activate && src.lights)
 				lights = 0
-				to_chat(usr,"The door bolt lights have been disabled.")
+				to_chat(usr, "The door bolt lights have been disabled.")
 			else if (activate && !src.lights)
 				lights = 1
-				to_chat(usr,"The door bolt lights have been enabled.")
+				to_chat(usr, "The door bolt lights have been enabled.")
 
 	update_icon()
 	return 1
@@ -913,7 +931,7 @@ About the new airlock wires panel:
 	return src.p_open && (operating < 0 || (!operating && welded && !src.arePowerSystemsOn() && density && (!src.locked || (stat & BROKEN))))
 
 /obj/machinery/door/airlock/attackby(obj/item/C, mob/user as mob)
-	//world << text("airlock attackby src [] obj [] mob []", src, C, user)
+	//to_world("airlock attackby src [src] obj [C] mob [user]")
 	if(!istype(usr, /mob/living/silicon))
 		if(src.isElectrified())
 			if(src.shock(user, 75))
@@ -941,7 +959,7 @@ About the new airlock wires panel:
 	else if(C.is_screwdriver())
 		if (src.p_open)
 			if (stat & BROKEN)
-				to_chat(usr,"<span class='warning'>The panel is broken and cannot be closed.</span>")
+				to_chat(usr, "<span class='warning'>The panel is broken and cannot be closed.</span>")
 			else
 				src.p_open = 0
 				playsound(src, C.usesound, 50, 1)
@@ -963,7 +981,7 @@ About the new airlock wires panel:
 			playsound(src, C.usesound, 75, 1)
 			user.visible_message("[user] removes the electronics from the airlock assembly.", "You start to remove electronics from the airlock assembly.")
 			if(do_after(user,40 * C.toolspeed))
-				to_chat(user,"<span class='notice'>You removed the airlock electronics!</span>")
+				to_chat(user, "<span class='notice'>You removed the airlock electronics!</span>")
 
 				var/obj/structure/door_assembly/da = new assembly_type(src.loc)
 				if (istype(da, /obj/structure/door_assembly/multi_tile))
@@ -991,9 +1009,9 @@ About the new airlock wires panel:
 				qdel(src)
 				return
 		else if(arePowerSystemsOn())
-			to_chat(user,"<span class='notice'>The airlock's motors resist your efforts to force it.</span>")
+			to_chat(user, "<span class='notice'>The airlock's motors resist your efforts to force it.</span>")
 		else if(locked)
-			to_chat(user,"<span class='notice'>The airlock's bolts prevent it from being forced.</span>")
+			to_chat(user, "<span class='notice'>The airlock's bolts prevent it from being forced.</span>")
 		else
 			if(density)
 				spawn(0)	open(1)
@@ -1005,12 +1023,12 @@ About the new airlock wires panel:
 		var/obj/item/W = C
 		if((W.pry == 1) && !arePowerSystemsOn())
 			if(locked)
-				to_chat(user,"<span class='notice'>The airlock's bolts prevent it from being forced.</span>")
+				to_chat(user, "<span class='notice'>The airlock's bolts prevent it from being forced.</span>")
 			else if( !welded && !operating )
 				if(istype(C, /obj/item/material/twohanded/fireaxe)) // If this is a fireaxe, make sure it's held in two hands.
 					var/obj/item/material/twohanded/fireaxe/F = C
 					if(!F.wielded)
-						to_chat(user,"<span class='warning'>You need to be wielding \the [F] to do that.</span>")
+						to_chat(user, "<span class='warning'>You need to be wielding \the [F] to do that.</span>")
 						return
 				// At this point, it's an armblade or a fireaxe that passed the wielded test, let's try to open it.
 				if(density)
@@ -1157,8 +1175,7 @@ About the new airlock wires panel:
 		var/obj/structure/window/killthis = (locate(/obj/structure/window) in turf)
 		if(killthis)
 			killthis.ex_act(2)//Smashin windows
-	..()
-	return
+	return ..()
 
 /obj/machinery/door/airlock/proc/lock(var/forced=0)
 	if(locked)
@@ -1201,7 +1218,7 @@ About the new airlock wires panel:
 
 		electronics = assembly.electronics
 		electronics.loc = src
-		wires = new/datum/wires/airlock(src) //so new default airlocks won't have 'null' wires
+
 		//update the door's access to match the electronics'
 		secured_wires = electronics.secure
 		if(electronics.one_access)

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -9,7 +9,8 @@ obj/machinery/door/airlock
 	var/cur_command = null	//the command the door is currently attempting to complete
 
 obj/machinery/door/airlock/process()
-	..()
+	if (..() == PROCESS_KILL && !cur_command)
+		. = PROCESS_KILL
 	if (arePowerSystemsOn())
 		execute_current_command()
 
@@ -22,6 +23,9 @@ obj/machinery/door/airlock/receive_signal(datum/signal/signal)
 
 	cur_command = signal.data["command"]
 	execute_current_command()
+	if(cur_command)
+		START_MACHINE_PROCESSING(src)
+
 
 obj/machinery/door/airlock/proc/execute_current_command()
 	if(operating)
@@ -91,7 +95,7 @@ obj/machinery/door/airlock/proc/command_completed(var/command)
 obj/machinery/door/airlock/proc/send_status(var/bumped = 0)
 	if(radio_connection)
 		var/datum/signal/signal = new
-		signal.transmission_method = 1 //radio signal
+		signal.transmission_method = TRANSMISSION_RADIO //radio signal
 		signal.data["tag"] = id_tag
 		signal.data["timestamp"] = world.time
 
@@ -145,6 +149,7 @@ obj/machinery/airlock_sensor
 	icon = 'icons/obj/airlock_machines.dmi'
 	icon_state = "airlock_sensor_off"
 	name = "airlock sensor"
+	desc = "Sends atmospheric readings to a nearby controller."
 
 	anchored = 1
 	power_channel = ENVIRON
@@ -171,7 +176,7 @@ obj/machinery/airlock_sensor/update_icon()
 
 obj/machinery/airlock_sensor/attack_hand(mob/user)
 	var/datum/signal/signal = new
-	signal.transmission_method = 1 //radio signal
+	signal.transmission_method = TRANSMISSION_RADIO //radio signal
 	signal.data["tag"] = master_tag
 	signal.data["command"] = command
 
@@ -185,7 +190,7 @@ obj/machinery/airlock_sensor/process()
 
 		if(abs(pressure - previousPressure) > 0.001 || previousPressure == null)
 			var/datum/signal/signal = new
-			signal.transmission_method = 1 //radio signal
+			signal.transmission_method = TRANSMISSION_RADIO //radio signal
 			signal.data["tag"] = id_tag
 			signal.data["timestamp"] = world.time
 			signal.data["pressure"] = num2text(pressure)
@@ -262,7 +267,7 @@ obj/machinery/access_button/attack_hand(mob/user)
 
 	else if(radio_connection)
 		var/datum/signal/signal = new
-		signal.transmission_method = 1 //radio signal
+		signal.transmission_method = TRANSMISSION_RADIO //radio signal
 		signal.data["tag"] = master_tag
 		signal.data["command"] = command
 

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -1,5 +1,3 @@
-//This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
-
 /obj/item/airlock_electronics
 	name = "airlock electronics"
 	icon = 'icons/obj/doors/door_assembly.dmi'
@@ -8,106 +6,148 @@
 
 	matter = list(DEFAULT_WALL_MATERIAL = 50,"glass" = 50)
 
-	req_access = list(access_engine)
+	req_one_access = list(access_engine) // Access to unlock the device, ignored if emagged
+	var/list/apply_any_access = list(access_engine) // Can apply any access, not just their own
 
 	var/secure = 0 //if set, then wires will be randomized and bolts will drop if the door is broken
 	var/list/conf_access = null
 	var/one_access = 0 //if set to 1, door would receive req_one_access instead of req_access
 	var/last_configurator = null
 	var/locked = 1
+	var/emagged = 0
 
-	attack_self(mob/user as mob)
-		if (!ishuman(user) && !istype(user,/mob/living/silicon/robot))
-			return ..(user)
+/obj/item/airlock_electronics/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
+		emagged = 1
+		to_chat(user, "<span class='notice'>You remove the access restrictions on [src]!</span>")
+		return 1
 
-		var/t1 = text("<B>Access control</B><br>\n")
+/obj/item/airlock_electronics/attack_self(mob/user as mob)
+	if (!ishuman(user) && !istype(user,/mob/living/silicon/robot))
+		return ..(user)
 
-		if (last_configurator)
-			t1 += "Operator: [last_configurator]<br>"
+	var/t1 = text("<B>Access control</B><br>\n")
 
-		if (locked)
-			t1 += "<a href='?src=\ref[src];login=1'>Swipe ID</a><hr>"
-		else
-			t1 += "<a href='?src=\ref[src];logout=1'>Block</a><hr>"
+	if (last_configurator)
+		t1 += "Operator: [last_configurator]<br>"
 
-			t1 += "Access requirement is set to "
-			t1 += one_access ? "<a style='color: green' href='?src=\ref[src];one_access=1'>ONE</a><hr>" : "<a style='color: red' href='?src=\ref[src];one_access=1'>ALL</a><hr>"
+	if (locked)
+		t1 += "<a href='?src=\ref[src];login=1'>Unlock Interface</a><hr>"
+	else
+		t1 += "<a href='?src=\ref[src];logout=1'>Lock Interface</a><hr>"
 
-			t1 += conf_access == null ? "<font color=red>All</font><br>" : "<a href='?src=\ref[src];access=all'>All</a><br>"
+		t1 += "Access requirement is set to "
+		t1 += one_access ? "<a style='color: green' href='?src=\ref[src];one_access=1'>ONE</a><hr>" : "<a style='color: red' href='?src=\ref[src];one_access=1'>ALL</a><hr>"
 
-			t1 += "<br>"
+		t1 += conf_access == null ? "<font color=red>All</font><br>" : "<a href='?src=\ref[src];access=all'>All</a><br>"
 
-			var/list/accesses = get_all_station_access()
-			for (var/acc in accesses)
-				var/aname = get_access_desc(acc)
+		t1 += "<br>"
 
-				if (!conf_access || !conf_access.len || !(acc in conf_access))
-					t1 += "<a href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
-				else if(one_access)
-					t1 += "<a style='color: green' href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
-				else
-					t1 += "<a style='color: red' href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
+		var/list/accesses = get_available_accesses(user)
+		for (var/acc in accesses)
+			var/aname = get_access_desc(acc)
 
-		t1 += text("<p><a href='?src=\ref[];close=1'>Close</a></p>\n", src)
-
-		user << browse(t1, "window=airlock_electronics")
-		onclose(user, "airlock")
-
-	Topic(href, href_list)
-		..()
-		if (usr.stat || usr.restrained() || (!ishuman(usr) && !istype(usr,/mob/living/silicon)))
-			return
-		if (href_list["close"])
-			usr << browse(null, "window=airlock")
-			return
-
-		if (href_list["login"])
-			if(istype(usr,/mob/living/silicon))
-				src.locked = 0
-				src.last_configurator = usr.name
+			if (!conf_access || !conf_access.len || !(acc in conf_access))
+				t1 += "<a href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
+			else if(one_access)
+				t1 += "<a style='color: green' href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
 			else
-				var/obj/item/I = usr.get_active_hand()
-				if (istype(I, /obj/item/pda))
-					var/obj/item/pda/pda = I
-					I = pda.id
-				if (I && src.check_access(I))
+				t1 += "<a style='color: red' href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
+
+	t1 += text("<p><a href='?src=\ref[];close=1'>Close</a></p>\n", src)
+
+	user << browse(t1, "window=airlock_electronics")
+	onclose(user, "airlock")
+
+/obj/item/airlock_electronics/Topic(href, href_list)
+	..()
+	if (usr.stat || usr.restrained() || (!ishuman(usr) && !istype(usr,/mob/living/silicon)))
+		return
+	if (href_list["close"])
+		usr << browse(null, "window=airlock")
+		return
+
+	if (href_list["login"])
+		if(emagged)
+			src.locked = 0
+			src.last_configurator = usr.name
+		else if(issilicon(usr))
+			src.locked = 0
+			src.last_configurator = usr.name
+		else if(isliving(usr))
+			var/obj/item/card/id/id
+			if(ishuman(usr))
+				var/mob/living/carbon/human/H = usr
+				id = H.get_idcard()
+				// In their ID slot?
+				if(id && src.check_access(id))
 					src.locked = 0
-					src.last_configurator = I:registered_name
+					src.last_configurator = id.registered_name
+			// Still locked, human handling didn't do it!
+			if(locked)
+				var/obj/item/I = usr.get_active_hand()
+				id = I?.GetID()
+				if(id && src.check_access(id))
+					src.locked = 0
+					src.last_configurator = id.registered_name
 
-		if (locked)
-			return
+	if (locked)
+		return
 
-		if (href_list["logout"])
-			locked = 1
+	if (href_list["logout"])
+		locked = 1
 
-		if (href_list["one_access"])
-			one_access = !one_access
+	if (href_list["one_access"])
+		one_access = !one_access
 
-		if (href_list["access"])
-			toggle_access(href_list["access"])
+	if (href_list["access"])
+		toggle_access(href_list["access"])
 
-		attack_self(usr)
+	attack_self(usr)
 
-	proc
-		toggle_access(var/acc)
-			if (acc == "all")
+/obj/item/airlock_electronics/proc/toggle_access(var/acc)
+	if (acc == "all")
+		conf_access = null
+	else
+		var/req = text2num(acc)
+
+		if (conf_access == null)
+			conf_access = list()
+
+		if (!(req in conf_access))
+			conf_access += req
+		else
+			conf_access -= req
+			if (!conf_access.len)
 				conf_access = null
-			else
-				var/req = text2num(acc)
 
-				if (conf_access == null)
-					conf_access = list()
+/obj/item/airlock_electronics/proc/get_available_accesses(var/mob/user)
+	var/obj/item/card/id/id
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		id = H.get_idcard()
+	else if(issilicon(user))
+		var/mob/living/silicon/R = user
+		id = R.idcard
 
-				if (!(req in conf_access))
-					conf_access += req
-				else
-					conf_access -= req
-					if (!conf_access.len)
-						conf_access = null
+	// Nothing
+	if(!id || !id.access)
+		return list()
 
+	// Has engineer access, can put any access
+	else if(has_access(null, apply_any_access, id.access))
+		return get_all_station_access()
+
+	// Not an engineer, can only pick your own accesses to program
+	else
+		return id.access
 
 /obj/item/airlock_electronics/secure
 	name = "secure airlock electronics"
 	desc = "designed to be somewhat more resistant to hacking than standard electronics."
 	origin_tech = list(TECH_DATA = 2)
 	secure = 1
+
+/obj/item/airlock_electronics/secure/emag_act(var/remaining_charges, var/mob/user)
+	to_chat(user, "<span class='warning'>You don't appear to be able to bypass this hardened device!</span>")
+	return -1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently if you rebuild or build an airlock with a circuit that requires certain access and then finish the airlock the access requirements aren't added to the door. Copying (and modifying so that it compiles) airlock.dm, airlock_control.dm, and airlock_electronics.dm from Virgo seems to have fixed the issue.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Airlocks should have the accesses you give them during construction.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
