### PR TITLE
Tether Map Tweaks 08-23

### DIFF
--- a/_maps/map_files/Tether/tether-01-surface1.dmm
+++ b/_maps/map_files/Tether/tether-01-surface1.dmm
@@ -2464,14 +2464,14 @@
 /area/tether/surfacebase/mining_main/ore)
 "aeD" = (
 /obj/effect/floor_decal/rust,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -2726,6 +2726,7 @@
 "aff" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "afg" = (
@@ -2952,6 +2953,7 @@
 /area/maintenance/lower/mining_eva)
 "afD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "afE" = (
@@ -3256,14 +3258,16 @@
 /area/tether/surfacebase/mining_main/ore)
 "agf" = (
 /obj/effect/floor_decal/rust,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "agg" = (
 /obj/structure/closet/crate,
 /obj/machinery/light,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "agh" = (
@@ -7337,6 +7341,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "anz" = (
@@ -7352,6 +7359,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
@@ -7391,6 +7401,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "anF" = (
@@ -7413,6 +7426,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
@@ -7445,6 +7461,9 @@
 	id = "mine_warehouse";
 	name = "Warehouse Shutters"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "anL" = (
@@ -7467,7 +7486,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "anO" = (
@@ -24152,6 +24171,13 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/xenobiology/xenoflora)
+"bkP" = (
+/obj/structure/table/standard,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/outside/outside1)
 "blj" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -31085,6 +31111,15 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/medical/triage)
 "cHR" = (
@@ -31145,6 +31180,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/public_garden_maintenence)
+"cXf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/wall,
+/area/tether/surfacebase/mining_main/ore)
 "cXn" = (
 /obj/machinery/access_button/airlock_exterior{
 	frequency = 8220;
@@ -31164,6 +31204,18 @@
 "cXx" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"cZX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
 /area/tether/surfacebase/medical/triage)
 "dbc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -31422,6 +31474,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
+"eGZ" = (
+/obj/structure/table/standard,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "eMI" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central1{
 	dir = 4
@@ -31435,6 +31493,10 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"eNX" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/tether/surfacebase/mining_main/ore)
 "ePE" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
@@ -31707,9 +31769,7 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/obj/item/clothing/accessory/holster/machete,
 /obj/item/material/knife/tacknife/survival,
-/obj/item/material/knife/machete,
 /obj/item/clothing/accessory/permit/gun/paramedic,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/medical/triage)
@@ -31725,6 +31785,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
@@ -31891,6 +31957,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/public_garden)
+"gEz" = (
+/obj/structure/table/standard,
+/obj/item/hand_labeler,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "gKf" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/structure/cable/green{
@@ -32444,6 +32515,16 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"jnw" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "jqT" = (
@@ -32528,6 +32609,14 @@
 /obj/effect/ceiling,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/mining_main/external)
+"jCJ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1;
+	pixel_x = 4
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "jGg" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -32757,6 +32846,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
+"kJY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/outside/outside1)
 "kOB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -32796,6 +32891,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/public_garden_maintenence)
+"laM" = (
+/obj/structure/table/standard,
+/obj/item/hand_labeler,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/outside/outside1)
 "lgd" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -32991,6 +33091,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/medical/triage)
 "mSi" = (
@@ -33088,6 +33191,25 @@
 "njz" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"njM" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen/red{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/pen/blue{
+	pixel_x = -5;
+	pixel_y = -1
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "nlP" = (
@@ -33251,6 +33373,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"oba" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/lobby)
 "oco" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -33259,6 +33392,18 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"ocr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -33426,6 +33571,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/medical/triage)
+"oYD" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/outside/outside1)
 "pev" = (
 /obj/structure/table/glass,
 /obj/item/backup_implanter{
@@ -33531,11 +33685,19 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/triage)
+"pCf" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "pCg" = (
 /turf/simulated/floor/plating,
@@ -33670,6 +33832,12 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
+"qcx" = (
+/obj/machinery/door/airlock/glass_mining{
+	name = "Department Mail Room"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/mining_main/ore)
 "qcH" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
 	frequency = 8220;
@@ -33844,6 +34012,13 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/public_garden_maintenence)
+"qNF" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1;
+	pixel_x = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/outside/outside1)
 "qQw" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/medical/triage)
@@ -33989,6 +34164,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_one)
+"rgF" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/outside/outside1)
 "rho" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -34118,15 +34302,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/medical/triage)
 "rZr" = (
@@ -34277,6 +34462,10 @@
 /obj/structure/table/glass,
 /obj/item/storage/box/cups,
 /obj/item/storage/box/cups,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -25
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "swM" = (
@@ -34555,13 +34744,17 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/medical/triage)
@@ -34574,6 +34767,11 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
+"twi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/outside/outside1)
 "tzX" = (
 /obj/structure/grille,
 /turf/simulated/floor/tiled/techmaint,
@@ -34787,19 +34985,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
-"uug" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
 "uwI" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -34921,6 +35106,25 @@
 	dir = 8
 	},
 /area/tether/surfacebase/medical/triage)
+"uXM" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen/red{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/pen/blue{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/outside/outside1)
 "vdW" = (
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 1
@@ -34990,6 +35194,13 @@
 /obj/item/storage/box/donkpockets,
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/medical/triage)
+"vBx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/mining_main/ore)
 "vBE" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -35099,6 +35310,15 @@
 	dir = 1
 	},
 /area/tether/surfacebase/public_garden_one)
+"vZz" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/mining_main/ore)
 "waw" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -35171,6 +35391,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall,
 /area/hallway/lower/first_west)
+"wNJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "wOU" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -35307,6 +35536,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/medical/triage)
+"xFN" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/outside/outside1)
 "xLU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -35396,6 +35635,13 @@
 /obj/structure/railing,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/public_garden_maintenence)
+"ydA" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Department Mail Room";
+	req_access = list(5)
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "yho" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -42853,7 +43099,7 @@ qQw
 jbM
 isB
 bVS
-uug
+hwQ
 xNl
 ahl
 xCf
@@ -45110,10 +45356,10 @@ qQw
 fBn
 qQw
 qQw
+ydA
+cZX
 qQw
 qQw
-qQw
-aah
 aah
 aah
 aah
@@ -45252,10 +45498,10 @@ qQw
 fTK
 fMD
 qQw
-aah
-aah
-aah
-aah
+uWj
+ocr
+njM
+qQw
 aah
 aah
 aah
@@ -45394,10 +45640,10 @@ qQw
 gNn
 sEa
 qQw
-aah
-aah
-aah
-aah
+jnw
+wNJ
+jCJ
+qQw
 aah
 aah
 aah
@@ -45536,10 +45782,10 @@ qQw
 qQw
 qQw
 qQw
-aah
-aah
-aah
-adK
+eGZ
+pCf
+gEz
+qQw
 abT
 abT
 abT
@@ -45677,10 +45923,10 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
+qQw
+qQw
+qQw
+qQw
 abT
 abT
 acQ
@@ -46828,9 +47074,9 @@ rTC
 rTC
 age
 aer
-aah
-aah
-aah
+adK
+adK
+adK
 agM
 awi
 axQ
@@ -46969,10 +47215,10 @@ aeD
 aff
 afD
 agf
-aer
-aah
-aah
-aah
+cXf
+twi
+xFN
+uXM
 agM
 aic
 axT
@@ -47110,11 +47356,11 @@ aer
 aeE
 aeF
 aeF
-aeF
-aer
-aah
-aah
-aah
+vZz
+qcx
+rgF
+kJY
+qNF
 agM
 aid
 axR
@@ -47251,12 +47497,12 @@ adV
 aer
 aeF
 aeF
-aeF
+vBx
 agg
-aer
-aah
-aah
-aah
+eNX
+bkP
+oYD
+laM
 agM
 aie
 axR
@@ -47396,7 +47642,7 @@ alN
 any
 afe
 aer
-aah
+adK
 agM
 agM
 agM
@@ -48103,7 +48349,7 @@ aea
 abL
 svt
 afj
-anL
+oba
 apW
 aeJ
 aeJ
@@ -48245,7 +48491,7 @@ aea
 abL
 aeL
 afk
-anL
+oba
 agl
 agx
 agC

--- a/_maps/map_files/Tether/tether-02-surface2.dmm
+++ b/_maps/map_files/Tether/tether-02-surface2.dmm
@@ -7776,10 +7776,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -8116,13 +8116,24 @@
 /turf/simulated/floor/tiled,
 /area/engineering/lower/lobby)
 "qQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/wood,
 /area/engineering/lower/breakroom)
 "qR" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/cups,
-/obj/item/storage/box/cups,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/lower/breakroom)
 "qS" = (
@@ -8512,6 +8523,12 @@
 "rK" = (
 /obj/structure/bed/chair{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/engineering/lower/breakroom)
@@ -17999,6 +18016,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"KP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/lower/breakroom)
 "Lg" = (
 /obj/machinery/telecomms/relay/preset/tether/midpoint,
 /turf/simulated/floor/tiled/dark{
@@ -18011,6 +18037,21 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/lower/bar)
+"Lq" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/lower/breakroom)
+"Lz" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/lower/breakroom)
 "LA" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/double,
@@ -18056,6 +18097,18 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/bar)
+"MG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/lower/breakroom)
 "MX" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -18211,6 +18264,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/tcommsat/computer)
+"Pn" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1;
+	pixel_x = 4
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/dark,
+/area/engineering/lower/breakroom)
 "Po" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -18305,6 +18366,12 @@
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"QC" = (
+/obj/structure/table/standard,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/turf/simulated/floor/tiled/dark,
+/area/engineering/lower/breakroom)
 "QM" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/decal/cleanable/dirt,
@@ -18353,6 +18420,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
+"Sk" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/carpet,
+/area/engineering/lower/breakroom)
 "Sn" = (
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -18483,6 +18566,14 @@
 /obj/structure/symbol/gu,
 /turf/simulated/wall,
 /area/tether/surfacebase/public_garden_two)
+"Uy" = (
+/obj/structure/table/glass,
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/carpet,
+/area/engineering/lower/breakroom)
 "UB" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -18515,6 +18606,11 @@
 	can_open = 1
 	},
 /area/vacant/vacant_bar_upper)
+"UV" = (
+/obj/structure/table/standard,
+/obj/item/hand_labeler,
+/turf/simulated/floor/tiled/dark,
+/area/engineering/lower/breakroom)
 "UX" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -18580,6 +18676,9 @@
 	dir = 1;
 	pixel_y = -25
 	},
+/obj/structure/table/glass,
+/obj/item/storage/box/cups,
+/obj/item/storage/box/cups,
 /turf/simulated/floor/wood,
 /area/engineering/lower/breakroom)
 "VI" = (
@@ -18623,6 +18722,25 @@
 /obj/effect/floor_decal/corner/lime/bordercorner,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"Wv" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen/red{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/pen/blue{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/lower/breakroom)
 "WA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
@@ -18766,6 +18884,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"Yx" = (
+/turf/simulated/floor/tiled/dark,
+/area/engineering/lower/breakroom)
 "YA" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/reagent_containers/food/drinks/bottle/orangejuice,
@@ -18833,6 +18954,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"YV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_atmos{
+	name = "Department Mail Room";
+	req_access = list(24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/lower/breakroom)
 "Zo" = (
 /obj/structure/table/bench/steel,
 /obj/effect/floor_decal/borderfloor/corner{
@@ -18883,6 +19020,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"ZH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/engineering/lower/breakroom)
 "ZN" = (
 /turf/simulated/floor/wood,
 /area/vacant/vacant_bar_upper)
@@ -31203,8 +31352,8 @@ Tc
 of
 oK
 px
-qf
-rK
+Uy
+Sk
 rH
 sl
 sG
@@ -31346,7 +31495,7 @@ ob
 oL
 oK
 qh
-oK
+ZH
 VA
 sl
 tg
@@ -31630,9 +31779,9 @@ ob
 ob
 ob
 ob
+YV
 ob
 ob
-sl
 ti
 ua
 uV
@@ -31771,10 +31920,10 @@ nA
 nW
 en
 dY
-ac
-ac
-ac
-sm
+Yx
+MG
+Wv
+ob
 tj
 ub
 uW
@@ -31913,10 +32062,10 @@ JT
 dY
 dY
 dY
-ac
-ac
-ac
-sm
+Lz
+KP
+Pn
+ob
 sm
 sm
 sm
@@ -32055,10 +32204,10 @@ nG
 dY
 oN
 rO
-ac
-ac
-ac
-ac
+QC
+Lq
+UV
+ob
 ac
 ac
 ac

--- a/_maps/map_files/Tether/tether-03-surface3.dmm
+++ b/_maps/map_files/Tether/tether-03-surface3.dmm
@@ -169,6 +169,15 @@
 	},
 /turf/simulated/open,
 /area/vacant/vacant_site2)
+"aH" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/assembly/robotics)
 "aI" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
@@ -679,6 +688,21 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/vacant/vacant_site2)
+"cd" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/shuttle_pad)
 "cg" = (
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/reading_room)
@@ -1855,6 +1879,15 @@
 /obj/random/maintenance/medical,
 /turf/simulated/floor/tiled/old_tile,
 /area/vacant/vacant_site2)
+"eK" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/hallway)
 "eN" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -3360,6 +3393,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/vacant_site2)
+"hL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/hallway)
 "hP" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -12623,6 +12663,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"xX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/hallway)
 "xY" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/machinery/light{
@@ -19063,6 +19111,12 @@
 /obj/item/mmi/digital/posibrain,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/mauve/bordercorner2{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
 "Ic" = (
@@ -19082,6 +19136,8 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/mauve/bordercorner2,
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
 "Ie" = (
@@ -19393,6 +19449,10 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "IE" = (
@@ -19472,6 +19532,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer)
 "IK" = (
@@ -19481,6 +19547,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer)
 "IL" = (
@@ -19496,6 +19566,12 @@
 /area/rnd/hallway)
 "IM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "IN" = (
@@ -20309,12 +20385,9 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/rnd/hallway)
 "KB" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/outside/outside3)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/rnd/hallway)
 "KC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20474,14 +20547,14 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "KU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/rnd/hallway)
@@ -20527,6 +20600,13 @@
 "KZ" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/mauve/bordercorner2{
+	dir = 9
+	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/rnd/hallway)
 "La" = (
@@ -20559,6 +20639,8 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/mauve/bordercorner2,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "Ld" = (
@@ -21043,6 +21125,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
+"Mr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/hallway)
 "Mu" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /turf/simulated/floor/grass,
@@ -21263,6 +21358,25 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
+"Ny" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen/red{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/pen/blue{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/hallway)
 "Nz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21372,6 +21486,11 @@
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/wood,
 /area/bridge)
+"NY" = (
+/obj/structure/table/standard,
+/obj/item/hand_labeler,
+/turf/simulated/floor/tiled,
+/area/rnd/hallway)
 "Oa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -21538,6 +21657,15 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
+"Oz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass_research{
+	name = "Department Mail Room";
+	req_access = list(47)
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/rnd/hallway)
 "OA" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
@@ -21840,6 +21968,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile,
 /area/tether/surfacebase/shuttle_pad)
+"Qa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/rnd/hallway)
 "Qb" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
@@ -23225,6 +23364,10 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/lounge)
+"WW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/wall/r_wall,
+/area/rnd/hallway)
 "Xb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/mist,
@@ -23437,6 +23580,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/public_garden_three)
+"Yd" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1;
+	pixel_x = 4
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled,
+/area/rnd/hallway)
 "Yj" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -23586,6 +23737,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
+"YO" = (
+/obj/structure/table/standard,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/turf/simulated/floor/tiled,
+/area/rnd/hallway)
 "YP" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -23770,6 +23927,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
+"ZK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/rnd/hallway)
 "ZQ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -32580,9 +32748,9 @@ KO
 KY
 AI
 Ay
-ac
-ac
-ac
+Ay
+Ay
+Ay
 ac
 ac
 ac
@@ -32720,11 +32888,11 @@ Da
 HS
 KU
 KZ
-Kx
+WW
 KB
-ac
-ac
-ac
+hL
+Ny
+Ay
 ac
 ac
 ac
@@ -32860,13 +33028,13 @@ DP
 Ib
 Ks
 Jd
-HX
-Lb
-Kx
-KB
-ac
-ac
-ac
+Mr
+ZK
+Oz
+Qa
+xX
+Yd
+KD
 ac
 ac
 ac
@@ -32999,16 +33167,16 @@ LO
 LX
 HO
 LB
-FV
+aH
 HG
 IM
 Ic
 Lc
 AI
+YO
+eK
+NY
 Ay
-ac
-ac
-ac
 ac
 ac
 ac
@@ -33148,9 +33316,9 @@ HX
 Lt
 AI
 Ay
-ac
-ac
-ac
+Ay
+Ay
+Ay
 ac
 ac
 ac
@@ -34422,7 +34590,7 @@ Hr
 Hr
 Hr
 KM
-Hr
+cd
 KM
 IZ
 Hr

--- a/_maps/map_files/Tether/tether-05-station1.dmm
+++ b/_maps/map_files/Tether/tether-05-station1.dmm
@@ -21117,9 +21117,6 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
-"bVa" = (
-/turf/simulated/wall,
-/area/space)
 "bVu" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -21637,12 +21634,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_prep)
-"dnQ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/space)
 "dom" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -21950,15 +21941,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_prep)
-"fUy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/space)
 "fVe" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -22058,18 +22040,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/station/explorer_medical)
-"hhq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/space)
 "hjG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -22238,22 +22208,6 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
-"iCM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/glass_atmos{
-	name = "Department Mail Room";
-	req_access = list(24)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/space)
 "iEx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -23034,11 +22988,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_prep)
-"mWo" = (
-/obj/structure/table/standard,
-/obj/item/hand_labeler,
-/turf/simulated/floor/tiled/dark,
-/area/space)
 "mYr" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor,
@@ -24641,15 +24590,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
-"vXL" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/space)
 "wbr" = (
 /obj/machinery/camera/network/northern_star{
 	dir = 5
@@ -24734,9 +24674,6 @@
 	},
 /turf/simulated/floor,
 /area/construction/observation)
-"wxS" = (
-/turf/simulated/floor/tiled/dark,
-/area/space)
 "wCH" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
@@ -32419,11 +32356,11 @@ aaa
 aaa
 aaa
 aaa
-bVa
-bVa
-iCM
-bVa
-bVa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aac
@@ -32561,11 +32498,11 @@ aaa
 aaa
 aaa
 aaa
-bVa
-wxS
-hhq
 aaa
-bVa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aac
@@ -32703,11 +32640,11 @@ aaa
 aaa
 aaa
 aaa
-bVa
-dnQ
-fUy
 aaa
-bVa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aac
@@ -32845,11 +32782,11 @@ aaa
 aaa
 aaa
 aaa
-bVa
 aaa
-vXL
-mWo
-bVa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -32987,11 +32924,11 @@ aaa
 aaa
 aaa
 aaa
-bVa
-bVa
-bVa
-bVa
-bVa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/Tether/tether-05-station1.dmm
+++ b/_maps/map_files/Tether/tether-05-station1.dmm
@@ -670,6 +670,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "aby" = (
@@ -867,12 +870,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_smes)
 "abN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 5
 	},
@@ -887,6 +884,13 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "abO" = (
@@ -1126,22 +1130,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
-"acq" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
 "acr" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -1588,6 +1576,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "adr" = (
@@ -1641,6 +1630,16 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
@@ -1918,25 +1917,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/lounge/kitchen_freezer)
-"adU" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
 "adV" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
@@ -2352,10 +2332,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "aeE" = (
@@ -21140,6 +21117,9 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
+"bVa" = (
+/turf/simulated/wall,
+/area/space)
 "bVu" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -21150,10 +21130,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_entry)
 "bWH" = (
-/obj/structure/bookcase,
-/obj/item/book/manual/command_guide,
-/obj/item/book/manual/standard_operating_procedure,
-/obj/item/book/manual/security_space_law,
+/obj/structure/bookcase/legal/sop,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "bXl" = (
@@ -21660,6 +21637,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_prep)
+"dnQ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/space)
 "dom" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -21967,6 +21950,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_prep)
+"fUy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/space)
 "fVe" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -22066,6 +22058,28 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/station/explorer_medical)
+"hhq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/space)
+"hjG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
 "hjP" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -22084,6 +22098,11 @@
 /obj/item/book/manual/standard_operating_procedure,
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_prep)
+"hnv" = (
+/obj/machinery/disposal/deliveryChute,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
 "hpl" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -22219,6 +22238,22 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
+"iCM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_atmos{
+	name = "Department Mail Room";
+	req_access = list(24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/space)
 "iEx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -22232,6 +22267,22 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
+"iGc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Department Mail Room";
+	req_access = list(11)
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
 "iNQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -22311,6 +22362,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_prep)
+"jlM" = (
+/obj/structure/table/standard,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
 "jnc" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -22562,6 +22622,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/station/explorer_medical)
+"kVC" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
 "kXm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/firealarm{
@@ -22970,6 +23034,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_prep)
+"mWo" = (
+/obj/structure/table/standard,
+/obj/item/hand_labeler,
+/turf/simulated/floor/tiled/dark,
+/area/space)
 "mYr" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor,
@@ -23119,6 +23188,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_entry)
+"nUp" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1;
+	pixel_x = 4
+	},
+/obj/structure/table/standard,
+/obj/item/hand_labeler,
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
 "nUx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -23411,6 +23489,25 @@
 	},
 /turf/simulated/floor,
 /area/construction/observation)
+"poH" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen/red{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/pen/blue{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
 "prz" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -23946,6 +24043,18 @@
 "syg" = (
 /turf/simulated/floor/tiled,
 /area/crew_quarters/lounge)
+"szy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
 "sNj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24532,6 +24641,15 @@
 /obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
+"vXL" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/space)
 "wbr" = (
 /obj/machinery/camera/network/northern_star{
 	dir = 5
@@ -24616,6 +24734,9 @@
 	},
 /turf/simulated/floor,
 /area/construction/observation)
+"wxS" = (
+/turf/simulated/floor/tiled/dark,
+/area/space)
 "wCH" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
@@ -32298,11 +32419,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bVa
+bVa
+iCM
+bVa
+bVa
 aaa
 aaa
 aac
@@ -32312,9 +32433,9 @@ acR
 adu
 abx
 abN
-acq
+aeV
 adq
-adU
+ajB
 aeD
 aeV
 afm
@@ -32440,18 +32561,18 @@ aaa
 aaa
 aaa
 aaa
+bVa
+wxS
+hhq
 aaa
-aaa
-aaa
-aaa
-aaa
+bVa
 aaa
 aaa
 aac
-aac
 acz
 acz
 acz
+iGc
 acz
 arM
 arM
@@ -32582,19 +32703,19 @@ aaa
 aaa
 aaa
 aaa
+bVa
+dnQ
+fUy
 aaa
-aaa
-aaa
-aaa
-aaa
+bVa
 aaa
 aaa
 aac
-aac
-aac
-aac
-aac
-aac
+acz
+jlM
+atW
+szy
+poH
 arM
 acx
 adt
@@ -32724,19 +32845,19 @@ aaa
 aaa
 aaa
 aaa
+bVa
+aaa
+vXL
+mWo
+bVa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aac
-aac
-aac
-aac
-aac
+acz
+hnv
+kVC
+hjG
+nUp
 arM
 acO
 adF
@@ -32866,11 +32987,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bVa
+bVa
+bVa
+bVa
+bVa
 aaa
 aaa
 aaa

--- a/_maps/map_files/Tether/tether-07-station3.dmm
+++ b/_maps/map_files/Tether/tether-07-station3.dmm
@@ -20723,13 +20723,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery/holosurgery)
-"Ig" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/suit_cycler/medical,
-/turf/simulated/floor/tiled/white,
-/area/space)
 "Ii" = (
 /obj/structure/table/standard,
 /obj/item/packageWrap,
@@ -27769,10 +27762,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock)
-"Ud" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/space)
 "Ue" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -28589,49 +28578,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
-"Wf" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/table/glass,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/button/remote{
-	id = "surgeryobs";
-	name = "Surgery Emergency Shutters";
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/machinery/button/windowtint{
-	dir = 4;
-	id = "surgeryobs";
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/machinery/light_switch{
-	name = "light switch ";
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/machinery/button/remote/airlock{
-	dir = 4;
-	id = "theaterdoorlock";
-	name = "Theater Door Locks";
-	pixel_x = -5;
-	pixel_y = -5;
-	specialfunctions = 4
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/item/paper{
-	info = "We misplaced the manual CMF sent with this new suite. Have them stand in the colored squares before you cycle? Reminder: Pin this to the board. -Sergio";
-	name = "note on process"
-	},
-/turf/simulated/floor/tiled/white,
-/area/space)
 "Wh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -28933,9 +28879,6 @@
 	name = "padded floor"
 	},
 /area/medical/psych_ward)
-"Xk" = (
-/turf/simulated/floor/tiled/white,
-/area/space)
 "Xl" = (
 /obj/machinery/door/airlock/glass_mining{
 	name = "Cargo Bay";
@@ -29360,24 +29303,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
-"YG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/white,
-/area/space)
 "YH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -29481,26 +29406,6 @@
 /obj/item/pen/crayon/red,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
-"YS" = (
-/obj/structure/closet/secure_closet{
-	icon_broken = "medicalbroken";
-	icon_closed = "medical";
-	icon_locked = "medical1";
-	icon_off = "medicaloff";
-	icon_opened = "medicalopen";
-	icon_state = "medical1";
-	name = "Surgical Pressure Gear"
-	},
-/obj/item/suit_cooling_unit,
-/obj/item/tank/oxygen,
-/obj/item/clothing/suit/space/void/medical/bio,
-/obj/item/clothing/head/helmet/space/void/medical/bio,
-/obj/machinery/alarm{
-	pixel_y = 22;
-	target_temperature = 277.15
-	},
-/turf/simulated/floor/tiled/white,
-/area/space)
 "YT" = (
 /obj/structure/bed/chair/comfy/brown,
 /turf/simulated/floor/carpet/blue,
@@ -40169,9 +40074,9 @@ aa
 aa
 aa
 aa
-YS
-Xk
-YG
+aa
+aa
+aa
 aa
 aa
 aa
@@ -40311,9 +40216,9 @@ aa
 aa
 aa
 aa
-Ig
-Ud
-Wf
+aa
+aa
+aa
 aa
 aa
 aa

--- a/_maps/map_files/Tether/tether-07-station3.dmm
+++ b/_maps/map_files/Tether/tether-07-station3.dmm
@@ -598,6 +598,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "aW" = (
@@ -1112,9 +1113,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/red/bordercorner,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
 "bR" = (
@@ -1247,6 +1251,7 @@
 	name = "Security EVA";
 	req_one_access = list(2,18)
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "cc" = (
@@ -4054,18 +4059,34 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "gW" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/security/eva)
@@ -4079,6 +4100,15 @@
 /obj/structure/table/reinforced,
 /obj/item/suit_cooling_unit,
 /obj/item/suit_cooling_unit,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "gY" = (
@@ -4600,6 +4630,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "hO" = (
@@ -5225,6 +5256,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
 "iG" = (
@@ -6373,10 +6405,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
 "kI" = (
-/obj/structure/bookcase,
-/obj/item/book/manual/security_space_law,
-/obj/item/book/manual/standard_operating_procedure,
-/obj/item/book/manual/command_guide,
+/obj/structure/bookcase/legal/combo,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
 "kJ" = (
@@ -7781,10 +7810,7 @@
 /turf/simulated/floor/wood,
 /area/security/breakroom)
 "ni" = (
-/obj/structure/bookcase,
-/obj/item/book/manual/security_space_law,
-/obj/item/book/manual/security_space_law,
-/obj/item/book/manual/standard_operating_procedure,
+/obj/structure/bookcase/legal/corpreg,
 /turf/simulated/floor/wood,
 /area/security/breakroom)
 "nj" = (
@@ -9839,9 +9865,7 @@
 /turf/simulated/floor/lino,
 /area/security/detectives_office)
 "qG" = (
-/obj/structure/bookcase,
-/obj/item/book/manual/security_space_law,
-/obj/item/book/manual/security_space_law,
+/obj/structure/bookcase/legal/combo,
 /turf/simulated/floor/lino,
 /area/security/detectives_office)
 "qH" = (
@@ -18557,40 +18581,15 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "Ec" = (
-/obj/structure/closet/secure_closet{
-	icon_broken = "medicalbroken";
-	icon_closed = "medical";
-	icon_locked = "medical1";
-	icon_off = "medicaloff";
-	icon_opened = "medicalopen";
-	icon_state = "medical1";
-	name = "Surgical Pressure Gear"
-	},
-/obj/item/suit_cooling_unit,
-/obj/item/tank/oxygen,
-/obj/item/clothing/suit/space/void/medical/bio,
-/obj/item/clothing/head/helmet/space/void/medical/bio,
-/obj/machinery/alarm{
-	pixel_y = 22;
-	target_temperature = 277.15
-	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/bed/psych,
+/turf/simulated/floor/carpet/blue,
 /area/medical/surgery)
 "Ed" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/suit_cycler/medical,
-/turf/simulated/floor/tiled/white,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet/blue,
 /area/medical/surgery)
 "Ef" = (
 /turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"Eg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/wall/r_wall,
 /area/medical/psych)
 "Eh" = (
 /obj/structure/table/woodentable,
@@ -18971,35 +18970,16 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "EX" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "surgeryobs";
-	name = "Holosuite Emergency Shutters";
-	opacity = 0
-	},
 /obj/machinery/door/airlock/medical{
-	name = "Holographic Surgery Control";
-	req_access = list(45)
+	id_tag = "mentaldoor";
+	name = "Mental Health";
+	req_access = list(64)
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "EY" = (
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/carpet/blue,
 /area/medical/surgery)
-"EZ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"Fa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/turf/simulated/wall/r_wall,
-/area/medical/psych)
 "Fb" = (
 /obj/structure/table/woodentable,
 /obj/item/folder/white,
@@ -19443,50 +19423,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"FO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/bed/chair/office/dark,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/white,
+/obj/structure/flora/pottedplant/fern,
+/turf/simulated/floor/carpet/blue,
 /area/medical/surgery)
 "FP" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/computer/HolodeckControl/holosurgery{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"FQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -19498,8 +19438,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/wall/r_wall,
-/area/medical/psych)
+/turf/simulated/floor/carpet/blue,
+/area/medical/surgery)
 "FR" = (
 /obj/structure/table/woodentable,
 /obj/structure/sign/poster{
@@ -20281,26 +20221,33 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "Hk" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "surgeryobs";
-	name = "Holosuite Emergency Shutters";
-	opacity = 0
-	},
 /obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
 /obj/structure/window/reinforced/polarized{
-	dir = 8;
+	dir = 10;
+	icon_state = "fwindow";
 	id = "surgeryobs"
 	},
-/obj/structure/window/phoronreinforced/full,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/plating,
 /area/medical/surgery)
 "Hl" = (
-/turf/simulated/floor/holofloor/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
 /area/medical/surgery/holosurgery)
+"Hn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
 "Hr" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
@@ -20768,9 +20715,27 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "If" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/holofloor/reinforced,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
 /area/medical/surgery/holosurgery)
+"Ig" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/suit_cycler/medical,
+/turf/simulated/floor/tiled/white,
+/area/space)
+"Ii" = (
+/obj/structure/table/standard,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/turf/simulated/floor/tiled/dark,
+/area/security/eva)
 "Ij" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -21084,6 +21049,17 @@
 	id_tag = "theaterdoorlock";
 	name = "Holographic Surgery Suite";
 	req_access = list(45)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
@@ -21617,6 +21593,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
+"JB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/security/eva)
+"JC" = (
+/obj/machinery/oxygen_pump/anesthetic,
+/turf/simulated/wall,
+/area/medical/surgery/holosurgery)
 "JF" = (
 /turf/simulated/wall,
 /area/maintenance/station/medbay)
@@ -21970,6 +21960,36 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
+"Kp" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/white/bordercorner2{
+	dir = 8
+	},
+/obj/machinery/iv_drip,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
+"Kq" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "Kt" = (
 /obj/structure/lattice,
 /obj/structure/cable/green{
@@ -24971,7 +24991,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/junction{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -25346,11 +25366,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_c)
 "Pm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Department Mail Room"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "Pn" = (
 /obj/machinery/alarm{
@@ -25933,8 +25953,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_c)
 "Qb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_c)
 "Qc" = (
@@ -25950,6 +25974,12 @@
 	pixel_x = 25
 	},
 /obj/structure/bed/padded,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_c)
 "Qd" = (
@@ -26916,6 +26946,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock)
+"RF" = (
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/surgery,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/white/border,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "RG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -27011,26 +27048,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
+"RT" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
 "RU" = (
 /obj/machinery/suit_cycler/headofsecurity,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
-"RV" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "surgeryobs";
-	name = "Holosuite Emergency Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/glass_medical{
-	id_tag = "theaterdoorlock";
-	name = "Holographic Surgery Control"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "RW" = (
 /obj/machinery/door/airlock/voidcraft{
 	frequency = 2020;
@@ -27042,6 +27069,14 @@
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/shuttle/floor/airless,
 /area/shuttle/belter/station)
+"RZ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1;
+	pixel_x = 4
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
 "Sa" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -27049,6 +27084,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/eva)
+"Sb" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "Sc" = (
 /obj/machinery/light{
 	dir = 1
@@ -27056,10 +27103,43 @@
 /obj/machinery/recharge_station,
 /turf/simulated/shuttle/floor/airless,
 /area/shuttle/belter/station)
+"Sd" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/white/border,
+/obj/item/stack/nanopaste,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/button/windowtint{
+	id = "surgeryobs";
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "Se" = (
 /obj/structure/sign/warning/nosmoking_1,
 /turf/simulated/wall/r_wall,
 /area/medical/psych_ward)
+"Sf" = (
+/obj/structure/table/standard,
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "Sg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
@@ -27100,6 +27180,26 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/psych)
+"Sl" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "Sn" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -27134,10 +27234,25 @@
 /obj/effect/rune,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
-"Ss" = (
-/obj/structure/closet/secure_closet/psych,
-/turf/simulated/floor/wood,
-/area/medical/psych)
+"St" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen/red{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/pen/blue{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
 "Su" = (
 /obj/structure/table/woodentable,
 /obj/item/book/manual/standard_operating_procedure,
@@ -27165,12 +27280,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "Sy" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/carpet/blue,
 /area/medical/surgery)
 "SB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -27220,6 +27334,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
+"SF" = (
+/obj/structure/table/standard,
+/obj/item/hand_labeler,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8;
+	pixel_y = -4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/eva)
 "SH" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/regular{
@@ -27302,9 +27425,6 @@
 	},
 /turf/simulated/shuttle/floor/airless,
 /area/shuttle/belter/station)
-"SW" = (
-/turf/simulated/mineral/vacuum,
-/area/space)
 "SZ" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -27433,6 +27553,11 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
+"Tv" = (
+/obj/machinery/optable,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "Tw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -27543,6 +27668,14 @@
 	},
 /turf/simulated/shuttle/floor/airless,
 /area/shuttle/belter/station)
+"TN" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/psych)
 "TO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27559,6 +27692,24 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai/foyer)
+"TQ" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/obj/item/reagent_containers/blood/OMinus,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	name = "light switch ";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "TS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -27576,6 +27727,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
+"TT" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
+"TU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/security/eva)
 "TX" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/shuttle/floor/airless,
@@ -27587,12 +27753,35 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock)
+"Ua" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass_security{
+	name = "Department Mail Room";
+	req_one_access = list(2,18)
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/security/eva)
 "Ub" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock)
+"Ud" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/space)
+"Ue" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/security/hallwayaux)
 "Uf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -27793,6 +27982,15 @@
 	name = "padded floor"
 	},
 /area/medical/psych_ward)
+"UB" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
 "UE" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 10
@@ -27931,6 +28129,26 @@
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
+"UZ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/white/bordercorner2{
+	dir = 10
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "Va" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 1
@@ -27948,6 +28166,12 @@
 /obj/item/tank/jetpack/void,
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock)
+"Vc" = (
+/obj/effect/floor_decal/industrial/loading{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "Ve" = (
 /obj/machinery/light{
 	dir = 1
@@ -28028,6 +28252,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
+"Vq" = (
+/obj/effect/floor_decal/industrial/loading,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "Vr" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -28127,6 +28355,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
+"VF" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/white/border,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "VG" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -28341,75 +28574,22 @@
 	name = "padded floor"
 	},
 /area/medical/psych_ward)
+"Wb" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/eva)
 "Wd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
-"Wh" = (
-/obj/structure/noticeboard,
-/turf/simulated/wall/r_wall,
-/area/medical/psych)
-"Wk" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_external{
-	frequency = 2020;
-	icon_state = "door_locked";
-	id_tag = "belt_dock_exterior";
-	locked = 1;
-	name = "Docking Port Airlock";
-	req_one_access = list(48)
-	},
-/turf/simulated/floor,
-/area/quartermaster/belterdock)
-"Wp" = (
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
-"Wq" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 5
-	},
-/obj/structure/table/standard,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
-"Ws" = (
-/obj/machinery/computer/shuttle_control/belter{
-	dir = 4
-	},
-/turf/simulated/shuttle/floor/airless,
-/area/shuttle/belter/station)
-"Wv" = (
-/obj/structure/window/reinforced/full,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/shuttle/floor/airless,
-/area/shuttle/belter/station)
-"Wx" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 4
-	},
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/belter/station)
-"WA" = (
+"Wf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -28451,6 +28631,104 @@
 	name = "note on process"
 	},
 /turf/simulated/floor/tiled/white,
+/area/space)
+"Wh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/psych)
+"Wk" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_external{
+	frequency = 2020;
+	icon_state = "door_locked";
+	id_tag = "belt_dock_exterior";
+	locked = 1;
+	name = "Docking Port Airlock";
+	req_one_access = list(48)
+	},
+/turf/simulated/floor,
+/area/quartermaster/belterdock)
+"Wp" = (
+/obj/effect/floor_decal/borderfloorwhite/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/psych_ward)
+"Wq" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 5
+	},
+/obj/structure/table/standard,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/psych_ward)
+"Wr" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 10
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/medical2,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
+"Ws" = (
+/obj/machinery/computer/shuttle_control/belter{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/airless,
+/area/shuttle/belter/station)
+"Wv" = (
+/obj/structure/window/reinforced/full,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/airless,
+/area/shuttle/belter/station)
+"Ww" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/eva)
+"Wx" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/belter/station)
+"WA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/blue,
 /area/medical/surgery)
 "WB" = (
 /obj/effect/floor_decal/borderfloorwhite,
@@ -28481,6 +28759,11 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/cargo)
+"WG" = (
+/obj/structure/table/standard,
+/obj/item/hand_labeler,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
 "WH" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -28545,6 +28828,10 @@
 /obj/structure/sign/nosmoking_1,
 /turf/simulated/wall/r_wall,
 /area/medical/psych_ward)
+"WU" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
 "WW" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -28646,6 +28933,9 @@
 	name = "padded floor"
 	},
 /area/medical/psych_ward)
+"Xk" = (
+/turf/simulated/floor/tiled/white,
+/area/space)
 "Xl" = (
 /obj/machinery/door/airlock/glass_mining{
 	name = "Cargo Bay";
@@ -28678,6 +28968,15 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/sec_upper)
+"Xx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/medical/patient_c)
 "Xy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28713,6 +29012,10 @@
 /area/medical/psych)
 "XG" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "XI" = (
@@ -28803,24 +29106,6 @@
 /obj/structure/sign/nosmoking_1,
 /turf/simulated/wall,
 /area/medical/patient_b)
-"XX" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "surgeryobs";
-	name = "Holosuite Emergency Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 6;
-	id = "surgeryobs"
-	},
-/obj/structure/window/phoronreinforced/full,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "XZ" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/brown/border,
@@ -28942,6 +29227,17 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 10
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "Yr" = (
@@ -28962,6 +29258,10 @@
 /obj/effect/floor_decal/corner/brown/bordercorner2,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
+"Ys" = (
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet/blue,
+/area/medical/psych)
 "Yt" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -28972,6 +29272,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
+"Yu" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/eva)
 "Yv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28997,6 +29306,23 @@
 /obj/structure/plushie/beepsky,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
+"Yy" = (
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/computer/operating,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "YA" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -29021,6 +29347,46 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock)
+"YF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
+"YG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/white,
+/area/space)
+"YH" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
 "YI" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/tiled,
@@ -29115,6 +29481,30 @@
 /obj/item/pen/crayon/red,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
+"YS" = (
+/obj/structure/closet/secure_closet{
+	icon_broken = "medicalbroken";
+	icon_closed = "medical";
+	icon_locked = "medical1";
+	icon_off = "medicaloff";
+	icon_opened = "medicalopen";
+	icon_state = "medical1";
+	name = "Surgical Pressure Gear"
+	},
+/obj/item/suit_cooling_unit,
+/obj/item/tank/oxygen,
+/obj/item/clothing/suit/space/void/medical/bio,
+/obj/item/clothing/head/helmet/space/void/medical/bio,
+/obj/machinery/alarm{
+	pixel_y = 22;
+	target_temperature = 277.15
+	},
+/turf/simulated/floor/tiled/white,
+/area/space)
+"YT" = (
+/obj/structure/bed/chair/comfy/brown,
+/turf/simulated/floor/carpet/blue,
+/area/medical/psych)
 "YW" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -29142,6 +29532,19 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
+"YY" = (
+/obj/structure/table/standard,
+/obj/item/healthanalyzer,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/white/bordercorner2,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "Za" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -29159,18 +29562,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Ze" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "Zf" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -29220,6 +29611,25 @@
 	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
+"Zi" = (
+/obj/structure/table/standard,
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "Zk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29240,6 +29650,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
+"Zl" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/hallwayaux)
+"Zn" = (
+/obj/structure/table/standard,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
 "Zp" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -29258,6 +29682,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock)
+"Zs" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/security/eva)
 "Zw" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/kafel_full{
@@ -29356,10 +29785,50 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock)
+"ZG" = (
+/obj/structure/table/standard,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen/red{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/pen/blue{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/eva)
+"ZH" = (
+/obj/structure/closet/secure_closet/psych,
+/turf/simulated/floor/carpet/blue,
+/area/medical/psych)
 "ZI" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock)
+"ZJ" = (
+/obj/structure/table/standard,
+/obj/item/healthanalyzer,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "ZK" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -29382,6 +29851,22 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/psych)
+"ZM" = (
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/surgery,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "ZO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
@@ -29403,6 +29888,39 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
+"ZS" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
+"ZT" = (
+/turf/simulated/floor/tiled/dark,
+/area/security/eva)
+"ZW" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery/holosurgery)
 "ZX" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
@@ -37574,7 +38092,7 @@ Rg
 Rg
 Rg
 gg
-SW
+ab
 ab
 ab
 aU
@@ -37716,7 +38234,7 @@ Rh
 Ri
 Rj
 gg
-SW
+ab
 ab
 ab
 aU
@@ -37726,7 +38244,7 @@ hL
 aT
 in
 bt
-iR
+Zl
 je
 cq
 dq
@@ -37858,9 +38376,9 @@ ae
 aa
 ed
 gg
-SW
-ab
-ab
+aU
+aU
+aU
 aU
 gU
 hr
@@ -37868,7 +38386,7 @@ hM
 hr
 io
 iE
-iR
+Zl
 cq
 jm
 dr
@@ -38000,17 +38518,17 @@ aO
 aa
 ed
 gg
-ab
-ab
-ab
 aU
+Ii
+ZG
+bc
 bj
 XG
 hN
 aV
 cb
 iF
-iR
+Ue
 cs
 jn
 ds
@@ -38142,13 +38660,13 @@ aa
 aa
 aa
 gg
-ab
-ab
-ab
 aU
+ZT
+Ww
+bc
 gV
-hr
-hM
+TU
+Zs
 aW
 aU
 iG
@@ -38284,10 +38802,10 @@ aa
 aa
 aa
 gg
-ab
-ab
-ab
 aU
+Wb
+JB
+Ua
 gW
 ZO
 Sa
@@ -38426,10 +38944,10 @@ aa
 aa
 aa
 gg
-ab
-ab
-ab
 aU
+Yu
+SF
+bc
 gX
 hr
 hM
@@ -38568,10 +39086,10 @@ aa
 aa
 aa
 gg
-ab
-ab
-ab
 aU
+aU
+bc
+bc
 bk
 hr
 hP
@@ -39047,7 +39565,7 @@ FL
 GA
 Hi
 Ic
-Wd
+YH
 Jy
 Km
 KS
@@ -39466,16 +39984,16 @@ zB
 Ay
 xX
 Ck
-TJ
+AA
 Ec
 EY
 FN
-RV
+RL
 Hl
-Hl
-Hl
-Hl
-Hl
+UZ
+Sl
+Kp
+Wr
 RN
 Lx
 LY
@@ -39608,16 +40126,16 @@ zC
 Az
 BD
 Cv
-TJ
+AA
 Ed
-EZ
+EY
 WA
-XX
-Hl
+RL
+ZW
 If
-If
-If
-Hl
+Kq
+TT
+VF
 RN
 Ly
 LZ
@@ -39651,9 +40169,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+YS
+Xk
+YG
 aa
 aa
 aa
@@ -39751,15 +40269,15 @@ AA
 BE
 AA
 zD
-TJ
-Ze
-FO
-XX
-Hl
-Hl
-Hl
-Hl
-Hl
+YT
+EY
+WA
+RL
+TQ
+ZS
+Yy
+Sb
+Sd
 RN
 Lz
 Ma
@@ -39793,9 +40311,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+Ig
+Ud
+Wf
 aa
 aa
 aa
@@ -39896,12 +40414,12 @@ BF
 Wh
 Sy
 FP
-XX
-Hl
-Hl
-Hl
-Hl
-Hl
+RL
+ZM
+Vq
+Tv
+Vc
+RF
 RN
 LA
 Ma
@@ -40034,16 +40552,16 @@ zD
 AC
 BF
 BF
-Ss
-Eg
-Fa
-FQ
+BF
+Eh
+Fb
+FR
 TJ
-Hl
-Hl
-Hl
-Hl
-Hl
+Zi
+YY
+JC
+ZJ
+Sf
 RN
 LB
 Mb
@@ -40177,9 +40695,9 @@ AD
 BF
 Cw
 BF
-Eh
-Fb
-FR
+Ei
+Fc
+FS
 TJ
 RL
 RL
@@ -40319,9 +40837,9 @@ AE
 BF
 BF
 WP
-Ei
-Fc
-FS
+Ys
+TN
+FT
 zD
 ab
 ab
@@ -40463,7 +40981,7 @@ Cx
 Du
 Ej
 Xh
-FT
+ZH
 zD
 ab
 ab
@@ -40481,7 +40999,7 @@ Ot
 OK
 SK
 Pj
-Pj
+Xx
 Pj
 Pj
 vt
@@ -40622,10 +41140,10 @@ NM
 Ou
 OL
 Pm
-vt
-vt
-vt
-vt
+WU
+YF
+St
+Dt
 vt
 vt
 vt
@@ -40763,11 +41281,11 @@ Dt
 Dt
 Dt
 OM
-JF
-ab
-ab
-ab
-vt
+Dt
+RT
+Hn
+RZ
+Dt
 vt
 vt
 vt
@@ -40906,10 +41424,10 @@ Nu
 Nu
 ON
 JF
-ab
-ab
-ab
-ab
+Zn
+UB
+WG
+Dt
 ab
 ab
 vt
@@ -41048,10 +41566,10 @@ NN
 Md
 Md
 JF
-ab
-ab
-ab
-ab
+Dt
+Dt
+Dt
+Dt
 ab
 ab
 ab

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -551,6 +551,14 @@
 	cell.use(cost*10)
 	return 1
 
+// this function displays the current cell charge in the stat panel
+/obj/item/rig/proc/show_cell_power()
+	if(cell)
+		stat(null, text("Charge Left: [round(cell.percent())]%"))
+		stat(null, text("Cell Rating: [round(cell.maxcharge)]")) // Round just in case we somehow get crazy values
+	else
+		stat(null, text("No Cell Inserted!"))
+
 /obj/item/rig/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/nano_state = inventory_state)
 	if(!user)
 		return
@@ -1078,6 +1086,17 @@
 	plane = PLANE_FULLSCREEN
 	mouse_opacity = 0
 	alpha = 20 //Animated up when loading
+
+//Shows cell charge on screen, ideally.
+
+var/obj/screen/cells = null
+
+// update the status screen display
+/obj/item/rig/Stat()
+	..()
+	if (statpanel("Status"))
+		show_cell_power()
+
 
 #undef ONLY_DEPLOY
 #undef ONLY_RETRACT

--- a/maps/tether/submaps/tether_misc.dmm
+++ b/maps/tether/submaps/tether_misc.dmm
@@ -9679,17 +9679,6 @@
 	icon_state = "floor_red"
 	},
 /area/syndicate_station/start)
-"vi" = (
-/obj/structure/table/standard,
-/obj/item/storage/firstaid/surgery,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
 "we" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/purple/border,
@@ -9701,43 +9690,12 @@
 	initial_gas_mix = "phoron=101;TEMP=293.15"
 	},
 /area/holodeck/holodorm/source_phoron)
-"wg" = (
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
 "wk" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/white{
 	initial_gas_mix = "phoron=101;TEMP=293.15"
 	},
 /area/holodeck/holodorm/source_phoron)
-"wr" = (
-/obj/structure/table/standard,
-/obj/item/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
 "wY" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -9848,23 +9806,6 @@
 	initial_gas_mix = "phoron=101;TEMP=293.15"
 	},
 /area/holodeck/holodorm/source_phoron)
-"Aa" = (
-/obj/structure/table/standard,
-/obj/item/healthanalyzer,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
 "Am" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/holofloor/reinforced,
@@ -9900,19 +9841,6 @@
 	initial_gas_mix = "phoron=101;TEMP=293.15"
 	},
 /area/holodeck/holodorm/source_phoron)
-"AP" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
-"AZ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
 "Bt" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
@@ -9969,10 +9897,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 4
 	},
-/obj/machinery/computer/operating{
-	dir = 8;
-	use_power = 0
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
@@ -9980,38 +9904,6 @@
 	initial_gas_mix = "phoron=101;TEMP=293.15"
 	},
 /area/holodeck/holodorm/source_phoron)
-"Dj" = (
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
-"Ey" = (
-/obj/machinery/computer/operating{
-	dir = 8;
-	use_power = 0
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
 "EX" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -10041,54 +9933,6 @@
 	initial_gas_mix = "phoron=101;TEMP=293.15"
 	},
 /area/holodeck/holodorm/source_phoron)
-"Fo" = (
-/obj/machinery/oxygen_pump/anesthetic,
-/turf/simulated/wall,
-/area/holodeck/holodorm/source_standard)
-"FM" = (
-/obj/structure/table/standard,
-/obj/item/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 5
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 21
-	},
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
-"FO" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 10
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
 "Ia" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -10149,11 +9993,6 @@
 	initial_gas_mix = "phoron=101;TEMP=293.15"
 	},
 /area/holodeck/holodorm/source_phoron)
-"JI" = (
-/obj/machinery/optable,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
 "JJ" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -10196,19 +10035,6 @@
 	initial_gas_mix = "phoron=101;TEMP=293.15"
 	},
 /area/holodeck/holodorm/source_phoron)
-"LD" = (
-/obj/structure/table/standard,
-/obj/item/healthanalyzer,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/corner/white/bordercorner2,
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
 "Mq" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -10225,10 +10051,6 @@
 	initial_gas_mix = "o2=410;TEMP=293.15"
 	},
 /area/holodeck/holodorm/source_zaddat)
-"MA" = (
-/obj/effect/floor_decal/industrial/loading,
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
 "NO" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -10245,22 +10067,6 @@
 	initial_gas_mix = "phoron=101;TEMP=293.15"
 	},
 /area/holodeck/holodorm/source_phoron)
-"NP" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 8
-	},
-/obj/machinery/iv_drip,
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
 "NU" = (
 /obj/structure/table/steel,
 /obj/item/healthanalyzer,
@@ -10275,36 +10081,6 @@
 	initial_gas_mix = "o2=410;TEMP=293.15"
 	},
 /area/holodeck/holodorm/source_zaddat)
-"Oa" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 1
-	},
-/obj/item/reagent_containers/blood/OMinus,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
-"OJ" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
-"OO" = (
-/obj/structure/table/standard,
-/obj/item/storage/firstaid/surgery,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/white/border,
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
 "QH" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/optable,
@@ -10423,48 +10199,8 @@
 	initial_gas_mix = "o2=410;TEMP=293.15"
 	},
 /area/holodeck/holodorm/source_zaddat)
-"Vy" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/white/border,
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
-"Wt" = (
-/obj/effect/floor_decal/industrial/loading{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
-"XA" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 10
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/medical2,
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
-"Yf" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/white/border,
-/obj/item/stack/nanopaste,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/holodeck/holodorm/source_standard)
 "Yr" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
+/turf/space,
 /area/holodeck/holodorm/source_standard)
 "ZY" = (
 /obj/structure/table/borosilicate,
@@ -23009,10 +22745,10 @@ fP
 eK
 dB
 Yr
-FO
-AZ
-NP
-XA
+Yr
+Yr
+Yr
+Yr
 dA
 xe
 xe
@@ -23150,11 +22886,11 @@ fo
 fP
 eK
 dB
-OJ
-AP
-AP
-AP
-Vy
+Yr
+Yr
+Yr
+Yr
+Yr
 dA
 xe
 Am
@@ -23292,11 +23028,11 @@ fo
 fP
 eK
 dB
-Oa
-wg
-Ey
-Dj
-Yf
+Yr
+Yr
+Yr
+Yr
+Yr
 dA
 xe
 xe
@@ -23434,11 +23170,11 @@ fo
 fP
 eK
 dB
-vi
-MA
-JI
-Wt
-OO
+Yr
+Yr
+Yr
+Yr
+Yr
 dA
 xe
 xe
@@ -23576,11 +23312,11 @@ fH
 fQ
 eK
 dB
-FM
-LD
-Fo
-Aa
-wr
+Yr
+Yr
+Yr
+Yr
+Yr
 dA
 xe
 xe


### PR DESCRIPTION
1. _Removes Paramedic machetes._
**Why:** Initially, Paramedics were granted machetes in the interests of mitigating risk during hazardous retrieval operations. Extended study has implied that more often than not, these machetes are not needed. Paramedics will retain their survival knives, but barring major incident, will not be granted machetes on the Tether.
2. _Adds Department Mail rooms to: Paramedic Bay, Atmospherics, Mining, Science, Engineering, Security, and Medbay._
**Why:** Attempted to mail crates back to Cargo earlier and was unable. Discovered the mail system on the Tether has been severely handicapped, either unintentionally or for some arcane reason. This adds a mail room to each major department.
3. _Adds fancy SOP and CorpReg bookcases to relevant areas (IA, Sec break room, HOS Office, Cap's Office)_
**Why:** I made them. Only fitting to add them.
4. _Adds RIG charge alert HUD._
**Why:** In memoriam. Dedicated Energy Alert Network implemented.
5. _Partially reverts Holosurgery, pending a more effective system._
**Why:** Turns out this doesn't actually work the way it's meant to. So I'm taking it out with plans to add in something fancy, like a teleport system or something. We'll see. I'm leaving the code and zones in, just in case I find another way to make it work, but for now, no more holosurgery.