### PR TITLE
fixes tanks

### DIFF
--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -59,6 +59,7 @@ var/list/global/tank_gauge_cache = list()
 
 /obj/item/tank/Initialize()
 	. = ..()
+	START_PROCESSING(SSobj, src)
 
 	src.init_proxy()
 	src.air_contents = new /datum/gas_mixture()
@@ -78,13 +79,6 @@ var/list/global/tank_gauge_cache = list()
 		qdel(TTV)
 
 	. = ..()
-
-/obj/item/weapon/tank/equipped() // Note that even grabbing into a hand calls this, so it should be fine as a 'has a player touched this'
-	. = ..()
-	// An attempt at optimization. There are MANY tanks during rounds that will never get touched.
-	// Don't see why any of those would explode spontaneously. So only tanks that players touch get processed.
-	// This could be optimized more, but it's a start!
-	START_PROCESSING(SSobj, src) // This has a built in safety to avoid multi-processing
 
 /obj/item/tank/examine(mob/user)
 	. = ..(user, 0)


### PR DESCRIPTION
for whatever reason equipped is not always called

"but kev why are you fixing the symptom and not the problem??"

because the bigger issue here is I don't see why tanks need to start processing when a mob PICKS I UP which can lead to edge cases if we ever have a case where tanks are modified in contents before a mob picks it up. see, premade ttvs, etc etc. 380 process() calls isn't worth this.