### PR TITLE
Make chemical patches more usefull

### DIFF
--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -29,12 +29,16 @@
 			if(!affecting)
 				to_chat(user, "<span class='warning'>The limb is missing!</span>")
 				return
-			if(affecting.status >= ORGAN_ROBOT)
+			if(affecting.robotic >= ORGAN_ROBOT)
 				to_chat(user, "<span class='notice'>\The [src] won't work on a robotic limb!</span>")
 				return
 
 			if(!H.can_inject(user, FALSE, L.zone_sel.selecting, pierce_material))
 				to_chat(user, "<span class='notice'>\The [src] can't be applied through such a thick material!</span>")
+				return
+			
+			if(affecting.open)// you cant place Bandaids on open surgeries, why chemical patches.
+				to_chat(user, "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>")
 				return
 
 			to_chat(H, "<span class='notice'>\The [src] is placed on your [affecting].</span>")
@@ -42,6 +46,15 @@
 			if(reagents.total_volume)
 				reagents.trans_to_mob(M, reagents.total_volume, CHEM_TOUCH)
 			qdel(src)
+
+			for(var/datum/wound/W in affecting.wounds)
+				if (W.internal)//ignore internal wounds and check the remaining
+					continue
+				if(W.bandaged)//already bandaged wounds dont need to be bandaged again
+					continue
+				W.bandage()
+				break;//dont bandage more than one wound, its only one patch you can have in your stack
+			affecting.update_damages()
 			return 1
 
 	else if(istype(M, /mob/living/carbon/human))
@@ -50,12 +63,16 @@
 		if(!affecting)
 			to_chat(user, "<span class='warning'>The limb is missing!</span>")
 			return
-		if(affecting.status >= ORGAN_ROBOT)
+		
+		if(affecting.robotic >= ORGAN_ROBOT)
 			to_chat(user, "<span class='notice'>\The [src] won't work on a robotic limb!</span>")
 			return
 
 		if(!H.can_inject(user, FALSE, L.zone_sel.selecting, pierce_material))
 			to_chat(user, "<span class='notice'>\The [src] can't be applied through such a thick material!</span>")
+			return
+		if(affecting.open)// you cant place Bandaids on open surgeries, why chemical patches.
+			to_chat(user, "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>")
 			return
 
 		user.visible_message("<span class='warning'>[user] attempts to place \the [src] onto [H]`s [affecting].</span>")
@@ -76,6 +93,15 @@
 		if(reagents.total_volume)
 			reagents.trans_to_mob(M, reagents.total_volume, CHEM_TOUCH)
 		qdel(src)
+
+		for(var/datum/wound/W in affecting.wounds)
+			if (W.internal)//ignore internal wounds and check the remaining
+				continue
+			if(W.bandaged)//already bandaged wounds dont need to be bandaged again
+				continue
+			W.bandage()
+			break;//dont bandage more than one wound, its only one patch you can have in your stack
+		affecting.update_damages()
 
 		return 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Chemical Patches made at the ChemMaster3000 are currently pretty useless, given there are only a few chemicals that function on touch, most are harmfull. So I went and basicly copied some elements from bruise packs to allow the patches to seal wounds as the name and icon suggests.
In addition to that I added a check to avoid applying patches onto open surgery sites, as is present in bruise pack code.
During testing I discovered a bug that would trigger the check for Robolimbs while on harm intent, even though there was clearly no robotic limb targeted or affected. Not sure where that comes from, my fix would be to have a harm-intend check before hand and kill the function before giving the wrong information to the user.

The Original bruis Pack code I copied was supplied by Kevinz000, just making sure to give them credit for their work.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It adds useability to the chemical patches although there are currently only Tricordrazine, Spaceacillin and Sterilise, that have affect_touch functions.
Next step would be to add receipts for the "topical gel"-variants of some chemicals, that are already present in code, and maybe even add some more varients to it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Chemical Patches work as a single use bruisepack. Applying thier Chemical and bandaging a single wound.
fix: Chemical Patches can no longer be placed on surgical sites.
fix: Chemical Patches now correctly check for robotic limbs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
