### PR TITLE
NanoTrasen Recycling Incentivization Program

### DIFF
--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -6,6 +6,7 @@ SUBSYSTEM_DEF(supply)
 	var/points_per_second = 1.5 / 30
 	var/points_per_slip = 2
 	var/points_per_money = 0.02 // 1 point for $50
+	var/points_per_trash = 0.1 // Weighted value, tentative.
 	// Control
 	var/ordernum
 	var/list/shoppinglist = list()			// Approved orders
@@ -134,6 +135,9 @@ SUBSYSTEM_DEF(supply)
 						EC.contents[EC.contents.len]["quantity"] = cashmoney.worth
 						EC.value += EC.contents[EC.contents.len]["value"]
 
+					// Sell trash
+					if(istype(A, /obj/item/trash))
+						EC.contents[EC.contents.len]["value"] = points_per_trash
 
 
 			// Make a log of it, but it wasn't shipped properly, and so isn't worth anything


### PR DESCRIPTION
_Corporate recently looked over last quarter's expenses, and noticed a distressing amount of waste in Central Command's logistical budget. On an entirely unrelated note, corporate has announced their brand new Recycling Incentivization Program! Every crew in the local sector will soon receive a Supply credit per individual item that meets the "trash" classification. If you are interested in participating in the NanoTrasen R.I.P. initiative, get in touch with your local Service or Cargo department today!_

1. _Gives all /trash/ family items an Export value of (0.1) via Cargo._
**Why:** Exporting trash is mostly a thematic touch, as well as an excuse to get the Janitors to want to actually collect garbage from bins. The current exchange rate is 0.1 per item. In initial tests it was 0.01, but this reward scale was determined to be too low.