### PR TITLE
disruptor ammunition - closed because i'm not dealing with conflicts

### DIFF
--- a/code/datums/autolathe/arms.dm
+++ b/code/datums/autolathe/arms.dm
@@ -1,6 +1,6 @@
 /datum/category_item/autolathe/arms/syringegun_ammo
 	name = "syringe gun cartridge"
-	path =/obj/item/syringe_cartridge
+	path = /obj/item/syringe_cartridge
 
 ////////////////
 /*Ammo casings*/
@@ -8,29 +8,29 @@
 
 /datum/category_item/autolathe/arms/shotgun_blanks
 	name = "ammunition (12g, blank)"
-	path =/obj/item/ammo_casing/a12g/blank
+	path = /obj/item/ammo_casing/a12g/blank
 
 /datum/category_item/autolathe/arms/shotgun_beanbag
 	name = "ammunition (12g, beanbag)"
-	path =/obj/item/ammo_casing/a12g/beanbag
+	path = /obj/item/ammo_casing/a12g/beanbag
 
 /datum/category_item/autolathe/arms/shotgun_flare
 	name = "ammunition (12g, flare)"
-	path =/obj/item/ammo_casing/a12g/flare
+	path = /obj/item/ammo_casing/a12g/flare
 
 /datum/category_item/autolathe/arms/shotgun
 	name = "ammunition (12g, slug)"
-	path =/obj/item/ammo_casing/a12g
+	path = /obj/item/ammo_casing/a12g
 	hidden = 1
 
 /datum/category_item/autolathe/arms/shotgun_pellet
 	name = "ammunition (12g, pellet)"
-	path =/obj/item/ammo_casing/a12g/pellet
+	path = /obj/item/ammo_casing/a12g/pellet
 	hidden = 1
 
 /datum/category_item/autolathe/arms/stunshell
 	name = "ammunition (stun cartridge, shotgun)"
-	path =/obj/item/ammo_casing/a12g/stunshell
+	path = /obj/item/ammo_casing/a12g/stunshell
 	hidden = 1
 
 //////////////////
@@ -41,63 +41,63 @@
 /*
 /datum/category_item/autolathe/arms/pistol_5mm
 	name = "pistol magazine (5mm)"
-	path =/obj/item/ammo_magazine/c5mm
+	path = /obj/item/ammo_magazine/c5mm
 	category = "Arms and Ammunition"
 	hidden = 1
 */
 ////// 10x24mm
 /datum/category_item/autolathe/arms/usmc/small
 	name = "small m41a magazine"
-	path =/obj/item/ammo_magazine/m10x24mm/small
+	path = /obj/item/ammo_magazine/m10x24mm/small
 	hidden = 1
 
 /datum/category_item/autolathe/arms/usmc/small/hp
 	name = "small m41a hp magazine"
-	path =/obj/item/ammo_magazine/m10x24mm/small/hp
+	path = /obj/item/ammo_magazine/m10x24mm/small/hp
 	hidden = 1
 
 /datum/category_item/autolathe/arms/usmc/small/ap
 	name = "small m41a ap magazine"
-	path =/obj/item/ammo_magazine/m10x24mm/small/ap
+	path = /obj/item/ammo_magazine/m10x24mm/small/ap
 	hidden = 1
 
 
 /////// .45
 /datum/category_item/autolathe/arms/pistol_45
 	name = "pistol magazine (.45)"
-	path =/obj/item/ammo_magazine/m45
+	path = /obj/item/ammo_magazine/m45
 	hidden = 1
 
 /datum/category_item/autolathe/arms/pistol_45h
 	name = "pistol magazine (.45 hunter)"
-	path =/obj/item/ammo_magazine/m45/hunter
+	path = /obj/item/ammo_magazine/m45/hunter
 	hidden = 1
 
 /datum/category_item/autolathe/arms/pistol_45p
 	name = "pistol magazine (.45 practice)"
-	path =/obj/item/ammo_magazine/m45/practice
+	path = /obj/item/ammo_magazine/m45/practice
 
 /datum/category_item/autolathe/arms/pistol_45r
 	name = "pistol magazine (.45 rubber)"
-	path =/obj/item/ammo_magazine/m45/rubber
+	path = /obj/item/ammo_magazine/m45/rubber
 
 /datum/category_item/autolathe/arms/pistol_45f
 	name = "pistol magazine (.45 flash)"
-	path =/obj/item/ammo_magazine/m45/flash
+	path = /obj/item/ammo_magazine/m45/flash
 
 /datum/category_item/autolathe/arms/pistol_45uzi
 	name = "uzi magazine (.45)"
-	path =/obj/item/ammo_magazine/m45uzi
+	path = /obj/item/ammo_magazine/m45uzi
 	hidden = 1
 
 /datum/category_item/autolathe/arms/tommymag
 	name = "Tommy Gun magazine (.45)"
-	path =/obj/item/ammo_magazine/m45tommy
+	path = /obj/item/ammo_magazine/m45tommy
 	hidden = 1
 
 /datum/category_item/autolathe/arms/tommydrum
 	name = "Tommy Gun drum magazine (.45)"
-	path =/obj/item/ammo_magazine/m45tommydrum
+	path = /obj/item/ammo_magazine/m45tommydrum
 	hidden = 1
 
 /////// 9mm
@@ -105,116 +105,116 @@
 // Full size pistol mags.
 /datum/category_item/autolathe/arms/pistol_9mm
 	name = "pistol magazine (9mm)"
-	path =/obj/item/ammo_magazine/m9mm
+	path = /obj/item/ammo_magazine/m9mm
 	hidden = 1
 
 /datum/category_item/autolathe/arms/pistol_9mmr
 	name = "pistol magazine (9mm rubber)"
-	path =/obj/item/ammo_magazine/m9mm/rubber
+	path = /obj/item/ammo_magazine/m9mm/rubber
 
 /datum/category_item/autolathe/arms/pistol_9mmp
 	name = "pistol magazine (9mm practice)"
-	path =/obj/item/ammo_magazine/m9mm/practice
+	path = /obj/item/ammo_magazine/m9mm/practice
 
 /datum/category_item/autolathe/arms/pistol_9mmf
 	name = "pistol magazine (9mm flash)"
-	path =/obj/item/ammo_magazine/m9mm/flash
+	path = /obj/item/ammo_magazine/m9mm/flash
 
 // Small mags for small or old guns.
 /datum/category_item/autolathe/arms/pistol_9mm_compact
 	name = "compact pistol magazine (9mm)"
-	path =/obj/item/ammo_magazine/m9mm/compact
+	path = /obj/item/ammo_magazine/m9mm/compact
 	hidden = 1
 
 /datum/category_item/autolathe/arms/pistol_9mmr_compact
 	name = "compact pistol magazine (9mm rubber)"
-	path =/obj/item/ammo_magazine/m9mm/compact/rubber
+	path = /obj/item/ammo_magazine/m9mm/compact/rubber
 	hidden = 1 // These are all hidden because they are traitor mags and will otherwise just clutter the Autolathe.
 
 /datum/category_item/autolathe/arms/pistol_9mmp_compact
 	name = "compact pistol magazine (9mm practice)"
-	path =/obj/item/ammo_magazine/m9mm/compact/practice
+	path = /obj/item/ammo_magazine/m9mm/compact/practice
 	hidden = 1
 
 /datum/category_item/autolathe/arms/pistol_9mmf_compact
 	name = "compact pistol magazine (9mm flash)"
-	path =/obj/item/ammo_magazine/m9mm/compact/flash
+	path = /obj/item/ammo_magazine/m9mm/compact/flash
 	hidden = 1
 
 // SMG mags
 /datum/category_item/autolathe/arms/smg_9mm
 	name = "top-mounted SMG magazine (9mm)"
-	path =/obj/item/ammo_magazine/m9mmt
+	path = /obj/item/ammo_magazine/m9mmt
 	hidden = 1
 
 /datum/category_item/autolathe/arms/smg_9mmh
 	name = "top-mounted SMG magazine (9mm hunter)"
-	path =/obj/item/ammo_magazine/m9mmt/hunter
+	path = /obj/item/ammo_magazine/m9mmt/hunter
 	hidden = 1
 
 /datum/category_item/autolathe/arms/smg_9mmr
 	name = "top-mounted SMG magazine (9mm rubber)"
-	path =/obj/item/ammo_magazine/m9mmt/rubber
+	path = /obj/item/ammo_magazine/m9mmt/rubber
 
 /datum/category_item/autolathe/arms/smg_9mmp
 	name = "top-mounted SMG magazine (9mm practice)"
-	path =/obj/item/ammo_magazine/m9mmt/practice
+	path = /obj/item/ammo_magazine/m9mmt/practice
 
 /datum/category_item/autolathe/arms/smg_9mmf
 	name = "top-mounted SMG magazine (9mm flash)"
-	path =/obj/item/ammo_magazine/m9mmt/flash
-	
+	path = /obj/item/ammo_magazine/m9mmt/flash
+
 /datum/category_item/autolathe/arms/smg_9mmp90h
 	name = "large capacity top mounted magazine (9mm hunter)"
-	path =/obj/item/ammo_magazine/m9mmp90/hunter
+	path = /obj/item/ammo_magazine/m9mmp90/hunter
 	hidden = 1
 
 /////// 10mm
 /datum/category_item/autolathe/arms/smg_10mm
 	name = "SMG magazine (10mm)"
-	path =/obj/item/ammo_magazine/m10mm
+	path = /obj/item/ammo_magazine/m10mm
 	hidden = 1
 
 /datum/category_item/autolathe/arms/pistol_44
 	name = "pistol magazine (.44)"
-	path =/obj/item/ammo_magazine/m44
+	path = /obj/item/ammo_magazine/m44
 	hidden = 1
 
 /////// 5.45mm
 /datum/category_item/autolathe/arms/rifle_545
 	name = "rifle magazine (5.45mm)"
-	path =/obj/item/ammo_magazine/m545
+	path = /obj/item/ammo_magazine/m545
 	hidden = 1
 
 /datum/category_item/autolathe/arms/rifle_545p
 	name = "rifle magazine (5.45mm practice)"
-	path =/obj/item/ammo_magazine/m545/practice
+	path = /obj/item/ammo_magazine/m545/practice
 
-/*/datum/category_item/autolathe/arms/rifle_545_hunter //VOREStation Edit Start. By request of Ace
+/datum/category_item/autolathe/arms/rifle_545_hunter
 	name = "rifle magazine (5.45mm hunting)"
-	path =/obj/item/ammo_magazine/m545/hunter*/ //VOREStation Edit End.
+	path = /obj/item/ammo_magazine/m545/hunter
 
 /datum/category_item/autolathe/arms/machinegun_545
 	name = "machinegun box magazine (5.45)"
-	path =/obj/item/ammo_magazine/m545saw
+	path = /obj/item/ammo_magazine/m545saw
 	hidden = 1
 
-/*/datum/category_item/autolathe/arms/machinegun_545_hunter //VOREStation Edit Start. By request of Ace
+/datum/category_item/autolathe/arms/machinegun_545_hunter
 	name = "machinegun box magazine (5.45 hunting)"
-	path =/obj/item/ammo_magazine/m545saw/hunter
-	hidden = 1*/ //VOREStation Edit End.
+	path = /obj/item/ammo_magazine/m545saw/hunter
+	hidden = 1
 
 /////// 7.62
 
 /datum/category_item/autolathe/arms/rifle_762
 	name = "rifle magazine (7.62mm)"
-	path =/obj/item/ammo_magazine/m762
+	path = /obj/item/ammo_magazine/m762
 	hidden = 1
 
 /*
 /datum/category_item/autolathe/arms/rifle_small_762
 	name = "rifle magazine (7.62mm)"
-	path =/obj/item/ammo_magazine/s762
+	path = /obj/item/ammo_magazine/s762
 	hidden = 1
 */
 
@@ -222,114 +222,114 @@
 
 /datum/category_item/autolathe/arms/shotgun_clip_beanbag
 	name = "2-round 12g speedloader (beanbag)"
-	path =/obj/item/ammo_magazine/clip/c12g/beanbag
+	path = /obj/item/ammo_magazine/clip/c12g/beanbag
 
 /datum/category_item/autolathe/arms/shotgun_clip_slug
 	name = "2-round 12g speedloader (slug)"
-	path =/obj/item/ammo_magazine/clip/c12g
+	path = /obj/item/ammo_magazine/clip/c12g
 	hidden = 1
 
 /datum/category_item/autolathe/arms/shotgun_clip_pellet
 	name = "2-round 12g speedloader (buckshot)"
-	path =/obj/item/ammo_magazine/clip/c12g/pellet
+	path = /obj/item/ammo_magazine/clip/c12g/pellet
 	hidden = 1
 
 /datum/category_item/autolathe/arms/shotgun_clip_beanbag
 	name = "2-round 12g speedloader (beanbag)"
-	path =/obj/item/ammo_magazine/clip/c12g/beanbag
+	path = /obj/item/ammo_magazine/clip/c12g/beanbag
 
 /* Commented out until autolathe stuff is decided/fixed. Will probably remove these entirely. -Spades
 // These should always be/empty! The idea is to fill them up manually with ammo clips.
 
 /datum/category_item/autolathe/arms/pistol_5mm
 	name = "pistol magazine (5mm)"
-	path =/obj/item/ammo_magazine/c5mm/empty
+	path = /obj/item/ammo_magazine/c5mm/empty
 	category = "Arms and Ammunition"
 	hidden = 1
 
 /datum/category_item/autolathe/arms/smg_5mm
 	name = "top-mounted SMG magazine (5mm)"
-	path =/obj/item/ammo_magazine/c5mmt/empty
+	path = /obj/item/ammo_magazine/c5mmt/empty
 	category = "Arms and Ammunition"
 	hidden = 1
 
 /datum/category_item/autolathe/arms/pistol_45
 	name = "pistol magazine (.45)"
-	path =/obj/item/ammo_magazine/m45/empty
+	path = /obj/item/ammo_magazine/m45/empty
 	category = "Arms and Ammunition"
 
 /datum/category_item/autolathe/arms/pistol_45uzi
 	name = "uzi magazine (.45)"
-	path =/obj/item/ammo_magazine/m45uzi/empty
+	path = /obj/item/ammo_magazine/m45uzi/empty
 	category = "Arms and Ammunition"
 	hidden = 1
 
 /datum/category_item/autolathe/arms/tommymag
 	name = "Tommy Gun magazine (.45)"
-	path =/obj/item/ammo_magazine/m45tommy/empty
+	path = /obj/item/ammo_magazine/m45tommy/empty
 	category = "Arms and Ammunition"
 	hidden = 1
 
 /datum/category_item/autolathe/arms/tommydrum
 	name = "Tommy Gun drum magazine (.45)"
-	path =/obj/item/ammo_magazine/m45tommydrum/empty
+	path = /obj/item/ammo_magazine/m45tommydrum/empty
 	category = "Arms and Ammunition"
 	hidden = 1
 
 /datum/category_item/autolathe/arms/pistol_9mm
 	name = "pistol magazine (9mm)"
-	path =/obj/item/ammo_magazine/m9mm/empty
+	path = /obj/item/ammo_magazine/m9mm/empty
 	category = "Arms and Ammunition"
 
 /datum/category_item/autolathe/arms/smg_9mm
 	name = "top-mounted SMG magazine (9mm)"
-	path =/obj/item/ammo_magazine/m9mmt/empty
+	path = /obj/item/ammo_magazine/m9mmt/empty
 	category = "Arms and Ammunition"
 
 /datum/category_item/autolathe/arms/smg_10mm
 	name = "SMG magazine (10mm)"
-	path =/obj/item/ammo_magazine/m10mm/empty
+	path = /obj/item/ammo_magazine/m10mm/empty
 	category = "Arms and Ammunition"
 	hidden = 1
 
 /datum/category_item/autolathe/arms/pistol_44
 	name = "pistol magazine (.44)"
-	path =/obj/item/ammo_magazine/m44/empty
+	path = /obj/item/ammo_magazine/m44/empty
 	category = "Arms and Ammunition"
 	hidden = 1
 
 /datum/category_item/autolathe/arms/rifle_545
 	name = "10rnd rifle magazine (5.45mm)"
-	path =/obj/item/ammo_magazine/m545saw/empty
+	path = /obj/item/ammo_magazine/m545saw/empty
 	category = "Arms and Ammunition"
 
 /datum/category_item/autolathe/arms/rifle_545m
 	name = "20rnd rifle magazine (5.45mm)"
-	path =/obj/item/ammo_magazine/m545sawm/empty
+	path = /obj/item/ammo_magazine/m545sawm/empty
 	category = "Arms and Ammunition"
 	hidden = 1
 
 /datum/category_item/autolathe/arms/rifle_SVD
 	name = "10rnd rifle magazine (7.62mm)"
-	path =/obj/item/ammo_magazine/m762svd/empty
+	path = /obj/item/ammo_magazine/m762svd/empty
 	category = "Arms and Ammunition"
 	hidden = 1
 
 /datum/category_item/autolathe/arms/rifle_762
 	name = "20rnd rifle magazine (7.62mm)"
-	path =/obj/item/ammo_magazine/m762/empty
+	path = /obj/item/ammo_magazine/m762/empty
 	category = "Arms and Ammunition"
 	hidden = 1
 
 /datum/category_item/autolathe/arms/machinegun_762
 	name = "machinegun box magazine (7.62)"
-	path =/obj/item/ammo_magazine/a762/empty
+	path = /obj/item/ammo_magazine/a762/empty
 	category = "Arms and Ammunition"
 	hidden = 1
 
 /datum/category_item/autolathe/arms/shotgun_magazine
 	name = "24rnd shotgun magazine (12g)"
-	path =/obj/item/ammo_magazine/m12gdrum/empty
+	path = /obj/item/ammo_magazine/m12gdrum/empty
 	category = "Arms and Ammunition"
 	hidden = 1*/
 
@@ -339,17 +339,17 @@
 
 /datum/category_item/autolathe/arms/speedloader_357
 	name = "speedloader (.357)"
-	path =/obj/item/ammo_magazine/s357
+	path = /obj/item/ammo_magazine/s357
 	hidden = 1
 
 /datum/category_item/autolathe/arms/speedloader_38
 	name = "speedloader (.38)"
-	path =/obj/item/ammo_magazine/s38
+	path = /obj/item/ammo_magazine/s38
 	hidden = 1
 
 /datum/category_item/autolathe/arms/speedloader_38r
 	name = "speedloader (.38 rubber)"
-	path =/obj/item/ammo_magazine/s38/rubber
+	path = /obj/item/ammo_magazine/s38/rubber
 
 /datum/category_item/autolathe/arms/speedloader_45
 	name = "speedloader (.45)"
@@ -363,99 +363,99 @@
 // Commented out until metal exploits with autolathe is fixed.
 /*/datum/category_item/autolathe/arms/pistol_clip_45
 	name = "ammo clip (.45)"
-	path =/obj/item/ammo_magazine/clip/c45
+	path = /obj/item/ammo_magazine/clip/c45
 	category = "Arms and Ammunition"
 	hidden = 1
 
 /datum/category_item/autolathe/arms/pistol_clip_45r
 	name = "ammo clip (.45 rubber)"
-	path =/obj/item/ammo_magazine/clip/c45/rubber
+	path = /obj/item/ammo_magazine/clip/c45/rubber
 	category = "Arms and Ammunition"
 
 /datum/category_item/autolathe/arms/pistol_clip_45f
 	name = "ammo clip (.45 flash)"
-	path =/obj/item/ammo_magazine/clip/c45/flash
+	path = /obj/item/ammo_magazine/clip/c45/flash
 	category = "Arms and Ammunition"
 
 /datum/category_item/autolathe/arms/pistol_clip_45p
 	name = "ammo clip (.45 practice)"
-	path =/obj/item/ammo_magazine/clip/c45/practice
+	path = /obj/item/ammo_magazine/clip/c45/practice
 	category = "Arms and Ammunition"
 
 /datum/category_item/autolathe/arms/pistol_clip_9mm
 	name = "ammo clip (9mm)"
-	path =/obj/item/ammo_magazine/clip/c9mm
+	path = /obj/item/ammo_magazine/clip/c9mm
 	category = "Arms and Ammunition"
 	hidden = 1
 
 /datum/category_item/autolathe/arms/pistol_clip_9mmr
 	name = "ammo clip (9mm rubber)"
-	path =/obj/item/ammo_magazine/clip/c9mm/rubber
+	path = /obj/item/ammo_magazine/clip/c9mm/rubber
 	category = "Arms and Ammunition"
 
 /datum/category_item/autolathe/arms/pistol_clip_9mmp
 	name = "ammo clip (9mm practice)"
-	path =/obj/item/ammo_magazine/clip/c9mm/practice
+	path = /obj/item/ammo_magazine/clip/c9mm/practice
 	category = "Arms and Ammunition"
 
 /datum/category_item/autolathe/arms/pistol_clip_9mmf
 	name = "ammo clip (9mm flash)"
-	path =/obj/item/ammo_magazine/clip/c9mm/flash
+	path = /obj/item/ammo_magazine/clip/c9mm/flash
 	category = "Arms and Ammunition"
 
 /datum/category_item/autolathe/arms/pistol_clip_5mm
 	name = "ammo clip (5mm)"
-	path =/obj/item/ammo_magazine/clip/c5mm
+	path = /obj/item/ammo_magazine/clip/c5mm
 	category = "Arms and Ammunition"
 	hidden = 1
 
 /datum/category_item/autolathe/arms/pistol_clip_10mm
 	name = "ammo clip (10mm)"
-	path =/obj/item/ammo_magazine/clip/c10mm
+	path = /obj/item/ammo_magazine/clip/c10mm
 	category = "Arms and Ammunition"
 	hidden = 1
 
 /datum/category_item/autolathe/arms/pistol_clip_50
 	name = "ammo clip (.44)"
-	path =/obj/item/ammo_magazine/clip/c50
+	path = /obj/item/ammo_magazine/clip/c50
 	category = "Arms and Ammunition"
 	hidden = 1
 */
 /datum/category_item/autolathe/arms/rifle_clip_545
 	name = "ammo clip (5.45mm)"
-	path =/obj/item/ammo_magazine/clip/c545
+	path = /obj/item/ammo_magazine/clip/c545
 	category = "Arms and Ammunition"
 	hidden = 1
 
 /datum/category_item/autolathe/arms/rifle_clip_545_practice
 	name = "ammo clip (5.45mm practice)"
-	path =/obj/item/ammo_magazine/clip/c545/practice
+	path = /obj/item/ammo_magazine/clip/c545/practice
 	category = "Arms and Ammunition"
 
 /datum/category_item/autolathe/arms/rifle_clip_762
 	name = "ammo clip (7.62mm)"
-	path =/obj/item/ammo_magazine/clip/c762
+	path = /obj/item/ammo_magazine/clip/c762
 	hidden = 1
 
-/*/datum/category_item/autolathe/arms/rifle_clip_762_hunter //VOREStation Edit Start. By request of Ace
+/datum/category_item/autolathe/arms/rifle_clip_762_hunter
 	name = "ammo clip (7.62mm hunting)"
-	path =/obj/item/ammo_magazine/clip/c762/hunter*/ //VOREStation Edit End.
+	path = /obj/item/ammo_magazine/clip/c762/hunter
 
 /datum/category_item/autolathe/arms/rifle_clip_762_practice
 	name = "ammo clip (7.62mm practice)"
-	path =/obj/item/ammo_magazine/clip/c762/practice
+	path = /obj/item/ammo_magazine/clip/c762/practice
 
 /datum/category_item/autolathe/arms/knuckledusters
 	name = "knuckle dusters"
-	path =/obj/item/clothing/gloves/knuckledusters
+	path = /obj/item/clothing/gloves/knuckledusters
 	hidden = 1
 
 /datum/category_item/autolathe/arms/tacknife
 	name = "tactical knife"
-	path =/obj/item/material/knife/tacknife
+	path = /obj/item/material/knife/tacknife
 	hidden = 1
 
 /datum/category_item/autolathe/arms/flamethrower
 	name = "flamethrower"
-	path =/obj/item/flamethrower/full
+	path = /obj/item/flamethrower/full
 	hidden = 1

--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -57,15 +57,16 @@
 /datum/supply_pack/randomised/munitions/disruptor_ammo_bundle
 	// if i could write out a blurb for these for flavortext, i would
 	// disruptor rounds: experimental, expensive, vaguely illegal due to the weird composition?
+	// what if the valuepack had assembly units that required users to shove material in
 	name = "Ammunition - Disruptor Value Pack"
 	num_contained = 5
 	contains = list(
-		/obj/item/ammo_magazine/clip/c762/disruptor
+		/obj/item/ammo_magazine/clip/c762/disruptor = 1
 	)
 	cost = 20
 	contraband = 1
- 	containertype = /obj/structure/closet/crate/secure/weapon
- 	containername = "Disruptor ammunition crate"
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "Disruptor ammunition crate"
 
 /datum/supply_pack/randomised/misc/telecrate //you get something awesome, a couple of decent things, and a few weak/filler things
 	name = "ERR_NULL_ENTRY" //null crate! also dream maker is hell,

--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -54,6 +54,19 @@
  	containertype = /obj/structure/closet/crate/secure/weapon
  	containername = "Ballistic weapons crate"
 
+/datum/supply_pack/randomised/munitions/disruptor_ammo_bundle
+	// if i could write out a blurb for these for flavortext, i would
+	// disruptor rounds: experimental, expensive, vaguely illegal due to the weird composition?
+	name = "Ammunition - Disruptor Value Pack"
+	num_contained = 5
+	contains = list(
+		/obj/item/ammo_magazine/clip/c762/disruptor
+	)
+	cost = 20
+	contraband = 1
+ 	containertype = /obj/structure/closet/crate/secure/weapon
+ 	containername = "Disruptor ammunition crate"
+
 /datum/supply_pack/randomised/misc/telecrate //you get something awesome, a couple of decent things, and a few weak/filler things
 	name = "ERR_NULL_ENTRY" //null crate! also dream maker is hell,
 	num_contained = 1

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -745,6 +745,10 @@
 	name = "rifle clip (7.62mm hunting)"
 	ammo_type = /obj/item/ammo_casing/a762/hunter
 
+/obj/item/ammo_magazine/clip/c762/disruptor
+	name = "rifle clip (7.62mm disruptor)"
+	ammo_type = /obj/item/ammo_casing/a762/disruptor
+
 /obj/item/ammo_magazine/clip/c762/silver
 	name = "rifle clip (7.62mm silver)"
 	icon_state = "agclip_rifle"

--- a/code/modules/projectiles/ammunition/rounds.dm
+++ b/code/modules/projectiles/ammunition/rounds.dm
@@ -30,7 +30,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 210)
 
 /obj/item/ammo_casing/a357/silver
-	desc = "A .357 silver bullet casing. Bless and Sancitfied to banish otherworlds entities."
+	desc = "A .357 silver bullet casing. Bless and sanctified to banish otherworlds entities."
 	caliber = ".357"
 	icon_state = "ag-casing"
 	projectile_type = /obj/item/projectile/bullet/pistol/strong
@@ -59,7 +59,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 130, "uranium" = 100)
 
 /obj/item/ammo_casing/a38/silver
-	desc = "A .38 silver bullet casing. Bless and Sancitfied to banish otherworlds entities."
+	desc = "A .38 silver bullet casing. Bless and sanctified to banish otherworlds entities."
 	icon_state = "ag-casing"
 	projectile_type = /obj/item/projectile/bullet/pistol/silver
 	matter = list(DEFAULT_WALL_MATERIAL = 130, "silver" = 100)
@@ -82,7 +82,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 60)
 
 /obj/item/ammo_casing/a44/silver
-	desc = "A .44 silver bullet casing. Bless and Sancitfied to banish otherworlds entities."
+	desc = "A .44 silver bullet casing. Bless and sanctified to banish otherworlds entities."
 	icon_state = "ag_casing"
 	projectile_type = /obj/item/projectile/bullet/pistol/strong/silver
 	matter = list(DEFAULT_WALL_MATERIAL = 350, "silver" = 200)
@@ -138,7 +138,7 @@
 	projectile_type = /obj/item/projectile/bullet/practice
 
 /obj/item/ammo_casing/a9mm/silver
-	desc = "A 9mm silver bullet casing. Bless and Sancitfied to banish otherworlds entities."
+	desc = "A 9mm silver bullet casing. Bless and sanctified to banish otherworlds entities."
 	icon_state = "ag-casing"
 	projectile_type = /obj/item/projectile/bullet/pistol/silver
 	matter = list(DEFAULT_WALL_MATERIAL = 130, "silver" = 100)
@@ -194,7 +194,7 @@
 
 /obj/item/ammo_casing/a45/silver
 	name = ".45 silver round"
-	desc = "A .45 silver bullet casing. Bless and Sancitfied to banish otherworlds entities."
+	desc = "A .45 silver bullet casing. Bless and sanctified to banish otherworlds entities."
 	icon_state = "ag-casing"
 	projectile_type = /obj/item/projectile/bullet/pistol/silver
 	matter = list(DEFAULT_WALL_MATERIAL = 130, "silver" = 100)
@@ -288,7 +288,7 @@
 //Silver 12g
 /obj/item/ammo_casing/a12g/silver
 	name = " Silver shotgun shell"
-	desc = "A 12 gauge slug. Bless and Sancitfied to banish otherworlds entities."
+	desc = "A 12 gauge slug. Bless and sanctified to banish otherworlds entities."
 	icon_state = "agshell"
 	caliber = "12g"
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun/silver
@@ -297,7 +297,7 @@
 //Wooden Stake 12g
 /obj/item/ammo_casing/a12g/stake
 	name = "Wooden stake shell"
-	desc = "A specialized shell designed to launch a wooden stake. Bless and Sancitfied to banish otherworlds entities."
+	desc = "A specialized shell designed to launch a wooden stake. Bless and sanctified to banish otherworlds entities."
 	icon_state = "agshell"
 	caliber = "12g"
 	projectile_type = /obj/item/projectile/bullet/shotgun/stake
@@ -338,8 +338,12 @@
 	desc = "A 7.62mm hunting bullet casing."
 	projectile_type = /obj/item/projectile/bullet/rifle/a762/hunter
 
+/obj/item/ammo_casing/a762/disruptor
+	desc = "A 7.62mm disruptor round casing."
+	projectile_type = /obj/item/projectile/bullet/rifle/a762/disruptor
+
 /obj/item/ammo_casing/a762/silver
-	desc = "A 7.62mm hunting bullet casing. Bless and Sancitfied to banish otherworlds entities."
+	desc = "A 7.62mm hunting bullet casing. Bless and sanctified to banish otherworlds entities."
 	icon_state = "agrifle-casing"
 	projectile_type = /obj/item/projectile/bullet/rifle/a762/silver
 	matter = list(DEFAULT_WALL_MATERIAL = 300, "silver" = 150)
@@ -410,7 +414,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 180)
 
 /obj/item/ammo_casing/a10x24mmcaseless/hp
-	desc = "A 10x24mm caseless round, common during the Xenomorph wars due to its use the the battle rifles of the United Solar Marine Corps. This one was meant to shred armored targets."
+	desc = "A 10x24mm caseless round, common during the Xenomorph wars due to its use the the battle rifles of the United Solar Marine Corps. This one was meant to shred unarmored targets."
 	caliber = "10x24mm caseless"
 	icon_state = "casing"
 	projectile_type = /obj/item/projectile/bullet/pistol/medium/hp

--- a/code/modules/projectiles/ammunition/rounds.dm
+++ b/code/modules/projectiles/ammunition/rounds.dm
@@ -266,7 +266,8 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 360, "glass" = 720)
 
 /obj/item/ammo_casing/a12g/stunshell/emp_act(severity)
-	if(prob(100/severity)) BB = null
+	if(prob(100/severity))
+		BB = null
 	update_icon()
 
 //Does not stun, only blinds, but has area of effect.
@@ -287,7 +288,7 @@
 
 //Silver 12g
 /obj/item/ammo_casing/a12g/silver
-	name = " Silver shotgun shell"
+	name = "silver shotgun shell"
 	desc = "A 12 gauge slug. Bless and sanctified to banish otherworlds entities."
 	icon_state = "agshell"
 	caliber = "12g"
@@ -296,8 +297,8 @@
 
 //Wooden Stake 12g
 /obj/item/ammo_casing/a12g/stake
-	name = "Wooden stake shell"
-	desc = "A specialized shell designed to launch a wooden stake. Bless and sanctified to banish otherworlds entities."
+	name = "wooden stake shell"
+	desc = "A specialized shell designed to launch a wooden stake. Blessed and sanctified to banish otherworlds entities."
 	icon_state = "agshell"
 	caliber = "12g"
 	projectile_type = /obj/item/projectile/bullet/shotgun/stake
@@ -340,10 +341,11 @@
 
 /obj/item/ammo_casing/a762/disruptor
 	desc = "A 7.62mm disruptor round casing."
+	description_info = "Disruptor rounds are hard to get ahold of and harder to manufacture, but prove themselves against creatures both mundane and less so, along with synthetic threats. Rumor has it the tips are durasteel with a hollow uranium core, letting it punch through targets and still expand inside."
 	projectile_type = /obj/item/projectile/bullet/rifle/a762/disruptor
 
 /obj/item/ammo_casing/a762/silver
-	desc = "A 7.62mm hunting bullet casing. Bless and sanctified to banish otherworlds entities."
+	desc = "A 7.62mm hunting bullet casing. Blessed and sanctified to banish otherworldly entities."
 	icon_state = "agrifle-casing"
 	projectile_type = /obj/item/projectile/bullet/rifle/a762/silver
 	matter = list(DEFAULT_WALL_MATERIAL = 300, "silver" = 150)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -237,6 +237,8 @@
 	fire_sound = 'sound/weapons/Gunshot_generic_rifle.ogg'
 	armor_penetration = 15
 	penetrating = 1
+	accuracy = 30 // 2 tiles closer, for reasons
+	// the day where rng miss is removed couldn't come soon enough
 
 /obj/item/projectile/bullet/rifle/a762
 	fire_sound = 'sound/weapons/Gunshot_heavy.ogg'
@@ -265,6 +267,11 @@
 	SA_bonus_damage = 50 // 70 total on animals.
 	SA_vulnerability = MOB_CLASS_DEMONIC
 	holy = TRUE
+
+/obj/item/projectile/bullet/rifle/a762/disruptor // hunter++
+	damage = 25
+	SA_bonus_damage = 70 // 95 total on animals/bots/xenos because it's a premium round
+	SA_vulnerability = MOB_CLASS_ANIMAL|MOB_CLASS_SYNTHETIC|MOB_CLASS_ABERRATION // not fucking around
 
 /obj/item/projectile/bullet/rifle/a545
 	fire_sound = 'sound/weapons/Gunshot_light.ogg'

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -264,13 +264,13 @@
 
 /obj/item/projectile/bullet/rifle/a762/silver // Hunting Demons with bolt action rifles.
 	damage = 20
-	SA_bonus_damage = 50 // 70 total on animals.
+	SA_bonus_damage = 50 // 70 total on demons.
 	SA_vulnerability = MOB_CLASS_DEMONIC
 	holy = TRUE
 
 /obj/item/projectile/bullet/rifle/a762/disruptor // hunter++
 	damage = 25
-	SA_bonus_damage = 70 // 95 total on animals/bots/xenos because it's a premium round
+	SA_bonus_damage = 50 // 75 total on animals/bots/xenos because it's a premium round
 	SA_vulnerability = MOB_CLASS_ANIMAL|MOB_CLASS_SYNTHETIC|MOB_CLASS_ABERRATION // not fucking around
 
 /obj/item/projectile/bullet/rifle/a545


### PR DESCRIPTION
## About The Pull Request
fucks around with the formatting in autolathes to add a space in the printed item path. also uncomments 5.45 and 7.62 hunter ammunition.
but that's not why we're here.
### DISRUPTOR ROUNDS:
probably illegal or at least hard to obtain due to the unusual composition and manufacturing processes required for these rounds, they're markedly useful against animals, silicons, and, most importantly for some, xenomorphs (or other creatures tagged as aberrations)
they do however still embed into people rather solidly, so, don't shoot your buddy with it as a joke
or do

todo: add more disruptor round types, add a way to obtain them other than cargo (board and snowflaked production method? idk)
## Why It's Good For The Game
hunter rounds are underwhelming
## Changelog
:cl:
balance: if you're reading this this is still a WIP PR don't fucking merge it
/:cl:

<!--
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->
