### PR TITLE
Fixes / Adds Teshari Quartermaster Cloak Loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_xeno.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno.dm
@@ -322,9 +322,9 @@
 	allowed_roles = list("Chief Medical Officer")
 
 /datum/gear/suit/dept/cloak/qm
-	display_name = "Teshari - Chief Medical Officer Cloak"
+	display_name = "Teshari - Quartermaster Cloak"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/qm
-	allowed_roles = list("Chief Medical Officer")
+	allowed_roles = list("Quartermaster")
 
 /datum/gear/suit/dept/cloak/cargo
 	display_name = "Teshari - Cargo Cloak"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR simply fixes the CMO being listed twice and the quartermaster not at all.

## Why It's Good For The Game

Every other role has a Teshari cloak, but the Quartermaster's was not working. 

## Changelog
:cl:
add: Teshari Quartermaster cloak is set properly in xeno loadout file. 

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
