### PR TITLE
something about slowdowns and item_slowdown_modifiers

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -93,10 +93,13 @@
 	tally += calculate_turf_slowdown(T, direct)
 
 	// Item related slowdown.
-	if(!(CE_SPEEDBOOST in chem_effects)) //Hyperzine ignores item slowdown
-		var/item_tally = calculate_item_encumbrance()
-		item_tally *= species.item_slowdown_mod
-		tally += item_tally
+	var/item_tally = calculate_item_encumbrance()
+	if(item_tally > 0) // is it greater than 0? run the wacky shit
+		item_tally *= species.item_slowdown_mod // your item slowdown kicks in, but
+		if(!(CE_SPEEDBOOST in chem_effects)) // hyperzine users ignore item slow
+			tally += item_tally // no hyperzine? slowed down by things
+	else
+		tally += item_tally // if it's less than 0 that means it speeds you up, theoretically, so, hit it
 
 	/* removed - kevinz000. A system will eventually be reintroduced to do this, but for the moment I'd rather this Not be a thing.
 	// Dragging heavy objects will also slow you down, similar to above.
@@ -131,7 +134,7 @@
 
 	// Hands are also included, to make the 'take off your armor instantly and carry it with you to go faster' trick no longer viable.
 	// This is done seperately to disallow negative numbers (so you can't hold shoes in your hands to go faster).
-	for(var/obj/item/I in list(r_hand, l_hand) )
+	for(var/obj/item/I in list(r_hand, l_hand))
 		. += max(I.slowdown, 0)
 
 // Similar to above, but for turf slowdown.


### PR DESCRIPTION
disregard the commit name i tested it
## About The Pull Request
item slowdowns only get affected by item slowdown modifiers if they're greater than 0, otherwise just applies them (negative slowdown items make you run fast as fuck btw)
basically a remake of pr #1560
## Why It's Good For The Game
being slow is unbased but being unable to benefit from negative slowdown items is also unbased
## Changelog
:cl:
balance: Items with negative slowdown now work nicely for people of any hardiness. This is a re-implementation of something lost in the hardsync.
/:cl:
