### PR TITLE
Pathfinders need normal-looking IDs.

### DIFF
--- a/code/game/objects/items/weapons/id cards/sprite_stacks_cit.dm
+++ b/code/game/objects/items/weapons/id cards/sprite_stacks_cit.dm
@@ -59,5 +59,5 @@
 	initial_sprite_stack = list("", "top-science-explorer")
 
 //Ditto in southern_cross_jobs_vr.dm
-/obj/item/card/id/science/head/pathfinder
+/obj/item/card/id/explorer/head/pathfinder
 	initial_sprite_stack = list("", "top-science-explorer", "pips-gold")


### PR DESCRIPTION
Un-triggers pathfinder players.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Returns the pathfinder's ID to what it was before whatever update broke it.

## Why It's Good For The Game

Pretty ID.

## Changelog
:cl:
fix: The path for the pathfinder sprite stacks is fixed to allow the icon to actually show up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
