### PR TITLE
Map Tweaks: Engineering Atmos and Mining Shuttle Relays

### DIFF
--- a/_maps/map_files/triumph/triumph-01-deck1.dmm
+++ b/_maps/map_files/triumph/triumph-01-deck1.dmm
@@ -1191,6 +1191,12 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
+"eC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/engineering/lower/corridor)
 "eD" = (
 /turf/simulated/wall/r_wall,
 /area/space)
@@ -7780,6 +7786,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
 "Ej" = (
@@ -7954,6 +7963,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
 "EJ" = (
@@ -8055,6 +8067,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
@@ -8460,6 +8475,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
@@ -22305,7 +22323,7 @@ fu
 gb
 zz
 XQ
-Tq
+eC
 Tq
 XQ
 nx

--- a/_maps/map_files/triumph/triumph-01-deck1.dmm
+++ b/_maps/map_files/triumph/triumph-01-deck1.dmm
@@ -11923,7 +11923,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+/obj/machinery/atmospherics/valve{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,

--- a/_maps/map_files/triumph/triumph-01-deck1.dmm
+++ b/_maps/map_files/triumph/triumph-01-deck1.dmm
@@ -434,9 +434,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "bt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -454,6 +451,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/triumph/station/stairs_one)
 "bu" = (
@@ -9369,6 +9367,7 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_one)
 "Jl" = (

--- a/_maps/map_files/triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/triumph/triumph-02-deck2.dmm
@@ -1787,7 +1787,7 @@
 /area/janitor)
 "fr" = (
 /obj/machinery/light,
-/obj/machinery/telecomms/relay/preset/mining,
+/obj/machinery/telecomms/relay/preset/telecomms,
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/belter)
 "fu" = (
@@ -4011,7 +4011,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "lJ" = (
-/obj/machinery/telecomms/relay/preset/mining,
+/obj/machinery/telecomms/relay/preset/telecomms,
 /turf/simulated/floor/airless,
 /area/shuttle/mining_ship/general)
 "lK" = (
@@ -10256,8 +10256,7 @@
 "FK" = (
 /obj/machinery/computer/roguezones,
 /obj/effect/floor_decal/industrial/warning/cee{
-	dir = 1;
-	icon_state = "warningcee"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/refinery)
@@ -16732,8 +16731,7 @@
 "ZF" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/freezer)

--- a/_maps/map_files/triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/triumph/triumph-02-deck2.dmm
@@ -1787,7 +1787,6 @@
 /area/janitor)
 "fr" = (
 /obj/machinery/light,
-/obj/machinery/telecomms/relay/preset/telecomms,
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/belter)
 "fu" = (
@@ -4011,7 +4010,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "lJ" = (
-/obj/machinery/telecomms/relay/preset/telecomms,
 /turf/simulated/floor/airless,
 /area/shuttle/mining_ship/general)
 "lK" = (

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -319,9 +319,9 @@
 	var/obj/item/reagent_containers/glass/beaker/B2 = new(src)
 
 	B1.reagents.add_reagent("fluorosurfactant", 30)
-	B2.reagents.add_reagent("cleaner", 30)
-	B2.reagents.add_reagent("holywater", 30)
+	B1.reagents.add_reagent("cleaner", 30)
 	B2.reagents.add_reagent("water", 30)
+	B2.reagents.add_reagent("holywater", 30)
 
 	detonator = new/obj/item/assembly_holder/timer_igniter(src)
 

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -318,9 +318,10 @@
 	var/obj/item/reagent_containers/glass/beaker/B1 = new(src)
 	var/obj/item/reagent_containers/glass/beaker/B2 = new(src)
 
-	B1.reagents.add_reagent("fluorosurfactant", 40)
-	B2.reagents.add_reagent("holywater", 40)
-	B2.reagents.add_reagent("cleaner", 10)
+	B1.reagents.add_reagent("fluorosurfactant", 30)
+	B2.reagents.add_reagent("cleaner", 30)
+	B2.reagents.add_reagent("holywater", 30)
+	B2.reagents.add_reagent("water", 30)
 
 	detonator = new/obj/item/assembly_holder/timer_igniter(src)
 


### PR DESCRIPTION
Just some small tweaks and fixes.

1. _Repairs missing air pipe segment on Level 1._
**Why:** Due to this missing pipe, areas of Level 1, like Telecomms, cannot currently be refilled with air automatically.

2. _Removes the Mining shuttle Relays._
**Why:** Apparently these just don't work. I would remove the Civilian Shuttle's too, but I know that file's about to be edited.

3. _Fixes Holy grenades._
**Why:** Foaming/cleaning agent wasn't working like it's supposed to. This should fix it.

4. _Adds a valve to the Engine loop so people don't accidentally vent the entire gas line into space._
**Why:** I did this last night, and it almost made the engine completely useless. So let's just add in a bit of user interaction to confirm before we let the entire loop fly out into space.