### PR TITLE
Adds ateopine and associated injectors + map changes

### DIFF
--- a/_maps/map_files/Tether/tether-05-station1.dmm
+++ b/_maps/map_files/Tether/tether-05-station1.dmm
@@ -23374,6 +23374,8 @@
 /obj/item/storage/box/pillbottles,
 /obj/item/storage/box/autoinjectors,
 /obj/item/storage/bag/chemistry,
+/obj/item/reagent_containers/hypospray/autoinjector/ateopine,
+/obj/item/reagent_containers/hypospray/autoinjector/ateopine,
 /turf/simulated/floor/tiled/monotile,
 /area/tether/station/explorer_prep)
 "oJC" = (
@@ -24609,6 +24611,8 @@
 /obj/item/storage/box/pillbottles,
 /obj/item/storage/box/autoinjectors,
 /obj/item/storage/bag/chemistry,
+/obj/item/reagent_containers/hypospray/autoinjector/ateopine,
+/obj/item/reagent_containers/hypospray/autoinjector/ateopine,
 /turf/simulated/floor/tiled/monotile,
 /area/tether/station/explorer_prep)
 "wcD" = (

--- a/_maps/map_files/Tether/tether-06-station2.dmm
+++ b/_maps/map_files/Tether/tether-06-station2.dmm
@@ -18685,6 +18685,14 @@
 /obj/item/radio{
 	pixel_x = -4
 	},
+/obj/item/reagent_containers/hypospray/autoinjector/ateopine{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/hypospray/autoinjector/ateopine{
+	pixel_x = -2;
+	pixel_y = -2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay_emt_bay)
 "Py" = (

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1279,7 +1279,6 @@
 
 /datum/reagent/ateopine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/chem_effective = 1
-	var/mob/living/carbon/human/H = M
 	if(alien != IS_DIONA)
 		M.add_chemical_effect(CE_STABLE, 5)
 		M.adjustBrainLoss(-5 * removed * chem_effective)
@@ -1292,10 +1291,11 @@
 		if(prob(33))
 			H.Confuse(10)
 	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
 		for(var/obj/item/organ/I in H.internal_organs)
 			if(I.robotic >= ORGAN_ROBOT || !(I.organ_tag in list(O_LUNGS, O_HEART)))
 				continue
-			if(I.damage > 15) // Fixes their heart and lungs about 5 points or until it hits 15.
+			if(I.damage > 10) // Fixes their heart and lungs about 5 points or until it hits 10.
 				I.damage = max(I.damage - 1 * removed * chem_effective, 0)
 				H.Confuse(5)
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1266,6 +1266,39 @@
 		M.make_dizzy(5)
 		M.make_jittery(5)
 
+/datum/reagent/ateopine
+	name = "Ateopine"
+	id = "ateopine"
+	description = "Ateopine is a medicine used to treat bradycardia and asystole patients when injected into heart muscle, it is also used to treat nerve gas and insecticide poisoning. Commonly used by emergency teams to resuscitate patients."
+	taste_description = "astringency"
+	reagent_state = LIQUID
+	color = "#DA00FF"
+	metabolism = REM * 1.5
+	overdose = 10
+	scannable = 1
+
+/datum/reagent/ateopine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	var/chem_effective = 1
+	var/mob/living/carbon/human/H = M
+	if(alien != IS_DIONA)
+		M.add_chemical_effect(CE_STABLE, 5)
+	if(alien == IS_SLIME)
+		chem_effective = 0.25
+		if(M.brainloss >= 10)
+			M.Weaken(5)
+		if(dose >= 5 && M.paralysis < 40)
+			M.AdjustParalysis(1)
+		if(prob(33))
+			H.Confuse(10)
+	M.adjustBrainLoss(-5 * removed * chem_effective)
+	if(ishuman(M))
+		for(var/obj/item/organ/I in H.internal_organs)
+			if(I.robotic >= ORGAN_ROBOT || !(I.organ_tag in list(O_LUNGS, O_HEART)))
+				continue
+			if(I.damage > 15) // Fixes their heart and lungs about 5 points or until it hits 15.
+				I.damage = max(I.damage - 1 * removed * chem_effective, 0)
+				H.Confuse(5)
+
 /* Antidepressants */
 
 #define ANTIDEPRESSANT_MESSAGE_DELAY 5*60*10

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1282,6 +1282,7 @@
 	var/mob/living/carbon/human/H = M
 	if(alien != IS_DIONA)
 		M.add_chemical_effect(CE_STABLE, 5)
+		M.adjustBrainLoss(-5 * removed * chem_effective)
 	if(alien == IS_SLIME)
 		chem_effective = 0.25
 		if(M.brainloss >= 10)
@@ -1290,7 +1291,6 @@
 			M.AdjustParalysis(1)
 		if(prob(33))
 			H.Confuse(10)
-	M.adjustBrainLoss(-5 * removed * chem_effective)
 	if(ishuman(M))
 		for(var/obj/item/organ/I in H.internal_organs)
 			if(I.robotic >= ORGAN_ROBOT || !(I.organ_tag in list(O_LUNGS, O_HEART)))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1269,7 +1269,7 @@
 /datum/reagent/ateopine
 	name = "Ateopine"
 	id = "ateopine"
-	description = "Ateopine is a medicine used to treat bradycardia and asystole patients when injected into heart muscle, it is also used to treat nerve gas and insecticide poisoning. Commonly used by emergency teams to resuscitate patients."
+	description = "Ateopine is a medicine used to treat bradycardia and asystole patients when injected into heart muscle. Commonly used by emergency teams to resuscitate patients."
 	taste_description = "astringency"
 	reagent_state = LIQUID
 	color = "#DA00FF"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1289,7 +1289,7 @@
 		if(dose >= 5 && M.paralysis < 40)
 			M.AdjustParalysis(1)
 		if(prob(33))
-			H.Confuse(10)
+			M.Confuse(10)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		for(var/obj/item/organ/I in H.internal_organs)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -191,8 +191,8 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/ateopine/do_injection(mob/living/carbon/human/H, mob/living/user)
 	. = ..()
-    if(!istype(H)
-        return
+	if(!istype(H))
+		return
 	var/error = can_resus(H)
 	if(error)
 		return // One of the conditions returned true, nothing will happen.

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -191,6 +191,8 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/ateopine/do_injection(mob/living/carbon/human/H, mob/living/user)
 	. = ..()
+    if(!istype(H)
+        return
 	var/error = can_resus(H)
 	if(error)
 		return // One of the conditions returned true, nothing will happen.
@@ -231,7 +233,6 @@
 	return null
 
 /obj/item/reagent_containers/hypospray/autoinjector/ateopine/proc/make_alive(mob/living/carbon/human/M, mob/living/user)
-//	var/deadtime = world.time - M.timeofdeath
 
 	dead_mob_list.Remove(M)
 	if((M in living_mob_list) || (M in dead_mob_list))
@@ -246,7 +247,6 @@
 	M.emote("gasp")
 	M.Weaken(rand(10,25))
 	M.updatehealth()
-//	apply_brain_damage(M, deadtime) // Ateopine heals brain damage anyway.
 
 	if (M.client && M.stat != DEAD)
 		log_and_message_admins("used \a [src] to revive [key_name(M)].")

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -211,7 +211,7 @@
 		return TRUE
 
 	var/deadtime = world.time - H.timeofdeath
-	if (deadtime > 15 MINUTES)
+	if (deadtime > 5 MINUTES)
 		return TRUE
 
 	H.updatehealth()


### PR DESCRIPTION
## About The Pull Request

Blind port of IS12 Warfare's Ateopine autoinjectors, redesigned and rebalanced for Citadel use.

## Why It's Good For The Game

A common complaint is that SaRs, and lesser so, parameds have a habit of 'powergaming' and 'carrying around medbay on their backs'. These complaints aren't necessarily true, a lot of this supposed powergaming is simply the necessary setup for SaRs prior to an expedition, of course one doesn't always have to prepare for an expedition but it is good practice in case a team capable arrives. 

So the problem here is the setup and amount of equipment needed, right. So how do we fix that?
We fix it by cutting down on the amount of unnecessary prepwork and running around.

To achieve this I will be gradually implementing new QoL changes and equipment for both medbay and SaR that hopefully push the meta away from chem grinding in chemistry for half an hour, then running around grabbing things for another half hour. First and foremost in this plan is to remove the need to carry a defib around on their backs or in their bags to be effective in long range recovery of wounded or deceased. Defibs aren't too common, they're massive and annoying to lug around, so I've introduced ateopine autoinjectors.

Ateopine autoinjectors are used to:
- Revive patients similarly to a defib shock about eight seconds after injection.
- Restore brain damage as a result of oxyloss or blood loss .
- Restore a SMALL amount of heart and lung damage, up to a maximum damage of 12, if damage is much higher than that, all they restore is 5 organ damage to each.
- Stabilize patients immediately for a short time.
- Enable SaRs and paramedics to quickly revive patients even through hardsuits or away from medbay.

However, being autoinjectors and not full-blown defibrillation machines, they do not advise you of who is able to be revived, when something prevents revivification, or prevent you from accidentally wasting an injector. It's a skill based reward sort of thing, if you can tell when someone is able to be revived, know when it is safe to do so, and keep them alive after injection, you will get a lot out of these.

![image](https://user-images.githubusercontent.com/50751907/86512518-528a3980-be46-11ea-8de9-16528fa90ea6.png)
You'll receive a message, as will the admins, on a fail, success, or in this case if they're revived but have no client (he's a spawned human).

## Changelog
:cl:
add: Ateopine and ateopine autoinjectors from IS12 Warfare
/:cl: