### PR TITLE
Dance pole improvements, resolves #2368

### DIFF
--- a/code/game/objects/structures/dancepole.dm
+++ b/code/game/objects/structures/dancepole.dm
@@ -1,0 +1,35 @@
+//Dance pole
+/obj/structure/dancepole
+	name = "dance pole"
+	desc = "Engineered for your entertainment"
+	icon = 'icons/obj/objects.dmi'
+	icon_state = "dancepole"
+	density = 0
+	anchored = 1
+
+/obj/structure/dancepole/attackby(var/obj/item/O as obj, var/mob/user as mob)
+	if(O.is_wrench())
+		anchored = !anchored
+		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+		if(anchored)
+			to_chat(user, "<font color='blue'>You secure \the [src].</font>")
+		else
+			to_chat(user, "<font color='blue'>You unsecure \the [src].</font>")
+
+	if(istype(O, /obj/item/weldingtool))
+		var/obj/item/weldingtool/WT = O
+		if(WT.remove_fuel(0, user))
+			playsound(src, WT.usesound, 25, 1)
+			for (var/mob/M in viewers(src))
+				M.show_message("<span class='notice'>[user.name] deconstructed \the [src].</span>", 3, "<span class='notice'>You hear welding.</span>", 2)
+			new /obj/item/stack/material/steel(loc)
+			qdel(src)
+
+/obj/structure/dancepole/get_description_interaction()
+	var/list/results = list()
+	results += "[desc_panel_image("welder")] to deconstruct."
+	if(anchored)
+		results += "[desc_panel_image("wrench")] to unbolt from the floor."
+	else
+		results += "[desc_panel_image("wrench")] to anchor to the floor."
+	return results

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -55,6 +55,7 @@
 	recipes += new/datum/stack_recipe("cannon frame", /obj/item/cannonframe, 10, time = 15, one_per_turf = 0, on_floor = 0)
 	recipes += new/datum/stack_recipe("regular floor tile", /obj/item/stack/tile/floor, 1, 4, 20)
 	recipes += new/datum/stack_recipe("roofing tile", /obj/item/stack/tile/roofing, 3, 4, 20)
+	recipes += new/datum/stack_recipe("dance pole", /obj/structure/dancepole, 1, time = 10, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("metal rod", /obj/item/stack/rods, 1, 2, 60)
 	recipes += new/datum/stack_recipe("frame", /obj/item/frame, 5, time = 25, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("mirror frame", /obj/item/frame/mirror, 1, time = 5, one_per_turf = 0, on_floor = 1)

--- a/maps/nsv_triumph/triumph_things.dm
+++ b/maps/nsv_triumph/triumph_things.dm
@@ -354,39 +354,6 @@ var/global/list/latejoin_shuttle   = list()
 /obj/machinery/cryopod/robot/door/dorms
 	spawnpoint_type = /datum/spawnpoint/shuttle
 
-//Dance pole
-/obj/structure/dancepole
-	name = "dance pole"
-	desc = "Engineered for your entertainment"
-	icon = 'icons/obj/objects.dmi'
-	icon_state = "dancepole"
-	density = 0
-	anchored = 1
-
-/obj/structure/dancepole/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(O.is_wrench())
-		anchored = !anchored
-		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-		if(anchored)
-			to_chat(user, "<font color='blue'>You secure \the [src].</font>")
-		else
-			to_chat(user, "<font color='blue'>You unsecure \the [src].</font>")
-
-	if(istype(O, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = O
-		if(WT.remove_fuel(0, user))
-			playsound(src, WT.usesound, 25, 1)
-			for (var/mob/M in viewers(src))
-				M.show_message("<span class='notice'>[user.name] deconstructed \the [src].</span>", 3, "<span class='notice'>You hear welding.</span>", 2)
-			new /obj/item/stack/material/steel(loc)
-			qdel(src)
-
-/obj/structure/dancepole/get_description_interaction()
-	var/list/results = list()
-	results += "[desc_panel_image("welder")] to deconstruct."
-	if(anchored) results += "[desc_panel_image("wrench")] to unbolt from the floor."
-	else results += "[desc_panel_image("wrench")] to anchor to the floor."
-	return results
 //
 // ### Wall Machines On Full Windows ###
 // To make sure wall-mounted machines placed on full-tile windows are clickable they must be above the window

--- a/maps/nsv_triumph/triumph_things.dm
+++ b/maps/nsv_triumph/triumph_things.dm
@@ -371,6 +371,22 @@ var/global/list/latejoin_shuttle   = list()
 			to_chat(user, "<font color='blue'>You secure \the [src].</font>")
 		else
 			to_chat(user, "<font color='blue'>You unsecure \the [src].</font>")
+
+	if(istype(O, /obj/item/weldingtool))
+		var/obj/item/weldingtool/WT = O
+		if(WT.remove_fuel(0, user))
+			playsound(src, WT.usesound, 25, 1)
+			for (var/mob/M in viewers(src))
+				M.show_message("<span class='notice'>[user.name] deconstructed \the [src].</span>", 3, "<span class='notice'>You hear welding.</span>", 2)
+			new /obj/item/stack/material/steel(loc)
+			qdel(src)
+
+/obj/structure/dancepole/get_description_interaction()
+	var/list/results = list()
+	results += "[desc_panel_image("welder")] to deconstruct."
+	if(anchored) results += "[desc_panel_image("wrench")] to unbolt from the floor."
+	else results += "[desc_panel_image("wrench")] to anchor to the floor."
+	return results
 //
 // ### Wall Machines On Full Windows ###
 // To make sure wall-mounted machines placed on full-tile windows are clickable they must be above the window

--- a/maps/tether/tether_things.dm
+++ b/maps/tether/tether_things.dm
@@ -505,23 +505,6 @@ var/global/list/latejoin_tram   = list()
 /obj/machinery/cryopod/robot/door/dorms
 	spawnpoint_type = /datum/spawnpoint/tram
 
-//Dance pole
-/obj/structure/dancepole
-	name = "dance pole"
-	desc = "Engineered for your entertainment"
-	icon = 'icons/obj/objects.dmi'
-	icon_state = "dancepole"
-	density = 0
-	anchored = 1
-
-/obj/structure/dancepole/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(O.is_wrench())
-		anchored = !anchored
-		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-		if(anchored)
-			to_chat(user, "<font color='blue'>You secure \the [src].</font>")
-		else
-			to_chat(user, "<font color='blue'>You unsecure \the [src].</font>")
 //
 // ### Wall Machines On Full Windows ###
 // To make sure wall-mounted machines placed on full-tile windows are clickable they must be above the window

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1256,6 +1256,7 @@
 #include "code\game\objects\structures\cliff.dm"
 #include "code\game\objects\structures\coathanger.dm"
 #include "code\game\objects\structures\curtains.dm"
+#include "code\game\objects\structures\dancepole.dm"
 #include "code\game\objects\structures\displaycase.dm"
 #include "code\game\objects\structures\dogbed.dm"
 #include "code\game\objects\structures\door_assembly.dm"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Implements deconstructing and constructing dance poles, also adds a get_description_interaction() based instructions blurb after the desc.

## Why It's Good For The Game

Not being able to destroy and build /obj/structures with steel is just wrong and unamerican.

## Changelog
:cl:
add: Steel sheet recipe to make dance poles (1 sheet)
add: Added construction/deconstruction functionality to dance poles
tweak: Fancy bluetext instructions for moving/removing dance poles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
