### PR TITLE
fixes is_animal

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -43,7 +43,7 @@
 
 #define isalien(A) istype(A, /mob/living/carbon/alien)
 
-#define isanimal(A) istype(A, /mob/living/simple_animal)
+#define isanimal(A) istype(A, /mob/living/simple_mob)
 
 #define isbrain(A) istype(A, /mob/living/carbon/brain)
 


### PR DESCRIPTION
mob/living/simple_animal is a deprecated class and has been removed from the code everywhere is_animal is referenced except here where it actually matters a fucking lot