### PR TITLE
prevents turbolifts from gibbing people while moving up. makes turbolift gib actions async.

### DIFF
--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -153,15 +153,17 @@
 	if(!istype(origin) || !istype(destination) || (origin == destination))
 		return 0
 
-	for(var/turf/T in destination)
-		for(var/atom/movable/AM in T)
-			if(istype(AM, /mob/living))
-				var/mob/living/M = AM
-				M.gib()
-			else if(istype(AM, /mob/zshadow))
-				AM.Destroy()		//prevent deleting shadow without deleting shadow's shadows
-			else if(AM.simulated && !(istype(AM, /mob/observer)))
-				qdel(AM)
+	if(!moving_upwards)
+		for(var/turf/T in destination)
+			set waitfor = FALSE		// no check ticks until we get better shuttlecode.
+			for(var/atom/movable/AM in T)
+				if(istype(AM, /mob/living))
+					var/mob/living/M = AM
+					M.gib()
+				else if(istype(AM, /mob/zshadow))
+					AM.Destroy()		//prevent deleting shadow without deleting shadow's shadows
+				else if(AM.simulated && !(istype(AM, /mob/observer)))
+					qdel(AM)
 
 	origin.move_contents_to(destination)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

zzz race conditions make my blood boil and this didn't make sense anyways
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: silicons
balance: turbolifts no longer gib people while moving up
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
