### PR TITLE
Unlocks Exploration Jump Console

### DIFF
--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -27644,7 +27644,8 @@
 /area/bridge/meeting_room)
 "tuX" = (
 /obj/machinery/computer/shuttle_control/explore/excursion{
-	dir = 4
+	dir = 4;
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/cockpit)


### PR DESCRIPTION
1. _Unlocks Exploration shuttle Jump Console._
**Why:** I hate that I'm still having to find and fix this stuff. Yeah I get that Pilots and the Pathfinder should be the ones with primary access to the shuttle controls, but news flash: Sometimes they aren't available, or they're _dead or incapacitated_. We're all adults here. If someone takes the shuttle that isn't supposed to, we can punish them. Not everyone preemptively.