### PR TITLE
Activates Triumph for Active Map [Test-Merge Toggle]

### DIFF
--- a/_maps/map_files/NSV_Triumph/triumph-01-deck1.dmm
+++ b/_maps/map_files/NSV_Triumph/triumph-01-deck1.dmm
@@ -353,6 +353,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_room)
 "bk" = (
@@ -810,6 +815,11 @@
 /obj/machinery/camera/network/engineering,
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_eva)
@@ -1313,6 +1323,17 @@
 /obj/structure/cable,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
+"gf" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
 "gh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1645,6 +1666,11 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_eva)
 "hW" = (
@@ -1863,6 +1889,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_smes)
@@ -2673,6 +2704,17 @@
 /obj/machinery/door/airlock/engineering,
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_one)
+"nR" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
 "nS" = (
 /obj/machinery/door/airlock,
 /turf/simulated/floor/tiled/white,
@@ -4317,6 +4359,11 @@
 	dir = 4
 	},
 /obj/machinery/camera/network/engineering,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/wood,
 /area/engineering/break_room)
 "wy" = (
@@ -4748,6 +4795,11 @@
 /obj/structure/table/reinforced,
 /mob/living/simple_mob/animal/passive/bird/parrot/polly/ultimate,
 /obj/item/flashlight/lamp,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
 "yo" = (
@@ -4757,6 +4809,14 @@
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
+"yt" = (
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/workshop)
 "yw" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/simulated/floor/tiled/dark{
@@ -4845,6 +4905,11 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer_mezzenine)
@@ -5307,6 +5372,15 @@
 	icon_state = "techmaint"
 	},
 /area/tcommsat/entrance)
+"AB" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -28;
+	req_access = list()
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
 "AE" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	input_tag = "n2_in";
@@ -5800,6 +5874,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/backup)
+"Dh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/backup)
 "Dn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -5810,6 +5895,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
+"Ds" = (
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/engine_room)
 "Dt" = (
 /obj/effect/landmark{
 	name = "carpspawn"
@@ -6049,6 +6142,11 @@
 	},
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 9
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/foyer)
@@ -7055,6 +7153,16 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/simulated/floor/reinforced/n20,
 /area/engineering/atmos)
+"KR" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/backup)
 "KZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7262,6 +7370,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"Mz" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/locker_room)
 "MB" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /obj/machinery/meter,
@@ -9551,6 +9671,17 @@
 "Xt" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/workshop)
+"Xy" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 6
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
 "XC" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -19667,7 +19798,7 @@ Kz
 Wn
 ti
 zz
-tg
+Ds
 NK
 Gw
 zz
@@ -20108,7 +20239,7 @@ if
 Tm
 WJ
 QZ
-if
+AB
 nC
 iq
 Tm
@@ -20522,7 +20653,7 @@ Fg
 km
 tZ
 bc
-mU
+Xy
 xM
 vr
 sY
@@ -21800,7 +21931,7 @@ BX
 Gv
 BX
 bc
-mM
+nR
 pG
 Mw
 ts
@@ -21812,7 +21943,7 @@ ts
 uh
 gC
 of
-Cb
+gf
 ts
 Cq
 uQ
@@ -22221,7 +22352,7 @@ CH
 uo
 MX
 BX
-qZ
+KR
 Dc
 YQ
 af
@@ -22357,7 +22488,7 @@ pi
 uP
 rn
 YJ
-Xt
+yt
 bV
 zK
 CM
@@ -23345,7 +23476,7 @@ fN
 iC
 Zj
 yk
-gq
+Mz
 aS
 zd
 Sx
@@ -23499,7 +23630,7 @@ bH
 vF
 qv
 BX
-eK
+Dh
 ym
 hE
 YQ

--- a/_maps/map_files/NSV_Triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/NSV_Triumph/triumph-02-deck2.dmm
@@ -679,6 +679,9 @@
 /area/triumph/station/stairs_two)
 "cn" = (
 /obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/fitness)
 "cp" = (
@@ -816,8 +819,22 @@
 /obj/structure/bed/chair/comfy/teal{
 	dir = 4
 	},
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_8)
+"cK" = (
+/obj/structure/cryofeed{
+	dir = 2
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/crew_quarters/sleep/cryo)
 "cM" = (
 /turf/simulated/wall,
 /area/janitor)
@@ -996,6 +1013,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_2)
 "dv" = (
@@ -1157,6 +1177,14 @@
 "ef" = (
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
+"eh" = (
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "ei" = (
 /turf/simulated/wall/r_wall,
 /area/quartermaster/miningdock)
@@ -2566,6 +2594,9 @@
 /area/crew_quarters/sleep/cryo)
 "hW" = (
 /obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
 "hY" = (
@@ -2763,6 +2794,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"iA" = (
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/recreation_area_hallway)
 "iB" = (
 /obj/structure/stairs/south,
 /turf/simulated/floor/tiled,
@@ -3378,6 +3415,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"kC" = (
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/triumph/station/stairs_two)
 "kD" = (
 /turf/simulated/wall/r_wall,
 /area/space)
@@ -3609,6 +3652,9 @@
 "lt" = (
 /obj/machinery/camera/network/civilian{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/port)
@@ -4447,6 +4493,9 @@
 "nP" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "nR" = (
@@ -5188,6 +5237,11 @@
 "qg" = (
 /obj/structure/table/woodentable,
 /obj/structure/flora/pottedplant/flower,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/coffee_shop)
 "qh" = (
@@ -5610,6 +5664,11 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/camera/network/cargo{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -28;
+	req_access = list()
 	},
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/refinery)
@@ -6784,6 +6843,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_5)
 "vd" = (
@@ -7239,6 +7301,11 @@
 /area/hallway/primary/starboard)
 "wY" = (
 /obj/machinery/camera/network/civilian,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/coffee_shop)
 "wZ" = (
@@ -8057,6 +8124,9 @@
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_3)
 "zL" = (
@@ -8471,6 +8541,11 @@
 	dir = 8
 	},
 /obj/machinery/disposal,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
 "Bj" = (
@@ -8577,6 +8652,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
+"BH" = (
+/obj/effect/floor_decal/techfloor,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
 "BI" = (
 /obj/machinery/conveyor_switch/oneway{
 	convdir = -1;
@@ -8620,6 +8702,11 @@
 /area/crew_quarters/lounge/kitchen_freezer)
 "BL" = (
 /obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/freezer)
 "BP" = (
@@ -8735,6 +8822,20 @@
 /obj/machinery/smartfridge,
 /turf/simulated/wall,
 /area/crew_quarters/kitchen)
+"Cf" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
 "Cg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -9198,6 +9299,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/vacant/vacant_shop)
+"DE" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/triumph/station/stairs_two)
 "DF" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -9258,6 +9368,11 @@
 "DQ" = (
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
 	},
 /turf/simulated/floor/wood,
 /area/triumph/station/stairs_two)
@@ -9324,6 +9439,14 @@
 /obj/machinery/floor_light/prebuilt,
 /turf/simulated/floor/tiled/old_tile/red,
 /area/crew_quarters/bar)
+"Ec" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/recreation_area_hallway)
 "Ed" = (
 /obj/structure/lattice,
 /turf/space,
@@ -9430,6 +9553,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/sleep/Apartment_A1)
+"EC" = (
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/Dorm_4)
 "EE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9605,6 +9734,11 @@
 /area/hydroponics)
 "Fh" = (
 /obj/machinery/vending/boozeomat,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "Fi" = (
@@ -9667,6 +9801,9 @@
 /obj/machinery/light,
 /obj/structure/bed/chair/comfy/teal{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -24
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_7)
@@ -9875,6 +10012,9 @@
 "FX" = (
 /obj/item/bedsheet/blue,
 /obj/structure/bed/padded,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Apartment_A1)
 "FY" = (
@@ -10007,6 +10147,14 @@
 "Gt" = (
 /turf/simulated/floor/carpet/sblucarpet,
 /area/quartermaster/foyer)
+"Gw" = (
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/vacant/vacant_shop)
 "Gx" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -10363,11 +10511,19 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
 "HD" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/engineering,
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -28;
+	req_access = list()
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "HF" = (
@@ -10555,6 +10711,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 1
 	},
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "Ir" = (
@@ -10666,7 +10825,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
 	},
-/obj/item/radio/beacon,
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
 "II" = (
@@ -11018,8 +11176,10 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
 	},
-/obj/structure/closet/crate/bin{
-	anchored = 1
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -11157,6 +11317,11 @@
 	dir = 1
 	},
 /obj/item/tank/jetpack/oxygen,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/storage)
 "Ki" = (
@@ -11716,6 +11881,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/port)
+"Mq" = (
+/obj/structure/closet/emcloset,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/warehouse)
 "Ms" = (
 /turf/simulated/floor/tiled/old_tile/red,
 /area/crew_quarters/bar)
@@ -11925,6 +12099,11 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
 	},
 /turf/simulated/floor/wood,
 /area/triumph/surfacebase/bar_backroom)
@@ -12764,6 +12943,9 @@
 /obj/structure/bed/chair/comfy/teal{
 	dir = 4
 	},
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_9)
 "Qm" = (
@@ -12921,6 +13103,14 @@
 /obj/item/clothing/suit/armor/vest,
 /turf/simulated/floor/wood,
 /area/triumph/surfacebase/bar_backroom)
+"QT" = (
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/triumph/station/stairs_two)
 "QU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13283,6 +13473,24 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Apartment_A1)
+"Sb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/cargo)
 "Sd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13330,9 +13538,6 @@
 "Si" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
-	},
-/obj/structure/closet/crate/bin{
-	anchored = 1
 	},
 /obj/machinery/ai_status_display{
 	pixel_y = -32
@@ -13477,6 +13682,9 @@
 /obj/machinery/light_switch{
 	pixel_x = -25
 	},
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_1)
 "SG" = (
@@ -13618,6 +13826,15 @@
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
+"Td" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lime/border,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "Te" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13744,6 +13961,11 @@
 /area/crew_quarters/fitness)
 "Tw" = (
 /obj/machinery/appliance/mixer/cereal,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "Tx" = (
@@ -14447,6 +14669,9 @@
 	dir = 1
 	},
 /obj/structure/table/woodentable,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Apartment_A2)
 "VC" = (
@@ -15222,6 +15447,14 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_9)
+"XV" = (
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -28;
+	req_access = list()
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "XW" = (
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
@@ -21592,7 +21825,7 @@ CR
 WE
 IS
 Ki
-oE
+zS
 gC
 tA
 ii
@@ -22442,7 +22675,7 @@ Ph
 WE
 CR
 WE
-dx
+Td
 Ki
 ai
 ue
@@ -24428,7 +24661,7 @@ nz
 nz
 nz
 Kw
-LP
+iA
 MF
 MF
 MF
@@ -24968,9 +25201,9 @@ XH
 XH
 as
 lq
-zq
+eh
 zX
-zq
+XV
 Ss
 WP
 gQ
@@ -26422,7 +26655,7 @@ vv
 hl
 hl
 hl
-vv
+EC
 Bp
 zG
 EQ
@@ -27126,7 +27359,7 @@ Ys
 xv
 Hj
 Yc
-JE
+Ec
 jW
 Mo
 vg
@@ -27257,7 +27490,7 @@ aV
 aV
 aV
 aV
-zL
+Rt
 GJ
 HM
 wX
@@ -27512,7 +27745,7 @@ rC
 ii
 cB
 rP
-JT
+Mq
 hQ
 JT
 JT
@@ -27971,7 +28204,7 @@ Rt
 Or
 nM
 wX
-hT
+BH
 cX
 gY
 Oe
@@ -28951,7 +29184,7 @@ Rj
 Rj
 Rj
 Rj
-aC
+Sb
 WY
 Sv
 dD
@@ -29668,7 +29901,7 @@ Rj
 Rj
 aC
 mQ
-GM
+Gw
 hu
 wn
 GM
@@ -29677,7 +29910,7 @@ Yp
 Qg
 ct
 zk
-uz
+cK
 LQ
 WZ
 zk
@@ -30241,7 +30474,7 @@ vo
 vo
 vo
 vo
-IY
+Cf
 wX
 gy
 zk
@@ -31386,7 +31619,7 @@ KJ
 fv
 qH
 AP
-pg
+kC
 mq
 ii
 ii
@@ -32094,7 +32327,7 @@ jT
 jT
 jT
 jT
-pg
+QT
 DB
 pg
 ZM
@@ -32364,7 +32597,7 @@ Ed
 ii
 cB
 mq
-xG
+DE
 zU
 GX
 iX

--- a/_maps/map_files/NSV_Triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/NSV_Triumph/triumph-03-deck3.dmm
@@ -584,6 +584,15 @@
 /obj/effect/floor_decal/corner/mauve/border,
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer_auxiliary)
+"bp" = (
+/obj/structure/table/standard,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/holodeck_control)
 "bq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -1754,6 +1763,10 @@
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
 "dR" = (
@@ -1935,6 +1948,11 @@
 	},
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
 	},
 /turf/simulated/floor/wood,
 /area/hallway/primary/aft)
@@ -2570,6 +2588,9 @@
 	dir = 4
 	},
 /obj/structure/flora/pottedplant/crystal,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled,
 /area/medical/ward)
 "fG" = (
@@ -3009,6 +3030,14 @@
 /obj/item/roller,
 /turf/simulated/floor/tiled/white,
 /area/medical/cmostore)
+"gC" = (
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/research_restroom)
 "gD" = (
 /obj/structure/table/woodentable,
 /obj/machinery/computer/med_data/laptop{
@@ -3313,6 +3342,9 @@
 "ho" = (
 /obj/structure/toilet{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
@@ -3841,6 +3873,11 @@
 /area/rnd/xenobiology/xenoflora_storage)
 "iq" = (
 /mob/living/simple_mob/slime/xenobio/rainbow/kendrick,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/rdoffice)
 "ir" = (
@@ -4882,6 +4919,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/steel,
 /area/medical/virologyaccess)
 "ky" = (
@@ -5323,6 +5363,11 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
 	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -28;
+	req_access = list()
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "lw" = (
@@ -5575,6 +5620,9 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 6
 	},
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "lX" = (
@@ -5596,6 +5644,10 @@
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 12
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
@@ -7674,6 +7726,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
+"qj" = (
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/rnd/anomaly_lab)
 "qk" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -8045,6 +8115,11 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 9
 	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
 "rc" = (
@@ -8337,6 +8412,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
+"rL" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/medical/ward)
 "rM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -9166,6 +9251,11 @@
 /area/rnd/research/testingrange)
 "tt" = (
 /obj/machinery/vending/medical,
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -28;
+	req_access = list()
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "tu" = (
@@ -9802,6 +9892,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
+"uL" = (
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/research/testingrange)
 "uM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -10950,6 +11048,19 @@
 "xa" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
+"xb" = (
+/obj/structure/sink/kitchen{
+	dir = 4;
+	name = "surgery sink";
+	pixel_x = -12
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -28;
+	req_access = list()
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryprep)
 "xc" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/borderfloor,
@@ -11040,6 +11151,11 @@
 	},
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/reception_desk)
@@ -11386,6 +11502,9 @@
 	dir = 4
 	},
 /obj/structure/flora/pottedplant/mysterious,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled,
 /area/medical/ward)
 "xX" = (
@@ -12002,6 +12121,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
+"zg" = (
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/wood,
+/area/hallway/primary/aft)
 "zh" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -12011,6 +12138,14 @@
 "zi" = (
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"zj" = (
+/obj/machinery/washing_machine,
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
 "zk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13489,6 +13624,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/resleeving)
+"Cc" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
 "Cd" = (
 /obj/machinery/light{
 	dir = 8
@@ -13845,6 +13993,11 @@
 	},
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer_auxiliary)
@@ -14364,6 +14517,9 @@
 	dir = 4
 	},
 /obj/structure/flora/pottedplant/decorative,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled,
 /area/medical/ward)
 "DN" = (
@@ -14916,6 +15072,11 @@
 /area/rnd/reception_desk)
 "EQ" = (
 /obj/machinery/vending/phoronresearch,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/test_area)
 "ER" = (
@@ -14943,6 +15104,11 @@
 	dir = 4
 	},
 /obj/structure/flora/pottedplant/shoot,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled,
 /area/medical/ward)
 "EV" = (
@@ -15831,6 +15997,10 @@
 /obj/structure/table/glass,
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/cmostore)
 "GQ" = (
@@ -16845,6 +17015,11 @@
 	dir = 1
 	},
 /obj/structure/table/steel,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
 "IU" = (
@@ -17092,6 +17267,11 @@
 	},
 /obj/item/robotanalyzer,
 /obj/item/robotanalyzer,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/old_cargo/purple,
 /area/medical/surgery{
 	name = "\improper Robotics Surgery Room"
@@ -17337,6 +17517,17 @@
 /obj/machinery/camera/network/civilian,
 /turf/simulated/wall/r_wall,
 /area/triumph/station/stairs_three)
+"Ke" = (
+/obj/structure/morgue{
+	dir = 2
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
 "Kf" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -17780,6 +17971,11 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 1
 	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer_auxiliary)
 "KU" = (
@@ -18214,6 +18410,9 @@
 /obj/item/storage/box/gloves{
 	pixel_x = 4;
 	pixel_y = 4
+	},
+/obj/structure/reagent_dispensers/virusfood{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
@@ -18820,6 +19019,11 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 1
 	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer_auxiliary)
 "MZ" = (
@@ -19079,6 +19283,17 @@
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/medbreak)
+"NA" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
 "NB" = (
 /obj/machinery/light_switch{
 	pixel_x = 25
@@ -19243,6 +19458,20 @@
 	},
 /turf/simulated/floor/airless,
 /area/space)
+"NS" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
 "NT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -19397,6 +19626,11 @@
 "Ok" = (
 /obj/machinery/camera/network/research,
 /obj/structure/flora/pottedplant/stoutbush,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
 /turf/simulated/floor/wood,
 /area/rnd/breakroom)
 "Ol" = (
@@ -20114,6 +20348,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
+"PI" = (
+/obj/machinery/camera/network/civilian,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
 "PJ" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -21528,6 +21774,9 @@
 /obj/machinery/camera/network/medbay{
 	dir = 1
 	},
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "SE" = (
@@ -22084,6 +22333,10 @@
 	pixel_y = 2
 	},
 /obj/item/stack/nanopaste,
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "TE" = (
@@ -22167,6 +22420,9 @@
 	},
 /obj/machinery/camera/network/medbay{
 	dir = 1
+	},
+/obj/structure/reagent_dispensers/virusfood{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
@@ -22517,6 +22773,9 @@
 /obj/item/reagent_containers/dropper,
 /obj/structure/table/glass,
 /obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "Uz" = (
@@ -23431,6 +23690,16 @@
 /obj/machinery/light,
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/heads/cmo)
+"Wo" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/triumph/station/stairs_three)
 "Wp" = (
 /turf/simulated/shuttle/wall,
 /area/shuttle/large_escape_pod1/station{
@@ -23633,6 +23902,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora/lab_atmos)
+"WN" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/wood/sif,
+/area/crew_quarters/medbreak)
 "WO" = (
 /obj/machinery/light{
 	dir = 4
@@ -23646,6 +23922,14 @@
 /obj/item/tank/emergency/oxygen/engi,
 /turf/simulated/floor/tiled,
 /area/rnd/anomaly_lab)
+"WP" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
 "WQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -23678,6 +23962,9 @@
 /obj/item/bedsheet/green,
 /obj/machinery/status_display{
 	pixel_x = -32
+	},
+/obj/item/radio/intercom{
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
@@ -24251,6 +24538,10 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay_emt_bay)
@@ -25124,6 +25415,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/escape/medical_escape_pod_hallway)
+"ZW" = (
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -28;
+	req_access = list()
+	},
+/turf/simulated/floor/tiled,
+/area/medical/ward)
 "ZX" = (
 /obj/machinery/station_map{
 	pixel_y = 32
@@ -29477,7 +29776,7 @@ gK
 gK
 gK
 FI
-uA
+Ke
 cZ
 OP
 Wz
@@ -31628,7 +31927,7 @@ jb
 vl
 vl
 YL
-vl
+Wo
 SK
 BO
 cd
@@ -31642,7 +31941,7 @@ Xr
 Xr
 Xr
 BO
-nL
+NS
 ny
 zF
 eS
@@ -32488,7 +32787,7 @@ ny
 wc
 Zj
 aY
-Sx
+xb
 Sx
 Sx
 et
@@ -32780,7 +33079,7 @@ mr
 yv
 kn
 Aj
-zF
+WP
 Ow
 hL
 Fj
@@ -32924,7 +33223,7 @@ zB
 md
 Aw
 Ow
-xl
+rL
 Fj
 Nw
 Wl
@@ -33478,7 +33777,7 @@ VW
 BO
 jK
 qr
-tL
+Cc
 Aw
 Qo
 gt
@@ -33486,7 +33785,7 @@ tL
 tL
 tL
 Xk
-tL
+Cc
 QX
 tL
 md
@@ -33776,7 +34075,7 @@ Nk
 Hd
 KF
 Ow
-Fj
+ZW
 gx
 Ow
 wL
@@ -34028,7 +34327,7 @@ Or
 LL
 Fz
 Xn
-vp
+zg
 QU
 QU
 nQ
@@ -35990,7 +36289,7 @@ gK
 gK
 gK
 nI
-ds
+qj
 ds
 ds
 fU
@@ -36585,7 +36884,7 @@ Rx
 Rx
 sA
 VL
-rO
+gC
 rO
 NW
 Pj
@@ -36705,7 +37004,7 @@ Tk
 Tk
 Tk
 Rg
-ts
+uL
 ts
 ts
 ts
@@ -37580,7 +37879,7 @@ Bz
 Rz
 TM
 Uj
-Tn
+bp
 gc
 Tn
 cn
@@ -37593,7 +37892,7 @@ eE
 Dj
 Dk
 Nz
-xe
+WN
 Zn
 qA
 uC
@@ -38002,7 +38301,7 @@ mp
 mp
 pA
 qK
-Bz
+NA
 Hl
 GM
 UA
@@ -38295,7 +38594,7 @@ RN
 RN
 sh
 le
-qq
+zj
 CI
 CI
 VX
@@ -38996,7 +39295,7 @@ tq
 tq
 tq
 tq
-Wd
+PI
 Hl
 Fi
 Uj

--- a/_maps/map_files/NSV_Triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/NSV_Triumph/triumph-04-deck4.dmm
@@ -315,6 +315,9 @@
 "apk" = (
 /obj/structure/table/standard,
 /obj/random/firstaid,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
 "apq" = (
@@ -395,6 +398,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/range)
+"arG" = (
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/security/riot_control)
 "ash" = (
 /turf/simulated/wall/r_wall,
 /area/security/tactical)
@@ -982,6 +991,9 @@
 /area/security/armoury)
 "aVG" = (
 /obj/machinery/light/small,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
 /area/library)
 "aVJ" = (
@@ -1037,6 +1049,9 @@
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 10
+	},
+/obj/item/radio/intercom{
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
@@ -1556,6 +1571,9 @@
 "bra" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled,
 /area/triumph/station/explorer_prep)
 "brg" = (
@@ -1830,6 +1848,9 @@
 "bCU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/item/radio/intercom{
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/gateway)
@@ -2773,6 +2794,9 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled,
 /area/security/hallway)
 "cpD" = (
@@ -3665,6 +3689,12 @@
 /obj/effect/floor_decal/corner/red/bordercorner,
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
+"des" = (
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood,
+/area/security/briefing_room)
 "deA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3740,6 +3770,9 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled,
 /area/security/hallway)
 "dii" = (
@@ -3759,6 +3792,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
+"djA" = (
+/obj/machinery/camera/network/command{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "djR" = (
 /obj/structure/sink{
 	dir = 8;
@@ -4091,6 +4134,18 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/plating,
 /area/maintenance/central)
+"dxM" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/Dorm_3{
+	name = "\improper CMO Dorm"
+	})
 "dye" = (
 /obj/structure/table/woodentable,
 /obj/item/book/manual/standard_operating_procedure,
@@ -4593,6 +4648,10 @@
 "dSq" = (
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/crew_quarters/sleep/Dorm_5{
@@ -7256,6 +7315,9 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 10
 	},
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled,
 /area/triumph/station/pathfinder_office)
 "fVZ" = (
@@ -9351,6 +9413,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/hallway)
+"hMG" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/security/prison)
 "hMJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -10499,6 +10569,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
+"iEs" = (
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/chapel/main)
 "iEI" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -11703,6 +11779,12 @@
 "jCj" = (
 /turf/simulated/floor/tiled,
 /area/security/range)
+"jCW" = (
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/maintenance/tool_storage)
 "jDA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/glass{
@@ -13222,6 +13304,9 @@
 /obj/structure/closet/wardrobe/tactical,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/green/border,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
 "kYP" = (
@@ -15328,6 +15413,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_1{
 	name = "\improper HoP Living Quarters"
@@ -15391,6 +15480,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/secondary/civilian_hallway_mid)
+"mII" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/security/interrogation)
 "mIQ" = (
 /turf/simulated/wall,
 /area/hydroponics/garden)
@@ -15535,6 +15632,9 @@
 /obj/item/storage/backpack/parachute{
 	pixel_x = 5;
 	pixel_y = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
 /area/triumph/station/explorer_prep)
@@ -16112,6 +16212,9 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/grass_edge,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "nll" = (
@@ -17020,6 +17123,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
+"nZe" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/item/clothing/under/swimsuit/stripper/cowbikini,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/triumph/surfacebase/sauna)
 "nZp" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/target_stake,
@@ -17127,6 +17240,9 @@
 /area/library)
 "oeN" = (
 /obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/white,
 /area/triumph/station/explorer_medical)
 "ofz" = (
@@ -17419,6 +17535,19 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/lounge)
+"orY" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/hallway)
 "ose" = (
 /obj/item/ammo_magazine/clip/c762/practice,
 /obj/item/ammo_magazine/clip/c762/practice,
@@ -17571,6 +17700,9 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "oCi" = (
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
 /area/security/breakroom)
 "oCE" = (
@@ -19123,6 +19255,10 @@
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/hallway/secondary/civilian_hallway_mid)
 "pJe" = (
@@ -20631,6 +20767,10 @@
 	pixel_x = 4;
 	pixel_y = 26
 	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "qBx" = (
@@ -20651,6 +20791,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/item/radio/intercom{
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
@@ -20897,11 +21040,12 @@
 /area/triumph/station/stairs_one)
 "qLK" = (
 /obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = -24
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
+/turf/simulated/floor/wood,
+/area/library)
 "qNq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -21817,6 +21961,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
+"rvG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "rvV" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -24624,6 +24785,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/security_bathroom)
+"tSx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/security/hallwayaux)
 "tSH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
@@ -24936,6 +25116,9 @@
 /area/lawoffice)
 "udl" = (
 /obj/effect/floor_decal/spline/plain,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/lawoffice)
 "uel" = (
@@ -25207,6 +25390,14 @@
 /obj/effect/mist,
 /turf/simulated/floor/water/pool,
 /area/triumph/surfacebase/sauna)
+"uoo" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/triumph/station/explorer_entry)
 "uoy" = (
 /obj/machinery/computer/card{
 	dir = 4
@@ -25939,6 +26130,9 @@
 	name = "east bump";
 	pixel_x = 24
 	},
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/eva)
 "uSJ" = (
@@ -26290,8 +26484,18 @@
 	},
 /turf/simulated/floor/lino,
 /area/chapel/office)
+"vet" = (
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood,
+/area/triumph/station/explorer_meeting)
 "vfk" = (
 /obj/structure/table/woodentable,
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/sleep/Dorm_4{
 	name = "\improper Research Director's Dorm"
@@ -26790,6 +26994,9 @@
 /obj/machinery/light/small,
 /obj/structure/table/woodentable,
 /obj/item/paper_bin,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
 /area/library)
 "vzq" = (
@@ -27130,6 +27337,9 @@
 	})
 "vNc" = (
 /obj/effect/floor_decal/spline/plain,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/lawoffice)
 "vNu" = (
@@ -28422,6 +28632,14 @@
 /obj/machinery/computer/med_data/laptop,
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
+"wOI" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/triumph/station/explorer_prep)
 "wPq" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -28522,6 +28740,14 @@
 /obj/item/pen,
 /turf/simulated/floor/wood,
 /area/library)
+"wTS" = (
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood,
+/area/bridge{
+	name = "\improper Official On-Site Office"
+	})
 "wTZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
@@ -28931,6 +29157,19 @@
 /area/crew_quarters/sleep/Dorm_1{
 	name = "\improper HoP Living Quarters"
 	})
+"xlE" = (
+/obj/structure/flora/pottedplant/stoutbush,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/security/hallway)
 "xmc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -28975,6 +29214,19 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
+"xoG" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/hallway/secondary/civilian_hallway_mid)
 "xpv" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -30118,6 +30370,15 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"yjS" = (
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/Dorm_2{
+	name = "\improper CE Dorm"
+	})
 "ykd" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -32372,7 +32633,7 @@ qPL
 ePE
 pON
 oWf
-bFl
+vet
 bFL
 dLn
 jWe
@@ -33374,7 +33635,7 @@ cVO
 mmj
 nif
 xdx
-pYB
+wOI
 sJC
 sJC
 sJC
@@ -33839,7 +34100,7 @@ hzP
 hzP
 hur
 mSg
-jhE
+hMG
 hur
 xxK
 jLC
@@ -35413,7 +35674,7 @@ oFQ
 oFQ
 qRG
 kGr
-kGr
+arG
 iGt
 dff
 nIK
@@ -35646,7 +35907,7 @@ xZs
 uXe
 nvY
 jFj
-mmU
+uoo
 jbl
 nIK
 nIK
@@ -37341,7 +37602,7 @@ cVO
 vcE
 fhd
 cgH
-wcm
+qLK
 wcm
 wcm
 wcm
@@ -38087,7 +38348,7 @@ wTZ
 gsa
 vqd
 vqd
-vqd
+des
 vma
 lxa
 tXp
@@ -38234,7 +38495,7 @@ vma
 hzN
 sNL
 mDd
-svu
+mII
 vma
 iGt
 jGO
@@ -38477,7 +38738,7 @@ tMS
 agH
 sTa
 cgH
-wcm
+qLK
 sNf
 ebD
 sZf
@@ -39247,7 +39508,7 @@ xzh
 qpW
 jtZ
 qEc
-gkm
+xlE
 wrw
 dff
 nIK
@@ -40902,7 +41163,7 @@ rde
 vIh
 hLr
 pAA
-vIh
+iEs
 ttb
 xkZ
 amB
@@ -42368,7 +42629,7 @@ yhQ
 fJZ
 hqz
 gwN
-eMU
+tSx
 pOh
 pOh
 nIK
@@ -42610,13 +42871,13 @@ pcn
 kRC
 rBF
 xfL
-xfL
+dxM
 xfL
 ucs
 oEK
 iwo
 iwo
-iwo
+yjS
 iwo
 uxB
 bAK
@@ -42884,7 +43145,7 @@ dlT
 krQ
 idd
 cym
-bhx
+nZe
 wke
 roY
 rSb
@@ -43056,7 +43317,7 @@ sNi
 xvg
 lqI
 sWX
-sWX
+jCW
 ksy
 ugw
 gMN
@@ -43184,7 +43445,7 @@ phn
 phn
 phn
 phn
-ubk
+xoG
 phn
 smu
 ubk
@@ -43788,7 +44049,7 @@ rIu
 vgx
 flL
 vgG
-alb
+rvG
 vgx
 vgx
 dff
@@ -46167,7 +46428,7 @@ eHr
 kTt
 kTt
 gZa
-kTt
+orY
 kTt
 cMg
 rYg
@@ -47142,7 +47403,7 @@ dOZ
 siD
 kMG
 nRc
-ruN
+wTS
 nYA
 pbU
 feE
@@ -47589,8 +47850,8 @@ feo
 kXI
 pWn
 poJ
-tDz
-qLK
+djA
+pox
 vug
 bvQ
 pdX

--- a/code/__DEFINES/atmospherics/atmospheres.dm
+++ b/code/__DEFINES/atmospherics/atmospheres.dm
@@ -9,6 +9,5 @@
 /// Virgo 3b (station) planetary atmosphere ID
 #define ATMOSPHERE_ID_VIRGO3B			/datum/atmosphere/planet/virgo3b
 /// Triumph Planet Atmos ID (If needed)
-/*
+
 #define ATMOSPHERE_ID_TRIUMPH			/datum/atmosphere/planet/virgo3b
-*/

--- a/code/game/turfs/unsimulated/planetary_vr.dm
+++ b/code/game/turfs/unsimulated/planetary_vr.dm
@@ -12,10 +12,9 @@
 	VIRGO3B_SET_ATMOS
 
 // This line below is placeholder for Triumph as the code base here gets really angry if there isn't an actual planet atmos to set. Might do something for Tirumph in the future to allow this.
-/*
+
 /turf/unsimulated/wall/planetary/triumph
 	name = "facility wall"
 	desc = "An eight-meter tall carbyne wall. For when the wildlife on your planet is mostly militant megacorps."
 	alpha = 0xFF
 	TRIUMPH_SET_ATMOS
-*/

--- a/maps/nsv_triumph/triumph_turfs.dm
+++ b/maps/nsv_triumph/triumph_turfs.dm
@@ -1,3 +1,6 @@
+// Be sure to update planetary_vr.dm and atmosphers.dm when switching to this map.
+
+
 //Simulated
 TRIUMPH_TURF_CREATE(/turf/simulated/open)
 /turf/simulated/open/triumph

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -10,6 +10,7 @@
 #define DEBUG
 // END_PREFERENCES
 // BEGIN_INCLUDE
+#include "_maps\triumph.dm"
 #include "code\_away_mission_tests.dm"
 #include "code\_macros.dm"
 #include "code\_map_tests.dm"
@@ -3499,6 +3500,7 @@
 #include "interface\interface.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
+#include "maps\nsv_triumph\triumph.dm"
 #include "maps\RandomZLevels\blackmarketpackers.dm"
 #include "maps\RandomZLevels\carpfarm.dm"
 #include "maps\RandomZLevels\listeningpost.dm"
@@ -3531,7 +3533,6 @@
 #include "maps\submaps\surface_submaps\plains\plains_areas.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness_areas.dm"
-#include "maps\tether\tether.dm"
 #include "maps\~map_system\maps.dm"
 #include "modular_citadel\code\global_cit.dm"
 #include "modular_citadel\code\datums\outfits\jobs\centcom.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Puts NSV Triumph as active map while this is active. Also minor tweaking to the ship map *dab*

## Why It's Good For The Game

Switches us to the new map

## Changelog
:cl:
server: Switches active map to Triumph with Tether going inactive
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
