### PR TITLE
nerfs berserk from -1 slowdown to -0.75 giving avg 8 tiles runspeed instead of 10

### DIFF
--- a/code/modules/mob/_modifiers/modifiers_misc.dm
+++ b/code/modules/mob/_modifiers/modifiers_misc.dm
@@ -51,7 +51,7 @@ the artifact triggers the rage.
 	stacks = MODIFIER_STACK_EXTEND
 
 	// The good stuff.
-	slowdown = -1							// Move a bit faster.
+	slowdown = -0.75							// Move a bit faster.
 	attack_speed_percent = 0.66				// Attack at 2/3 the normal delay.
 	outgoing_melee_damage_percent = 1.5		// 50% more damage from melee.
 	max_health_percent = 1.5				// More health as a buffer, however the holder might fall into crit after this expires if they're mortally wounded.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

apparently some simplemobs have this and just decimate people
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: berserk modifier used by saviks reduces slowdown by 0.75 instead of 1
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
