### PR TITLE
Search & Rescue Access Fix Pt 2 & Gear

### DIFF
--- a/_maps/map_files/Tether/tether-05-station1.dmm
+++ b/_maps/map_files/Tether/tether-05-station1.dmm
@@ -1684,9 +1684,6 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 9
 	},
-/obj/machinery/iv_drip,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/white,
 /area/tether/station/explorer_medical)
@@ -1743,6 +1740,10 @@
 	name = "O- Blood Locker";
 	pixel_y = -32
 	},
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/machinery/iv_drip,
 /turf/simulated/floor/tiled/white,
 /area/tether/station/explorer_medical)
 "adF" = (
@@ -23367,9 +23368,12 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/sar{
-	req_access = list(5,66);
+	req_access = list(5);
 	req_one_access = list(5)
 	},
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/autoinjectors,
+/obj/item/storage/bag/chemistry,
 /turf/simulated/floor/tiled/monotile,
 /area/tether/station/explorer_prep)
 "oJC" = (
@@ -24582,7 +24586,7 @@
 /area/tether/station/excursion_dock)
 "wbE" = (
 /obj/structure/closet/secure_closet/sar{
-	req_access = list(5,66);
+	req_access = list(5);
 	req_one_access = list(5)
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
@@ -24602,6 +24606,9 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/autoinjectors,
+/obj/item/storage/bag/chemistry,
 /turf/simulated/floor/tiled/monotile,
 /area/tether/station/explorer_prep)
 "wcD" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is an update to the SNR gear to compensate regarding the access adjustment to ensure they can still provide assistance to their away teams & on-site when no parameds are around.

## Why It's Good For The Game

Quality of Life and quick fix for access and & gear. Cleaned up the Triage center in the exploration bay.

## Changelog
:cl:
tweak: tweaked SNR lockers to ensure access is not messed up. (for reals this time oh god)
balance: Added needed chemistry gear for SNR due to chem access being revoked 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
