### PR TITLE
BL3 P Sprite fix

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools_vr.dm
+++ b/code/game/mecha/equipment/tools/medical_tools_vr.dm
@@ -1,8 +1,10 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/medigun
+	w_class = ITEMSIZE_LARGE
+	desc = "The BL-3 'Phoenix' is a portable medical system used to treat external injuries from afar."
 	equip_cooldown = 6
 	name = "\improper BL-3 \"Phoenix\" directed restoration system"
-	desc = "The BL-3 'Phoenix' is a portable medical system used to treat external injuries from afar."
-	icon_state = "mecha_medbeam"
+	icon = 'icons/mecha/mecha_equipment_vr.dmi'
+	icon_state = "medbeam"
 	energy_drain = 1000
 	projectile = /obj/item/projectile/beam/medigun
 	fire_sound = 'sound/weapons/eluger.ogg'


### PR DESCRIPTION
All this does is ensures that the BL-3 P is no longer invisible as there was no sprite properly tied to the item at the time. Not much else to really say about it. 

![PR photo2](https://user-images.githubusercontent.com/66703848/94628473-f1bba300-0274-11eb-997e-0273233f96be.png)

Most I really did is take a working item layout and did this. Fully aware of the upcoming changes so I will touch up on this when that happens. 

closes #2380
closes #2153
 

## Changelog
:cl:
fix: BL3 Phoenix sprite now visible.
/:cl: