### PR TITLE
Supplypacks _vr Merging & Minor Jukebox UI Adjustment

### DIFF
--- a/nano/templates/jukebox.tmpl
+++ b/nano/templates/jukebox.tmpl
@@ -49,6 +49,7 @@ Used In File(s): \code\game\machinery\jukebox.dm
     {{for data.tracks}}
         <div class="item">
             {{:helper.link(value.title, 'gear', {'change_track' : value.ref}, data.current_track_ref == value.ref ? 'disabled' : null, null)}}
+			{{:helper.link(value.artist)}}
         </div>
     {{/for}}
 </div>


### PR DESCRIPTION
## About The Pull Request

Cleans up the area of code related to supplypacks aka cargo crates by merging all of the items in the _vr files with their respective matching files, deleting the original _vr files, and doing my best to remove any _vr suffixes within item declarations. If I missed anything I'll look stupid but that's nothing new, since I'm still too incompetent to figure out why separate branches are just merging with other branches in my PRs and making one colossal clusterfuck PR every time I want to make more than one fucking adjustment.

## Why It's Good For The Game

Part of the ongoing effort to sanitize _vr suffixes and clean up bloat.

## Changelog
:cl:
code: Good old _vr cleanup.
/:cl: