### PR TITLE
Removes the Omni "Ultimate" Poly that someone decided should be the pet spawn for the CE

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/pets/parrot.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/pets/parrot.dm
@@ -112,10 +112,6 @@
 	my_headset = /obj/item/radio/headset/headset_eng
 	say_list_type = /datum/say_list/bird/polly
 
-// Best Bird with best headset.
-/mob/living/simple_mob/animal/passive/bird/parrot/polly/ultimate
-	my_headset = /obj/item/radio/headset/omni
-
 /mob/living/simple_mob/animal/passive/bird/parrot/kea
 	name = "kea"
 	desc = "A species of parrot. On Earth, they are unique among other parrots for residing in alpine climates. \


### PR DESCRIPTION
Removing the Omni Headset Poly. Polly/Poly was and always should only be on Engineer comms. If someone wants to waste an in-game obtained Omni card on Poly's headset, be my guest. Making a guaranteed spawned Omni card is bad ju-ju. 


## Changelog
:cl:
del: Removed Omni Headset Poly of Powergay
/:cl:
