### PR TITLE
Minor Jukebox UI Adjustment

### DIFF
--- a/nano/templates/jukebox.tmpl
+++ b/nano/templates/jukebox.tmpl
@@ -49,6 +49,7 @@ Used In File(s): \code\game\machinery\jukebox.dm
     {{for data.tracks}}
         <div class="item">
             {{:helper.link(value.title, 'gear', {'change_track' : value.ref}, data.current_track_ref == value.ref ? 'disabled' : null, null)}}
+			{{:helper.link(value.artist)}}
         </div>
     {{/for}}
 </div>


### PR DESCRIPTION
## About The Pull Request
Tiny 1-line Jukebox UI adjustment that displays the artist name alongside the song title. Mainly done just to refresh myself on how to get back into contributing with git and github and see if I finally figured out how to get upstream fetching done properly so I don't need to re-download everything when someone touches a map file.

I'm not filling out the pregenerated github categories for this because hardly anyone does, plus changelog hasn't been updated for about a year if not longer.
