### PR TITLE
Fixes airlocks not having wires after being constructed

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1222,10 +1222,8 @@ About the new airlock wires panel:
 		//update the door's access to match the electronics'
 		secured_wires = electronics.secure
 		if(electronics.one_access)
-			req_access.Cut()
 			req_one_access = src.electronics.conf_access
 		else
-			req_one_access.Cut()
 			req_access = src.electronics.conf_access
 
 		//get the name from the assembly


### PR DESCRIPTION
We had this bug for over a year and deleting this line was all it took to fix.

Left over oversight from an old PR ages back that optimised airlocks by not generating access lists unless needed, which was runtiming airlock construction.