### PR TITLE
Adds "Sizeshift" trait for custom-species.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -180,12 +180,12 @@
 	desc = "You bleed 25% slower."
 	cost = 1
 	var_changes = list("bloodloss_rate" = 0.75)
-
+	
 /datum/trait/size_change
 	name = "Sizeshift"
 	desc = "Lets you shift sizes by yourself. Remember that abusing size mechanics is against the rules!"
 	cost = 4
-
+	
 /datum/trait/size_change/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
 	H.verbs |= /mob/living/proc/set_size

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -180,4 +180,12 @@
 	desc = "You bleed 25% slower."
 	cost = 1
 	var_changes = list("bloodloss_rate" = 0.75)
-	
+
+/datum/trait/size_change
+	name = "Sizeshift"
+	desc = "Lets you shift sizes by yourself. Remember that abusing size mechanics is against the rules!"
+	cost = 4
+
+/datum/trait/size_change/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/proc/set_size


### PR DESCRIPTION
## About The Pull Request

Adds a sizeshift trait that costs 4 points, but allows the player to shift between 25%/200% sizes at a whim. 

## Why It's Good For The Game

Not having to rely on NIFsofts/science/maint runs for sizeguns is nice. At a 4 point cost, this shouldn't fuck with balance.

## Changelog
:cl:
add: Added Sizeshift trait for custom species.
/:cl: