### PR TITLE
Psych Ward Hotfix

### DIFF
--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -856,9 +856,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/computer/cryopod{
-	pixel_x = 32
-	},
+/obj/machinery/computer/cryopod,
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
 "bt" = (
@@ -5241,12 +5239,12 @@
 "jW" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/bottle/chloralhydrate,
-/obj/item/reagent_containers/glass/bottle/chloralhydrate{
-	pixel_x = -5;
-	pixel_y = 5
-	},
 /obj/machinery/light,
+/obj/item/reagent_containers/glass/bottle/stoxin{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/item/reagent_containers/glass/bottle/stoxin,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "jX" = (
@@ -17358,13 +17356,21 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/engineering/shaft)
+"Gv" = (
+/obj/machinery/button/remote/blast_door{
+	id = "yard_riot_3";
+	name = "Emergency Lockdown";
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/psych_ward)
 "Gw" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
 "GC" = (
 /obj/machinery/door/blast/regular{
 	dir = 1;
-	id = "psych cell 1";
+	id = "yard_riot";
 	name = "Yard Access"
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4,
@@ -17766,6 +17772,17 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/public_meeting_room)
+"Jt" = (
+/obj/structure/table/standard,
+/obj/item/storage/box/syringes,
+/obj/machinery/light,
+/obj/item/reagent_containers/glass/bottle/stoxin,
+/obj/item/reagent_containers/glass/bottle/stoxin{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/psych_ward)
 "JD" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -17878,7 +17895,7 @@
 "Kw" = (
 /obj/machinery/door/blast/regular{
 	dir = 1;
-	id = "psych cell 1";
+	id = "yard_riot_3";
 	name = "Yard Access"
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -18752,6 +18769,9 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"Pt" = (
+/turf/simulated/mineral/vacuum,
+/area/space)
 "Py" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -27869,7 +27889,7 @@ aa
 aa
 aa
 aa
-eM
+Pt
 VR
 VR
 VR
@@ -28007,11 +28027,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-eM
-eM
-eM
+Pt
+Pt
+Pt
+Pt
+Pt
 VR
 Ya
 Oo
@@ -28148,12 +28168,12 @@ ac
 aa
 aa
 aa
-eM
-eM
-eM
-aP
-aP
-aP
+Pt
+Pt
+Pt
+ac
+ac
+ac
 VR
 Oy
 GI
@@ -28290,12 +28310,12 @@ AU
 Cy
 CN
 aP
-aP
-aP
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
+ac
+ac
 VR
 XB
 XB
@@ -28433,11 +28453,11 @@ Cz
 CO
 aP
 aP
-aP
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
+ac
 VR
 Oq
 Oq
@@ -28578,8 +28598,8 @@ aP
 aP
 aP
 aP
-aP
-aP
+ac
+ac
 VR
 VR
 VR
@@ -28721,7 +28741,7 @@ aP
 aP
 aP
 aP
-aP
+ac
 VR
 Mv
 SZ
@@ -29003,9 +29023,9 @@ ac
 ac
 aP
 Lz
-aP
-aP
-aP
+ac
+ac
+ac
 VR
 Cn
 Hr
@@ -29145,9 +29165,9 @@ AG
 AG
 aP
 Lz
-aP
-aP
-aP
+ac
+ac
+ac
 VR
 VR
 VR
@@ -29287,9 +29307,9 @@ Dd
 Di
 aP
 Lz
-aP
-aP
-aP
+ac
+ac
+ac
 VR
 GR
 GR
@@ -29430,8 +29450,8 @@ UZ
 EQ
 Gi
 aP
-aP
-aP
+ac
+ac
 VR
 XB
 XB
@@ -29865,7 +29885,7 @@ Ue
 VR
 VR
 VR
-Ri
+Gv
 ZG
 VR
 aa
@@ -30008,7 +30028,7 @@ FM
 XO
 FM
 Xu
-jW
+Jt
 VR
 aa
 aa

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -27738,6 +27738,9 @@
 /obj/machinery/camera/network/medbay{
 	c_tag = "MED - Psych Ward Center"
 	},
+/obj/machinery/computer/cryopod{
+	pixel_y = 30
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "SB" = (
@@ -27793,6 +27796,14 @@
 /obj/machinery/door/airlock/glass_medical{
 	name = "Holding Cells"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "SI" = (
@@ -27844,6 +27855,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
+"Tf" = (
+/turf/simulated/mineral/floor/vacuum,
+/area/space)
 "Tr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -28437,17 +28451,17 @@
 	pixel_y = 5
 	},
 /obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/bottle/chloralhydrate,
-/obj/item/reagent_containers/glass/bottle/chloralhydrate{
-	pixel_x = -5;
-	pixel_y = 5
-	},
 /obj/machinery/button/remote/blast_door{
 	dir = 8;
 	id = "psych cell 2";
 	name = "Cell 2";
 	pixel_x = 25;
 	pixel_y = -5
+	},
+/obj/item/reagent_containers/glass/bottle/tramadol,
+/obj/item/reagent_containers/glass/bottle/stoxin{
+	pixel_x = 5;
+	pixel_y = 7
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
@@ -29124,7 +29138,7 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/regular{
 	dir = 1;
-	id = "psych cell 1";
+	id = "yard_riot_3";
 	name = "Yard Access"
 	},
 /turf/simulated/floor/tiled/white,
@@ -29188,17 +29202,17 @@
 	pixel_y = 5
 	},
 /obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/bottle/chloralhydrate,
-/obj/item/reagent_containers/glass/bottle/chloralhydrate{
-	pixel_x = -5;
-	pixel_y = 5
-	},
 /obj/machinery/button/remote/blast_door{
 	dir = 4;
 	id = "psych cell 1";
 	name = "Cell 1";
 	pixel_x = -25;
 	pixel_y = -5
+	},
+/obj/item/reagent_containers/glass/bottle/tramadol,
+/obj/item/reagent_containers/glass/bottle/stoxin{
+	pixel_x = -6;
+	pixel_y = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
@@ -29253,6 +29267,14 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "ZX" = (
@@ -29261,6 +29283,14 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
@@ -36191,13 +36221,13 @@ aa
 aa
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+gg
+gg
+gg
+gg
+gg
+gg
+gg
 aa
 aa
 aa
@@ -36335,11 +36365,11 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
+gg
+gg
+gg
+gg
+gg
 aa
 aa
 aa
@@ -36481,7 +36511,7 @@ Ug
 Ug
 Ug
 Ug
-aa
+gg
 aa
 aa
 aa
@@ -36627,8 +36657,8 @@ Ug
 Ug
 Ug
 Ug
-aa
-aa
+gg
+gg
 aa
 aa
 aa
@@ -36769,9 +36799,9 @@ XQ
 YQ
 XQ
 Ug
-aa
-aa
-aa
+gg
+gg
+gg
 aa
 aa
 aa
@@ -36911,9 +36941,9 @@ Ug
 Ug
 Ug
 Ug
-aa
-aa
-aa
+gg
+gg
+gg
 aa
 aa
 aa
@@ -38047,9 +38077,9 @@ Ug
 Ug
 Ug
 Ug
-aa
-aa
-ae
+gg
+gg
+gg
 ae
 ae
 ad
@@ -38189,9 +38219,9 @@ XQ
 Ut
 XQ
 Ug
-ae
-ad
-ad
+gg
+gg
+gg
 aa
 aa
 ae
@@ -38331,9 +38361,9 @@ Ug
 Ug
 Ug
 Ug
-ae
-ad
-ad
+gg
+gg
+aa
 ad
 ad
 aa
@@ -38459,7 +38489,7 @@ vt
 vt
 vt
 vt
-ae
+Tf
 vt
 vt
 ab
@@ -38469,7 +38499,7 @@ Ug
 Ug
 Ug
 Ug
-aa
+gg
 aa
 aa
 ae
@@ -38601,17 +38631,17 @@ vt
 vt
 vt
 vt
-ae
-ae
-aa
-vt
-vt
-vt
-vt
-vt
-aa
-aa
-aa
+Tf
+Tf
+Tf
+vs
+vs
+vs
+vs
+vs
+gg
+gg
+gg
 ad
 ae
 ae
@@ -38743,17 +38773,17 @@ vt
 vt
 vt
 vt
-ae
-ae
-aa
-aa
-aa
-ae
-ae
-ae
-ae
-ae
-ad
+Tf
+Tf
+Tf
+gg
+gg
+gg
+gg
+gg
+gg
+gg
+gg
 ae
 aa
 ad
@@ -38885,17 +38915,17 @@ vt
 vt
 vt
 vt
+Tf
+Tf
+Tf
+Tf
+Tf
+Tf
+aa
+aa
 ae
-aa
-aa
-aa
-aa
 ae
-ae
-aa
-aa
-ae
-aa
+ad
 aa
 aa
 ae
@@ -39027,16 +39057,16 @@ vt
 vt
 vt
 vt
-aa
-ad
-aa
-aa
-aa
-ad
+Tf
+Tf
+Tf
+Tf
 aa
 aa
 aa
 aa
+aa
+ae
 aa
 aa
 aa
@@ -39169,9 +39199,9 @@ vt
 vt
 vt
 vt
-ad
-ae
-aa
+Tf
+Tf
+Tf
 aa
 aa
 aa
@@ -39311,7 +39341,7 @@ vt
 vt
 vt
 vt
-aa
+Tf
 aa
 aa
 aa
@@ -39453,7 +39483,7 @@ vt
 vt
 vt
 vt
-aa
+Tf
 aa
 aa
 aa
@@ -39594,7 +39624,7 @@ vt
 vt
 vt
 vt
-aa
+Tf
 aa
 aa
 aa
@@ -39735,8 +39765,8 @@ vt
 vt
 vt
 vt
-aa
-aa
+Tf
+Tf
 aa
 aa
 aa
@@ -39877,8 +39907,8 @@ vt
 vt
 vt
 vt
-aa
-aa
+Tf
+Tf
 aa
 aa
 aa
@@ -40019,8 +40049,8 @@ vt
 vt
 vt
 vt
-aa
-aa
+Tf
+Tf
 aa
 aa
 aa
@@ -40161,8 +40191,8 @@ vt
 vt
 vt
 vt
-aa
-aa
+Tf
+Tf
 aa
 aa
 aa
@@ -40303,8 +40333,8 @@ vt
 vt
 vt
 vt
-aa
-aa
+Tf
+Tf
 aa
 aa
 aa
@@ -40445,8 +40475,8 @@ vt
 vt
 vt
 vt
-aa
-aa
+Tf
+Tf
 aa
 aa
 aa
@@ -40587,7 +40617,7 @@ vt
 vt
 vt
 vt
-aa
+Tf
 aa
 aa
 aa
@@ -41013,7 +41043,7 @@ vt
 vt
 vt
 vt
-aa
+Tf
 aa
 aa
 aa
@@ -41296,7 +41326,7 @@ ab
 ab
 ab
 ab
-vt
+ab
 aa
 aa
 aa


### PR DESCRIPTION
More of a warm fix by this point. Repairs oversights and mapping errors in the recent Psych Ward update:
-Links buttons to Riot Control/Yard Access to the appropriate blast doors.
-Adds a computer to Area that should stop players entering cryo from alerting Admins. (Unsure. Testing linkage.)
-Replaces all chloral hydrate bottles with more appropriate medications and sedatives.
-Adds in missing pipes and power lines.
-Rearranges external turfs to align correctly between z-levels.