### PR TITLE
Reverts "Micro Chips" in the microwave recipes.

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -257,12 +257,11 @@ I said no!
 	items = list(/obj/item/reagent_containers/food/snacks/cheesewedge)
 	result = /obj/item/reagent_containers/food/snacks/loadedbakedpotato
 
-/datum/recipe/microchips
-	appliance = MICROWAVE
+/datum/recipe/fries
 	items = list(
-		/obj/item/reagent_containers/food/snacks/rawsticks
+		/obj/item/weapon/reagent_containers/food/snacks/rawsticks
 	)
-	result = /obj/item/reagent_containers/food/snacks/microchips
+	result = /obj/item/weapon/reagent_containers/food/snacks/fries
 
 /datum/recipe/cheesyfries
 	items = list(


### PR DESCRIPTION
Someone changed regular fries that are cooked from raw potato sticks into "micro chips", with their own special product, which was unique and couldn't be used to make any of the other fry recipes, making them unattainable. This changes it back since regular fries are still in the code.

## About The Pull Request

Changes "Micro Chips" back to "Fries"

## Why It's Good For The Game

Makes it so you can actually make fries and their sub-foods again.

## Changelog
:cl:
tweak: Tweaked "Micro Chips" back to "Fries"
/:cl:
