### PR TITLE
quick pr - adds the ability to have generic planetary atmospherics set using ZTRAIT_DEFAULT_ATMOS and a turfmaker for making generic map-independent automatically setting planetary turfs 

### DIFF
--- a/code/__DEFINES/atmospherics/atmospheres.dm
+++ b/code/__DEFINES/atmospherics/atmospheres.dm
@@ -1,5 +1,8 @@
 // Atmosphere IDs
 
+/// SPECIAL ATMOSPHERE ID THAT FORCES ATMOS TO BE WHATEVER IS DEFINED AS A ZTRAIT, DEFAULTING TO SPACE.
+#define ATMOSPHERE_ID_USE_ZTRAIT		"USE_ZTRAIT"
+
 // Tethermap
 /// Virgo 2 planetary atmosphere ID
 #define ATMOSPHERE_ID_VIRGO2			/datum/atmosphere/planet/virgo2

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -93,6 +93,9 @@ require only minor tweaks.
 // string - type path of the z-level's baseturf (defaults to space)
 #define ZTRAIT_BASETURF "Baseturf"
 
+/// Default gas string. Use for things like setting planetary gasmixtures and such. ATMOSPHERE_ID_USE_ZTRAIT to have a turf use it.
+#define ZTRAIT_DEFAULT_ATMOS "Default Gas String"
+
 // default trait definitions, used by SSmapping
 #define ZTRAITS_CENTCOM list(ZTRAIT_CENTCOM = TRUE)
 #define ZTRAITS_STATION list(ZTRAIT_LINKAGE = CROSSLINKED, ZTRAIT_STATION = TRUE)

--- a/code/__DEFINES/turfs/turfmakers.dm
+++ b/code/__DEFINES/turfs/turfmakers.dm
@@ -1,0 +1,2 @@
+/// Makes a generic, outdoors planetary turf that uses atmos from a ztrait.
+#define CREATE_TURF_PLANETARY_OUTDOORS(path)		path/generated/planetary/outdoors=TRUE;path/generated/planetary/initial_gas_mix=ATMOSPHERE_ID_USE_ZTRAIT;path/generated/planetary/allow_gas_overlays=FALSE

--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -288,9 +288,11 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 /**
   * Preprocess a gas string, replacing it with a specific atmosphere's if necessary.
   */
-/datum/controller/subsystem/air/proc/preprocess_gas_string(gas_string)
+/datum/controller/subsystem/air/proc/preprocess_gas_string(gas_string, turf/T)
 	if(!generated_atmospheres)
 		generate_atmospheres()
+	if(gas_string == ATMOSPHERE_ID_USE_ZTRAIT)
+		gas_string = SSmapping.level_trait(T.z, ZTRAIT_DEFAULT_ATMOS) || GAS_STRING_VACCUM
 	gas_string = "[gas_string]"
 	if(!generated_atmospheres[gas_string])
 		return gas_string

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -105,6 +105,7 @@
 #include "code\__DEFINES\misc\misc.dm"
 #include "code\__DEFINES\mobs\cooldowns.dm"
 #include "code\__DEFINES\mobs\intent.dm"
+#include "code\__DEFINES\turfs\turfmakers.dm"
 #include "code\__HELPERS\_core.dm"
 #include "code\__HELPERS\_global_objects.dm"
 #include "code\__HELPERS\_global_objects_vr.dm"


### PR DESCRIPTION
hey maybe use these so we don't have 4 different kinds of turfs...