### PR TITLE
changes endnotify to notify for consistency with main

### DIFF
--- a/code/modules/admin/chat_commands.dm
+++ b/code/modules/admin/chat_commands.dm
@@ -87,7 +87,7 @@
 GLOBAL_LIST(round_end_notifiees)
 
 /datum/tgs_chat_command/endnotify
-	name = "endnotify"
+	name = "notify"
 	help_text = "Pings the invoker when the round ends"
 	admin_only = FALSE
 


### PR DESCRIPTION
why did i make it endnotify instead of notify this is just annoying to have to memorize both