### PR TITLE
Removes defib timer. Replaces with brain damage over time. Alien species can now be defibbed.

### DIFF
--- a/code/__DEFINES/species_languages.dm
+++ b/code/__DEFINES/species_languages.dm
@@ -10,6 +10,7 @@
 #define NO_BLOOD		  0x100  // Never bleed, never show blood amount
 #define UNDEAD			  0x200	 // Various things that living things don't do, mostly for skeletons
 #define NO_INFECT		  0x400  // Don't allow infections in limbs or organs, similar to IS_PLANT, without other strings.
+#define NO_DEFIB          0x800  // Cannot be defibbed
 // unused: 0x8000 - higher than this will overflow
 
 // Species spawn flags

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -263,7 +263,7 @@
 //Checks for various conditions to see if the mob is revivable
 /obj/item/shockpaddles/proc/can_defib(mob/living/carbon/human/H) //This is checked before doing the defib operation
 	if((H.species.flags & NO_DEFIB))
-		return "buzzes, \"Unrecogized physiology. Operation aborted.\""
+		return "buzzes, \"Alien physiology. Operation aborted. Consider alternative resucitation methods.\""
 	else if(H.isSynthetic() && !use_on_synthetic)
 		return "buzzes, \"Synthetic Body. Operation aborted.\""
 	else if(!H.isSynthetic() && use_on_synthetic)

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -1,4 +1,4 @@
-#define DEFIB_TIME_LIMIT (10 MINUTES) //past this many seconds, defib is useless.
+#define DEFIB_TIME_LIMIT (10 MINUTES) //past this many seconds, defib will cause maximum brain damage.
 #define DEFIB_TIME_LOSS  (2 MINUTES) //past this many seconds, brain damage occurs.
 
 //backpack item
@@ -262,7 +262,7 @@
 
 //Checks for various conditions to see if the mob is revivable
 /obj/item/shockpaddles/proc/can_defib(mob/living/carbon/human/H) //This is checked before doing the defib operation
-	if((H.species.flags & NO_SCAN))
+	if((H.species.flags & NO_DEFIB))
 		return "buzzes, \"Unrecogized physiology. Operation aborted.\""
 	else if(H.isSynthetic() && !use_on_synthetic)
 		return "buzzes, \"Synthetic Body. Operation aborted.\""
@@ -278,11 +278,6 @@
 	return null
 
 /obj/item/shockpaddles/proc/can_revive(mob/living/carbon/human/H) //This is checked right before attempting to revive
-
-	var/deadtime = world.time - H.timeofdeath
-	if (deadtime > DEFIB_TIME_LIMIT && !H.isSynthetic())
-		return "buzzes, \"Resuscitation failed - Excessive neural degeneration. Further attempts futile.\""
-
 	H.updatehealth()
 
 	if(H.isSynthetic())
@@ -505,6 +500,8 @@
 
 	var/brain_damage = clamp((deadtime - DEFIB_TIME_LOSS)/(DEFIB_TIME_LIMIT - DEFIB_TIME_LOSS)*brain.max_damage, H.getBrainLoss(), brain.max_damage)
 	H.setBrainLoss(brain_damage)
+	make_announcement("beeps, \"Warning. Subject neurological structure has sustained damage.\"", "notice")
+	playsound(get_turf(src), 'sound/machines/defib_failed.ogg', 50, 0)
 
 /obj/item/shockpaddles/proc/make_announcement(var/message, var/msg_class)
 	audible_message("<b>\The [src]</b> [message]", "\The [src] vibrates slightly.")

--- a/code/modules/mob/living/carbon/human/species/outsider/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/skeleton.dm
@@ -11,7 +11,7 @@
 	max_age = 110
 	health_hud_intensity = 1.5
 
-	flags = NO_SCAN | NO_PAIN | NO_SLIP | NO_POISON | NO_MINOR_CUT | NO_BLOOD | UNDEAD
+	flags = NO_SCAN | NO_PAIN | NO_SLIP | NO_POISON | NO_MINOR_CUT | NO_BLOOD | UNDEAD | NO_DEFIB
 	spawn_flags = SPECIES_IS_RESTRICTED
 	appearance_flags = null
 

--- a/code/modules/mob/living/carbon/human/species/station/station_special.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special.dm
@@ -89,7 +89,7 @@
 	//primitive_form = "Farwa"
 
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED | SPECIES_WHITELIST_SELECTABLE//Whitelisted as restricted is broken.
-	flags = NO_SCAN | NO_INFECT //Dying as a chimera is, quite literally, a death sentence. Well, if it wasn't for their revive, that is.
+	flags = NO_SCAN | NO_INFECT | NO_DEFIB //Dying as a chimera is, quite literally, a death sentence. Well, if it wasn't for their revive, that is.
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 
 	has_organ = list(

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -106,7 +106,6 @@ var/list/organ_cache = list()
 	handle_organ_mod_special(TRUE)
 	if(owner && vital)
 		owner.death()
-		owner.can_defib = 0
 
 /obj/item/organ/proc/adjust_germ_level(var/amount)		// Unless you're setting germ level directly to 0, use this proc instead
 	germ_level = clamp(germ_level + amount, 0, INFECTION_LEVEL_MAX)
@@ -362,7 +361,6 @@ var/list/organ_cache = list()
 		if(user)
 			add_attack_logs(user,owner,"Removed vital organ [src.name]")
 		owner.death()
-		owner.can_defib = 0
 
 	handle_organ_mod_special(TRUE)
 


### PR DESCRIPTION
This PR removes the slightly unfun defib timer, and instead replaces it with brain damage (i.e. mandatory surgery) that increases the longer the subject was dead.

Also adds a species flag, NO_DEFIB, since using NO_SCAN to check if someone could be defibbed is stupid.

So now your Vox/Alraune/Shadekin/etc. can all be defibbed, but not resleeved. Except Xenochi, since they have a unique revive mechanic.