### PR TITLE
puts an explorer/offstation firing pin in the pathfinder's m41a instead of an unrestricted one

### DIFF
--- a/code/modules/projectiles/guns/projectile/caseless.dm
+++ b/code/modules/projectiles/guns/projectile/caseless.dm
@@ -29,6 +29,7 @@
 	caliber = "10mmCL"
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
 	slot_flags = SLOT_BACK
+	pin = /obj/item/firing_pin/explorer
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/m10x24mm/small
 	allowed_magazines = list(/obj/item/ammo_magazine/m10x24mm/small, /obj/item/ammo_magazine/m10x24mm/med, /obj/item/ammo_magazine/m10x24mm/large)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

>all of the other guns are locked but not the funny burst rifle gun they shouldn't even have

pog
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: pathfinder's m41a is now explorer-pinned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
