### PR TITLE
removes some of the goddawful shitcode from protean rigs, removes their complete radiation and taser immunity

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -127,28 +127,18 @@
 	name = "nanosuit control cluster"
 	suit_type = "nanomachine"
 	icon_state = "nanomachine_rig"
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 100)
-	emp_protection = -100 //nice.
-	siemens_coefficient= 0
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 90)
+	siemens_coefficient = 0.5
 	slowdown = 0
 	offline_slowdown = 0
 	seal_delay = 1
-	unremovable_cell = TRUE //it is the protean. kinda.
 	var/mob/living/carbon/human/myprotean
 	initial_modules = list(/obj/item/rig_module/power_sink)
-	ai_override_enabled = TRUE
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/protean
 	boot_type = /obj/item/clothing/shoes/magboots/rig/protean
 	chest_type = /obj/item/clothing/suit/space/rig/protean
 	glove_type = /obj/item/clothing/gloves/gauntlets/rig/protean
-
-/obj/item/rig/protean/process()
-	ai_override_enabled = TRUE
-	if(myprotean.nutrition > 40 && cell.charge < cell.maxcharge)
-		myprotean.nutrition = max(myprotean.nutrition-10, 45)
-		cell.give(7000/450*10) //this is the same amount of power as a cyborg station uses btw
-	..()
 
 /obj/item/rig/protean/relaymove(mob/user, var/direction)
 	if(user.stat || user.stunned)
@@ -158,26 +148,23 @@
 /obj/item/clothing/head/helmet/space/rig/protean
 	name = "mass"
 	desc = "A helmet-shaped clump of nanomachines."
-	siemens_coefficient= 0
 	light_overlay = "should not use a light overlay"
 	species_restricted = list(SPECIES_HUMAN, SPECIES_PROMETHEAN, SPECIES_VASILISSAN, SPECIES_ALRAUNE) //anything that's roughly humanoid ie uses human spritesheets
 
 /obj/item/clothing/gloves/gauntlets/rig/protean
 	name = "mass"
 	desc = "Glove-shaped clusters of nanomachines."
-	siemens_coefficient= 0
+	siemens_coefficient = 0
 	species_restricted = list(SPECIES_HUMAN, SPECIES_PROMETHEAN, SPECIES_VASILISSAN, SPECIES_ALRAUNE) //anything that's roughly humanoid.
 
 /obj/item/clothing/shoes/magboots/rig/protean
 	name = "mass"
 	desc = "Boot-shaped clusters of nanomachines."
-	siemens_coefficient= 0
 	species_restricted = list(SPECIES_HUMAN, SPECIES_PROMETHEAN, SPECIES_VASILISSAN, SPECIES_ALRAUNE) //anything that's roughly humanoid.
 
 /obj/item/clothing/suit/space/rig/protean
 	name = "mass"
 	desc = "A body-hugging mass of nanomachines."
-	siemens_coefficient= 0
 	can_breach = 0
 	species_restricted = list(SPECIES_HUMAN, SPECIES_PROMETHEAN, SPECIES_VASILISSAN, SPECIES_ALRAUNE) //anything that's roughly humanoid, ie uses human spritesheets
 	allowed = list(/obj/item/gun,/obj/item/flashlight,/obj/item/tank,/obj/item/suit_cooling_unit,/obj/item/melee/baton,/obj/item/storage/backpack,/obj/item/subspaceradio)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

no more internal unremovable cells that selfcharge
no more snowflake emp protection
no more ai override because IT DOESNT EVEN WORK
their gloves are insulated but the rest of them only halves conductivity
radiation is now 90% instead of 100%
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

if you want an unremovable cell that links to their nutrition, do it right instead of something that makes the powersink useless
also unironically powercreeped to shit while not even working right
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: protean rigs are slightly less godawful
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
