### PR TITLE
Fixes broken icon states for carp

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/carp.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/carp.dm
@@ -117,9 +117,9 @@
 	desc = "An obviously holographic, but still ferocious looking carp."
 	// Might be worth using a filter similar to AI holograms in the future.
 	icon = 'icons/mob/AI.dmi'
-	icon_state = "holo4"
-	icon_living = "holo4"
-	icon_dead = "holo4"
+	icon_state = "holo-carp"
+	icon_living = "holo-carp"
+	icon_dead = "holo-carp"
 	alpha = 127
 	icon_gib = null
 	meat_amount = 0

--- a/code/modules/mob/living/simple_mob/subtypes/vore/zz_vore_overrides.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/zz_vore_overrides.dm
@@ -109,6 +109,13 @@
 	vore_active = 1
 	vore_icons = SA_ICON_LIVING
 
+/mob/living/simple_mob/animal/space/carp/large
+	vore_icons = 0
+/mob/living/simple_mob/animal/space/carp/large/huge
+	vore_icons = 0
+/mob/living/simple_mob/animal/space/carp/holographic
+	vore_icons = 0
+
 /* //VOREStation AI Temporary removal
 /mob/living/simple_mob/hostile/creature/vore
 	vore_active = 1


### PR DESCRIPTION
This would fix the missing icon states for the holographic carp as per spawned by the holodeck as well as the large and huge carp from turning invisible once they eat some unfortunate victim as the vore64x64.dmi sprite set is no longer in use.