### PR TITLE
Intern Reassignment Initiative

### DIFF
--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -12,7 +12,7 @@
 	access = list()			//See /datum/job/assistant/get_access()
 	minimal_access = list()	//See /datum/job/assistant/get_access()
 	outfit_type = /decl/hierarchy/outfit/job/assistant
-	alt_titles = list("Visitor" = /decl/hierarchy/outfit/job/assistant/visitor, "Tourist")
+	alt_titles = list("Visitor" = /decl/hierarchy/outfit/job/assistant/visitor, "Server" = /decl/hierarchy/outfit/job/service/server, "Tourist")
 
 /datum/job/assistant/get_access()
 	if(config_legacy.assistant_maint)
@@ -33,32 +33,3 @@
 
 /datum/job/assistant/get_access()
 	return list()
-
-/datum/job/intern
-	title = "Intern"
-	flag = INTERN
-	department = "Civilian"
-	department_flag = ENGSEC // Ran out of bits
-	faction = "Station"
-	total_positions = -1
-	spawn_positions = -1
-	supervisors = "the staff from the department you're interning in"
-	selection_color = "#555555"
-	economic_modifier = 2
-	access = list()			//See /datum/job/intern/get_access()
-	minimal_access = list()	//See /datum/job/intern/get_access()
-	outfit_type = /decl/hierarchy/outfit/job/assistant/intern
-	alt_titles = list("Assistant", "Apprentice Engineer","Medical Intern","Lab Assistant","Security Cadet","Jr. Cargo Tech", "Jr. Explorer", "Server" = /decl/hierarchy/outfit/job/service/server)
-	timeoff_factor = 0 // Interns, noh
-
-/datum/job/intern/New()
-	..()
-	if(config)
-		total_positions = config_legacy.limit_interns
-		spawn_positions = config_legacy.limit_interns
-
-/datum/job/intern/get_access()
-	if(config_legacy.assistant_maint)
-		return list(access_maint_tunnels)
-	else
-		return list()

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -88,7 +88,7 @@
 	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
 
 	outfit_type = /decl/hierarchy/outfit/job/cargo/cargo_tech
-	alt_titles = list("Logistics Specialist")
+	alt_titles = list("Logistics Specialist", "Jr. Cargo Tech")
 
 /datum/job/mining
 	title = "Shaft Miner"

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -46,7 +46,7 @@
 	economic_modifier = 5
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics)
 	minimal_access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction)
-	alt_titles = list("Maintenance Technician","Engine Technician","Electrician","Third Engineer","Shipwright")
+	alt_titles = list("Maintenance Technician","Engine Technician","Electrician","Third Engineer","Shipwright","Apprentice Engineer")
 
 	minimal_player_age = 3
 

--- a/code/game/jobs/job/exploration.dm
+++ b/code/game/jobs/job/exploration.dm
@@ -85,7 +85,7 @@
 	selection_color = "#999440"
 	idtype = /obj/item/card/id/explorer/explorer
 	economic_modifier = 6
-	alt_titles = list("Field Scout", "Pioneer")
+	alt_titles = list("Field Scout", "Pioneer", "Jr. Explorer")
 	access = list(access_explorer, access_research)
 	minimal_access = list(access_explorer, access_research)
 	outfit_type = /decl/hierarchy/outfit/job/explorer2

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -47,7 +47,8 @@
 		"Emergency Physician" = /decl/hierarchy/outfit/job/medical/doctor/emergency_physician,
 		"Nurse" = /decl/hierarchy/outfit/job/medical/doctor/nurse,
 		"Virologist" = /decl/hierarchy/outfit/job/medical/doctor/virologist,
-		"Medical Resident")
+		"Medical Resident",
+		"Medical Intern")
 
 //Chemist is a medical job damnit	//YEAH FUCK YOU SCIENCE	-Pete	//Guys, behave -Erro
 /datum/job/chemist

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -46,7 +46,7 @@
 	minimal_player_age = 14
 
 	outfit_type = /decl/hierarchy/outfit/job/science/scientist
-	alt_titles = list("Xenoarchaeologist", "Anomalist", "Phoron Researcher", "Circuit Designer", "Field Technician")
+	alt_titles = list("Xenoarchaeologist", "Anomalist", "Phoron Researcher", "Circuit Designer", "Field Technician", "Lab Assistant")
 
 /datum/job/xenobiologist
 	title = "Xenobiologist"

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -79,4 +79,4 @@
 	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_external_airlocks)
 	minimal_player_age = 3
 	outfit_type = /decl/hierarchy/outfit/job/security/officer
-	alt_titles = list("Patrolman","Junior Officer", "Constable", "Peacekeeper")
+	alt_titles = list("Patrolman","Junior Officer", "Constable", "Peacekeeper", "Security Cadet")


### PR DESCRIPTION
Interns are no longer a class of Assistant. Instead, Intern titles are now sub-titles of the related base department job. You can still RP being an Intern/Trainee, but now you don't have to deal with guest passes and janky shit.

1. _Removes the Intern subset of Assistant, and redistributes its titles._
**Why:** QOL for "Intern" RPers.