### PR TITLE
Removes firing pin requirement from: Temperature gun and Phase weapons. 

### DIFF
--- a/code/modules/projectiles/guns/energy/phase.dm
+++ b/code/modules/projectiles/guns/energy/phase.dm
@@ -10,6 +10,7 @@
 	charge_cost = 240
 	projectile_type = /obj/item/projectile/energy/phase
 	one_handed_penalty = 15
+	no_pin_required = 1
 
 /obj/item/gun/energy/phasegun/pistol
 	name = "phase pistol"

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -5,7 +5,7 @@
 	charge_cost = 240
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 4, TECH_POWER = 3, TECH_MAGNET = 2)
 	slot_flags = SLOT_BELT|SLOT_BACK
-
+	no_pin_required = 1
 	projectile_type = /obj/item/projectile/temp
 
 	firemodes = list(


### PR DESCRIPTION
## About The Pull Request
This PR does the following:
Removes the pin requirement from phase weapons. Allowing crew and Science to still have phase weapons available if there are situations that Security are absent.

As well removes the requirement for pins on temperature guns as they're generally used to kill slimes. 

This PR is a follow up to the in

## Why It's Good For The Game

Enables crew to defend themselves with more than just improvised weapons, screwdrivers and what ever other oddities they may find, in the case of a random event occurring that causes hostile mobs to spawn and there are no Security on to handle the situation. As Phase weapons do barely any damage to carbon mobs.

## Changelog
:cl:
tweak: Removes pin requirement from Phase weapons.
tweak: Removes pin requirement from Temperature guns.
/:cl: