### PR TITLE
Fixes Stacker Console Runtime

### DIFF
--- a/_maps/map_files/Tether/tether-01-surface1.dmm
+++ b/_maps/map_files/Tether/tether-01-surface1.dmm
@@ -322,7 +322,7 @@
 	dir = 4;
 	id = "mining_interior"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/plating,
 /area/tether/surfacebase/mining_main/refinery)
 "aaN" = (
 /obj/machinery/conveyor{
@@ -612,11 +612,6 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/refinery)
 "abt" = (
-/obj/machinery/mineral/stacking_unit_console{
-	density = 0;
-	layer = 3.3;
-	pixel_y = 30
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/surfacebase/mining_main/refinery)
 "abu" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Runtime happened because there was no more stacker for the console to connect to. This removes the stacker console on the map. I also changed the tech floor the stacker originally was on to plating to match the rest of the conveyor path.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
