### PR TITLE
Unfucks autopsy scanners, external surgery tweak

### DIFF
--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -166,9 +166,6 @@
 	if(!istype(M))
 		return 0
 
-	if (user.a_intent == INTENT_HELP)
-		return ..()
-
 	if(target_name != M.name)
 		target_name = M.name
 		src.wdata = list()

--- a/code/modules/surgery/external_repair.dm
+++ b/code/modules/surgery/external_repair.dm
@@ -35,8 +35,7 @@
 
 /datum/surgery_step/repairflesh/scan_injury
 	allowed_tools = list(
-	/obj/item/autopsy_scanner = 100,
-	/obj/item/healthanalyzer = 80,
+	/obj/item/healthanalyzer = 100,
 	/obj/item/analyzer = 10
 	)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Vorecode in its infinite wisdom had the autopsy scanner used for external repair surgery. Moreover, it broke using the autopsy scanner on help intent. The autopsy scanner is now strictly an autopsy tool, as intended by God.

For external repair surgery, the health scanner is now the ideal tool to use, but hey if a doctor wants to use an atmospheric analyser to inspect a wound I guess they can still try that too idk

## Why It's Good For The Game
Standard fucking behavior, jesus christ vorecode pls
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: autopsy scanner now works on help intent
tweak: autopsy scanner no longer used for external repair surgery
tweak: health analyzer now the right tool for external repair surgery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
