### PR TITLE
Firearm Recoil (but funny)

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs.dm
@@ -146,7 +146,7 @@
 	projectiletype = /obj/item/projectile/bullet/pistol/medium
 //	casingtype = /obj/item/ammo_casing/spent	//Makes infinite stacks of bullets when put in PoIs.
 	projectilesound = 'sound/weapons/Gunshot_light.ogg'
-	loot_list = list(/obj/item/gun/projectile/colt = 100)
+	loot_list = list(/obj/item/gun/projectile/colt/rigged/chance = 100)
 
 	needs_reload = TRUE
 	reload_max = 7		// Not the best default, but it fits the pistol
@@ -157,7 +157,7 @@
 	icon_state = "syndicateranged_smg"
 	icon_living = "syndicateranged_smg"
 
-	loot_list = list(/obj/item/gun/projectile/automatic/c20r = 100)
+	loot_list = list(/obj/item/gun/projectile/automatic/c20r/rigged/chance = 100)
 
 	base_attack_cooldown = 5 // Two attacks a second or so.
 	reload_max = 20
@@ -167,7 +167,7 @@
 	icon_living = "blueforranged_smg"
 
 	corpse = /obj/effect/landmark/mobcorpse/solarpeacekeeper
-	loot_list = list(/obj/item/gun/projectile/automatic/c20r = 100)
+	loot_list = list(/obj/item/gun/projectile/automatic/c20r/rigged/chance = 100)
 
 	base_attack_cooldown = 5 // Two attacks a second or so.
 	reload_max = 20
@@ -179,7 +179,7 @@
 	projectiletype = /obj/item/projectile/beam/midlaser
 	projectilesound = 'sound/weapons/Laser.ogg'
 
-	loot_list = list(/obj/item/gun/energy/laser = 100)
+	loot_list = list(/obj/item/gun/energy/laser/rigged/chance = 100)
 
 	reload_max = 10
 
@@ -190,7 +190,7 @@
 	projectiletype = /obj/item/projectile/ion
 	projectilesound = 'sound/weapons/Laser.ogg'
 
-	loot_list = list(/obj/item/gun/energy/ionrifle = 100)
+	loot_list = list(/obj/item/gun/energy/ionrifle/rigged/chance = 100)
 
 	reload_max = 10
 
@@ -201,7 +201,7 @@
 	projectiletype = /obj/item/projectile/bullet/pellet/shotgun		// Buckshot
 	projectilesound = 'sound/weapons/Gunshot_shotgun.ogg'
 
-	loot_list = list(/obj/item/gun/projectile/shotgun/pump = 100)
+	loot_list = list(/obj/item/gun/projectile/shotgun/pump/rigged = 100)
 
 	reload_max = 4
 	reload_time = 1.5 SECONDS	// It's a shotgun, it takes a moment

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -106,6 +106,7 @@
 	var/obj/item/firing_pin/pin = /obj/item/firing_pin
 	var/no_pin_required = 0
 	var/shootback = FALSE
+	var/fix_attempts = 0
 
 /obj/item/gun/CtrlClick(mob/user)
 	if(can_flashlight && ishuman(user) && src.loc == usr && !user.incapacitated(INCAPACITATION_ALL))
@@ -297,6 +298,21 @@
 				verbs -= /obj/item/gun/verb/allow_dna
 		else
 			to_chat(user, "<span class='warning'>\The [src] is not accepting modifications at this time.</span>")
+	if(A.is_multitool() && src.shootback)
+		var/unrig_chance = 5 + (fix_attempts * 2.5)
+		to_chat(user, "<span class='notice'>You begin pulsing the trigger of \the [src] with [A].</span>")
+		playsound(src, A.usesound, 50, 1)
+		if(do_after(user, 25 * A.toolspeed))
+			fix_attempts++
+			if(prob(unrig_chance))
+				to_chat(user, "<span class='notice'>You unrig \the [src], making it safe to use.</span>")
+				shootback = FALSE
+			else
+				to_chat(user, "<span class='warning'>Uh oh.</span>")
+				special_check(user)
+		else
+			to_chat(user, "<span class='warning'>Uh oh.</span>")
+			special_check(user)
 	..()
 
 /obj/item/gun/emag_act(var/remaining_charges, var/mob/user)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -206,18 +206,22 @@
 		to_chat(M, "<span class='danger'>Your fingers are much too large for the trigger guard!</span>")
 		return 0
 	if(shootback)
-		var/obj/P = consume_next_projectile()
-		var/targetedlimb = pick(BP_HEAD, BP_TORSO)
-		if(P)
-			if(process_projectile(P, user, user, targetedlimb))
-				to_chat(user, "<span class='warning'>UNAUTHORIZED USER DETECTED.</span>")
-				user.visible_message(
-					"<span class='danger'>\The [src] buzzes, firing by itself into [user]'s [targetedlimb]!</span>",
-					"<span class='danger'>\The [src] buzzes, and as your grip loosens on it, it fires point-blank into your [targetedlimb]!</span>"
-					)
-				handle_post_fire(user, user, TRUE)
-		else
-			handle_click_empty(user)
+		var/burstcount = burst
+		while(burstcount)
+			var/obj/P = consume_next_projectile()
+			var/targetedlimb = pick(BP_HEAD, BP_TORSO)
+			if(P)
+				if(process_projectile(P, user, user, targetedlimb))
+					to_chat(user, "<span class='warning'>USER AUTHENTICATION FAILED.</span>")
+					user.visible_message(
+						"<span class='danger'>\The [src] buzzes, firing by itself into [user]'s [targetedlimb]!</span>",
+						"<span class='danger'>You lose your grip as \the [src] buzzes, firing point-blank into your [targetedlimb]!</span>"
+						)
+					handle_post_fire(user, user, TRUE)
+			else
+				handle_click_empty(user)
+			burstcount--
+		M.drop_item() // dropping at the end of the blunder
 		return FALSE
 	if((CLUMSY in M.mutations) && prob(40)) //Clumsy handling
 		var/obj/P = consume_next_projectile()
@@ -300,7 +304,7 @@
 			to_chat(user, "<span class='warning'>\The [src] is not accepting modifications at this time.</span>")
 	if(A.is_multitool() && src.shootback)
 		var/unrig_chance = 5 + (fix_attempts * 1)
-		to_chat(user, "<span class='notice'>You begin pulsing the trigger of \the [src] with [A].</span>")
+		to_chat(user, "<span class='notice'>You begin pulsing the trigger assembly of \the [src] with [A]...</span>")
 		playsound(src, A.usesound, 50, 1)
 		if(do_after(user, 100 * A.toolspeed))
 			playsound(src, A.usesound, 50, 1)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -299,10 +299,11 @@
 		else
 			to_chat(user, "<span class='warning'>\The [src] is not accepting modifications at this time.</span>")
 	if(A.is_multitool() && src.shootback)
-		var/unrig_chance = 5 + (fix_attempts * 2.5)
+		var/unrig_chance = 5 + (fix_attempts * 1)
 		to_chat(user, "<span class='notice'>You begin pulsing the trigger of \the [src] with [A].</span>")
 		playsound(src, A.usesound, 50, 1)
-		if(do_after(user, 25 * A.toolspeed))
+		if(do_after(user, 100 * A.toolspeed))
+			playsound(src, A.usesound, 50, 1)
 			fix_attempts++
 			if(prob(unrig_chance))
 				to_chat(user, "<span class='notice'>You unrig \the [src], making it safe to use.</span>")
@@ -311,7 +312,7 @@
 				to_chat(user, "<span class='warning'>Uh oh.</span>")
 				special_check(user)
 		else
-			to_chat(user, "<span class='warning'>Uh oh.</span>")
+			to_chat(user, "<span class='warning'>Probably should've kept your hand steady...</span>")
 			special_check(user)
 	..()
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -105,6 +105,7 @@
 
 	var/obj/item/firing_pin/pin = /obj/item/firing_pin
 	var/no_pin_required = 0
+	var/shootback = FALSE
 
 /obj/item/gun/CtrlClick(mob/user)
 	if(can_flashlight && ishuman(user) && src.loc == usr && !user.incapacitated(INCAPACITATION_ALL))
@@ -203,6 +204,20 @@
 	if(HULK in M.mutations)
 		to_chat(M, "<span class='danger'>Your fingers are much too large for the trigger guard!</span>")
 		return 0
+	if(shootback)
+		var/obj/P = consume_next_projectile()
+		var/targetedlimb = pick(BP_HEAD, BP_TORSO)
+		if(P)
+			if(process_projectile(P, user, user, targetedlimb))
+				to_chat(user, "<span class='warning'>UNAUTHORIZED USER DETECTED.</span>")
+				user.visible_message(
+					"<span class='danger'>\The [src] buzzes, firing by itself into [user]'s [targetedlimb]!</span>",
+					"<span class='danger'>\The [src] buzzes, and as your grip loosens on it, it fires point-blank into your [targetedlimb]!</span>"
+					)
+				handle_post_fire(user, user, TRUE)
+		else
+			handle_click_empty(user)
+		return FALSE
 	if((CLUMSY in M.mutations) && prob(40)) //Clumsy handling
 		var/obj/P = consume_next_projectile()
 		if(P)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -19,6 +19,14 @@
 		list(mode_name="suppressive", fire_delay=5, projectile_type=/obj/item/projectile/beam/weaklaser, charge_cost = 60),
 		)
 
+/obj/item/gun/energy/laser/rigged
+	shootback = TRUE
+
+/obj/item/gun/energy/laser/rigged/chance/Initialize()
+	. = ..()
+	if(prob(40))
+		shootback = FALSE
+
 /obj/item/gun/energy/laser/mounted
 	self_recharge = 1
 	use_external_power = 1

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -13,6 +13,14 @@
 /obj/item/gun/energy/ionrifle/emp_act(severity)
 	..(max(severity, 4)) //so it doesn't EMP itself, I guess
 
+/obj/item/gun/energy/ionrifle/rigged
+	shootback = TRUE
+
+/obj/item/gun/energy/ionrifle/rigged/chance/Initialize()
+	. = ..()
+	if(prob(40))
+		shootback = FALSE
+
 /obj/item/gun/energy/ionrifle/pistol
 	name = "ion pistol"
 	desc = "The NT Mk63 EW Pan is a man portable anti-armor weapon designed to disable mechanical threats, produced by NT. This model sacrifices capacity for portability."

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -66,6 +66,14 @@
 		icon_state = "c20r"
 	return
 
+/obj/item/gun/projectile/automatic/c20r/rigged
+	shootback = TRUE
+
+/obj/item/gun/projectile/automatic/c20r/rigged/chance/Initialize()
+	. = ..()
+	if(prob(40))
+		shootback = FALSE
+
 /obj/item/gun/projectile/automatic/sts35
 	name = "assault rifle"
 	desc = "The rugged STS-35 is a durable automatic weapon of a make popular on the frontier worlds. Uses 5.45mm rounds."

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -69,6 +69,15 @@
 /obj/item/gun/projectile/automatic/c20r/rigged
 	shootback = TRUE
 
+/obj/item/gun/projectile/automatic/c20r/rigged/Initialize()
+	. = ..() // firemode switching on initialize doesn't seem to work so PLEASE excuse the bullshit about to occur here
+	mode_name = "3-round bursts"
+	burst = 3
+	fire_delay = null
+	move_delay = 4
+	burst_accuracy = list(0, -15, -15)
+	dispersion = list(0.0, 0.6, 1.0)
+
 /obj/item/gun/projectile/automatic/c20r/rigged/chance/Initialize()
 	. = ..()
 	if(prob(40))

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -22,6 +22,14 @@
 		else
 			icon_state = "[initial(icon_state)]-e"
 
+/obj/item/gun/projectile/colt/rigged
+	shootback = TRUE
+
+/obj/item/gun/projectile/colt/rigged/chance/Initialize()
+	. = ..()
+	if(prob(40))
+		shootback = FALSE
+
 /obj/item/gun/projectile/colt/detective
 	desc = "A Martian recreation of an old pistol. Uses .45 rounds."
 	magazine_type = /obj/item/ammo_magazine/m45/rubber
@@ -337,9 +345,9 @@
 	load_method = SPEEDLOADER
 	max_shells = 10
 	ammo_type = /obj/item/ammo_casing/a9mm
-	
+
 /obj/item/gun/projectile/r9/holy
-	name = "Blessed Red 9"	
+	name = "Blessed Red 9"
 	desc = "Ah, the choice of an avid gun collector! It's a nice gun, stranger."
 	ammo_type = /obj/item/ammo_casing/a9mm/silver
 	holy = TRUE

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -57,6 +57,14 @@
 /obj/item/gun/projectile/shotgun/pump/slug
 	ammo_type = /obj/item/ammo_casing/a12g
 
+/obj/item/gun/projectile/shotgun/pump/rigged
+	shootback = TRUE
+
+/obj/item/gun/projectile/shotgun/pump/rigged/chance/Initialize()
+	. = ..()
+	if(prob(40))
+		shootback = FALSE
+
 /obj/item/gun/projectile/shotgun/pump/combat
 	name = "combat shotgun"
 	desc = "Built for close quarters combat, the Hephaestus Industries KS-40 is widely regarded as a weapon of choice for repelling boarders. Uses 12g rounds."
@@ -92,7 +100,7 @@
 
 /obj/item/gun/projectile/shotgun/doublebarrel/pellet
 	ammo_type = /obj/item/ammo_casing/a12g/pellet
-	
+
 /obj/item/gun/projectile/shotgun/doublebarrel/holy
 	ammo_type = /obj/item/ammo_casing/a12g/silver
 	desc = "Alright you primitive screw heads, listen up. See this? This... is my BOOMSTICK."
@@ -140,7 +148,7 @@
 	ammo_type = /obj/item/ammo_casing/a12g/pellet
 	w_class = ITEMSIZE_NORMAL
 	force = 5
-	
+
 /obj/item/gun/projectile/shotgun/doublebarrel/sawn/alt
 	icon_state = "shotpistol"
 


### PR DESCRIPTION
## About The Pull Request
Recoil - (of an action) have an adverse reactive effect on (the originator).
Adds a "shootback" var to guns, which, when enabled, makes every shot fired shoot the user in either the chest or the head.
Mercenaries drop weapons which have a 60% chance to have shootback enabled, except the Grenadier, whose shotgun is always shootback.
## Why It's Good For The Game
Heho funny.
## Changelog
:cl:
add: Reports of mercenary outfits across the sector outfitting their arms with advanced recoil systems have increased.
/:cl: