### PR TITLE
Fixes dough and bun foodbag behavior, resolves issue #2277

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -3219,6 +3219,8 @@
 		new /obj/item/reagent_containers/food/snacks/sliceable/flatdough(src)
 		to_chat(user, "You flatten the dough.")
 		qdel(src)
+	else
+		. = ..()
 
 // slicable into 3xdoughslices
 /obj/item/reagent_containers/food/snacks/sliceable/flatdough
@@ -4493,6 +4495,11 @@ END CITADEL CHANGE */
 
 // Moved /bun/attackby() from /code/modules/food/food/snacks.dm
 /obj/item/reagent_containers/food/snacks/bun/attackby(obj/item/W as obj, mob/user as mob)
+	//i honestly should probably refactor this whole thing but idgaf
+	if(istype(W,/obj/item/storage))
+		. = ..() //if you want to bag a ton of buns idk i don't play chef
+		return
+
 	var/obj/item/reagent_containers/food/snacks/result = null
 	// Bun + meatball = burger
 	if(istype(W,/obj/item/reagent_containers/food/snacks/meatball))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin. Resolves the override failing to include the base type's attackby behavior when not being attacked by the specified object. "Properly" for the dough, and quick and dirty for the bun. Both should be fine, tho.

## Why It's Good For The Game

Makes the foodbag more useful

## Changelog
:cl:
fix: Makes buns and dough enter foodbags normally
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
