### PR TITLE
Fixes Spineapple and pineapple slices

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -236,6 +236,12 @@
 					new /obj/item/reagent_containers/food/snacks/soydope(get_turf(src))
 					qdel(src)
 					return
+				else if(!isnull(seed.chems["pineapplejuice"]))
+					to_chat(user, "You slice \the [src] into slices.")
+					for(var/i=i;i<=4;i++)
+						new /obj/item/reagent_containers/food/snacks/pineapple_ring(get_turf(src))
+					qdel(src)
+					return
 				else if(seed.get_trait(TRAIT_FLESH_COLOUR))
 					to_chat(user, "You slice up \the [src].")
 					var/slices = rand(3,5)

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -1055,8 +1055,8 @@
 	name = "spineapple"
 	seed_name = "spineapple"
 	display_name = "spineapple"
-	kitchen_tag = "pineapple"
-	chems = list("nutriment" = list(1,5), "enzyme" = list(1,5), "pineapplejuice" = list(1, 20))
+	kitchen_tag = "spineapple"
+	chems = list("nutriment" = list(3,5), "enzyme" = list(3,5), "pineapplejuice" = list(15, 20))
 
 /datum/seed/spineapple/New()
 	..()


### PR DESCRIPTION
How can you make the accursed pineapple pizza if pineapple slices are unobtainable?

PR fixes a typo in the Spineapple fruit preventing it from generating chems, as well as makes Spineapple sliceable into pineapple slices.