### PR TITLE
bandaid fix - cult/rat signals no longer do anything if it's not the main ship triggering because exploration shuttles causing a cult invasion on the actual station due to bad piloting on THEIR shuttle is STUPID

### DIFF
--- a/code/modules/events/cult.dm
+++ b/code/modules/events/cult.dm
@@ -91,6 +91,12 @@
 	command_announcement.Announce("Attention [station_name()], the ship has ran into a hostile sub-sector and reports of humanoid and non-humanoid entities are warping onto the ships! Advise immediate removal of these intruders before productivy aboard gets hindered!", "Screaming Signals Intercepted", new_sound = 'sound/effects/c_alarm.mp3')
 	return
 
+/datum/event/cult/overmap/start()		// override - cancel if not main ship since it doesn't properly target the actual triggering ship
+	if(!istype(victim, /obj/effect/overmap/visitable/ship/triumph))
+		kill()
+		return
+	return ..()
+
 #undef LOC_LIBRARY
 #undef LOC_SECURITY
 #undef LOC_RESEARCH

--- a/code/modules/events/hostile_migration_vr.dm
+++ b/code/modules/events/hostile_migration_vr.dm
@@ -96,6 +96,13 @@
 	command_announcement.Announce("Unidentified hostile lifesigns detected migrating towards [station_name()]'s [locstring]. Secure any exterior access, including ducting and ventilation.", "Hostile Vermin Boarding Alert", new_sound = 'sound/AI/aliens.ogg')
 	return
 
+// override: cancel if not main ship as this is too dumb to target the actual ship crossing it.
+/datum/event/hostile_migration/overmap/start()
+	if(!istype(victim, /obj/effect/overmap/visitable/ship/triumph))
+		kill()
+		return
+	return ..()
+
 #undef LOC_KITCHEN
 #undef LOC_LIBRARY
 #undef LOC_HALLWAYS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

SIGH
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: exploration can no longer end the round with bad piloting skill
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
