### PR TITLE
Fixes typo in solar storm announcement

### DIFF
--- a/code/modules/events/solar_storm.dm
+++ b/code/modules/events/solar_storm.dm
@@ -18,7 +18,7 @@
 
 
 /datum/event/solar_storm/start()
-	command_announcement.Announce("The solar storm has reached the station. Please refain from EVA and remain inside the station until it has passed.", "Anomaly Alert")
+	command_announcement.Announce("The solar storm has reached the station. Please refrain from EVA and remain inside the station until it has passed.", "Anomaly Alert")
 	adjust_solar_output(5)
 
 


### PR DESCRIPTION
## About The Pull Request

Fixes "refain" to "refrain" in the solar storm comms announcement thingy. Extensive, I know.

## Why It's Good For The Game

grammer

## Changelog
:cl:
spellcheck: fixed typo in solar storm announcement
:cl: