### PR TITLE
General Map Fixes/QOL

### DIFF
--- a/_maps/map_files/Tether/tether-01-surface1.dmm
+++ b/_maps/map_files/Tether/tether-01-surface1.dmm
@@ -318,8 +318,8 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/mining_main/refinery)
 "aaM" = (
-/obj/machinery/mineral/processing_unit_console{
-	pixel_y = 32
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/surfacebase/mining_main/refinery)
@@ -5639,12 +5639,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "akb" = (
+/obj/effect/ceiling,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside1)
 "akc" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/ceiling,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/storage/surface_eva/external)
 "akd" = (
@@ -5951,6 +5953,7 @@
 /turf/simulated/wall,
 /area/maintenance/lower/research)
 "akH" = (
+/obj/effect/ceiling,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/storage/surface_eva/external)
 "akI" = (
@@ -6598,6 +6601,7 @@
 /obj/machinery/camera/network/civilian{
 	dir = 9
 	},
+/obj/effect/ceiling,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/storage/surface_eva/external)
 "ama" = (
@@ -18561,11 +18565,13 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 9
 	},
+/obj/effect/ceiling,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/rnd/external)
 "aIr" = (
 /obj/machinery/camera/network/research,
 /obj/machinery/floodlight,
+/obj/effect/ceiling,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/rnd/external)
 "aIs" = (
@@ -31082,6 +31088,7 @@
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/medical/triage)
 "cHR" = (
+/obj/effect/ceiling,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/medical/triage)
 "cHS" = (
@@ -31167,6 +31174,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline,
+/obj/effect/ceiling,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/mining_main/external)
 "den" = (
@@ -32438,6 +32446,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
+"jqT" = (
+/obj/machinery/mineral/processing_unit_console{
+	pixel_x = -32;
+	pixel_y = -3
+	},
+/turf/simulated/wall,
+/area/tether/surfacebase/mining_main/refinery)
 "jrz" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -32510,6 +32525,7 @@
 /area/tether/surfacebase/medical/triage)
 "jAw" = (
 /obj/machinery/mech_recharger,
+/obj/effect/ceiling,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/mining_main/external)
 "jGg" = (
@@ -33344,6 +33360,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/effect/ceiling,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/mining_main/external)
 "oMP" = (
@@ -34279,6 +34296,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline,
+/obj/effect/ceiling,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/storage/surface_eva/external)
 "sAe" = (
@@ -34977,6 +34995,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/ceiling,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/storage/surface_eva/external)
 "vCB" = (
@@ -35085,6 +35104,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/ceiling,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/mining_main/external)
 "whR" = (
@@ -48639,7 +48659,7 @@ aah
 aah
 aar
 aaL
-aar
+jqT
 abe
 abJ
 abM

--- a/_maps/map_files/Tether/tether-06-station2.dmm
+++ b/_maps/map_files/Tether/tether-06-station2.dmm
@@ -4458,9 +4458,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/table/rack,
 /obj/item/rig/medical/equipped,
 /turf/simulated/floor/tiled/dark,
@@ -17629,6 +17626,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay_emt_bay)
 "Kg" = (
@@ -18628,6 +18628,7 @@
 /obj/item/radio{
 	pixel_x = -4
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay_emt_bay)
 "Py" = (

--- a/maps/tether/submaps/tether_underdark.dmm
+++ b/maps/tether/submaps/tether_underdark.dmm
@@ -144,6 +144,10 @@
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/mine/explored/underdark)
+"A" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/mine/explored/underdark)
 "B" = (
 /obj/machinery/light/small{
 	icon_state = "bulb1";
@@ -218,6 +222,10 @@
 "T" = (
 /obj/effect/decal/remains/mouse,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
+/area/mine/explored/underdark)
+"U" = (
+/obj/machinery/mineral/equipment_vendor/survey,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/mine/explored/underdark)
 "W" = (
 /obj/item/bone/skull,
@@ -17706,10 +17714,10 @@ g
 g
 g
 h
-g
-g
-g
-g
+U
+s
+s
+o
 T
 o
 B
@@ -17848,9 +17856,9 @@ g
 g
 g
 h
-g
-g
-g
+A
+s
+o
 o
 R
 o
@@ -17990,7 +17998,7 @@ g
 g
 g
 h
-g
+s
 N
 o
 o


### PR DESCRIPTION
1. _Adds Department Vendors for Exploration and Mining to the Underdark._
**Why:** Simple quality of life addition. Adds an Exploration and Mining vendor to the UD so that crew with points on their cards can replenish supplies/purchase better gear without having to walk two z-levels back without reason.

2. _Adds ceiling tiles to all external charging bays/air ports._
**Why:** I realized recently that snow covers these areas. I've added ceilings in to prevent snow from covering the ports/pads. Purely aesthetic.

3. _Removes a light fixture in Station Paramedic Staging._
**Why:** This was left over from when the area was remapped, apparently. Only just now located. This deletes the errant fixture and adjusts the lighting to maintain an even coverage.

4. _Repositions Mining Processing Console. _
**Why:** This console was improperly positioned, resulting in the blockage of an otherwise unobstructed floor tile. This repositions the machine so that it can be activated without blocking the floor.