### PR TITLE
buffs teshari brute/burn damage resistaances to 10% vuln instead of 35%, and item slowdown mod to 1.25 from 2

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/teshari.dm
+++ b/code/modules/mob/living/carbon/human/species/station/teshari.dm
@@ -48,10 +48,10 @@
 
 	slowdown	= -0.5
 	snow_movement = -1		// Ignores light snow
-	item_slowdown_mod = 2	// Tiny birds don't like heavy things
+	item_slowdown_mod = 1.25	// Tiny birds don't like heavy things
 	total_health = 75
-	brute_mod	 = 1.35
-	burn_mod	 = 1.35
+	brute_mod	 = 1.1
+	burn_mod	 = 1.1
 	mob_size	 = MOB_SMALL
 	pass_flags	 = PASSTABLE
 	holder_type	 = /obj/item/holder/human


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

i missed item slowdown mod in the original pr and now they move like a snail in a hardsuit which is too hard of a nerf
plus 1.1x mod with 75 health is already really weak, we can tune it back again if it turns out this is bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: teshari have been given a bit less damage vulnerability and item slowdown mod.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
