### PR TITLE
fixes supermatter weapons

### DIFF
--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -57,7 +57,7 @@
 	force = round(force*force_divisor)
 	if(dulled)
 		force = round(force*dulled_divisor)
-	if(material == /datum/material/supermatter)
+	if(material.name == "supermatter")
 		damtype = BURN //its hot
 		force = 150 //double the force of a durasteel claymore.
 		armor_penetration = 100 //regardless of armor

--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -57,11 +57,13 @@
 	force = round(force*force_divisor)
 	if(dulled)
 		force = round(force*dulled_divisor)
+	throwforce = round(material.get_blunt_damage()*thrown_force_divisor)
 	if(material.name == "supermatter")
 		damtype = BURN //its hot
 		force = 150 //double the force of a durasteel claymore.
 		armor_penetration = 100 //regardless of armor
-	throwforce = round(material.get_blunt_damage()*thrown_force_divisor)
+		throwforce = 150
+
 	//spawn(1)
 	//	world << "[src] has force [force] and throwforce [throwforce] when made from default material [material.name]"
 

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -43,6 +43,14 @@
 
 /obj/item/material/twohanded/update_force()
 	base_name = name
+	if(material.name == "supermatter")
+		damtype = BURN //its hot
+		force_wielded = 150 //double the force of a durasteel claymore.
+		force_unwielded = 150 //double the force of a durasteel claymore.
+		armor_penetration = 100 //regardless of armor
+		throwforce = 150
+		force = force_unwielded
+		return
 	if(sharp || edge)
 		force_wielded = material.get_edge_damage()
 	else


### PR DESCRIPTION
`material == /datum/material/supermatter` doesnt work
`material.name == "supermatter"` does