### PR TITLE
Restores 15,000 Rated Borg  Starting Cell

### DIFF
--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -150,8 +150,8 @@
 
 	// cyborgs produced by Robotize get an automatic power cell
 	O.cell = new(O)
-	O.cell.maxcharge = 10000
-	O.cell.charge = 10000
+	O.cell.maxcharge = 15000
+	O.cell.charge = 15000
 
 
 	O.gender = gender

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -150,8 +150,8 @@
 
 	// cyborgs produced by Robotize get an automatic power cell
 	O.cell = new(O)
-	O.cell.maxcharge = 7500
-	O.cell.charge = 7500
+	O.cell.maxcharge = 10000
+	O.cell.charge = 10000
 
 
 	O.gender = gender


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
We had changed borg cells to start with 15,000 charge rating pre-hard sync. but it was reverted. This restores that.

Edit: It was actually 15,000.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bit of QoL for borgs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
