### PR TITLE
Adds soulcatchers to NIFs by default

### DIFF
--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -103,6 +103,9 @@ GLOBAL_LIST_INIT(nif_id_lookup, init_nif_id_lookup())
 
 	//Free civilian AR included
 	new /datum/nifsoft/ar_civ(src)
+	
+	//Free soulcatcher because why not, people barely even use it.
+	new /datum/nifsoft/soulcatcher(src)
 
 	//If given wear (like when spawned) then done
 	if(wear)


### PR DESCRIPTION
## About The Pull Request

Adds soulcatchers to all NIFs by default. This means that, whenever a fresh NIF is installed in someone, they will get a soulcatcher automatically, much like commlinks.

## Why It's Good For The Game

People barely use soulcatchers and this'll hopefully encourage their usage a bit more.

## Changelog
:cl:
add: Adds soulcatchers to NIFs by default.
/:cl: