### PR TITLE
Adds Portable Shield Diffusor to Cargo

### DIFF
--- a/_maps/map_files/Tether/tether-07-station3.dmm
+++ b/_maps/map_files/Tether/tether-07-station3.dmm
@@ -15471,6 +15471,7 @@
 /obj/item/retail_scanner/civilian{
 	dir = 1
 	},
+/obj/item/shield_diffuser,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
 /obj/effect/floor_decal/borderfloor/corner2,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
In light of being unable to get a floor diffusor so that the cargo shuttle is blocked, I've added a handheld one. Especially now that they can be recharged as well.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents cargo from being blocked from their own shuttle.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Handheld diffusor added to a table on cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
