### PR TITLE
removes ghost orbits removing mouse opacity

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1,4 +1,4 @@
-/mob/observer
+w/mob/observer
 	name = "observer"
 	desc = "This shouldn't appear"
 	density = 0
@@ -32,9 +32,6 @@
 	var/anonsay = 0
 	var/ghostvision = 1 //is the ghost able to see things humans can't?
 	incorporeal_move = 1
-
-	/// Whether or not our mouse opacity is set to transparent while following.
-	var/mouse_opacity_yield_while_following = TRUE
 
 	var/is_manifest = 0 //If set to 1, the ghost is able to whisper. Usually only set if a cultist drags them through the veil.
 	var/ghost_sprite = null
@@ -329,16 +326,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 
 	orbit(target, actually_orbit = FALSE)
-
-/mob/observer/dead/start_orbit(datum/component/orbiter/orbits)
-	. = ..()
-	if(mouse_opacity_yield_while_following)
-		mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-
-/mob/observer/dead/stop_orbit(datum/component/orbiter/orbits)
-	. = ..()
-	if(mouse_opacity_yield_while_following)
-		mouse_opacity = initial(mouse_opacity)
 
 /mob/observer/dead/verb/jumptomob(input in getmobs()) //Moves the ghost instead of just changing the ghosts's eye -Nodrak
 	set category = "Ghost"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1,4 +1,4 @@
-w/mob/observer
+/mob/observer
 	name = "observer"
 	desc = "This shouldn't appear"
 	density = 0


### PR DESCRIPTION
this was needed because examine didn't work for ghosts now it does so uh let's not because this actually lets ghosts see each other on right click