### PR TITLE
General Tweaks: Recoil Edition

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/mouse_army.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/mouse_army.dm
@@ -164,6 +164,7 @@
 
 	ai_holder_type = /datum/ai_holder/simple_mob/ranged
 
+	var/datum/effect_system/spark_spread/spark_system
 	var/ruptured = FALSE
 
 /mob/living/simple_mob/animal/space/mouse_army/pyro/death()
@@ -177,14 +178,28 @@
 			else
 				color = "#FF0000"
 			sleep(1)
+	..()
 
-	spawn(rand (1,5))
+	var/turf/simulated/T = get_turf(src)
+	if(!T)
+		return
+	var/datum/gas_mixture/GM = new
+	if(prob(10))
+		T.assume_gas(/datum/gas/phoron, 100, 1500+T0C)
+		T.visible_message("<span class='critical'>\The [src]'s tank vents a cloud of heated gas!</span>")
+	else
+		T.assume_gas(/datum/gas/phoron, 5, istype(T) ? T.air.temperature : T20C)
+		visible_message("<span class='critical'>\The [src]'s tank ruptures!</span>")
+	T.assume_air(GM)
+	return
+
+	spawn(rand(1,5))
 		if(src && !ruptured)
-			visible_message("<span class='critical'>\The [src]'s tank ruptures!</span>")
+			visible_message("<span class='critical'>\The [src]'s suit sparks!</span>")
+			spark_system.set_up(5, 0, src)
+			spark_system.attach(src)
+			spark_system.start()
 			ruptured = 1
-			qdel(src)
-			adjust_fire_stacks(2)
-			IgniteMob()
 	return ..()
 
 //Ammo Mouse

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -9,7 +9,7 @@
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	w_class = ITEMSIZE_NORMAL
 	matter = list(DEFAULT_WALL_MATERIAL = 1000)
-	recoil = 1
+	recoil = 0
 	projectile_type = /obj/item/projectile/bullet/pistol/strong	//Only used for chameleon guns
 
 	var/caliber = ".357"		//determines which casings will fit

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -241,6 +241,7 @@
 	desc = "Little more than a barrel, handle, and firing mechanism, cheap makeshift firearms like this one are not uncommon in frontier systems."
 	icon_state = "sawnshotgun"
 	item_state = "sawnshotgun"
+	recoil = 3 //Improvised weapons = poor ergonomics
 	handle_casings = CYCLE_CASINGS //player has to take the old casing out manually before reloading
 	load_method = SINGLE_CASING
 	max_shells = 1 //literally just a barrel

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -130,6 +130,7 @@
 	desc = "Omar's coming!" // I'm not gonna add "Uses 12g rounds." to this one. I'll just let this reference go undisturbed.
 	icon_state = "sawnshotgun"
 	item_state = "sawnshotgun"
+	recoil = 3
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	ammo_type = /obj/item/ammo_casing/a12g/pellet
 	w_class = ITEMSIZE_NORMAL
@@ -140,6 +141,7 @@ obj/item/gun/projectile/shotgun/doublebarrel/quad
 	desc = "A shotgun pattern designed to make the most out of the limited machining capability of the frontier. 4 Whole barrels of death, loads using 12 gauge rounds."
 	icon_state = "qshotgun"
 	item_state = "qshotgun"
+	recoil = 2
 	load_method = SINGLE_CASING|SPEEDLOADER
 	handle_casings = CYCLE_CASINGS
 	max_shells = 4

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2632,7 +2632,7 @@
 	name = "The Outlaw"
 	id = "theoutlaw"
 	result = "theoutlaw"
-	required_reagents = list("tequila" = 3, "gold" = 1, "bitters" = 1)
+	required_reagents = list("vodka" = 3, "gold" = 1, "bitters" = 1)
 	result_amount = 5
 
 /datum/chemical_reaction/drinks/thelawman


### PR DESCRIPTION
1. _Removes Recoil from Ballistics. (Boy, these **shake** weapons sure aren't **shudder** viable for some reason **spin**.)_
**Why:** Making an entire class of weapons irredeemably terrible for some reason is simply not fun. Now recoil exists as a variable the way it should: Sawn off shotguns, zip guns, and heavy caliber weaponry have boosted recoil stats due to poor ergonomics.

2. _Fixes the Outlaw drink._
**Why:** Tequila isn't a recognized reagent. Replaces tequila with vodka.

3. _Hopefully fixes the Pyro Mouse death proc._
**Why:** The Pyro mouse is meant to vent plasma and sparks, like its fuel tank has ruptured. Hopefully this code will finally allow that to happen. I really hope it will. I love the Mouse Army, but boy do I want a break from this .dm already.