### PR TITLE
Unfucks buckling, adds check if a mob is already buckled to a different before forcemoving

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -120,6 +120,9 @@
 	if(M in buckled_mobs)
 		to_chat(user, "<span class='warning'>\The [M] is already buckled to \the [src].</span>")
 		return FALSE
+	if(M.buckled) //actually check if the mob is already buckled before forcemoving it jfc
+		to_chat(user, "<span class='warning'>\The [M] is already buckled to \the [M.buckled].</span>")
+		return FALSE
 	//can't buckle unless you share locs so try to move M to the obj.
 	if(M.loc != src.loc)
 		if(M.Adjacent(src) && user.Adjacent(src))


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Beds, chairs, etc. did not check if the mob was already buckled to any other chairs before forcemoving the mob onto the destination tile, letting mobs be moved between chairs without unbuckling them from the first. This is a simple three line change to implement the overlooked check.

## Why It's Good For The Game
Bugfix.

## Changelog
:cl:
fix: can no longer slide between beds/chairs with clickdrag while buckled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
