### PR TITLE
Event Weight Lowering Adjustments & Patching

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -1,12 +1,12 @@
-/var/const/meteor_wave_delay = 625 //minimum wait between waves in tenths of seconds
+/var/const/meteor_wave_delay = 425 //minimum wait between waves in tenths of seconds
 //set to at least 100 unless you want evarr ruining every round
 
 //Meteors probability of spawning during a given wave
 /var/list/meteors_normal = list(/obj/effect/meteor/dust=3, /obj/effect/meteor/medium=8, /obj/effect/meteor/big=3, \
 						  /obj/effect/meteor/flaming=1, /obj/effect/meteor/irradiated=3) //for normal meteor event
 
-/var/list/meteors_threatening = list(/obj/effect/meteor/medium=5, /obj/effect/meteor/big=10, \
-						  /obj/effect/meteor/flaming=3, /obj/effect/meteor/irradiated=3, /obj/effect/meteor/emp=3) //for threatening meteor event
+/var/list/meteors_threatening = list(/obj/effect/meteor/medium=5, /obj/effect/meteor/big=15, \
+						  /obj/effect/meteor/flaming=4, /obj/effect/meteor/irradiated=4, /obj/effect/meteor/emp=4) //for threatening meteor event
 
 /var/list/meteors_catastrophic = list(/obj/effect/meteor/medium=5, /obj/effect/meteor/big=75, \
 						  /obj/effect/meteor/flaming=10, /obj/effect/meteor/irradiated=10, /obj/effect/meteor/emp=10) //, /obj/effect/meteor/tunguska = 1) //for catastrophic meteor event

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -205,7 +205,7 @@
 	if(heavy)
 		shake_players()
 
-
+/// CITADEL STATION EDITS - Making meteors less deadly to make this a non station-ending event, but still give engineering stuff to do for once.
 ///////////////////////
 //Meteor types
 ///////////////////////
@@ -224,26 +224,26 @@
 /obj/effect/meteor/medium
 	name = "meteor"
 	dropamt = 3
-	wall_power = 200
+	wall_power = 75 // CitadelStation Edit: Down from 200
 
 /obj/effect/meteor/medium/meteor_effect(var/explode)
 	..()
 	if(explode)
-		explosion(src.loc, 0, 1, 2, 3, 0)
+		explosion(src.loc, 0, 0, 1, 1, 0) // CitadelStation Edit: Down from 0,1,2,3,0)
 
 // Large-sized meteors generally pack the most punch, but are more concentrated towards the epicenter.
 /obj/effect/meteor/big
 	name = "large meteor"
 	icon_state = "large"
-	hits = 8
+	hits = 2
 	heavy = 1
 	dropamt = 4
-	wall_power = 400
+	wall_power = 125 // CitadelStation Edit: Down from 400
 
 /obj/effect/meteor/big/meteor_effect(var/explode)
 	..()
 	if(explode)
-		explosion(src.loc, devastation_range = 2, heavy_impact_range = 4, light_impact_range = 6, flash_range = 12, adminlog = 0)
+		explosion(src.loc, devastation_range = 1, heavy_impact_range = 2, light_impact_range = 3, flash_range = 12, adminlog = 0) // CitadelStation Edit: Down from 2,4,6,12
 
 // 'Flaming' meteors do less overall damage but are spread out more due to a larger but weaker explosion at the end.
 /obj/effect/meteor/flaming

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -205,7 +205,7 @@
 	if(heavy)
 		shake_players()
 
-/// CITADEL STATION EDITS - Making meteors less deadly to make this a non station-ending event, but still give engineering stuff to do for once.
+
 ///////////////////////
 //Meteor types
 ///////////////////////
@@ -224,12 +224,11 @@
 /obj/effect/meteor/medium
 	name = "meteor"
 	dropamt = 3
-	wall_power = 75 // CitadelStation Edit: Down from 200
-
+	wall_power = 75
 /obj/effect/meteor/medium/meteor_effect(var/explode)
 	..()
 	if(explode)
-		explosion(src.loc, 0, 0, 1, 1, 0) // CitadelStation Edit: Down from 0,1,2,3,0)
+		explosion(src.loc, 0, 0, 1, 1, 0)
 
 // Large-sized meteors generally pack the most punch, but are more concentrated towards the epicenter.
 /obj/effect/meteor/big
@@ -238,12 +237,12 @@
 	hits = 2
 	heavy = 1
 	dropamt = 4
-	wall_power = 125 // CitadelStation Edit: Down from 400
+	wall_power = 125
 
 /obj/effect/meteor/big/meteor_effect(var/explode)
 	..()
 	if(explode)
-		explosion(src.loc, devastation_range = 1, heavy_impact_range = 2, light_impact_range = 3, flash_range = 12, adminlog = 0) // CitadelStation Edit: Down from 2,4,6,12
+		explosion(src.loc, devastation_range = 1, heavy_impact_range = 2, light_impact_range = 3, flash_range = 12, adminlog = 0)
 
 // 'Flaming' meteors do less overall damage but are spread out more due to a larger but weaker explosion at the end.
 /obj/effect/meteor/flaming

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -33,8 +33,8 @@
 
 /datum/event/electrical_storm
 	announceWhen = 0		// Warn them shortly before it begins.
-	startWhen = 30			// 1 minute
-	endWhen = 60			// Set in setup()
+	startWhen = 15			// 30 seconds
+	endWhen = 30			// Set in setup() Reduced from 60
 	var/tmp/lightning_color
 	var/tmp/list/valid_apcs		// List of valid APCs.
 
@@ -46,14 +46,14 @@
 		if(EVENT_LEVEL_MODERATE)
 			command_announcement.Announce("The station is about to pass through an electrical storm. Please secure sensitive electrical equipment until the storm passes.", "Weather Sensor Array")
 		if(EVENT_LEVEL_MAJOR)
-			command_announcement.Announce("Alert. A strong electrical storm has been detected in proximity of the station. It is recommended to immediately secure sensitive electrical equipment until the storm passes.", "Weather Sensor Array")
+			command_announcement.Announce("A strong electrical storm has been detected in proximity of the station. It is recommended to immediately secure sensitive electrical equipment until the storm passes.", "Weather Sensor Array")
 
 /datum/event/electrical_storm/start()
 	..()
 	valid_apcs = list()
 	for(var/obj/machinery/power/apc/A in global.machines)
 		valid_apcs.Add(A)
-	endWhen = (severity * 60) + startWhen
+	endWhen = (severity * 30) + startWhen // Reducing endWhen by half
 
 /datum/event/electrical_storm/tick()
 	..()
@@ -63,7 +63,7 @@
 		log_debug("No valid APCs found for electrical storm event!")
 		return
 	var/list/picked_apcs = list()
-	for(var/i=0, i< severity * 2, i++) // up to 2/4/6 APCs per tick depending on severity
+	for(var/i=0, i< severity * 3, i++) // up to 3/6/9 APCs per tick depending on severity
 		picked_apcs |= pick(valid_apcs)
 	for(var/obj/machinery/power/apc/T in picked_apcs)
 		affect_apc(T)

--- a/code/modules/events/event_container_vr.dm
+++ b/code/modules/events/event_container_vr.dm
@@ -36,7 +36,7 @@
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Canister Leak",		/datum/event/canister_leak,		10, 	list(ASSIGNMENT_ENGINEER = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Space Dust",		/datum/event/dust,	 			0, 		list(ASSIGNMENT_ENGINEER = 20), 0, 0, 50),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Economic News",		/datum/event/economic_event,	300),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Electrical Storm",	/datum/event/electrical_storm, 	100,	list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_JANITOR = 100), 1),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Electrical Storm",	/datum/event/electrical_storm, 	25,		list(ASSIGNMENT_ENGINEER = 5, ASSIGNMENT_JANITOR = 10), 1),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Lost Carp",			/datum/event/carp_migration, 	0, 		list(ASSIGNMENT_SECURITY = 10), 1),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Hacker",		/datum/event/money_hacker, 		0, 		list(ASSIGNMENT_ANY = 4), 1, 10, 25),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Lotto",		/datum/event/money_lotto, 		0, 		list(ASSIGNMENT_ANY = 1), 1, 5, 15),
@@ -63,8 +63,8 @@
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Carp School",				/datum/event/carp_migration,			0, 		list(ASSIGNMENT_SECURITY = 30), 1),
 		// Just disables comms for a short while.
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Communication Blackout",	/datum/event/communications_blackout,	100,	list(ASSIGNMENT_AI = 75, ASSIGNMENT_SECURITY = 60), 1),
-		// Just blows out a few lights
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Electrical Storm",			/datum/event/electrical_storm, 			50,		list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_JANITOR = 50), 1),
+		// Lights get blown around station
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Electrical Storm",			/datum/event/electrical_storm, 			25,		list(ASSIGNMENT_ENGINEER = 3, ASSIGNMENT_JANITOR = 8), 1),
 		// This one is just too fun.
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Gravity Failure",			/datum/event/gravity,	 				75,		list(ASSIGNMENT_ENGINEER = 60), 1),
 		// Temporary power failure, but mitigatead by subgrids
@@ -83,10 +83,10 @@
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grub Infestation",			/datum/event/grub_infestation,			0,		list(ASSIGNMENT_SECURITY = 10, ASSIGNMENT_ENGINEER = 30), 1),
 		//Angry rats that are going to cause a bad day to nearby crew (Dorms protected)
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rat Migration",			/datum/event/hostile_migration,			40,		list(ASSIGNMENT_SECURITY = 30, ASSIGNMENT_ENGINEER = 10)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meteor Shower",			/datum/event/meteor_wave,				15,		list(ASSIGNMENT_ENGINEER = 20), 1),
 	)
 	add_disabled_events(list(
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Appendicitis", 			/datum/event/spontaneous_appendicitis, 	0,		list(ASSIGNMENT_MEDICAL = 30), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meteor Shower",			/datum/event/meteor_wave,				30,		list(ASSIGNMENT_ENGINEER = 20)),
 		// Not bad (dorms are shielded) but inconvenient
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Radiation Storm",			/datum/event/radiation_storm, 			50,		list(ASSIGNMENT_MEDICAL = 50), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		30,		list(ASSIGNMENT_SECURITY = 30), 1),
@@ -98,15 +98,15 @@
 	available_events = list(
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",				/datum/event/nothing,			3600),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Atmos Leak",			/datum/event/atmos_leak, 		30,		list(ASSIGNMENT_ENGINEER = 25), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Electrical Storm",	/datum/event/electrical_storm, 	10,		list(ASSIGNMENT_ENGINEER = 2, ASSIGNMENT_JANITOR = 15), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Electrical Storm",	/datum/event/electrical_storm, 	10,		list(ASSIGNMENT_ENGINEER = 1, ASSIGNMENT_JANITOR = 5), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Strike",		/datum/event/meteor_strike,		10,		list(ASSIGNMENT_ENGINEER = 15), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",			/datum/event/spacevine, 		35,		list(ASSIGNMENT_ENGINEER = 7), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",		/datum/event/carp_migration,	10,		list(ASSIGNMENT_SECURITY = 5), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Containment Breach",	/datum/event/prison_break/station,0,	list(ASSIGNMENT_ANY = 5), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",			/datum/event/meteor_wave,		10,		list(ASSIGNMENT_ENGINEER = 15),	1),
 	)
 	add_disabled_events(list(
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",				/datum/event/blob, 				10,	list(ASSIGNMENT_ENGINEER = 60), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",			/datum/event/meteor_wave,		30,		list(ASSIGNMENT_ENGINEER = 15),	1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",				/datum/event/blob, 				10,		list(ASSIGNMENT_ENGINEER = 60), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Supply Demand",		/datum/event/supply_demand,		0,		list(ASSIGNMENT_ANY = 5, ASSIGNMENT_SCIENCE = 15, ASSIGNMENT_GARDENER = 10, ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_MEDICAL = 15), 1),
 	))
 

--- a/code/modules/events/event_container_vr.dm
+++ b/code/modules/events/event_container_vr.dm
@@ -75,7 +75,7 @@
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Prison Break",				/datum/event/prison_break,				10,		list(ASSIGNMENT_SECURITY = 100), 1),
 		// Radiation, but only in space.
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",				/datum/event/rogue_drone, 				0,		list(ASSIGNMENT_SECURITY = 20), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Solar Storm",				/datum/event/solar_storm, 				30,		list(ASSIGNMENT_ENGINEER = 40, ASSIGNMENT_SECURITY = 30), 1),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Solar Storm",				/datum/event/solar_storm, 				40,		list(ASSIGNMENT_ENGINEER = 40, ASSIGNMENT_SECURITY = 30), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space Dust",				/datum/event/dust,	 					0,		list(ASSIGNMENT_ENGINEER = 20), 1, 0, 50),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Virology Breach",			/datum/event/prison_break/virology,		0,		list(ASSIGNMENT_MEDICAL = 100), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Xenobiology Breach",		/datum/event/prison_break/xenobiology,	0,		list(ASSIGNMENT_SCIENCE = 100), 1),
@@ -83,7 +83,7 @@
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grub Infestation",			/datum/event/grub_infestation,			0,		list(ASSIGNMENT_SECURITY = 10, ASSIGNMENT_ENGINEER = 30), 1),
 		//Angry rats that are going to cause a bad day to nearby crew (Dorms protected)
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rat Migration",			/datum/event/hostile_migration,			40,		list(ASSIGNMENT_SECURITY = 30, ASSIGNMENT_ENGINEER = 10)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meteor Shower",			/datum/event/meteor_wave,				15,		list(ASSIGNMENT_ENGINEER = 20), 1),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meteor Shower",			/datum/event/meteor_wave,				15,		list(ASSIGNMENT_ENGINEER = 10), 1),
 	)
 	add_disabled_events(list(
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Appendicitis", 			/datum/event/spontaneous_appendicitis, 	0,		list(ASSIGNMENT_MEDICAL = 30), 1),

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -27,7 +27,7 @@
 		endWhen = worst_case_end()
 
 /datum/event/meteor_wave/proc/worst_case_end()
-	return activeFor + ((14 / severity) * waves) + 10
+	return activeFor + ((14 / severity) * waves) + 5
 
 /datum/event/meteor_wave/end()
 	switch(severity)

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -13,21 +13,21 @@
 /datum/event/meteor_wave/announce()
 	switch(severity)
 		if(EVENT_LEVEL_MAJOR)
-			command_announcement.Announce("Meteors have been detected on collision course with \the [station_name()].", "Meteor Alert", new_sound = 'sound/AI/meteors.ogg')
+			command_announcement.Announce("Danger! A large meteor storm has been detected on approach with \the [station_name()]!", "Meteor Alert", new_sound = sound('sound/effects/meteor_storm.wav',volume=5))
 		else
-			command_announcement.Announce("\The [station_name()] is now in a meteor shower.", "Meteor Alert")
+			command_announcement.Announce("Caution. Meteors have been detected on collision course with \the [station_name()].", "Meteor Alert", new_sound = 'sound/AI/meteors.ogg')
 
 /datum/event/meteor_wave/tick()
 	if(waves && activeFor >= next_meteor)
 		var/pick_side = prob(80) ? start_side : (prob(50) ? turn(start_side, 90) : turn(start_side, -90))
 
 		spawn() spawn_meteors(severity * rand(1,2), get_meteors(), pick_side)
-		next_meteor += rand(15, 30) / severity
+		next_meteor += rand(5, 14) / severity
 		waves--
 		endWhen = worst_case_end()
 
 /datum/event/meteor_wave/proc/worst_case_end()
-	return activeFor + ((30 / severity) * waves) + 10
+	return activeFor + ((14 / severity) * waves) + 10
 
 /datum/event/meteor_wave/end()
 	switch(severity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR focuses on adjusting the weights of the Electrical storm, and Meteor Wave events. The Electrical storm is now a shorter running event, and has less chance to proc. The Meteor wave weight is reduced, and the damage the meteors can do is severely reduced to not cause a station-ending event on the round, but will give Engineering more work to do later in the round.

## Why It's Good For The Game

QOL and balance fixing.

## Changelog
:cl:
tweak: Reduced weight and duration of Electrical Storm events
tweak: Reduced danger of Meteor Wave events
balance: Damage and weight adjustments of the above events.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
