### PR TITLE
local expedition team found crashing through meteors at 60 Gm/h after proteans fall asleep in cyborg recharger, more at 10

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -1,3 +1,5 @@
+#define SYNTHETIC_NUTRITION_CHARGE_RATE 15			// amount of cell charge to use per 1 nutrition, given that synthetics are full at 450 nutrition
+
 /obj/machinery/recharge_station
 	name = "cyborg recharging station"
 	desc = "A heavy duty rapid charging system, designed to quickly recharge cyborg power reserves."
@@ -7,7 +9,7 @@
 	anchored = 1
 	circuit = /obj/item/circuitboard/recharge_station
 	use_power = USE_POWER_IDLE
-	idle_power_usage = 50
+	idle_power_usage = 10
 	var/mob/occupant = null
 	var/obj/item/cell/cell = null
 	var/icon_update_tick = 0	// Used to rebuild the overlay only once every 10 ticks
@@ -117,8 +119,10 @@
 
 			// Also recharge their internal battery.
 			if(H.isSynthetic() && H.nutrition < 450)
-				H.nutrition = min(H.nutrition+10, 450)
-				cell.use(7000/450*10)
+				var/needed = min(10, H.nutrition)
+				var/drained = cell.use(needed * SYNTHETIC_NUTRITION_CHARGE_RATE)
+				H.nutrition += drained / SYNTHETIC_NUTRITION_CHARGE_RATE
+				// cell.use(7000/450*10)		YOU CAN JUST SAY 155.333, JACKASS
 
 			// And clear up radiation
 			if(H.radiation > 0)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -119,7 +119,7 @@
 
 			// Also recharge their internal battery.
 			if(H.isSynthetic() && H.nutrition < 450)
-				var/needed = min(10, 450 - H.nutrition)
+				var/needed = clamp(450 - H.nutrition, 0, 10)
 				var/drained = cell.use(needed * SYNTHETIC_NUTRITION_CHARGE_RATE)
 				H.nutrition += drained / SYNTHETIC_NUTRITION_CHARGE_RATE
 				// cell.use(7000/450*10)		YOU CAN JUST SAY 155.333, JACKASS

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -119,7 +119,7 @@
 
 			// Also recharge their internal battery.
 			if(H.isSynthetic() && H.nutrition < 450)
-				var/needed = min(10, H.nutrition)
+				var/needed = min(10, 450 - H.nutrition)
 				var/drained = cell.use(needed * SYNTHETIC_NUTRITION_CHARGE_RATE)
 				H.nutrition += drained / SYNTHETIC_NUTRITION_CHARGE_RATE
 				// cell.use(7000/450*10)		YOU CAN JUST SAY 155.333, JACKASS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

makes charger code less goddamn awful by a tiny bit

chargers now only drain the power needed to recharge missing rather than full at all times
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

as funny as this is i don't need to keep having to ask people to stop afking in the chargers every round so the engines don't die mid-flight
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: now introducing nanotrasen SMART CHARGE - no longer will expedition ships be shut down by 50 powergamers rolling protean and erping in the rechargers.
tweak: cyborg chargers now waste less power while idle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
