### PR TITLE
the "Use Your Eyes" update for mining: sand digging speed and yields, feedback messages mostly removed, ripley drill faster

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -25,7 +25,7 @@
 #define BORGMESON 0x1
 #define BORGTHERM 0x2
 #define BORGXRAY  0x4
-#define BORGMATERIAL  8
+#define BORGMATERIAL  0x8
 
 #define STANCE_ATTACK    11 // Backwards compatability
 #define STANCE_ATTACKING 12 // Ditto

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -127,7 +127,7 @@
 	name = "drill"
 	desc = "This is the drill that'll pierce the heavens! (Can be attached to: Combat and Engineering Exosuits)"
 	icon_state = "mecha_drill"
-	equip_cooldown = 30
+	equip_cooldown = 13
 	energy_drain = 10
 	force = 15
 	required_type = list(/obj/mecha/working/ripley, /obj/mecha/combat)
@@ -177,7 +177,7 @@
 	desc = "This is an upgraded version of the drill that'll pierce the heavens! (Can be attached to: Combat and Engineering Exosuits)"
 	icon_state = "mecha_diamond_drill"
 	origin_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
-	equip_cooldown = 10
+	equip_cooldown = 5
 	force = 15
 
 /obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill/action(atom/target)

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -177,7 +177,7 @@
 	desc = "This is an upgraded version of the drill that'll pierce the heavens! (Can be attached to: Combat and Engineering Exosuits)"
 	icon_state = "mecha_diamond_drill"
 	origin_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
-	equip_cooldown = 5
+	equip_cooldown = 2
 	force = 15
 
 /obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill/action(atom/target)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -123,7 +123,7 @@
 		if(world.time >= last_message == 0)
 			to_chat(user, "<span class='notice'>You fail to pick anything up with \the [src].</span>")
 			last_message = world.time + 90
-	if(istype(user.pulling, /obj/structure/ore_box/)) // buffy fix with last_message, no more spam
+	if(istype(user.pulling, /obj/structure/ore_box)) // buffy fix with last_message, no more spam
 		var/obj/structure/ore_box/O = user.pulling
 		O.attackby(src, user)
 

--- a/code/modules/mining/drilling/scanner.dm
+++ b/code/modules/mining/drilling/scanner.dm
@@ -61,13 +61,18 @@
 			else
 				ore_type = metal
 			if(ore_type)
-				metals[ore_type] += T.resources[metal]
+				if(metals[ore_type])
+					metals[ore_type] += T.resources[metal]
+				else
+					metals[ore_type] = T.resources[metal]
 
-	var/message = "\icon[src] <span class='notice'>The scanner beeps and displays a readout.</span>"
+	to_chat(user, "\icon[src] <span class='notice'>The scanner beeps and displays a readout.</span>")
+	var/list/results = list()
 	for(var/ore_type in metals)
 		var/result = "no sign"
+
 		if(exact_amount)
-			result = "- [metals[ore_type]] [ore_type]"
+			result = "- [metals[ore_type]] of [ore_type]"
 		else
 			switch(metals[ore_type])
 				if(1 to 25)
@@ -76,8 +81,9 @@
 					result = "significant amounts of [ore_type]"
 				if(76 to INFINITY)
 					result = "huge quantities of [ore_type]"
-		message += "<br><span class='notice'>[result]</span>"
-	to_chat(user, message)
+		results += result
+	to_chat(user, results.Join("<br>"))
+
 
 /obj/item/mining_scanner/advanced
 	name = "advanced ore detector"

--- a/code/modules/mining/drilling/scanner.dm
+++ b/code/modules/mining/drilling/scanner.dm
@@ -82,7 +82,7 @@
 				if(76 to INFINITY)
 					result = "huge quantities of [ore_type]"
 		results += result
-	to_chat(user, results.Join("<br>"))
+	to_chat(user, results)
 
 /obj/item/mining_scanner/advanced
 	name = "advanced ore detector"

--- a/code/modules/mining/drilling/scanner.dm
+++ b/code/modules/mining/drilling/scanner.dm
@@ -8,7 +8,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 150)
 	var/scanrange = 2
 	var/maxscanrange = 2
-	var/scan_time = 5 SECONDS
+	var/scan_time = 3 SECONDS
 	var/scan_exact_ores = FALSE
 	var/scan_exact_amounts = FALSE
 
@@ -28,7 +28,7 @@
 	. = ..()
 
 /obj/item/mining_scanner/attack_self(mob/user)
-	to_chat(user,"You begin sweeping \the [src] about, scanning for metal deposits.")
+	to_chat(user, "<span class='notice'>You begin sweeping \the [src] about, scanning for metal deposits.</span>")
 	playsound(loc, 'sound/items/goggles_charge.ogg', 50, 1, -6)
 
 	if(!do_after(user, scan_time))
@@ -61,18 +61,13 @@
 			else
 				ore_type = metal
 			if(ore_type)
-				if(metals[ore_type])
-					metals[ore_type] += T.resources[metal]
-				else
-					metals[ore_type] = T.resources[metal]
+				metals[ore_type] += T.resources[metal]
 
-	to_chat(user, "\icon[src] <span class='notice'>The scanner beeps and displays a readout.</span>")
-	var/list/results = list()
+	var/message = "\icon[src] <span class='notice'>The scanner beeps and displays a readout.</span>"
 	for(var/ore_type in metals)
 		var/result = "no sign"
-
 		if(exact_amount)
-			result = "- [metals[ore_type]] of [ore_type]"
+			result = "- [metals[ore_type]] [ore_type]"
 		else
 			switch(metals[ore_type])
 				if(1 to 25)
@@ -81,8 +76,8 @@
 					result = "significant amounts of [ore_type]"
 				if(76 to INFINITY)
 					result = "huge quantities of [ore_type]"
-		results += result
-	to_chat(user, results)
+		message += "<br><span class='notice'>[result]</span>"
+	to_chat(user, message)
 
 /obj/item/mining_scanner/advanced
 	name = "advanced ore detector"

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -21,6 +21,7 @@
 	w_class = ITEMSIZE_LARGE
 	matter = list(DEFAULT_WALL_MATERIAL = 3750)
 	var/digspeed = 40 //moving the delay to an item var so R&D can make improved picks. --NEO
+	var/sand_dig = FALSE
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	attack_verb = list("hit", "pierced", "sliced", "attacked")
 	var/drill_sound = 'sound/weapons/Genhit.ogg'
@@ -46,6 +47,7 @@
 	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	desc = "Yours is the drill that will pierce through the rock walls."
 	drill_verb = "drilling"
+	sand_dig = TRUE
 
 /obj/item/pickaxe/jackhammer
 	name = "sonic jackhammer"
@@ -88,7 +90,7 @@
 	desc = "A pickaxe with a diamond pick head."
 	drill_verb = "picking"
 
-/obj/item/pickaxe/diamonddrill //When people ask about the badass leader of the mining tools, they are talking about ME!
+/obj/item/pickaxe/diamonddrill // When people ask about the badass leader of the mining tools, they are talking about ME!
 	name = "diamond mining drill"
 	icon_state = "diamonddrill"
 	item_state = "jackhammer"
@@ -96,6 +98,7 @@
 	origin_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 5)
 	desc = "Yours is the drill that will pierce the heavens!"
 	drill_verb = "drilling"
+	sand_dig = TRUE
 
 /obj/item/pickaxe/borgdrill
 	name = "enhanced sonic jackhammer"
@@ -104,6 +107,7 @@
 	digspeed = 15
 	desc = "Cracks rocks with sonic blasts. This one seems like an improved design."
 	drill_verb = "hammering"
+	sand_dig = TRUE
 
 /obj/item/pickaxe/icepick //Cannot actually lobotomize people. Yet.
 	name = "icepick"
@@ -114,7 +118,7 @@
 	icon_state = "icepick"
 	item_state = "spickaxe" //im lazy fuck u
 	w_class = ITEMSIZE_SMALL
-	matter = list(DEFAULT_WALL_MATERIAL = 2750, "titanium" = 2000) 
+	matter = list(DEFAULT_WALL_MATERIAL = 2750, "titanium" = 2000)
 	digspeed = 25 //More expensive than a diamond pick, a lot smaller but decently slower.
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	attack_verb = list("mined", "pierced", "stabbed", "attacked")

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -143,6 +143,7 @@
 	attack_verb = list("bashed", "bludgeoned", "thrashed", "whacked")
 	sharp = 0
 	edge = 1
+	var/digspeed = 40
 
 /obj/item/shovel/spade
 	name = "spade"

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -427,7 +427,7 @@ turf/simulated/mineral/floor/light_corner
 					else if(newDepth > F.excavation_required - F.clearance_range) // Not quite right but you still extract your find, the closer to the bottom the better, but not above 80%
 						excavate_find(prob(80 * (F.excavation_required - newDepth) / F.clearance_range), F)
 
-				to_chat(user, "<span class='notice'>You finish [P.drill_verb] \the [src].</span>")
+				//to_chat(user, "<span class='notice'>You finish [P.drill_verb] \the [src].</span>")
 
 				if(newDepth >= 200) // This means the rock is mined out fully
 					if(P.destroy_artefacts)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -302,12 +302,15 @@ turf/simulated/mineral/floor/light_corner
 			)
 */
 		if(istype(W, /obj/item/shovel))
+			var/obj/item/shovel/S = W
 			valid_tool = 1
+			digspeed = S.digspeed
 
 		if(istype(W, /obj/item/pickaxe))
 			var/obj/item/pickaxe/P = W
-			valid_tool = 1
-			digspeed = P.digspeed
+			if(P.sand_dig)
+				valid_tool = 1
+				digspeed = P.digspeed
 
 		if(valid_tool)
 			if(sand_dug)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -291,34 +291,40 @@ turf/simulated/mineral/floor/light_corner
 
 	if(!density)
 
+		var/valid_tool = 0
+		var/digspeed = 40
+/*
 		var/list/usable_tools = list(
 			/obj/item/shovel,
 			/obj/item/pickaxe/diamonddrill,
 			/obj/item/pickaxe/drill,
 			/obj/item/pickaxe/borgdrill
 			)
+*/
+		if(istype(W, /obj/item/shovel))
+			valid_tool = 1
 
-		var/valid_tool
-		for(var/valid_type in usable_tools)
-			if(istype(W,valid_type))
-				valid_tool = 1
-				break
+		if(istype(W, /obj/item/pickaxe))
+			var/obj/item/pickaxe/P = W
+			valid_tool = 1
+			digspeed = P.digspeed
 
 		if(valid_tool)
-			if (sand_dug)
+			if(sand_dug)
 				to_chat(user, "<span class='warning'>This area has already been dug.</span>")
 				return
 
 			var/turf/T = user.loc
-			if (!(istype(T)))
+			if(!(istype(T)))
 				return
 
-			to_chat(user, "<span class='notice'>You start digging.</span>")
+			// to_chat(user, "<span class='notice'>You start digging.</span>")
 			playsound(user.loc, 'sound/effects/rustle1.ogg', 50, 1)
 
-			if(!do_after(user,40)) return
+			if(!do_after(user,digspeed))
+				return
 
-			to_chat(user, "<span class='notice'>You dug a hole.</span>")
+			// to_chat(user, "<span class='notice'>You dug a hole.</span>")
 			GetDrilled()
 
 		else if(istype(W,/obj/item/storage/bag/ore))
@@ -407,9 +413,10 @@ turf/simulated/mineral/floor/light_corner
 			if(finds && finds.len)
 				var/datum/find/F = finds[1]
 				if(newDepth > F.excavation_required) // Digging too deep can break the item. At least you won't summon a Balrog (probably)
-					fail_message = ". <b>[pick("There is a crunching noise","[W] collides with some different rock","Part of the rock face crumbles away","Something breaks under [W]")]</b>"
+					fail_message = "<b>[pick("There is a crunching noise","[W] collides with some different rock","Part of the rock face crumbles away","Something breaks under [W]")]</b>"
 				wreckfinds(P.destroy_artefacts)
-			to_chat(user, "<span class='notice'>You start [P.drill_verb][fail_message].</span>")
+			if(fail_message)
+				to_chat(user, "<span class='notice'>[fail_message].</span>")
 
 			if(do_after(user,P.digspeed))
 
@@ -530,7 +537,7 @@ turf/simulated/mineral/floor/light_corner
 	if(!density)
 		if(!sand_dug)
 			sand_dug = 1
-			for(var/i=0;i<(rand(3)+2);i++)
+			for(var/i=0;i<5;i++)
 				new/obj/item/ore/glass(src)
 			update_icon()
 		return

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -25,7 +25,7 @@
 		S.hide_from(usr)
 		for(var/obj/item/ore/O in S.contents)
 			S.remove_from_storage(O, src) //This will move the item to this item's contents
-		to_chat(user,"<span class='notice'>You empty the satchel into the box.</span>")
+		// to_chat(user,"<span class='notice'>You empty the satchel into the box.</span>")
 
 	update_ore_count()
 


### PR DESCRIPTION
## About The Pull Request
removes feedback messages from ore satchels and ore boxes, along with mining and digging, except you'll still get notified if you hit a rock with an anomaly in it (which you should still take as a cue to maybe not hit the rock with the anomaly in it)

also lets the digspeed of mining tools affect digging because nobody likes standing still for 10 seconds to get 3 sand
also increases sand yield per tile to 5 sand per, because i like having glass

buffs exosuit drills (30 to 13 for standard, 10 to 3 for diamond)
## Why It's Good For The Game
man i sure love half of my chatlog being pushed out of the way by "You empty the satchel into the box" or "You start drilling"
## Changelog
:cl:
tweak: A fair bit of feedback messages from your ore satchel or hitting rocks has been removed. Except the bit that pops up when you hit an anomaly-bearing rock. That's still there. Use your eyes. 
tweak: Digging-capable mining tools (cyborg jackhammer, advanced drill, diamond drill, etc) now use their digspeeds instead of the default 40 digspeed when digging up sand.
tweak: Sand tiles now yield a flat 5 sand. All the time. Forever.
balance: Exosuit drills are faster. Theoretically.
/:cl:
