### PR TITLE
Setting to Scrub NO2 Should Scrub NO2, not Fuel

### DIFF
--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -234,10 +234,10 @@
 	else if(signal.data["toggle_tox_scrub"])
 		toggle += /datum/gas/phoron
 
-	if(!isnull(signal.data["n2o_scrub"]) && text2num(signal.data["n2o_scrub"]) != (/datum/gas/volatile_fuel in scrubbing_gas))
-		toggle += /datum/gas/volatile_fuel
+	if(!isnull(signal.data["n2o_scrub"]) && text2num(signal.data["n2o_scrub"]) != (/datum/gas/nitrous_oxide in scrubbing_gas))
+		toggle += /datum/gas/nitrous_oxide
 	else if(signal.data["toggle_n2o_scrub"])
-		toggle += /datum/gas/volatile_fuel
+		toggle += /datum/gas/nitrous_oxide
 
 	if(!isnull(signal.data["fuel_scrub"]) && text2num(signal.data["fuel_scrub"]) != (/datum/gas/volatile_fuel in scrubbing_gas))
 		toggle += /datum/gas/volatile_fuel


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so setting scrubbers to filter NO2 actually filters NO2 and doesn't set it to scrub fuel.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We want to be able to scrub NO2.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
