### PR TITLE
fixes curtains, typo in toy code

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -921,7 +921,7 @@
 /obj/item/toy/plushie/attackby(obj/item/I as obj, mob/user as mob)
 	if(istype(I, /obj/item/toy/plushie) || istype(I, /obj/item/organ/external/head))
 		user.visible_message("<span class='notice'>[user] makes \the [I] kiss \the [src]!.</span>", \
-		"<span class='notice'>You make \the [I] kiss \the [src]!.</span>")
+		"<span class='notice'>You make \the [I] kiss \the [src]!</span>")
 	return ..()
 
 /obj/item/toy/plushie/nymph

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -10,7 +10,7 @@
 /obj/structure/curtain/open
 	icon_state = "open"
 	plane = OBJ_PLANE
-	layer = OBJ_LAYER
+	layer = 3.3 //3.3 so its above windows, not the same as them. anything below 3.3 puts the curtain beneath the window sprite in current build
 	opacity = 0
 
 /obj/structure/curtain/bullet_act(obj/item/projectile/P, def_zone)
@@ -34,7 +34,7 @@
 	else
 		icon_state = "open"
 		plane = OBJ_PLANE
-		layer = OBJ_LAYER
+		layer = 3.3
 
 /obj/structure/curtain/attackby(obj/item/P, mob/user)
 	if(P.is_wirecutter())

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -806,8 +806,6 @@
 					raise, salute, scream, sneeze, shake, shiver, shrug, sigh, signal-#1-10, slap-(none)/mob, smile, sneeze, sniff, snore, stare-(none)/mob, stopsway/swag, squeak, sway/wag, swish, tremble, twitch, \
 					twitch_v, vomit, weh, whimper, wink, yawn. Synthetics: beep, buzz, yes, no, rcough, rsneeze, ping. Vox: shriekshort, shriekloud")
 
-		else
-			to_chat(src, "<font color='blue'>Unusable emote '[act]'. Say *help or *vhelp for a list.</font>") //VOREStation Edit, mention *vhelp for Virgo-specific emotes located in emote_vr.dm.
 
 	if (message)
 		custom_emote(m_type,message)
@@ -938,6 +936,9 @@
 			message = "purrs softly."
 			m_type = 2
 			playsound(loc, 'modular_citadel/sound/voice/purr.ogg', 50, 1, -1)
+
+		else
+			to_chat(src, "<font color='blue'>Unusable emote '[act]'. Say *help or *vhelp for a list.</font>")
 
 	if (message)
 		custom_emote(m_type,message)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -938,7 +938,7 @@
 			playsound(loc, 'modular_citadel/sound/voice/purr.ogg', 50, 1, -1)
 
 		else
-			to_chat(src, "<font color='blue'>Unusable emote '[act]'. Say *help or *vhelp for a list.</font>")
+			to_chat(src, "<font color='blue'>Unusable emote '[act]'. Say *help for a list.</font>")
 
 	if (message)
 		custom_emote(m_type,message)


### PR DESCRIPTION
:cl:
fix: fixes curtains so they dont vanish underneath the window
fix: fixes plushie code typo
/:cl:

