### PR TITLE
Make Cells Appear to be Empty on Fabrication

### DIFF
--- a/code/game/objects/structures/trash_pile.dm
+++ b/code/game/objects/structures/trash_pile.dm
@@ -246,7 +246,7 @@
 					prob(1);/obj/item/sleevemate,
 				//	prob(1);/obj/item/bodysnatcher, //VORECode default probability, 0.2%
 					prob(1);/obj/item/beartrap,
-					prob(1);/obj/item/cell/hyper, // Changed to hyper because empty cells no longer exist
+					prob(1);/obj/item/cell/hyper/empty,
 				//	prob(1);/obj/item/disk/nifsoft/compliance, //VORECode default probability, 0.2%
 					prob(1);/obj/item/material/knife/tacknife,
 					prob(1);/obj/item/clothing/accessory/storage/brown_vest,

--- a/code/game/objects/structures/trash_pile.dm
+++ b/code/game/objects/structures/trash_pile.dm
@@ -246,7 +246,7 @@
 					prob(1);/obj/item/sleevemate,
 				//	prob(1);/obj/item/bodysnatcher, //VORECode default probability, 0.2%
 					prob(1);/obj/item/beartrap,
-					prob(1);/obj/item/cell/hyper/empty,
+					prob(1);/obj/item/cell/hyper, // Changed to hyper because empty cells no longer exist
 				//	prob(1);/obj/item/disk/nifsoft/compliance, //VORECode default probability, 0.2%
 					prob(1);/obj/item/material/knife/tacknife,
 					prob(1);/obj/item/clothing/accessory/storage/brown_vest,

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -29,9 +29,10 @@
 	var/overlay_full_state = "cell-o2" // Overlay used when fully charged.
 	var/last_overlay_state = null // Used to optimize update_icon() calls.
 
-/obj/item/cell/New()
-	..()
-	charge = maxcharge
+/obj/item/cell/Initialize(mapload)
+	. = ..()
+	if(charge = null)
+		charge = maxcharge
 	update_icon()
 	if(self_recharge)
 		START_PROCESSING(SSobj, src)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -31,7 +31,7 @@
 
 /obj/item/cell/Initialize(mapload)
 	. = ..()
-	if(charge = null)
+	if(charge == null)
 		charge = maxcharge
 	update_icon()
 	if(self_recharge)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -14,7 +14,7 @@
 	throw_speed = 3
 	throw_range = 5
 	w_class = ITEMSIZE_NORMAL
-	var/charge = 0	// note %age conveted to actual charge in New
+	var/charge
 	var/maxcharge = 1000
 	var/rigged = 0		// true if rigged to explode
 	var/minor_fault = 0 //If not 100% reliable, it will build up faults.
@@ -31,7 +31,7 @@
 
 /obj/item/cell/Initialize(mapload)
 	. = ..()
-	if(charge == null)
+	if(!isnull(charge))
 		charge = maxcharge
 	update_icon()
 	if(self_recharge)

--- a/code/modules/power/cells/device_cells.dm
+++ b/code/modules/power/cells/device_cells.dm
@@ -13,12 +13,18 @@
 	matter = list("metal" = 350, "glass" = 50)
 	preserve_item = 1
 
+/obj/item/cell/device/empty
+	charge = 0
+
 /obj/item/cell/device/weapon
 	name = "weapon power cell"
 	desc = "A small power cell designed to power handheld weaponry."
 	icon_state = "wcell"
 	maxcharge = 2400
 	charge_amount = 20
+
+/obj/item/cell/device/weapon/empty
+	charge = 0
 
 /obj/item/cell/device/weapon/recharge
 	name = "self-charging weapon power cell"

--- a/code/modules/power/cells/device_cells.dm
+++ b/code/modules/power/cells/device_cells.dm
@@ -20,11 +20,6 @@
 	maxcharge = 2400
 	charge_amount = 20
 
-/obj/item/cell/device/weapon/empty/Initialize()
-	. = ..()
-	charge = 0
-	update_icon()
-
 /obj/item/cell/device/weapon/recharge
 	name = "self-charging weapon power cell"
 	desc = "A small power cell designed to power handheld weaponry. This one recharges itself."

--- a/code/modules/power/cells/power_cells.dm
+++ b/code/modules/power/cells/power_cells.dm
@@ -18,6 +18,7 @@
 /obj/item/cell/secborg/empty/New()
 	..()
 	charge = 0
+	update_icon()
 
 /obj/item/cell/apc
 	name = "heavy-duty power cell"
@@ -35,6 +36,7 @@
 /obj/item/cell/high/empty/New()
 	..()
 	charge = 0
+	update_icon()
 
 /obj/item/cell/super
 	name = "super-capacity power cell"
@@ -46,6 +48,7 @@
 /obj/item/cell/super/empty/New()
 	..()
 	charge = 0
+	update_icon()
 
 /obj/item/cell/hyper
 	name = "hyper-capacity power cell"
@@ -57,6 +60,7 @@
 /obj/item/cell/hyper/empty/New()
 	..()
 	charge = 0
+	update_icon()
 
 /obj/item/cell/infinite
 	name = "infinite-capacity power cell!"

--- a/code/modules/power/cells/power_cells.dm
+++ b/code/modules/power/cells/power_cells.dm
@@ -5,11 +5,17 @@
 	maxcharge = 500
 	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 40)
 
+/obj/item/cell/crap/empty
+	charge = 0
+
 /obj/item/cell/secborg
 	name = "security borg rechargable D battery"
 	origin_tech = list(TECH_POWER = 0)
 	maxcharge = 600	//600 max charge / 100 charge per shot = six shots
 	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 40)
+
+/obj/item/cell/secborg/empty
+	charge = 0
 
 /obj/item/cell/apc
 	name = "heavy-duty power cell"
@@ -24,6 +30,9 @@
 	maxcharge = 10000
 	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 60)
 
+/obj/item/cell/high/empty
+	charge = 0
+
 /obj/item/cell/super
 	name = "super-capacity power cell"
 	origin_tech = list(TECH_POWER = 5)
@@ -31,12 +40,18 @@
 	maxcharge = 20000
 	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 70)
 
+/obj/item/cell/super/empty
+	charge = 0
+
 /obj/item/cell/hyper
 	name = "hyper-capacity power cell"
 	origin_tech = list(TECH_POWER = 6)
 	icon_state = "hpcell"
 	maxcharge = 30000
 	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 80)
+
+/obj/item/cell/hyper/empty
+	charge = 0
 
 /obj/item/cell/infinite
 	name = "infinite-capacity power cell!"

--- a/code/modules/power/cells/power_cells.dm
+++ b/code/modules/power/cells/power_cells.dm
@@ -5,20 +5,11 @@
 	maxcharge = 500
 	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 40)
 
-/obj/item/cell/crap/empty/New()
-	..()
-	charge = 0
-
 /obj/item/cell/secborg
 	name = "security borg rechargable D battery"
 	origin_tech = list(TECH_POWER = 0)
 	maxcharge = 600	//600 max charge / 100 charge per shot = six shots
 	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 40)
-
-/obj/item/cell/secborg/empty/New()
-	..()
-	charge = 0
-	update_icon()
 
 /obj/item/cell/apc
 	name = "heavy-duty power cell"
@@ -33,11 +24,6 @@
 	maxcharge = 10000
 	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 60)
 
-/obj/item/cell/high/empty/New()
-	..()
-	charge = 0
-	update_icon()
-
 /obj/item/cell/super
 	name = "super-capacity power cell"
 	origin_tech = list(TECH_POWER = 5)
@@ -45,22 +31,12 @@
 	maxcharge = 20000
 	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 70)
 
-/obj/item/cell/super/empty/New()
-	..()
-	charge = 0
-	update_icon()
-
 /obj/item/cell/hyper
 	name = "hyper-capacity power cell"
 	origin_tech = list(TECH_POWER = 6)
 	icon_state = "hpcell"
 	maxcharge = 30000
 	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 80)
-
-/obj/item/cell/hyper/empty/New()
-	..()
-	charge = 0
-	update_icon()
 
 /obj/item/cell/infinite
 	name = "infinite-capacity power cell!"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -62,3 +62,12 @@ other types of metals and chemistry for reagents).
 
 /datum/design/item
 	build_type = PROTOLATHE
+
+//Make sure items don't get free power
+/datum/design/item/Fabricate()
+	var/obj/item/I = ..()
+	var/obj/item/cell/C = I.get_cell()
+	if(C)
+		C.charge = 0
+		I.update_icon()
+	return I

--- a/code/modules/research/designs/power_cells.dm
+++ b/code/modules/research/designs/power_cells.dm
@@ -12,6 +12,7 @@
 /datum/design/item/powercell/Fabricate()
 	var/obj/item/cell/C = ..()
 	C.charge = 0 //shouldn't produce power out of thin air.
+	C.update_icon()
 	return C
 
 /datum/design/item/powercell/basic


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tin
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
So people don't think their cell is full when printing a new one.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Cells appear empty when fabricated with no energy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
