### PR TITLE
Adds fission monitoring program to modular computers.

### DIFF
--- a/code/modules/power/fission/computer.dm
+++ b/code/modules/power/fission/computer.dm
@@ -52,44 +52,11 @@
 
 	var/data[0]
 
-	if(isnull(linked))
+	if(isnull(linked) || !linked.anchored)
 		data["not_connected"] = 1
-	else if (!linked.powered())
-		data["powered"] = 0
-		data["integrity_percentage"] = round(linked.get_integrity())
-		data["core_temp"] = round(linked.temperature)
-		data["max_temp"] = round(linked.max_temp)
 	else
+		data = linked.ui_data(TRUE)
 		data["not_connected"] = 0
-		data["powered"] = 1
-		data["integrity_percentage"] = round(linked.get_integrity())
-		var/datum/gas_mixture/env = null
-		if(!isnull(linked.loc) && !istype(linked.loc, /turf/space))
-			env = linked.loc.return_air()
-
-		if(!env)
-			data["ambient_temp"] = 0
-			data["ambient_pressure"] = 0
-		else
-			data["ambient_temp"] = round(env.temperature)
-			data["ambient_pressure"] = round(env.return_pressure())
-
-		data["core_temp"] = round(linked.temperature)
-		data["max_temp"] = round(linked.max_temp)
-		data["cutoff_point"] = linked.cutoff_temp
-
-		data["rods"] = new /list(linked.rods.len)
-		for(var/i=1,i<=linked.rods.len,i++)
-			var/obj/item/fuelrod/rod = linked.rods[i]
-			var/roddata[0]
-			roddata["rod"] = "\ref[rod]"
-			roddata["name"] = rod.name
-			roddata["integrity_percentage"] = round(between(0, rod.integrity, 100))
-			roddata["life_percentage"] = round(between(0, rod.life, 100))
-			roddata["heat"] = round(rod.temperature)
-			roddata["melting_point"] = rod.melting_point
-			roddata["insertion"] = round(rod.insertion * 100)
-			data["rods"][i] = roddata
 
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)

--- a/code/modules/power/fission/modular_computer.dm
+++ b/code/modules/power/fission/modular_computer.dm
@@ -1,0 +1,111 @@
+/datum/computer_file/program/fission_monitor
+	filename = "fismon"
+	filedesc = "Fission Monitoring"
+	nanomodule_path = /datum/nano_module/fission_monitor/
+	program_icon_state = "smmon_0"
+	program_key_state = "tech_key"
+	program_menu_icon = "notice"
+	extended_desc = "This program connects to specially calibrated sensors to provide information on the status of a fission core."
+	ui_header = "smmon_0.gif"
+	required_access = access_engine
+	requires_ntnet = 1
+	network_destination = "fission monitoring system"
+	size = 5
+	var/last_status = 0
+
+/datum/computer_file/program/fission_monitor/process_tick()
+	..()
+	var/datum/nano_module/fission_monitor/NMS = NM
+	var/new_status = istype(NMS) ? NMS.get_status() : 0
+	if(last_status != new_status)
+		last_status = new_status
+		ui_header = "smmon_[last_status].gif"
+		program_icon_state = "smmon_[last_status]"
+		if(istype(computer))
+			computer.update_icon()
+
+/datum/nano_module/fission_monitor
+	name = "Fission monitor"
+	var/list/fissioncores
+	var/obj/machinery/power/fission/active = null		// Currently selected fission core.
+
+/datum/nano_module/fission_monitor/Destroy()
+	. = ..()
+	active = null
+	fissioncores = null
+
+/datum/nano_module/fission_monitor/New()
+	..()
+	refresh()
+
+// Refreshes list of active fission cores
+/datum/nano_module/fission_monitor/proc/refresh()
+	fissioncores = list()
+	var/z = get_z(nano_host())
+	if(!z)
+		return
+	var/valid_z_levels = GLOB.using_map.get_map_levels(z)
+	for(var/obj/machinery/power/fission/F in machines)
+		// Unsecured, blown up, not within coverage, not on a tile.
+		if(!F.anchored || F.exploded || !(F.z in valid_z_levels) || !istype(F.loc, /turf/))
+			continue
+		fissioncores.Add(F)
+
+	if(!(active in fissioncores))
+		active = null
+
+/datum/nano_module/fission_monitor/proc/get_status()
+	. = FALSE
+	for(var/obj/machinery/power/fission/F in fissioncores)
+		if(F.anchored && F.powered())
+			. = TRUE
+			break
+
+/datum/nano_module/fission_monitor/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
+	var/list/data = host.initial_data()
+
+	if(istype(active) && active.anchored)
+		data = data + active.ui_data(TRUE)
+		data["active"] = 1
+
+	else
+		var/list/FCS = list()
+		for(var/obj/machinery/power/fission/F in fissioncores)
+			var/area/A = get_area(F)
+			if(!A)
+				fissioncores = fissioncores - F
+				continue
+
+			FCS.Add(list(list(
+			"area_name" = A.name,
+			"core_temp" = round(F.temperature),
+			"uid" = F.uid
+			)))
+
+		data["active"] = 0
+		data["fissioncores"] = FCS
+
+	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, data, force_open)
+	if (!ui)
+		ui = new(user, src, ui_key, "fission_monitor_prog.tmpl", "Nuclear Fission Core", 500, 600, state = state)
+		if(host.update_layout())
+			ui.auto_update_layout = 1
+		ui.set_initial_data(data)
+		ui.open()
+		ui.set_auto_update(1)
+
+/datum/nano_module/fission_monitor/Topic(href, href_list)
+	if(..())
+		return 1
+	if( href_list["clear"] )
+		active = null
+		return 1
+	if( href_list["refresh"] )
+		refresh()
+		return 1
+	if( href_list["set"] )
+		var/newuid = text2num(href_list["set"])
+		for(var/obj/machinery/power/fission/F in fissioncores)
+			if(F.uid == newuid)
+				active = F
+		return 1

--- a/nano/templates/fission_monitor_prog.tmpl
+++ b/nano/templates/fission_monitor_prog.tmpl
@@ -1,0 +1,96 @@
+{{if data.active}}
+	{{:helper.link('Back to Menu', null, {'clear' : 1})}}<br>
+	<h3>Core</h3>
+	<span class="itemLabel">
+		Integrity:
+	</span>
+	<span class="itemContent">
+		{{:helper.displayBar(data.integrity_percentage, 0, 100, (data.integrity_percentage >= 90) ? 'good' : (data.integrity_percentage >= 50) ? 'average' : 'bad')}}
+		<b>{{:data.integrity_percentage}} %</b>
+	</span>
+	<span class="itemLabel">
+		Temperature:
+	</span>
+	<span class="itemContent">
+		{{:helper.displayBar(data.core_temp, 0, data.max_temp, (data.core_temp >= (data.max_temp / 2)) ? 'bad' : (data.core_temp >= (data.max_temp / 2.5)) ? 'average' : 'good')}}
+		<b>{{:data.core_temp}} K</b>
+	</span>
+	{{if data.powered}}
+		<span class="itemLabel">
+			Cutoff Temperature:
+		</span>
+		<span class="itemContent">
+			<b>{{:data.cutoff_point}} K</b><br>
+		</span>
+		<h3>Environment</h3>
+		<span class="itemLabel">
+			Pressure:
+		</span>
+		<span class="itemContent">
+			<b>{{:data.ambient_pressure}} kPa</b>
+		</span>
+		<span class="itemLabel">
+			Temperature:
+		</span>
+		<span class="itemContent">
+			{{:helper.displayBar(data.ambient_temp, 0, data.max_temp, (data.ambient_temp >= (data.max_temp / 2)) ? 'bad' : (data.ambient_temp >= (data.max_temp / 2.5)) ? 'average' : 'good')}}
+			<b>{{:data.ambient_temp}} K</b>
+		</span>
+		{{for data.rods}}
+			<h3>{{:value.name}}</h3>
+			<span class="itemLabel">
+				Integrity:
+			</span>
+			<span class="itemContent">
+				{{:helper.displayBar(value.integrity_percentage, 0, 100, (value.integrity_percentage >= 90) ? 'good' : (value.integrity_percentage >= 50) ? 'average' : 'bad')}}
+				<b>{{:value.integrity_percentage}} %</b>
+			</span>
+			<span class="itemLabel">
+				Lifespan:
+			</span>
+			<span class="itemContent">
+				{{:helper.displayBar(value.life_percentage, 0, 100, (value.life_percentage >= 90) ? 'good' : (value.life_percentage >= 50) ? 'average' : 'bad')}}
+				<b>{{:value.life_percentage}} %</b>
+			</span>
+			<span class="itemLabel">
+				Temperature:
+			</span>
+			<span class="itemContent">
+				{{:helper.displayBar(value.heat, 0, value.melting_point, (value.heat >= (value.melting_point / 1.33)) ? 'bad' : (value.heat >= (value.melting_point / 2)) ? 'average' : 'good')}}
+				<b>{{:value.heat}} K</b>
+			</span>
+			<span class="itemLabel">
+				Insertion:
+			</span>
+			<span class="itemContent">
+				<b>{{:value.insertion}} %</b>
+			</span>
+		{{/for}}
+	{{else}}
+		<h3>No Power!</h3>
+	{{/if}}
+{{else}}
+	{{:helper.link('Refresh', null, {'refresh' : 1})}}<br>
+	{{for data.fissioncores}}
+		<div class="item">
+			<div class="itemLabel">
+				Area:
+			</div>
+			<div class="itemContent">
+				{{:value.area_name}} - (#{{:value.uid}})
+			</div>
+			<div class="itemLabel">
+				Temperature:
+			</div>
+			<div class="itemContent">
+				{{:value.core_temp}} K
+			</div>
+			<div class="itemLabel">
+				Options:
+			</div>
+			<div class="itemContent">
+				{{:helper.link('View Details', null, {'set' : value.uid})}}
+			</div>			
+		</div>	
+	{{/for}}
+{{/if}}

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2943,6 +2943,7 @@
 #include "code\modules\power\fission\carry.dm"
 #include "code\modules\power\fission\computer.dm"
 #include "code\modules\power\fission\engine.dm"
+#include "code\modules\power\fission\modular_computer.dm"
 #include "code\modules\power\fission\rods.dm"
 #include "code\modules\power\fusion\_setup.dm"
 #include "code\modules\power\fusion\fusion_circuits.dm"


### PR DESCRIPTION
## About The Pull Request
Simple PR to add a modular computer program to check on the fission engine.
Varies from the standard fission monitor computer in two key ways:
 • Does not require a multitool to link it.
 • Operates in a read only mode.
This is to ensure that sabotaging the fission engine requires more effort than "Buy or own any modular computer/tablet."

(Achieving modular computer compatibility required a fair bit of a change on the engine's back end, however.)

## Why It's Good For The Game
This allows engineers to check on the engine temperature and reaction rate while busy with other tasks.

## Changelog
:cl:
add: Added modular fission monitor program.
/:cl: