### PR TITLE
Takes the Really Big Eraser for Really Big Mistakes to Deathclaw Mobvore

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/deathclaw.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/deathclaw.dm
@@ -39,15 +39,6 @@
 
 	ai_holder_type = /datum/ai_holder/simple_mob/melee/deathclaw
 
-// Activate Noms!
-/mob/living/simple_mob/vore/aggressive/deathclaw
-	vore_active = 1
-	vore_capacity = 2
-	vore_max_size = RESIZE_HUGE
-	vore_min_size = RESIZE_SMALL
-	vore_pounce_chance = 0 // Beat them into crit before eating.
-	vore_icons = SA_ICON_LIVING
-
 /* //VOREStation AI Temporary Removal
 /mob/living/simple_animal/hostile/deathclaw/Login()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Fixes an issue related to a lack of new deathclaw voresprites by removing simplemob mobvore from deathclaw simplemobs.

## Why It's Good For The Game

Look I get vore - alright that's a lie, but I can at least respect that you want to have mechanics for your fetish. Despite the snowflake nature of that - and yes, it is snowflake - I'm not proposing a full-on removal of vore (at least not with this PR). But really, an NPC swallowing you whole? With no RP involved? Honestly, mobvore as a whole deserves axing. It causes far more headaches than is worth it in my opinion.

## Changelog
:cl:
del: Fixes a REALLY big mistake with deathclaws and simplemobvore.
/:cl: