### PR TITLE
Buff Chem Machines before re-work

### DIFF
--- a/code/modules/reagents/dispenser/_defines.dm
+++ b/code/modules/reagents/dispenser/_defines.dm
@@ -1,6 +1,6 @@
-#define CARTRIDGE_VOLUME_LARGE  500
-#define CARTRIDGE_VOLUME_MEDIUM 250
-#define CARTRIDGE_VOLUME_SMALL  100
+#define CARTRIDGE_VOLUME_LARGE  1000
+#define CARTRIDGE_VOLUME_MEDIUM 500
+#define CARTRIDGE_VOLUME_SMALL  250
 
 // Chemistry dispenser starts with 21
 // ERT dispenser starts with 28

--- a/code/modules/reagents/dispenser/dispenser2_energy.dm
+++ b/code/modules/reagents/dispenser/dispenser2_energy.dm
@@ -21,7 +21,7 @@
 			var/obj/item/reagent_containers/chem_disp_cartridge/C = cartridges[R.name]
 			if(C && C.reagents.total_volume < C.reagents.maximum_volume)
 				var/to_restore = min(C.reagents.maximum_volume - C.reagents.total_volume, 5)
-				use_power(to_restore * 500)
+				use_power(to_restore * 200)
 				C.reagents.add_reagent(id, to_restore)
 				. = 1
 		if(.)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Doubles the storage of the reagent containers while we're in transition of updating the chem dispensers to run from a battery similar to TG.

## Why It's Good For The Game

QOL

## Changelog
:cl:
tweak: Buffed the container capacity of the reagent containers.
balance: reduced power cost to recharge
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
