### PR TITLE
Xenohybrid Racial Adjustments

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -949,6 +949,17 @@
 	hunger_factor = 0.1 //In exchange, they get hungry a tad faster.
 	num_alternate_languages = 2
 
+	//Return Xeno space immunity and racial resistances/vulnerabilities to Hybrids, since they're literally still Xenomorphs in terms of biology.
+	brute_mod = 0.5 // Hardened carapace.
+	burn_mod = 2    // Weak to fire.
+
+	warning_low_pressure = 50
+	hazard_low_pressure = -1
+
+	cold_level_1 = 50
+	cold_level_2 = -1
+	cold_level_3 = -1
+
 	min_age = 18
 	max_age = 80
 


### PR DESCRIPTION
For some reason, Xenohybrids - literal Xenomorphs with either a genetic or technological separation from the hivemind - don't have basic Xeno traits. I've given them _some_.

1. _Adjusts Xenohybrid racial traits: Xenohybrids are now fully spaceproof, but still require Oxygen. They now take double fire damage, and half brute damage._
**Why:** Hybrids have been brought more in line with standard Xenomorph biology with this update, with small adjustments for balance.