### PR TITLE
Closes #2342

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station/drone.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/drone.dm
@@ -17,7 +17,7 @@
 	src.modules += new /obj/item/multitool(src)
 	src.modules += new /obj/item/lightreplacer(src)
 	src.modules += new /obj/item/gripper(src)
-	src.modules += new /obj/item/soap(src)
+	src.modules += new /obj/item/mop(src)
 	src.modules += new /obj/item/gripper/no_use/loader(src)
 	src.modules += new /obj/item/extinguisher(src)
 	src.modules += new /obj/item/pipe_painter(src)


### PR DESCRIPTION
Humans use soap, not silicons.
Silicons are able to use mops, however.
Therefore, the soap that is given to drones (and only drones, no doubt an ancient unfixed strand of spaghetti) must be replaced by a mop to restore their ability to clean floors.

They must wet the mop in a sink, as any other synthetic or humanoid, then use it as normal.
