### PR TITLE
Removes floral somatoray pin requirement

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -40,8 +40,8 @@
 	projectile_type = /obj/item/projectile/energy/floramut
 	origin_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_POWER = 3)
 	modifystate = "floramut"
-	cell_type = /obj/item/cell/device/weapon/recharge
-    no_pin_required = 1
+	cell_type = /obj/item/cell/device/weapon/recharge	
+	no_pin_required = 1
 	battery_lock = 1
 	var/decl/plantgene/gene = null
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -41,6 +41,7 @@
 	origin_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_POWER = 3)
 	modifystate = "floramut"
 	cell_type = /obj/item/cell/device/weapon/recharge
+    no_pin_required = 1
 	battery_lock = 1
 	var/decl/plantgene/gene = null
 


### PR DESCRIPTION
## About The Pull Request

Makes it so that Xenobotanists  can use it for Xenobotany without having to go to Sec or asking their RD for a pin.

Adds one line of code to ensure that the floral somatoray is usable on station for Xenobotany.

## Why It's Good For The Game

Allows Xenobotanists to actually use their equipment rather than having to take over the firing range for their projects. 

## Changelog
:cl:
adds: Removes the floral somatoray's pin requirement to be usable on station. 
/:cl:
