### PR TITLE
Adds an "Event Rewards" section to the loadout. Changes Donator Items to cost 0 loadout points.

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_donator.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_donator.dm
@@ -1,6 +1,7 @@
 /datum/gear/donator
-	display_name = "If this item can be chosen or seen, ping a coder immediately!"
 	sort_category = "Donator"
+	cost = 0 // If they went out of their way to PAY for a custom item, given our no-gameplay-advantage-granting-items rule, it's only right that they aren't penalized and need to re-adjust their loadout to compensate for their new item's cost.
+	display_name = "If this item can be chosen or seen, ping a coder immediately!"
 	path = /obj/item/bikehorn
 	ckeywhitelist = list("This entry should never be choosable with this variable set.") //If it does, then that means somebody fucked up the whitelist system pretty hard
 

--- a/code/modules/client/preference_setup/loadout/loadout_event_rewards.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_event_rewards.dm
@@ -1,0 +1,13 @@
+/datum/gear/event_reward
+	sort_category = "Event Rewards"
+	cost = 0 // If they got something custom, it's only right that they aren't penalized and need to re-adjust their loadout to compensate for their new item's cost.
+	display_name = "If this item can be chosen or seen, ping a coder immediately!"
+	path = /obj/item/bikehorn
+	ckeywhitelist = list("This entry should never be choosable with this variable set.") // Reminder - ckeys are always all lowercase, regardless of what someone's username displays (and apparently without spaces)
+/*
+/datum/gear/event_reward/imperium       <------   Example Item
+	display_name = "Imperium"
+	path = /obj/item/clothing/suit/armor/combat/imperial/centurion
+	slot = slot_wear_suit               <------   Important to change to whichever slot the item should be worn on. If it's not a piece of clothing/equipment, leaving it blank should put it into their backpack.
+	ckeywhitelist = list("drofoljaelisglis")
+*/

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1689,6 +1689,7 @@
 #include "code\modules\client\preference_setup\loadout\loadout_cosmetics.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_donator.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_ears.dm"
+#include "code\modules\client\preference_setup\loadout\loadout_event_rewards.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_eyes.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_general.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_gloves.dm"


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

**Donator Items:** If someone went out of their way to PAY for a custom item, given our no-gameplay-advantage-granting-items rule, it's only right that they aren't penalized and need to re-adjust their loadout to compensate for their new item's cost.

**Event Rewards:** Grants a reward for participating in events that people can show off. This encourages people to participate in events to have a chance at earning one (when applicable), grants something permanent to veterans of the community who remain around long enough to have earned something shiny to show off, and adds extra flavor to the game.

## Changelog
:cl:
add: Added an "Event Rewards" category to the loadout. 
tweak: Donator Items now cost 0 loadout points.
/:cl: