### PR TITLE
Null Rod Tweaks/Buff

### DIFF
--- a/code/game/objects/items/weapons/nullrod.dm
+++ b/code/game/objects/items/weapons/nullrod.dm
@@ -20,6 +20,9 @@
 			slot_r_hand_str = 'icons/mob/items/righthand_melee.dmi',
 			)
 
+	var/SA_bonus_damage = 25 // 40 total against demons and aberrations.
+	var/SA_vulnerability = MOB_CLASS_DEMONIC, MOB_CLASS_ABERRATION
+
 /obj/item/nullrod/Initialize()
 	. = ..()
 	AddComponent(/datum/component/anti_magic, TRUE, TRUE, FALSE, null, null, FALSE)

--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/cultist.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/cultist.dm
@@ -9,6 +9,7 @@
 	icon = 'icons/mob/cult.dmi'
 	icon_state = "initiate"
 	faction = "cult"
+	mob_class = MOB_CLASS_DEMONIC
 
 /mob/living/simple_mob/humanoid/cultist/human
 	name = "cultist"


### PR DESCRIPTION
Finally remembered to update the Null Rod's SA Vulnerability flags. It'll now do bonus damage to Cult mobs and Aberrations.

1. _Adds the SA flags to the Null Rod._
**Why:** The anti-magic/anti-cult weapon should probably have the appropriate buff.

2. _Makes Cult mobs count under the appropriate Mob Class._
**Why:** The SA isn't triggering on mobs that are meant to be vulnerable.