### PR TITLE
Cures the Silence of Sergals

### DIFF
--- a/code/modules/mob/language/station_vr.dm
+++ b/code/modules/mob/language/station_vr.dm
@@ -22,7 +22,7 @@
 	desc = "The dominant language of the Sergal homeworld, Vilous. It consists of aggressive low-pitched hissing and throaty growling."
 	speech_verb = "snarls"
 	colour = "sergal"
-	key = ""
+	key = "T"
 	syllables = list ("grr", "gah", "woof", "arf", "arra", "rah", "wor", "sarg")
 
 /datum/language/vulpkanin


### PR DESCRIPTION
## About The Pull Request

Fixes Sagaru by porting the T language key from Virgo. I tried a few times to do a bigger refactor of saycode to bring it up to date but holy shit I'm not ready lmao.

I didn't merge the VR files because it might make it more painful to refactor/update saycode later. I don't have enough understanding of the system and all files involved yet to overhaul properly

`say ",T Gold Ring for life."`

If only there was a PR mirror bot :( could've just dismissed the unwanted PRs

## Changelog
:cl:
fix: You can now speak Sagaru with ,T. Why there wasn't a language key at all before is a mystery.
/:cl: