### PR TITLE
Prevents Cargo Ordering Terminal Shenanigans

### DIFF
--- a/code/game/machinery/computer/supply.dm
+++ b/code/game/machinery/computer/supply.dm
@@ -14,6 +14,7 @@
 	var/active_category = null
 	var/menu_tab = 0
 	var/list/expanded_packs = list()
+	authorization = 0
 
 // Supply control console
 /obj/machinery/computer/supplycomp/control
@@ -53,11 +54,6 @@
 	var/pack_list[0]		// List of supply packs within the active_category
 	var/orders[0]
 	var/receipts[0]
-
-	if(!allowed(user))
-		authorization = 0
-	else
-		authorization = SUP_SEND_SHUTTLE | SUP_ACCEPT_ORDERS
 
 	var/datum/shuttle/ferry/supply/shuttle = SSsupply.shuttle
 	if(shuttle)

--- a/code/game/machinery/computer/supply.dm
+++ b/code/game/machinery/computer/supply.dm
@@ -14,7 +14,6 @@
 	var/active_category = null
 	var/menu_tab = 0
 	var/list/expanded_packs = list()
-	authorization = 0
 
 // Supply control console
 /obj/machinery/computer/supplycomp/control


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removed If/Else logic that caused the supply ordering terminal to allow approving, denying, and sending the shuttle instead of just being limited to the control terminal. Control terminal requires cargo access to open again.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Locking the control terminal via an if/else does very little good if you can just approve orders on the non control terminal anyway.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
