### PR TITLE
Activates Triumph for Rotation again [Test-merge] [PREP FOR OVERMAP SYSTEM FOR TRIUMPH]

### DIFF
--- a/_maps/map_files/NSV_Triumph/triumph-01-deck1.dmm
+++ b/_maps/map_files/NSV_Triumph/triumph-01-deck1.dmm
@@ -19587,8 +19587,8 @@ fN
 fN
 fN
 fN
-fN
-fN
+eD
+eD
 ui
 vd
 jx
@@ -19729,7 +19729,7 @@ fN
 fN
 fN
 fN
-fN
+eD
 ui
 ui
 Vz

--- a/_maps/map_files/NSV_Triumph/triumph-01-deck1.dmm
+++ b/_maps/map_files/NSV_Triumph/triumph-01-deck1.dmm
@@ -68,12 +68,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/camera/network/tcomms,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
@@ -311,12 +311,13 @@
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
 "ba" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor/bluegrid{
+	initial_gas_mix = "n2=100;TEMP=80";
+	name = "Mainframe Base"
+	},
 /area/tcommsat/chamber)
 "bb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
@@ -560,13 +561,13 @@
 	},
 /area/engineering/engine_room)
 "cB" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/camera/network/engineering{
 	dir = 8
 	},
 /obj/structure/sign/department/ass{
 	pixel_x = 29
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_one)
 "cD" = (
@@ -664,6 +665,14 @@
 	icon_state = "techmaint"
 	},
 /area/tcommsat/computer)
+"cY" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/tcommsat/entrance)
 "cZ" = (
 /obj/machinery/camera/network/engine{
 	dir = 9
@@ -675,11 +684,6 @@
 /area/engineering/engine_room)
 "da" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/wall/r_wall,
 /area/tcommsat/computer)
 "dg" = (
@@ -765,12 +769,7 @@
 /area/engineering/atmos)
 "dv" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -1213,12 +1212,20 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_smes)
 "fx" = (
-/obj/structure/cable,
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/super;
 	dir = 8;
 	name = "west bump";
 	pixel_x = -30
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
@@ -1487,6 +1494,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
@@ -1919,6 +1931,22 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_smes)
+"js" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/tcommsat/computer)
 "ju" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
@@ -2247,11 +2275,6 @@
 /area/storage/tech)
 "la" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/bluegrid{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "Mainframe Base"
@@ -2263,6 +2286,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
@@ -2607,10 +2635,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/backup)
 "na" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled{
-	icon_state = "techmaint"
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Telecomms Grid"
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plating,
 /area/tcommsat/entrance)
 "nc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3687,10 +3720,10 @@
 "sT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
@@ -3816,6 +3849,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
@@ -4051,6 +4089,19 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
+"uE" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/tcommsat/entrance)
 "uK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -4158,15 +4209,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_eva)
 "vt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "TELECOMMS"
 	},
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled{
-	icon_state = "techmaint"
-	},
+/turf/simulated/floor/plating,
 /area/tcommsat/entrance)
 "vv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -4482,13 +4528,13 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_room)
 "wQ" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
@@ -4529,11 +4575,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -4651,6 +4692,16 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space)
+"xE" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/tcommsat/entrance)
 "xH" = (
 /obj/machinery/disposal,
 /turf/simulated/floor/tiled,
@@ -4693,6 +4744,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"xN" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/tcommsat/entrance)
 "xP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5274,11 +5335,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "zW" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_one)
@@ -5802,6 +5863,18 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/storage/tech)
+"Cp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/tcommsat/entrance)
 "Cq" = (
 /obj/machinery/atmospherics/valve/digital/open{
 	name = "Air Cutoff"
@@ -6013,15 +6086,19 @@
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
 "Ea" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/tcomms,
-/turf/simulated/floor/tiled{
-	icon_state = "techmaint"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
+/turf/simulated/floor/plating,
 /area/tcommsat/entrance)
 "Eb" = (
 /obj/machinery/atmospherics/unary/heater{
@@ -6483,6 +6560,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"GB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/tcommsat/entrance)
 "GC" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/donkpockets,
@@ -6592,9 +6685,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_eva)
 "Hn" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -6941,6 +7031,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
@@ -7443,6 +7538,19 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/backup)
+"MF" = (
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Telecomms";
+	name_tag = "Telecomms Subgrid"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/tcommsat/entrance)
 "MH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/power/apc{
@@ -7525,7 +7633,6 @@
 /area/triumph/station/stairs_one)
 "MV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/storage/tech)
 "MW" = (
@@ -7636,15 +7743,10 @@
 /area/engineering/engine_room)
 "Nv" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
@@ -8002,6 +8104,21 @@
 "OT" = (
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
+"OV" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/tcommsat/entrance)
 "OW" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -8105,6 +8222,11 @@
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
@@ -9288,6 +9410,15 @@
 	icon_state = "techmaint"
 	},
 /area/tcommsat/chamber)
+"Vr" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/tcommsat/entrance)
 "Vu" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4;
@@ -9367,11 +9498,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/wall/r_wall,
 /area/tcommsat/entrance)
 "VK" = (
@@ -9494,6 +9620,11 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
@@ -9565,13 +9696,11 @@
 /area/engineering/engine_room)
 "WH" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled{
-	icon_state = "techmaint"
-	},
+/turf/simulated/floor/plating,
 /area/tcommsat/entrance)
 "WJ" = (
 /obj/machinery/atmospherics/omni/atmos_filter{
@@ -10262,6 +10391,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/storage/tech)
+"ZV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/tcommsat/entrance)
 "ZW" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techmaint,
@@ -20406,8 +20545,8 @@ FQ
 HD
 yc
 sT
-Ld
-Ld
+sT
+Cp
 Ld
 Ld
 aP
@@ -20548,10 +20687,10 @@ cO
 qc
 mS
 WH
-nJ
-nJ
-nJ
-nJ
+cY
+uE
+xN
+xN
 tx
 gV
 Wp
@@ -20690,13 +20829,13 @@ DN
 Wi
 mS
 Ea
-nJ
-nJ
-nJ
-nJ
+Vr
+OV
+xE
+xE
 lb
 rY
-nJ
+ZV
 Pf
 kn
 KA
@@ -20833,12 +20972,12 @@ Ho
 mS
 vt
 na
-nJ
+MF
 pv
 nJ
-lb
+GB
 RO
-nJ
+ZV
 Pf
 kn
 Ox
@@ -20973,7 +21112,7 @@ Se
 Se
 Ul
 Se
-ba
+Se
 Se
 yC
 yC
@@ -21404,7 +21543,7 @@ Pm
 Kf
 Hn
 fx
-JL
+js
 ce
 yC
 Pf
@@ -21962,10 +22101,10 @@ fN
 fN
 Se
 JA
-PQ
+ba
 Yd
 Eo
-PQ
+ba
 bu
 tD
 EV
@@ -26388,10 +26527,10 @@ fN
 fN
 eM
 kZ
-hC
-hC
+qL
+qL
 iW
-hC
+qL
 nq
 PX
 eM

--- a/_maps/map_files/NSV_Triumph/triumph-01-deck1.dmm
+++ b/_maps/map_files/NSV_Triumph/triumph-01-deck1.dmm
@@ -1377,7 +1377,7 @@
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
-/area/engineering/engine_airlock)
+/area/engineering/engine_eva)
 "gh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2985,7 +2985,7 @@
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
-/area/engineering/engine_airlock)
+/area/engineering/engine_eva)
 "oK" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -3569,9 +3569,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_room)
-"rG" = (
-/turf/simulated/wall/r_wall,
-/area/engineering/engine_airlock)
 "rH" = (
 /obj/machinery/telecomms/server/presets/unused,
 /turf/simulated/floor/tiled/dark{
@@ -3745,7 +3742,7 @@
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
-/area/engineering/engine_airlock)
+/area/engineering/engine_eva)
 "sx" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -8784,7 +8781,7 @@
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
-/area/engineering/engine_airlock)
+/area/engineering/engine_eva)
 "Rt" = (
 /obj/machinery/computer/telecomms/monitor,
 /turf/simulated/floor/tiled/dark,
@@ -9409,7 +9406,7 @@
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
-/area/engineering/engine_airlock)
+/area/engineering/engine_eva)
 "UC" = (
 /obj/machinery/telecomms/bus/preset_two/triumph,
 /turf/simulated/floor/tiled/dark{
@@ -9699,7 +9696,7 @@
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
-/area/engineering/engine_airlock)
+/area/engineering/engine_eva)
 "Wg" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -10282,7 +10279,7 @@
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
-/area/engineering/engine_airlock)
+/area/engineering/engine_eva)
 "Yz" = (
 /obj/machinery/floodlight,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -10387,7 +10384,7 @@
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
-/area/engineering/engine_airlock)
+/area/engineering/engine_eva)
 "YU" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -19733,7 +19730,7 @@ fN
 fN
 fN
 fN
-rG
+ui
 ui
 Vz
 MJ
@@ -19872,10 +19869,10 @@ fN
 Zj
 fN
 jH
-rG
-rG
-rG
-rG
+ui
+ui
+ui
+ui
 Vz
 Vz
 MJ
@@ -20298,10 +20295,10 @@ fN
 fN
 fN
 kq
-rG
+ui
 Yw
 Yw
-rG
+ui
 Vz
 Vz
 MJ

--- a/_maps/map_files/NSV_Triumph/triumph-01-deck1.dmm
+++ b/_maps/map_files/NSV_Triumph/triumph-01-deck1.dmm
@@ -16,16 +16,6 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/obj/structure/closet/crate/secure/engineering,
-/obj/item/storage/briefcase/fission/fuelmixed,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Fuel Rods";
-	req_access = list(11)
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_room)
 "ae" = (
@@ -359,6 +349,14 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/meter{
+	frequency = 1443;
+	id = "dist_aux_meter";
+	name = "Distribution Loop"
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_room)
 "bk" = (
@@ -435,6 +433,14 @@
 /obj/item/toy/plushie/deer,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
+"bI" = (
+/obj/machinery/door/airlock/vault{
+	name = "REACTOR ROOM";
+	req_one_access = list(10)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/engine_room)
 "bK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/meter,
@@ -1352,6 +1358,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"gg" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1380;
+	id_tag = "airlock_eng_pump"
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1380;
+	id_tag = "airlock_eng";
+	pixel_x = -24;
+	req_one_access = list(13);
+	tag_airpump = "airlock_eng_pump";
+	tag_chamber_sensor = "airlock_eng_sensor";
+	tag_exterior_door = "airlock_eng_outer";
+	tag_interior_door = "airlock_eng_inner"
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/engineering/engine_airlock)
 "gh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1370,6 +1396,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/foyer)
+"gj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/engine_room)
 "go" = (
 /obj/structure/closet/crate,
 /obj/item/circuitboard/smes,
@@ -1488,6 +1518,21 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/checkpoint/engineering)
+"gU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/engineering/engine_eva)
 "gV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -1911,6 +1956,14 @@
 "iY" = (
 /turf/simulated/floor/carpet/blucarpet,
 /area/crew_quarters/heads/chief)
+"jb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/engineering/engine_eva)
 "je" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 5
@@ -2869,6 +2922,9 @@
 	name = "REACTOR ROOM";
 	req_one_access = list(10)
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "ow" = (
@@ -2920,6 +2976,16 @@
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
+"oJ" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1380;
+	id_tag = "airlock_eng_pump"
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/engineering/engine_airlock)
 "oK" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -3503,6 +3569,9 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_room)
+"rG" = (
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_airlock)
 "rH" = (
 /obj/machinery/telecomms/server/presets/unused,
 /turf/simulated/floor/tiled/dark{
@@ -3602,6 +3671,12 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engineering/atmos)
+"se" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/engineering/engine_eva)
 "sj" = (
 /obj/machinery/air_sensor{
 	frequency = 1443;
@@ -3659,6 +3734,18 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/backup)
+"sw" = (
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "airlock_eng_outer";
+	locked = 1;
+	name = "Docking Port Airlock"
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/engineering/engine_airlock)
 "sx" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -6085,6 +6172,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
+"DZ" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
 "Ea" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8499,6 +8592,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
+"QG" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "airlock_eng";
+	name = "interior access button";
+	pixel_x = -28;
+	pixel_y = 23;
+	req_one_access = list(13)
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/engineering/engine_eva)
 "QI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -8621,16 +8728,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engine_room)
 "Ri" = (
-/obj/structure/closet/crate/secure/engineering,
-/obj/item/storage/briefcase/fission/uranium,
-/obj/machinery/camera/network/engine,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Fuel Rods";
-	req_access = list(11)
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_room)
@@ -8675,6 +8774,17 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
+"Rs" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/obj/machinery/meter{
+	frequency = 1443;
+	id = "dist_aux_meter";
+	name = "Distribution Loop"
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/engineering/engine_airlock)
 "Rt" = (
 /obj/machinery/computer/telecomms/monitor,
 /turf/simulated/floor/tiled/dark,
@@ -8842,6 +8952,9 @@
 /obj/structure/cable/cyan{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_room)
@@ -9283,6 +9396,20 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
+"Uu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/engine_room)
+"UA" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/engineering/engine_airlock)
 "UC" = (
 /obj/machinery/telecomms/bus/preset_two/triumph,
 /turf/simulated/floor/tiled/dark{
@@ -9561,6 +9688,18 @@
 	icon_state = "techmaint"
 	},
 /area/engineering/storage)
+"We" = (
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "airlock_eng_inner";
+	locked = 1;
+	name = "Engineering Airlock"
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/engineering/engine_airlock)
 "Wg" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -9646,6 +9785,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
+"Wx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/engineering/engine_eva)
 "Wz" = (
 /obj/item/storage/briefcase/fission,
 /obj/structure/closet/crate/secure/engineering,
@@ -9735,6 +9882,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/storage/tech)
+"WM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/engine_room)
 "WO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -10120,6 +10273,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/storage/tech)
+"Yw" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1380;
+	id_tag = "airlock_eng_pump"
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/engineering/engine_airlock)
 "Yz" = (
 /obj/machinery/floodlight,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -10212,6 +10375,19 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/workshop)
+"YT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "airlock_eng_inner";
+	locked = 1;
+	name = "Engineering Airlock"
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "techmaint"
+	},
+/area/engineering/engine_airlock)
 "YU" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -10273,18 +10449,17 @@
 /turf/simulated/floor,
 /area/storage/tech)
 "Zm" = (
-/obj/structure/closet/crate/secure/engineering,
-/obj/item/storage/briefcase/fission/uranium,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "airlock_eng";
+	name = "exterior access button";
+	pixel_x = -26;
+	pixel_y = -24;
+	req_one_access = list(13)
 	},
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Fuel Rods";
-	req_access = list(11)
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_room)
+/turf/simulated/floor/airless,
+/area/space)
 "Zp" = (
 /obj/structure/shuttle/engine/router,
 /turf/simulated/wall/r_wall,
@@ -14874,7 +15049,7 @@ fN
 fN
 fN
 fN
-iC
+dX
 bX
 BL
 bX
@@ -15320,7 +15495,7 @@ fN
 fN
 fN
 fN
-iC
+dX
 fN
 fN
 fN
@@ -16010,7 +16185,7 @@ fN
 fN
 fN
 fN
-iC
+dX
 Rg
 Rg
 cL
@@ -18134,7 +18309,7 @@ fN
 fN
 fN
 fN
-Zj
+dX
 Zj
 Zj
 iC
@@ -18273,9 +18448,9 @@ fN
 fN
 fN
 fN
-fN
-fN
-fN
+dX
+Zj
+jH
 Zj
 fN
 fN
@@ -18415,13 +18590,13 @@ fN
 fN
 fN
 fN
-fN
+Zj
 fN
 fN
 Zj
 fN
 fN
-kq
+jH
 Fn
 ui
 Vz
@@ -18557,12 +18732,12 @@ fN
 fN
 fN
 fN
-fN
+Zj
 fN
 fN
 Zj
 fN
-kq
+jH
 eH
 JG
 vn
@@ -18699,13 +18874,13 @@ fN
 fN
 fN
 fN
-fN
+Zj
 fN
 fN
 Zj
 fN
 fN
-kq
+jH
 TS
 ui
 bn
@@ -18841,7 +19016,7 @@ fN
 fN
 fN
 fN
-fN
+Zj
 fN
 fN
 Zj
@@ -18981,11 +19156,11 @@ fN
 fN
 fN
 fN
-fN
-fN
-fN
-fN
-fN
+dX
+Zj
+Zj
+Zj
+Zj
 Zj
 Zj
 Zj
@@ -19123,10 +19298,10 @@ fN
 fN
 fN
 fN
+iC
 fN
 fN
-fN
-fN
+Zj
 fN
 fN
 fN
@@ -19265,10 +19440,10 @@ fN
 fN
 fN
 fN
+iC
 fN
 fN
-fN
-fN
+Zj
 fN
 fN
 fN
@@ -19276,7 +19451,7 @@ fN
 Zj
 Zj
 ui
-Vz
+EL
 dK
 zz
 Rm
@@ -19407,15 +19582,15 @@ fN
 fN
 fN
 fN
-fN
-fN
-fN
-fN
-fN
-fN
+dX
 fN
 fN
 Zj
+fN
+fN
+fN
+fN
+fN
 fN
 ui
 vd
@@ -19425,7 +19600,7 @@ Gb
 Gb
 Lo
 zz
-Zm
+XP
 Qo
 Fj
 Dn
@@ -19549,16 +19724,16 @@ fN
 fN
 fN
 fN
-fN
-fN
-fN
-fN
-fN
-fN
+Zj
 fN
 fN
 Zj
 fN
+fN
+fN
+fN
+fN
+rG
 ui
 Vz
 MJ
@@ -19691,17 +19866,17 @@ fN
 fN
 fN
 fN
-fN
-fN
-fN
-fN
-fN
-fN
+Zj
 fN
 fN
 Zj
 fN
-ui
+jH
+rG
+rG
+rG
+rG
+Vz
 Vz
 MJ
 zz
@@ -19833,25 +20008,25 @@ iC
 iC
 Zj
 Zj
+dX
+Zj
+gy
 Zj
 Zj
-iC
-iC
-iC
-iC
-iC
-Zj
-iC
-iC
-ui
-EL
-MJ
-zz
-JB
+Zm
+sw
+gg
+oJ
+We
+QG
+jb
+gU
+bI
+gj
+Uu
 tg
-tg
 zz
-XP
+DZ
 Ur
 MI
 AF
@@ -19980,18 +20155,18 @@ fN
 fN
 fN
 fN
-fN
-fN
-fN
-fN
-fN
-ui
-Vz
+jH
+sw
+UA
+Rs
+YT
+se
+Wx
 wV
 zz
 JB
-tg
-Pj
+WM
+JB
 zz
 bj
 Ur
@@ -20122,17 +20297,17 @@ fN
 fN
 fN
 fN
-fN
-fN
-fN
-fN
-fN
-ui
+kq
+rG
+Yw
+Yw
+rG
+Vz
 Vz
 MJ
 zz
 bD
-tg
+WM
 ww
 zz
 Sk
@@ -20818,7 +20993,7 @@ fN
 fN
 fN
 fN
-Zj
+iC
 fN
 fN
 mS
@@ -20960,7 +21135,7 @@ fN
 fN
 fN
 fN
-Zj
+iC
 Zj
 Zj
 mS

--- a/_maps/map_files/NSV_Triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/NSV_Triumph/triumph-02-deck2.dmm
@@ -9165,6 +9165,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
+"Dq" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/toilet)
 "Ds" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -25614,7 +25618,7 @@ LP
 MF
 Bk
 Bk
-Kv
+Dq
 VP
 HC
 MF

--- a/_maps/map_files/NSV_Triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/NSV_Triumph/triumph-02-deck2.dmm
@@ -1739,7 +1739,8 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Deck 2 Grid"
+	RCon_tag = "Deck 2 Grid";
+	input_level_max = 500000
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plating,

--- a/_maps/map_files/NSV_Triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/NSV_Triumph/triumph-03-deck3.dmm
@@ -8483,6 +8483,15 @@
 /obj/structure/flora/pottedplant/unusual,
 /turf/simulated/floor/wood,
 /area/medical/psych)
+"rQ" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/medical/psych_ward)
 "rR" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled,
@@ -12573,9 +12582,6 @@
 /obj/machinery/alarm{
 	frequency = 1441;
 	pixel_y = 22
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/machinery/camera/network/medbay,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -29906,7 +29912,7 @@ HD
 Yi
 To
 RD
-zh
+rQ
 jA
 Qt
 vW

--- a/_maps/map_files/NSV_Triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/NSV_Triumph/triumph-03-deck3.dmm
@@ -12265,11 +12265,6 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"

--- a/_maps/map_files/NSV_Triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/NSV_Triumph/triumph-04-deck4.dmm
@@ -81,6 +81,14 @@
 /obj/item/multitool/triumph_buffered,
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
+"aei" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/r_wall,
+/area/ai)
 "aeD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -3731,7 +3739,8 @@
 /area/security/hallwayaux)
 "dcC" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Deck 4 Grid"
+	RCon_tag = "Deck 4 Grid";
+	input_level_max = 500000
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -7699,6 +7708,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
+"gpN" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_server_room)
 "gpP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7912,6 +7929,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/bluegrid,
 /area/ai)
 "gxB" = (
@@ -7992,13 +8014,18 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
 "gCB" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/bluegrid,
 /area/ai_server_room)
 "gCM" = (
@@ -8010,6 +8037,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai_server_room)
@@ -8305,7 +8337,7 @@
 	},
 /obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/tiled,
-/area/triumph/station/explorer_entry)
+/area/triumph/station/explorer_prep)
 "gRh" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
@@ -9331,6 +9363,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
+"hEL" = (
+/obj/machinery/porta_turret/ai_defense,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_server_room)
 "hFe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13105,6 +13146,11 @@
 "kLf" = (
 /obj/structure/table/standard,
 /obj/item/aiModule/freeform,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_server_room)
 "kLA" = (
@@ -13596,16 +13642,16 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/tool_storage)
 "ldI" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai_server_room)
@@ -13634,6 +13680,11 @@
 	control_area = "\improper AI Chamber";
 	name = "AI Upload turret control";
 	pixel_y = -26
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_server_room)
@@ -17126,7 +17177,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/triumph/station/explorer_entry)
+/area/triumph/station/explorer_prep)
 "nOV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -21767,15 +21818,13 @@
 /turf/simulated/floor/water/pool,
 /area/triumph/surfacebase/sauna)
 "rff" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green,
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -32
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_server_room)
@@ -22531,6 +22580,11 @@
 /area/triumph/station/excursion_dock)
 "rEg" = (
 /obj/machinery/ai_slipper,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ai)
 "rEj" = (
@@ -23786,7 +23840,7 @@
 	req_one_access = list(19,43,67)
 	},
 /turf/simulated/floor/tiled,
-/area/triumph/station/explorer_entry)
+/area/triumph/station/explorer_prep)
 "sGq" = (
 /obj/structure/table/woodentable,
 /obj/item/tape_recorder{
@@ -30101,6 +30155,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_server_room)
 "xDD" = (
@@ -36380,8 +36439,8 @@ bim
 bim
 bim
 bim
-jbl
-jbl
+sJC
+sJC
 ihS
 rVT
 xZs
@@ -36522,7 +36581,7 @@ cVO
 hKb
 cVO
 cVO
-brT
+cVO
 sGl
 iqQ
 brT
@@ -36664,7 +36723,7 @@ bnm
 aIn
 jrs
 jrs
-gwO
+jrs
 nOy
 jSu
 brT
@@ -36807,7 +36866,7 @@ sTa
 gfO
 gBY
 gQP
-jbl
+sJC
 oiQ
 kqN
 jzZ
@@ -47502,7 +47561,7 @@ qzM
 usH
 bbx
 xTO
-bbx
+hEL
 uWf
 xcj
 vZU
@@ -47644,7 +47703,7 @@ uUo
 usH
 bMZ
 xTO
-rxh
+gpN
 uWf
 bNI
 vZU
@@ -47788,7 +47847,7 @@ tgt
 iJy
 xBR
 kLf
-bNI
+aei
 rEg
 gxh
 sNo

--- a/_maps/map_files/NSV_Triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/NSV_Triumph/triumph-04-deck4.dmm
@@ -29,7 +29,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/range)
 "acp" = (
-/obj/machinery/computer/borgupload,
+/obj/machinery/computer/robotics{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/purple/full{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "acE" = (
@@ -194,20 +199,15 @@
 /turf/simulated/floor/tiled/white,
 /area/security/security_bathroom)
 "ajj" = (
-/obj/structure/window/phoronreinforced{
-	dir = 8;
-	icon_state = "phoronrwindow"
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/obj/structure/window/phoronreinforced/full,
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "bridge_lockdown";
-	name = "Bridge Lockdown"
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 8
 	},
-/turf/simulated/shuttle/floor/voidcraft,
-/area/bridge)
+/obj/machinery/door/firedoor/glass/hidden/steel,
+/turf/simulated/floor/tiled,
+/area/bridge/hallway)
 "akM" = (
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/ai_status_display{
@@ -497,11 +497,18 @@
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "avO" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 10
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/hallway)
 "awx" = (
 /obj/machinery/scale,
 /turf/simulated/floor/carpet/bcarpet,
@@ -580,7 +587,9 @@
 /obj/machinery/camera/network/command{
 	dir = 1
 	},
-/obj/machinery/papershredder,
+/obj/effect/floor_decal/corner/purple{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "aAy" = (
@@ -731,6 +740,9 @@
 "aJO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/purple{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1228,6 +1240,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
+"bcj" = (
+/obj/item/modular_computer/console{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "bem" = (
 /turf/simulated/wall,
 /area/maintenance/central)
@@ -1726,6 +1747,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "bvS" = (
@@ -1987,6 +2011,10 @@
 "bFl" = (
 /turf/simulated/floor/wood,
 /area/triumph/station/explorer_meeting)
+"bFH" = (
+/obj/effect/floor_decal/borderfloor,
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "bFL" = (
 /turf/simulated/wall,
 /area/triumph/station/explorer_medical)
@@ -2418,6 +2446,9 @@
 	dir = 1
 	},
 /obj/machinery/recharge_station,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
 /turf/simulated/floor/tiled,
 /area/bridge/hallway)
 "bYj" = (
@@ -2531,9 +2562,7 @@
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "cda" = (
-/obj/machinery/camera/network/command{
-	dir = 9
-	},
+/obj/structure/table/marble,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "cdk" = (
@@ -2696,6 +2725,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "cjN" = (
@@ -3383,7 +3413,12 @@
 	dir = 8;
 	pixel_x = 32
 	},
-/obj/structure/bed/chair/office/dark,
+/obj/machinery/computer/rdservercontrol{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/purple{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "cHO" = (
@@ -3653,6 +3688,18 @@
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/tiled/freezer,
 /area/hallway/secondary/civilian_hallway_mid)
+"cYt" = (
+/obj/machinery/camera/network/command{
+	dir = 9
+	},
+/obj/item/modular_computer/console{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "cYJ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3872,6 +3919,9 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "djR" = (
@@ -3895,6 +3945,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/triumph/station/stairs_one)
+"dlK" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel,
+/turf/simulated/floor/tiled,
+/area/bridge/hallway)
 "dlT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -4038,14 +4103,17 @@
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "dqW" = (
-/obj/structure/window/reinforced/tinted/frosted{
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/corner/blue/full,
-/obj/item/flashlight/lamp,
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
+/turf/simulated/floor/tiled,
+/area/bridge/hallway)
 "dri" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -4150,7 +4218,6 @@
 	icon_state = "4-8"
 	},
 /obj/item/radio/beacon,
-/obj/effect/floor_decal/steeldecal/steel_decals_central6,
 /turf/simulated/floor/tiled,
 /area/bridge/hallway)
 "dvw" = (
@@ -4238,16 +4305,18 @@
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
 "dBa" = (
-/obj/structure/window/reinforced/tinted/frosted{
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 8
 	},
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/hallway)
 "dBl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -4647,10 +4716,19 @@
 	name = "\improper Official On-Site Office"
 	})
 "dPR" = (
-/obj/structure/closet/crate/bin{
-	anchored = 1
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/grille,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "bridge_lockdown";
+	name = "Bridge Lockdown";
+	opacity = 0
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft,
 /area/bridge)
 "dPV" = (
 /obj/effect/floor_decal/borderfloor{
@@ -5580,6 +5658,9 @@
 "eDS" = (
 /obj/item/flashlight/lamp,
 /obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "eEj" = (
@@ -6663,6 +6744,7 @@
 "fqo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloor,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "frd" = (
@@ -7413,6 +7495,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"fXb" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/hallway)
 "fXg" = (
 /obj/structure/bookcase{
 	name = "bookcase (Reference)"
@@ -7547,6 +7646,16 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/triumph/station/pathfinder_office)
+"gjx" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 10
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Bridge"
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "gkj" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/trashcart,
@@ -8200,6 +8309,27 @@
 /obj/item/flashlight/lamp/green,
 /turf/simulated/floor/wood,
 /area/library)
+"gLz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/hallway)
 "gMb" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
@@ -8211,8 +8341,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/civilian_hallway_mid)
 "gMx" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/skills,
+/obj/machinery/papershredder,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "gMA" = (
@@ -8275,7 +8404,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
 	dir = 4
@@ -8284,6 +8412,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/beige/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -8606,11 +8737,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "hba" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 5
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Bridge";
+	departmentType = 5;
+	name = "Bridge RC";
+	pixel_y = 32
 	},
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "hbO" = (
@@ -9065,6 +9198,10 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
+/obj/machinery/alarm{
+	frequency = 1441;
+	pixel_y = 22
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "hvu" = (
@@ -9210,6 +9347,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
+"hAS" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/modular_computer/console{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "hBd" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -9843,6 +9992,18 @@
 /obj/machinery/camera/network/civilian,
 /turf/simulated/floor/tiled/dark,
 /area/triumph/station/stairs_one)
+"hUu" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/modular_computer/console{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "hUO" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -9941,7 +10102,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/computer/mecha,
+/obj/effect/floor_decal/corner/purple{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "hYe" = (
@@ -11216,6 +11379,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/lobby)
+"iVw" = (
+/obj/structure/grille,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "bridge_lockdown";
+	name = "Bridge Lockdown";
+	opacity = 0
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/bridge)
 "iVA" = (
 /obj/structure/table/woodentable,
 /obj/machinery/recharger{
@@ -11240,13 +11416,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/triumph/station/stairs_one)
 "iWz" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 10
+	},
 /obj/structure/table/reinforced,
-/obj/machinery/computer/med_data/laptop{
-	dir = 8
-	},
-/obj/machinery/ai_status_display{
-	pixel_y = -32
-	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "iWU" = (
@@ -11743,6 +11916,10 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/hallway/secondary/civilian_hallway_mid)
 "jpG" = (
@@ -12121,11 +12298,19 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/secondary/civilian_hallway_mid)
 "jIv" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/window/phoronreinforced{
+	dir = 1
 	},
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/grille,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "bridge_lockdown";
+	name = "Bridge Lockdown";
+	opacity = 0
+	},
+/turf/simulated/shuttle/floor/voidcraft,
 /area/bridge)
 "jJt" = (
 /obj/machinery/alarm{
@@ -12888,6 +13073,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/plaque,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "kvw" = (
@@ -12905,11 +13091,10 @@
 /turf/simulated/floor/tiled,
 /area/triumph/station/pathfinder_office)
 "kwc" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced,
+/turf/simulated/shuttle/floor/voidcraft,
 /area/bridge)
 "kwn" = (
 /obj/machinery/door/airlock/glass_security{
@@ -12920,6 +13105,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/eva)
+"kxN" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/hallway)
 "kzc" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 10
@@ -12957,13 +13161,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/captain)
 "kzW" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
 /obj/machinery/light,
+/obj/machinery/computer/borgupload{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "kAF" = (
@@ -13963,13 +14171,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "lql" = (
-/obj/effect/floor_decal/corner/red/full{
-	dir = 4
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	icon_state = "phoronrwindow"
 	},
-/obj/machinery/computer/prisoner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/grille,
+/turf/simulated/shuttle/floor/voidcraft,
 /area/bridge)
 "lqF" = (
 /obj/structure/table/standard,
@@ -14004,6 +14212,9 @@
 /obj/machinery/computer/guestpass{
 	dir = 4;
 	pixel_x = -28
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
@@ -14828,12 +15039,7 @@
 /turf/simulated/floor/tiled/white,
 /area/triumph/station/explorer_medical)
 "lUu" = (
-/obj/machinery/computer/card{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red/full{
-	dir = 1
-	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "lUE" = (
@@ -15083,6 +15289,9 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "mfa" = (
@@ -15791,6 +16000,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "mKR" = (
@@ -16285,6 +16495,9 @@
 	},
 /obj/machinery/light_switch{
 	pixel_y = -26
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/lawoffice)
@@ -17987,6 +18200,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
+"oyY" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/med_data/laptop{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "oAG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -18723,19 +18946,13 @@
 /turf/simulated/floor/tiled,
 /area/security/hallway)
 "pat" = (
-/obj/structure/window/phoronreinforced{
-	dir = 4
+/obj/machinery/computer/card{
+	dir = 8
 	},
-/obj/structure/window/phoronreinforced/full,
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "bridge_lockdown";
-	name = "Bridge Lockdown";
-	opacity = 0
+/obj/effect/floor_decal/corner/red/full{
+	dir = 1
 	},
-/turf/simulated/shuttle/floor/voidcraft,
+/turf/simulated/floor/tiled/dark,
 /area/bridge)
 "pbe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -18843,7 +19060,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/light{
+/obj/structure/closet/crate/bin{
+	anchored = 1
+	},
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -19178,6 +19398,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "ppM" = (
@@ -19199,6 +19422,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"pql" = (
+/obj/effect/floor_decal/corner/purple/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "prc" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
@@ -19334,6 +19563,17 @@
 /area/crew_quarters/sleep/Dorm_2{
 	name = "\improper CE Dorm"
 	})
+"pwe" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/flashlight/lamp{
+	pixel_y = 12
+	},
+/obj/effect/floor_decal/corner/grey/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "pwx" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -19499,14 +19739,19 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "pFz" = (
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 8
+/obj/structure/window/phoronreinforced{
+	dir = 4
 	},
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/grille,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "bridge_lockdown";
+	name = "Bridge Lockdown";
+	opacity = 0
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/shuttle/floor/voidcraft,
 /area/bridge)
 "pFE" = (
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -19892,7 +20137,12 @@
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
 "pQT" = (
-/obj/structure/table/reinforced,
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "pRh" = (
@@ -20021,6 +20271,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"pVG" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/hallway)
 "pWc" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
@@ -20347,6 +20615,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "qdA" = (
@@ -21261,10 +21530,9 @@
 /turf/simulated/floor/tiled,
 /area/security/security_equiptment_storage)
 "qGF" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/flashlight/lamp{
-	pixel_y = 12
+/obj/structure/filingcabinet/filingcabinet,
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
@@ -21944,8 +22212,19 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/captain)
 "rjc" = (
-/obj/structure/filingcabinet/filingcabinet,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	icon_state = "phoronrwindow"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/grille,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "bridge_lockdown";
+	name = "Bridge Lockdown"
+	},
+/turf/simulated/shuttle/floor/voidcraft,
 /area/bridge)
 "rjo" = (
 /obj/structure/bed/chair/comfy/black{
@@ -22400,6 +22679,9 @@
 /obj/item/storage/secure/briefcase,
 /obj/item/book/manual/command_guide,
 /obj/item/book/manual/standard_operating_procedure,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "rAu" = (
@@ -23035,6 +23317,7 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled,
 /area/bridge/hallway)
 "rZq" = (
@@ -24909,6 +25192,9 @@
 /obj/machinery/camera/network/command{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "tDC" = (
@@ -24992,6 +25278,14 @@
 /obj/machinery/bookbinder,
 /turf/simulated/floor/wood,
 /area/library)
+"tGQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/effect/floor_decal/corner/purple{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "tHQ" = (
 /obj/structure/sign/directions/evac{
 	dir = 8
@@ -25011,6 +25305,15 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/shuttle/floor/voidcraft,
 /area/shuttle/excursion/triumph)
+"tIS" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "tJG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -25206,6 +25509,14 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/chapel/main)
+"tUj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "tUk" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
@@ -25723,6 +26034,10 @@
 	},
 /turf/simulated/shuttle/wall/voidcraft/blue,
 /area/shuttle/excursion/triumph)
+"ult" = (
+/obj/effect/floor_decal/steeldecal/steel_decals_central6,
+/turf/simulated/floor/tiled,
+/area/bridge/hallway)
 "umg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26148,6 +26463,17 @@
 	},
 /turf/simulated/floor/lino,
 /area/chapel/office)
+"uBW" = (
+/obj/structure/table/reinforced,
+/obj/machinery/ai_status_display{
+	pixel_y = -32
+	},
+/obj/machinery/recharger,
+/obj/effect/floor_decal/corner/grey/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "uCs" = (
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_1{
@@ -26759,6 +27085,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "vaq" = (
@@ -26872,13 +27201,12 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/security/briefing_room)
 "vde" = (
-/obj/structure/window/phoronreinforced{
-	dir = 8;
-	icon_state = "phoronrwindow"
+/obj/effect/floor_decal/corner/red{
+	dir = 5
 	},
-/obj/structure/window/phoronreinforced/full,
-/obj/structure/grille,
-/turf/simulated/shuttle/floor/voidcraft,
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp,
+/turf/simulated/floor/tiled/dark,
 /area/bridge)
 "ved" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -27306,6 +27634,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "vum" = (
@@ -27453,6 +27784,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "vzS" = (
@@ -27484,6 +27818,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/security_bathroom)
+"vAl" = (
+/obj/effect/floor_decal/corner/red/full{
+	dir = 4
+	},
+/obj/machinery/computer/prisoner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "vAH" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -27674,13 +28017,18 @@
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
 "vJX" = (
-/obj/machinery/computer/secure_data{
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
 /turf/simulated/floor/tiled/dark,
+/area/bridge)
+"vKe" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft,
 /area/bridge)
 "vKj" = (
 /obj/machinery/shieldwallgen,
@@ -27761,6 +28109,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/breakroom)
+"vMy" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/skills,
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "vMP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -29027,19 +29383,9 @@
 /area/security/security_equiptment_storage)
 "wMH" = (
 /obj/structure/table/reinforced,
-/obj/item/radio{
-	pixel_x = 2;
-	pixel_y = 3
+/obj/effect/floor_decal/corner/purple/full{
+	dir = 4
 	},
-/obj/item/radio,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Bridge";
-	departmentType = 5;
-	name = "Bridge RC";
-	pixel_y = -32
-	},
-/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "wNw" = (
@@ -29265,9 +29611,6 @@
 /turf/simulated/floor/wood,
 /area/security/breakroom)
 "wVS" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -29434,6 +29777,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
+"xcI" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "xdr" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 9
@@ -29723,6 +30072,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
+"xoA" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "xoG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -30054,14 +30409,9 @@
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
 "xyv" = (
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 8
+/obj/effect/floor_decal/corner/red{
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/blue/full{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "xyD" = (
@@ -30298,11 +30648,16 @@
 /turf/simulated/floor/tiled,
 /area/security/riot_control)
 "xJj" = (
-/obj/machinery/photocopier,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/effect/floor_decal/corner/purple/full,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "xJm" = (
@@ -30360,6 +30715,12 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/shuttle/floor/darkred,
 /area/shuttle/excursion/triumph)
+"xMa" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "xMj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -30476,6 +30837,10 @@
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/hallway/secondary/civilian_hallway_mid)
@@ -46959,13 +47324,13 @@ kTt
 kTt
 eHr
 jQy
-kTt
+ajj
 gZa
 kTt
 eZi
 kTt
 eHr
-kTt
+dBa
 kTt
 gZa
 orY
@@ -46977,10 +47342,10 @@ kTt
 epL
 rCn
 lSG
+dlK
 xdz
-xdz
-xdz
-xdz
+fXb
+gLz
 xdz
 xdz
 fpA
@@ -47101,7 +47466,7 @@ qdH
 avk
 avk
 avk
-avk
+avO
 tDC
 avk
 qjT
@@ -47113,16 +47478,16 @@ tDC
 oMQ
 avk
 nsT
-avk
+avO
 avk
 avk
 eAF
 avk
 pZY
-eve
+kxN
 eve
 gOt
-eve
+pVG
 eve
 odm
 gzW
@@ -47243,7 +47608,7 @@ mYf
 oet
 oet
 glL
-oet
+dqW
 moZ
 oet
 mYf
@@ -47255,7 +47620,7 @@ moZ
 kMy
 oet
 glL
-oet
+dqW
 wbW
 oqg
 fDn
@@ -47827,7 +48192,7 @@ gef
 gub
 oqg
 fDn
-oqg
+ult
 jHz
 riZ
 iEd
@@ -48391,17 +48756,17 @@ kXI
 pWn
 poJ
 djA
-pox
+vJX
 vug
 bvQ
 pdX
-pox
+vJX
 lrV
 tDz
 rzQ
 uZT
-pox
-pox
+pql
+tGQ
 xJj
 duy
 duy
@@ -48534,16 +48899,16 @@ nvw
 meW
 owt
 rUm
-aza
+tUj
 aza
 ktB
 aza
-aza
+tUj
 rUm
 owt
 fqo
 aJO
-kWa
+tIS
 aAj
 duy
 duy
@@ -48675,17 +49040,17 @@ ubE
 nfc
 vzr
 qnX
-dPR
-xyv
-dBa
-pFz
-pFz
-dqW
-dPR
+pox
+duy
+duy
+duy
+duy
+duy
+pox
 iTO
-pox
+bFH
 hYd
-pox
+xMa
 kzW
 duy
 duy
@@ -48825,7 +49190,7 @@ sBc
 rpc
 pox
 iTO
-pox
+bFH
 acp
 cHL
 wMH
@@ -49107,7 +49472,7 @@ qFH
 rFt
 lGq
 fAv
-rjc
+pox
 scG
 qdb
 duy
@@ -49238,12 +49603,12 @@ pkc
 nIK
 nIK
 nIK
-dff
+nIK
 duy
 duy
 hba
-ubE
-avO
+pox
+pox
 pox
 ggU
 iEI
@@ -49254,7 +49619,7 @@ wVS
 cjJ
 duy
 duy
-dff
+nIK
 nIK
 nIK
 nIK
@@ -49381,21 +49746,21 @@ nIK
 nIK
 nIK
 nIK
-duy
-duy
+dPR
+kwc
 lUu
-vJX
-lql
-jIv
+pox
+pox
+pox
 pox
 cda
 pox
-kwc
+pox
 qGF
-pQT
+pox
 iWz
-duy
-duy
+vKe
+iVw
 nIK
 nIK
 nIK
@@ -49523,21 +49888,21 @@ nIK
 nIK
 nIK
 nIK
-duy
-duy
+jIv
+kwc
 vde
-ajj
-vde
-vde
-vde
-vde
-vde
-vde
-vde
-vde
-vde
-duy
-duy
+ubE
+xyv
+xcI
+ubE
+cda
+ubE
+xoA
+vMy
+xMa
+gjx
+vKe
+iVw
 jJF
 nIK
 nIK
@@ -49668,16 +50033,16 @@ nIK
 duy
 duy
 pat
-pat
-pat
-pat
-pat
-pat
-pat
-pat
-pat
-pat
-pat
+pQT
+vAl
+hUu
+bcj
+cYt
+bcj
+hAS
+pwe
+oyY
+uBW
 duy
 duy
 nIK
@@ -49807,21 +50172,21 @@ nIK
 nIK
 nIK
 nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
+duy
+duy
+lql
+rjc
+lql
+lql
+lql
+lql
+lql
+lql
+lql
+lql
+lql
+duy
+duy
 nIK
 nIK
 nIK
@@ -49949,21 +50314,21 @@ nIK
 nIK
 nIK
 nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
-nIK
+duy
+duy
+pFz
+pFz
+pFz
+pFz
+pFz
+pFz
+pFz
+pFz
+pFz
+pFz
+pFz
+duy
+duy
 nIK
 nIK
 nIK

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -10,6 +10,7 @@
 #define DEBUG
 // END_PREFERENCES
 // BEGIN_INCLUDE
+#include "_maps\triumph.dm"
 #include "code\_away_mission_tests.dm"
 #include "code\_macros.dm"
 #include "code\_map_tests.dm"
@@ -3498,6 +3499,7 @@
 #include "interface\interface.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
+#include "maps\nsv_triumph\triumph.dm"
 #include "maps\RandomZLevels\blackmarketpackers.dm"
 #include "maps\RandomZLevels\carpfarm.dm"
 #include "maps\RandomZLevels\listeningpost.dm"
@@ -3530,7 +3532,6 @@
 #include "maps\submaps\surface_submaps\plains\plains_areas.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness_areas.dm"
-#include "maps\tether\tether.dm"
 #include "maps\~map_system\maps.dm"
 #include "modular_citadel\code\global_cit.dm"
 #include "modular_citadel\code\datums\outfits\jobs\centcom.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Set-up the map to handle Overmaps once that is merged to begin proper utilization

## Why It's Good For The Game

Yeet

## Changelog
:cl:
server: Triumph active again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
