### PR TITLE
Fixes Optical Meson Aviators in the Loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_eyes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes.dm
@@ -82,13 +82,21 @@
 	path = /obj/item/clothing/glasses/hud/health/aviator/prescription
 
 /datum/gear/eyes/meson
-	display_name = "EngSci & Mining Optical Meson Scanners"
+	display_name = "EngSci and Mining - Optical Meson Scanners"
 	path = /obj/item/clothing/glasses/meson
 	allowed_roles = list("Station Engineer","Chief Engineer","Atmospheric Technician", "Scientist", "Research Director", "Shaft Miner")
 
 /datum/gear/eyes/meson/prescription
-	display_name = "EngSci & Mining Optical Meson Scanners - Prescription"
+	display_name = "EngSci and Mining - Optical Meson Scanners - Prescription"
 	path = /obj/item/clothing/glasses/meson/prescription
+
+/datum/gear/eyes/meson/aviator
+	display_name = "EngSci and Mining - Optical Meson Scanners - Aviators"
+	path = /obj/item/clothing/glasses/meson/aviator
+
+/datum/gear/eyes/meson/aviator/prescription
+	display_name = "EngSci and Mining - Optical Meson Scanners - Aviators - Prescription"
+	path = /obj/item/clothing/glasses/meson/aviator/prescription
 
 /datum/gear/eyes/material
 	display_name = "Mining Optical Material Scanners"
@@ -98,14 +106,6 @@
 /datum/gear/eyes/material/prescription
 	display_name = "Mining Optical Material Scanners - Prescription"
 	path = /obj/item/clothing/glasses/material/prescription
-
-/datum/gear/eyes/meson/aviator
-	display_name = "EngSci & Mining Optical Meson - Aviators"
-	path = /obj/item/clothing/glasses/meson/aviator
-
-/datum/gear/eyes/meson/aviator/prescription
-	display_name = "EngSci & Mining Optical Meson - Aviators - Prescription"
-	path = /obj/item/clothing/glasses/meson/aviator/prescription
 
 /datum/gear/eyes/glasses/fakesun
 	display_name = "Civilian - Sunglasses - Stylish"


### PR DESCRIPTION
Something something ampersands were a mistake

## Changelog
:cl: RealDonaldTrump
fix: Optical Meson Scanner aviators can now be chosen again in the loadout
/:cl:

Closes #2396 