### PR TITLE
Removes smart internals gas type detection, internals automatically targets your active hand and then rig in priority, makes internal handling a bit saner and less complicated. 

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -261,7 +261,7 @@
 							var/list/tanks = list()
 							// first, hand
 							locnames += "in your hand"
-							tanks += get_active_hand()
+							tanks += C.get_active_hand()
 							// yes, the above can result in duplicates.
 							// snowflake rig handling, second highest priority
 							if(istype(C.back, /obj/item/rig))
@@ -294,18 +294,18 @@
 							else
 								// right/left hands
 								locnames += "in your right hand"
-								tanks += H.r_hand
+								tanks += C.r_hand
 								locnames += "in your left hand"
-								tanks += H.l_hand
+								tanks += C.l_hand
 								// back
 								locnames += "on your back"
-								tanks += H.back
+								tanks += C.back
 							// no more hugbox and stupid "smart" checks. take the first one we can find and use it. they can use active hand to override if needed.
 							for(var/index = 1 to length(tanks))
 								if(!istype(tanks[index], /obj/item/tank))
 									continue
 								C.internal = tanks[index]
-								to_chat(C, "<span class='notice'>You are now running on internals from [tank] on your [locnames[index]]</span>")
+								to_chat(C, "<span class='notice'>You are now running on internals from [tanks[index]] on your [locnames[index]]</span>")
 								if(C.internals)
 									C.internals.icon_state = "internal1"
 								return

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -254,93 +254,63 @@
 							to_chat(C, "<span class='notice'>You are not wearing a suitable mask or helmet.</span>")
 							return 1
 						else
-							var/list/nicename = null
-							var/list/tankcheck = null
-							var/breathes = /datum/gas/oxygen  //default, we'll check later
-							var/list/contents = list()
-							var/from = "on"
-
+							// groan. lazy time.
+							// location name
+							var/list/locnames = list()
+							// tank ref, can include nulls! FIRST VALID TANK FROM THIS IS CHOSEN.
+							var/list/tanks = list()
+							// first, hand
+							locnames += "in your hand"
+							tanks += get_active_hand()
+							// yes, the above can result in duplicates.
+							// snowflake rig handling, second highest priority
+							if(istype(C.back, /obj/item/rig))
+								var/obj/item/rig/R = C.back
+								if(R.air_supply && !R.offline)
+									locnames += "in your hardsuit"
+									tanks += R.air_supply
+							// now, slots
 							if(ishuman(C))
 								var/mob/living/carbon/human/H = C
-								breathes = H.species.breath_type
-								nicename = list ("suit", "back", "belt", "right hand", "left hand", "left pocket", "right pocket")
-								tankcheck = list (H.s_store, C.back, H.belt, C.r_hand, C.l_hand, H.l_store, H.r_store)
+								// suit storage
+								locnames += "on your suit"
+								tanks += H.s_store
+								// right/left hands
+								locnames += "in your right hand"
+								tanks += H.r_hand
+								locnames += "in your left hand"
+								tanks += H.l_hand
+								// pockets
+								locnames += "in your left pocket"
+								tanks += H.l_store
+								locnames += "in your right pocket"
+								tanks += H.r_store
+								// belt
+								locnames += "on your belt"
+								tanks += H.belt
+								// back
+								locnames += "on your back"
+								tanks += H.back
 							else
-								nicename = list("right hand", "left hand", "back")
-								tankcheck = list(C.r_hand, C.l_hand, C.back)
-
-							// Rigs are a fucking pain since they keep an air tank in nullspace.
-							if(istype(C.back,/obj/item/rig))
-								var/obj/item/rig/rig = C.back
-								if(rig.air_supply && !rig.offline)
-									from = "in"
-									nicename |= "hardsuit"
-									tankcheck |= rig.air_supply
-
-							for(var/i=1, i<tankcheck.len+1, ++i)
-								if(istype(tankcheck[i], /obj/item/tank))
-									var/obj/item/tank/t = tankcheck[i]
-									if (!isnull(t.manipulated_by) && t.manipulated_by != C.real_name && findtext(t.desc,breathes))
-										contents.Add(t.air_contents.total_moles)	//Someone messed with the tank and put unknown gasses
-										continue					//in it, so we're going to believe the tank is what it says it is
-									switch(breathes)
-																		//These tanks we're sure of their contents
-										if(/datum/gas/nitrogen) 							//So we're a bit more picky about them.
-
-											if(t.air_contents.gas[/datum/gas/nitrogen] && !t.air_contents.gas[/datum/gas/oxygen])
-												contents.Add(t.air_contents.gas[/datum/gas/nitrogen])
-											else
-												contents.Add(0)
-
-										if (/datum/gas/oxygen)
-											if(t.air_contents.gas[/datum/gas/oxygen] && !t.air_contents.gas[/datum/gas/phoron])
-												contents.Add(t.air_contents.gas[/datum/gas/oxygen])
-											else
-												contents.Add(0)
-
-										// No races breath this, but never know about downstream servers.
-										if (/datum/gas/carbon_dioxide)
-											if(t.air_contents.gas[/datum/gas/carbon_dioxide] && !t.air_contents.gas[/datum/gas/phoron])
-												contents.Add(t.air_contents.gas[/datum/gas/carbon_dioxide])
-											else
-												contents.Add(0)
-
-										// And here's for the Vox
-										if (/datum/gas/phoron)
-											if(t.air_contents.gas[/datum/gas/phoron] && !t.air_contents.gas[/datum/gas/oxygen])
-												contents.Add(t.air_contents.gas[/datum/gas/phoron])
-											else
-												contents.Add(0)
-
-
-								else
-									//no tank so we set contents to 0
-									contents.Add(0)
-
-							//Alright now we know the contents of the tanks so we have to pick the best one.
-
-							var/best = 0
-							var/bestcontents = 0
-							for(var/i=1, i <  contents.len + 1 , ++i)
-								if(!contents[i])
+								// right/left hands
+								locnames += "in your right hand"
+								tanks += H.r_hand
+								locnames += "in your left hand"
+								tanks += H.l_hand
+								// back
+								locnames += "on your back"
+								tanks += H.back
+							// no more hugbox and stupid "smart" checks. take the first one we can find and use it. they can use active hand to override if needed.
+							for(var/index = 1 to length(tanks))
+								if(!istype(tanks[index], /obj/item/tank))
 									continue
-								if(contents[i] > bestcontents)
-									best = i
-									bestcontents = contents[i]
-
-
-							//We've determined the best container now we set it as our internals
-
-							if(best)
-								to_chat(C, "<span class='notice'>You are now running on internals from [tankcheck[best]] [from] your [nicename[best]].</span>")
-								C.internal = tankcheck[best]
-
-
-							if(C.internal)
+								C.internal = tanks[index]
+								to_chat(C, "<span class='notice'>You are now running on internals from [tank] on your [locnames[index]]</span>")
 								if(C.internals)
 									C.internals.icon_state = "internal1"
-							else
-								to_chat(C, "<span class='notice'>You don't have a[breathes=="oxygen" ? "n oxygen" : addtext(" ",breathes)] tank.</span>")
+								return
+							to_chat(C, "<span class='warning'>You don't have an internals tank.</span.")
+							return
 		if("act_intent")
 			usr.a_intent_change("right")
 		if(INTENT_HELP)


### PR DESCRIPTION
New internal target priroity:
Active hand
Rigsuit
Suit storage
Right hand
Left hand
Left pocket
Right pocket
Belt
Back

The first tank found is used. No more gotchas, no more smart gas detection where it tried to find the "best" tank, no more anti sabotage snowflake check (the check is just bad code at this point and not as maintainable as I want it to be). If you want to override which tank it uses, just hold the tank you want in your active hand and it'll be used instead of the other tanks. 

## Why:

Yes, I could make super complicated checks that mimiced prior behavior. Yes, I could build something to do a smart identification where it allows sabotage. But at the end of the day it's just harder to maintain, and it honestly doesn't make a lot of sense that you should be able to automatically use the best tank with the code invisibly detecting the gases for you. People are perfectly capable of putting internal tanks in hand to manipulate them directly and this should be the default override behavior instead of some complex, unreadable and pretty terrible code to try to do it for them.
The old code didn't even have an inhand override.
It was stupid.