### PR TITLE
No More Magic Power

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -120,16 +120,17 @@ Class Procs:
 	var/speed_process = FALSE			//If false, SSmachines. If true, SSfastprocess.
 
 /obj/machinery/Initialize(mapload, newdir)
+	.=..()
 	if(newdir)
 		setDir(newdir)
 	if(ispath(circuit))
 		circuit = new circuit(src)
-	. = ..()
 	global.machines += src
 	if(!speed_process)
 		START_MACHINE_PROCESSING(src)
 	else
 		START_PROCESSING(SSfastprocess, src)
+	power_change()
 
 /obj/machinery/Destroy()
 	if(!speed_process)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -120,11 +120,11 @@ Class Procs:
 	var/speed_process = FALSE			//If false, SSmachines. If true, SSfastprocess.
 
 /obj/machinery/Initialize(mapload, newdir)
-	.=..()
 	if(newdir)
 		setDir(newdir)
 	if(ispath(circuit))
 		circuit = new circuit(src)
+	.=..()
 	global.machines += src
 	if(!speed_process)
 		START_MACHINE_PROCESSING(src)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -124,7 +124,7 @@ Class Procs:
 		setDir(newdir)
 	if(ispath(circuit))
 		circuit = new circuit(src)
-	.=..()
+	. = ..()
 	global.machines += src
 	if(!speed_process)
 		START_MACHINE_PROCESSING(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Newly made machines respect the area power instead of just being made.
Newly made machines default to stat = 0 which means they have power which is fine in most cases but if made in an area with no power (no APC) or an area where the machine power is disabled on the APC, they pull power anyway. Now they detect power properly.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->



<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
