### PR TITLE
Undo's Polly and brings back the Soul of Poly

### DIFF
--- a/_maps/map_files/NSV_Triumph/triumph-01-deck1.dmm
+++ b/_maps/map_files/NSV_Triumph/triumph-01-deck1.dmm
@@ -5144,7 +5144,7 @@
 /area/engineering/atmos/backup)
 "yn" = (
 /obj/structure/table/reinforced,
-/mob/living/simple_mob/animal/passive/bird/parrot/polly/ultimate,
+/mob/living/simple_mob/animal/passive/bird/parrot/poly/ultimate,
 /obj/item/flashlight/lamp,
 /obj/item/radio/intercom{
 	dir = 1;

--- a/_maps/map_files/Tether/tether-05-station1.dmm
+++ b/_maps/map_files/Tether/tether-05-station1.dmm
@@ -24247,7 +24247,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/station/explorer_entry)
 "ufh" = (
-/mob/living/simple_mob/animal/passive/bird/parrot/polly{
+/mob/living/simple_mob/animal/passive/bird/parrot/poly{
 	desc = "The CE's tried and true beloved pet to everyone that doesn't wear a headset."
 	},
 /turf/simulated/floor/carpet/oracarpet,

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -290,7 +290,7 @@
 			if("crab")				M.change_mob_type( /mob/living/simple_mob/animal/passive/crab , null, null, delmob )
 			if("coffee")			M.change_mob_type( /mob/living/simple_mob/animal/passive/crab/Coffee , null, null, delmob )
 			if("parrot")			M.change_mob_type( /mob/living/simple_mob/animal/passive/bird/parrot , null, null, delmob )
-			if("pollyparrot")		M.change_mob_type( /mob/living/simple_mob/animal/passive/bird/parrot/polly , null, null, delmob )
+			if("polyparrot")		M.change_mob_type( /mob/living/simple_mob/animal/passive/bird/parrot/poly , null, null, delmob )
 			if("constructarmoured")	M.change_mob_type( /mob/living/simple_mob/construct/juggernaut , null, null, delmob )
 			if("constructbuilder")	M.change_mob_type( /mob/living/simple_mob/construct/artificer , null, null, delmob )
 			if("constructwraith")	M.change_mob_type( /mob/living/simple_mob/construct/wraith , null, null, delmob )

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -628,7 +628,7 @@ var/list/ai_verbs_default = list(
 				"bear",
 				"slime",
 				"runtime",
-				"polly",
+				"poly",
 				"gondola"
 
 			)
@@ -694,7 +694,7 @@ var/list/ai_verbs_default = list(
 						holo_icon = getHologramIcon(icon('icons/mob/slimes.dmi',"cerulean adult slime"))
 					if("runtime")
 						holo_icon = getHologramIcon(icon('icons/mob/animal.dmi',"cat"))
-					if("polly")
+					if("poly")
 						holo_icon = getHologramIcon(icon('icons/mob/animal.dmi',"parrot_fly"))
 					if("gondola")
 						holo_icon = getHologramIcon(icon('icons/mob/animal.dmi',"gondola"))

--- a/code/modules/mob/living/simple_animal/animals/parrot.dm
+++ b/code/modules/mob/living/simple_animal/animals/parrot.dm
@@ -72,7 +72,7 @@
 	var/list/speech_buffer = list()
 	var/list/available_channels = list()
 
-	//Headset for Polly to yell at engineers :)
+	//Headset for Poly to yell at engineers :)
 	var/obj/item/radio/headset/ears = null
 
 	//The thing the parrot is currently interested in. This gets used for items the parrot wants to pick up, mobs it wants to steal from,
@@ -687,12 +687,12 @@
 /*
  * Sub-types
  */
-/mob/living/simple_mob/parrot/Polly
-	name = "Polly"
-	desc = "Polly the Parrot. An expert on quantum cracker theory."
-	speak = list("Polly wanna cracker!", ":e Check the singlo, you chucklefucks!",":e Wire the solars, you lazy bums!",":e WHO TOOK THE DAMN HARDSUITS?",":e OH GOD ITS FREE CALL THE SHUTTLE")
+/mob/living/simple_mob/parrot/Poly
+	name = "Poly"
+	desc = "Poly the Parrot. An expert on quantum cracker theory."
+	speak = list("Poly wanna cracker!", ":e Check the singlo, you chucklefucks!",":e Wire the solars, you lazy bums!",":e WHO TOOK THE DAMN HARDSUITS?",":e OH GOD ITS FREE CALL THE SHUTTLE")
 
-/mob/living/simple_mob/parrot/Polly/New()
+/mob/living/simple_mob/parrot/Poly/New()
 	ears = new /obj/item/radio/headset/headset_eng(src)
 	available_channels = list(":e")
 	..()

--- a/code/modules/mob/living/simple_mob/subtypes/animal/pets/parrot.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/pets/parrot.dm
@@ -12,9 +12,9 @@
 	var/obj/item/radio/headset/my_headset = null
 
 // Say list
-/datum/say_list/bird/polly
+/datum/say_list/bird/poly
 	speak = list(
-		"Polly wanna cracker!",
+		"Poly wanna cracker!",
 		"Check the singulo, you chucklefucks!",
 		"Wire the solars, you lazy bums!",
 		"WHO TOOK THE DAMN HARDSUITS?",
@@ -102,18 +102,18 @@
 // Subtypes.
 
 // Best Bird
-/mob/living/simple_mob/animal/passive/bird/parrot/polly
-	name = "Polly"
+/mob/living/simple_mob/animal/passive/bird/parrot/poly
+	name = "Poly"
 	desc = "It's a parrot. An expert on quantum cracker theory."
-	icon_state = "polly"
-	icon_rest = "polly-held"
-	icon_dead = "polly-dead"
+	icon_state = "poly"
+	icon_rest = "poly-held"
+	icon_dead = "poly-dead"
 	tt_desc = "E Ara macao"
 	my_headset = /obj/item/radio/headset/headset_eng
-	say_list_type = /datum/say_list/bird/polly
+	say_list_type = /datum/say_list/bird/poly
 
 // Best Bird with best headset.
-/mob/living/simple_mob/animal/passive/bird/parrot/polly/ultimate
+/mob/living/simple_mob/animal/passive/bird/parrot/poly/ultimate
 	my_headset = /obj/item/radio/headset/omni
 
 /mob/living/simple_mob/animal/passive/bird/parrot/kea

--- a/maps/nsv_triumph/submaps/gateway/zoo.dmm
+++ b/maps/nsv_triumph/submaps/gateway/zoo.dmm
@@ -7158,7 +7158,7 @@
 /turf/simulated/floor/holofloor/desert,
 /area/awaymission/zoo)
 "sJ" = (
-/mob/living/simple_mob/animal/passive/bird/parrot/polly{
+/mob/living/simple_mob/animal/passive/bird/parrot/poly{
 	faction = "zoo"
 	},
 /turf/simulated/floor/holofloor/grass,

--- a/maps/tether/submaps/gateway/zoo.dmm
+++ b/maps/tether/submaps/gateway/zoo.dmm
@@ -7158,7 +7158,7 @@
 /turf/simulated/floor/holofloor/desert,
 /area/awaymission/zoo)
 "sJ" = (
-/mob/living/simple_mob/animal/passive/bird/parrot/polly{
+/mob/living/simple_mob/animal/passive/bird/parrot/poly{
 	faction = "zoo"
 	},
 /turf/simulated/floor/holofloor/grass,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Why It's Good For The Game
Polly may be grammatically correct, but Poly is a programming / math reference like most other pets, and so it should stay like that.
## Changelog
:cl:
spellcheck: Poly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
