### PR TITLE
beartraps upgraded

### DIFF
--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -13,6 +13,7 @@
 	var/deployed = 0
 	var/camo_net = FALSE
 	var/stun_length = 0.25 SECONDS
+	var/trap_damage = 30
 	slot_flags = SLOT_MASK
 	item_icons = list(
 		slot_wear_mask_str = 'icons/mob/mask.dmi'
@@ -58,10 +59,13 @@
 				)
 			playsound(src.loc, 'sound/machines/click.ogg',70, 1)
 
-			deployed = 1
 			user.drop_from_inventory(src)
-			update_icon()
-			anchored = 1
+			activate()
+
+/obj/item/beartrap/proc/activate()
+	deployed = 1
+	anchored = 1
+	update_icon()
 
 /obj/item/beartrap/attack_hand(mob/user as mob)
 	if(has_buckled_mobs() && can_use(user))
@@ -112,7 +116,7 @@
 	if(soaked >= 30)
 		return
 
-	if(!L.apply_damage(30, BRUTE, target_zone, blocked, soaked, used_weapon=src))
+	if(!L.apply_damage(trap_damage, BRUTE, target_zone, blocked, soaked, used_weapon=src))
 		return 0
 
 	//trap the victim in place
@@ -158,7 +162,16 @@
 	name = "hunting trap"
 	desc = "A mechanically activated leg trap. High-tech and reliable. Looks like it could really hurt if you set it off."
 	stun_length = 1 SECOND
+	trap_damage = 45
 	camo_net = TRUE
 	color = "#C9DCE1"
 
 	origin_tech = list(TECH_MATERIAL = 4, TECH_BLUESPACE = 3, TECH_MAGNET = 4, TECH_PHORON = 2, TECH_ARCANE = 1)
+
+/obj/item/beartrap/hunting/emp
+	name = "stealth disruptor trap"
+	desc = "A mechanically activated leg trap. High tech and reliable. Looks like it could really be a problem for unshielded electronics."
+
+/obj/item/beartrap/hunting/emp/attack_mob(mob/living/L)
+	. = ..()
+	empulse(L.loc, 0, 0, 0, 0)	// very localized, apparently


### PR DESCRIPTION
## About The Pull Request
adds an activate() proc to beartraps so you don't have to manually set them with a mob
adds an adminspawn only "disruptor trap" that EMPs whoever it latches onto
buffs hunting trap to 45 force instead of 30 because it's science shit and it requires quirky materials
## Why It's Good For The Game
beartraps are criminally underutilized
## Changelog
:cl:
tweak: Bear traps now have an activation proc, instead of relying on manual placement.
/:cl: