### PR TITLE
Meteor Wave Buffs. Also Re-enables TUNGUSKA OH GOD

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -8,8 +8,8 @@
 /var/list/meteors_threatening = list(/obj/effect/meteor/medium=5, /obj/effect/meteor/big=15, \
 						  /obj/effect/meteor/flaming=4, /obj/effect/meteor/irradiated=4, /obj/effect/meteor/emp=4) //for threatening meteor event
 
-/var/list/meteors_catastrophic = list(/obj/effect/meteor/medium=5, /obj/effect/meteor/big=75, \
-						  /obj/effect/meteor/flaming=10, /obj/effect/meteor/irradiated=10, /obj/effect/meteor/emp=10) //, /obj/effect/meteor/tunguska = 1) //for catastrophic meteor event
+/var/list/meteors_catastrophic = list(/obj/effect/meteor/medium=5, /obj/effect/meteor/big=50, \
+						  /obj/effect/meteor/flaming=10, /obj/effect/meteor/irradiated=10, /obj/effect/meteor/emp=10, /obj/effect/meteor/tunguska = 1) //for catastrophic meteor event
 
 /var/list/meteors_dust = list(/obj/effect/meteor/dust) //for space dust event
 

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -21,7 +21,7 @@
 	if(waves && activeFor >= next_meteor)
 		var/pick_side = prob(80) ? start_side : (prob(50) ? turn(start_side, 90) : turn(start_side, -90))
 
-		spawn() spawn_meteors(severity * rand(1,2), get_meteors(), pick_side)
+		spawn() spawn_meteors(severity * rand(2,4), get_meteors(), pick_side)
 		next_meteor += rand(5, 14) / severity
 		waves--
 		endWhen = worst_case_end()
@@ -38,7 +38,7 @@
 
 /datum/event/meteor_wave/proc/get_meteors()
 	if(severity == EVENT_LEVEL_MAJOR)
-		if(prob(10))
+		if(prob(35))
 			return meteors_catastrophic
 		else
 			return meteors_threatening


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

God I don't know why I hate myself this much BUUUTTT. Buffs the meteor wave threat to throw more rocks and a SMALL chance of throwing a mega death rock. The damage numbers for the meteors have NOT been adjusted, including the Tunguska (which is VERY likely going to get SOMETHING adjusted or re-disabled if its unfun)

## Why It's Good For The Game

Because people love chaos a lot more than you'd think on this server. 

## Changelog
:cl:
tweak: Re-enabled the meteor type Tunguska (Will spawn NO more than one)
balance: Adjusted spawn chance and count of current meteors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
