### PR TITLE
Speech bubbles appear above objects you're inside of.

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -338,6 +338,17 @@ proc/get_radio_key_from_channel(var/channel)
 	//var/image/speech_bubble = image('icons/mob/talk_vr.dmi',src,"h[speech_bubble_test]") //VOREStation Edit. Commented this out in case we need to reenable.
 	var/speech_type = speech_bubble_appearance()
 	var/image/speech_bubble = image('icons/mob/talk_vr.dmi',src,"[speech_type][speech_bubble_test]") //VOREStation Edit - talk_vr.dmi instead of talk.dmi for right-side icons
+	var/sb_alpha = 255
+	var/atom/loc_before_turf = src
+	if(isbelly(loc))
+		speech_bubble.pixel_y = -13 //teehee. - Very funny.
+	while(loc_before_turf && !isturf(loc_before_turf.loc))
+		loc_before_turf = loc_before_turf.loc
+		sb_alpha -= 50
+		if(sb_alpha < 0)
+			break
+	speech_bubble.loc = loc_before_turf
+	speech_bubble.alpha = CLAMP(sb_alpha, 0, 255)
 	images_to_clients[speech_bubble] = list()
 
 	// Attempt Multi-Z Talking


### PR DESCRIPTION
See title.

Ported from polaris again, makes speech bubbles appear above containers if you're inside of one.