### PR TITLE
Closes #2463

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -47,9 +47,10 @@
 				return
 
 /obj/machinery/chem_master/attackby(var/obj/item/B as obj, var/mob/user as mob)
-
 	if(istype(B, /obj/item/reagent_containers/glass) || istype(B, /obj/item/reagent_containers/food))
-
+		if(!B.is_open_container())
+			to_chat(user, "<span class='warning'>You don't see how \the [src] could dispense reagents into \the [B]. Try removing the lid.</span>")
+			return
 		if(src.beaker)
 			to_chat(user, "\A [beaker] is already loaded into the machine.")
 			return


### PR DESCRIPTION
This is a sanity check that runs is_open_container() before allowing the beaker to be inserted. With this addition, you will no longer be able to insert a closed beaker into any chem dispensers, and potentially lose contents.

