### PR TITLE
Adds way of Unbricking RIGs

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig_wiring.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_wiring.dm
@@ -23,6 +23,12 @@
 			if(mended)
 				rig.req_access = initial(rig.req_access)
 				rig.req_one_access = initial(rig.req_one_access)
+		if(RIG_SYSTEM_CONTROL)
+			if(!mended)
+				rig.shock(usr,100) // Intended to keep players from trying to mend in the middle of combat. Second way of getting shocked as pulsing this wire ALSO shocks you.
+			else if(mended)
+				rig.malfunctioning = 0
+				rig.malfunction_delay = 0
 		if(RIG_INTERFACE_SHOCK)
 			rig.electrified = mended ? 0 : -1
 			rig.shock(usr,100)
@@ -42,6 +48,7 @@
 			if(rig.malfunction_delay <= 0)
 				rig.malfunction_delay = 20
 			rig.shock(usr,100)
+			rig.visible_message("\The [rig] beeps stridently as a surge of power runs through it.") // Hints to the fact that if you pulse this while wearing it you get zappoed.
 		if(RIG_INTERFACE_LOCK)
 			rig.interface_locked = !rig.interface_locked
 			rig.visible_message("\The [rig] clicks audibly as the software interface [rig.interface_locked?"darkens":"brightens"].")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If RIGs get emp_acted on or if the control wire is pulsed they gain some 'malfunctioning' and malfunction_delay numbers which are just two timers that count down before you can do anything with the suit again. The problem is these numbers only count down if the rig is initialized and equipped as that's the only time where the rig is seeming to be processed.

This means if someone pulses the control wire or if the rig happens to get emped when not equipped, it becomes a paperweight. There's already a more or less unused wire (well, that is if you want to add malfunction OR zap yourself) I hooked into to be used as a method of resetting both these vars. The max emp_act seems to add 30 of each as well as drain charge, meaning the rig is normally out of commission for a minute at most, unless if it's stacked on. If you cut and mend the control wire, you'll first zap yourself if you're wearing it and then on mending it it will clear the malfunction.

Added a visual indicator for the wire as well, as before it just did this silently when pulsed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents RIG bricking.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added function to the control wire of RIGs to allow for removal of malfunctioning and malfunction_delay to an unequipped, otherwise bricked, RIG.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
