### PR TITLE
Buffs/Adjustments to Anti-Cult Weaponry

### DIFF
--- a/code/game/objects/items/weapons/nullrod.dm
+++ b/code/game/objects/items/weapons/nullrod.dm
@@ -20,7 +20,7 @@
 			slot_r_hand_str = 'icons/mob/items/righthand_melee.dmi',
 			)
 
-	var/SA_bonus_damage = 25 // 40 total against demons and aberrations.
+	var/SA_bonus_damage = 35 // 50 total against demons and aberrations.
 	var/SA_vulnerability = MOB_CLASS_DEMONIC | MOB_CLASS_ABERRATION
 
 /obj/item/nullrod/Initialize()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -5,6 +5,9 @@
 	icon_state = "energy"
 	fire_sound_text = "laser blast"
 
+	accuracy = 100
+	dispersion = -100
+
 	var/obj/item/cell/power_supply //What type of power cell this uses
 	var/charge_cost = 240 //How much energy is needed to fire.
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -320,7 +320,7 @@ obj/item/gun/energy/staff/focus
 	force = 5
 	slot_flags = SLOT_BELT
 	w_class = ITEMSIZE_NORMAL
-	projectile_type = /obj/item/projectile/bullet/pistol/medium
+	projectile_type = /obj/item/projectile/bullet/pistol/medium/silver
 	origin_tech = null
 	fire_delay = 10		//Old pistol
 	charge_cost = 480	//to compensate a bit for self-recharging
@@ -368,27 +368,27 @@ obj/item/gun/energy/staff/focus
 /obj/item/gun/energy/service/shatter
 	name = "service weapon (shatter)"
 	icon_state = "service_shatter"
-	projectile_type = /obj/item/projectile/bullet/pellet/shotgun
-	fire_delay = 20		//Doubled for strength.
+	projectile_type = /obj/item/projectile/bullet/pellet/shotgun/silver
+	fire_delay = 15		//Increased by 50% for strength.
 	charge_cost = 600	//Charge increased due to shotgun round.
 
 /obj/item/gun/energy/service/spin
 	name = "service weapon (spin)"
 	icon_state = "service_spin"
 	projectile_type = /obj/item/projectile/bullet/pistol/spin
-	fire_delay = 1		//High fire rate.
-	charge_cost = 100	//Lower cost per shot to encourage rapid fire.
+	fire_delay = 0	//High fire rate.
+	charge_cost = 80	//Lower cost per shot to encourage rapid fire.
 
 /obj/item/gun/energy/service/pierce
 	name = "service weapon (pierce)"
 	icon_state = "service_pierce"
-	projectile_type = /obj/item/projectile/bullet/rifle/a762/ap
-	fire_delay = 20		//Doubled for strength.
+	projectile_type = /obj/item/projectile/bullet/rifle/a762/ap/silver
+	fire_delay = 15		//Increased by 50% for strength.
 	charge_cost = 600	//Charge increased due to sniper round.
 
 /obj/item/gun/energy/service/charge
 	name = "service weapon (charge)"
 	icon_state = "service_charge"
-	projectile_type = /obj/item/projectile/bullet/burstbullet    //Formerly: obj/item/projectile/bullet/gyro. A little too robust.
-	fire_delay = 30
+	projectile_type = /obj/item/projectile/bullet/burstbullet/service    //Formerly: obj/item/projectile/bullet/gyro. A little too robust.
+	fire_delay = 20
 	charge_cost = 800	//Three shots.

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -110,7 +110,7 @@
 /obj/item/projectile/bullet/pistol/medium/silver
 	damage = 15
 	SA_bonus_damage = 45 // 60 total against demons
-	SA_vulnerability = MOB_CLASS_DEMONIC
+	SA_vulnerability = MOB_CLASS_DEMONIC | MOB_CLASS_ABERRATION
 	embed_chance = -1
 	holy = TRUE
 
@@ -135,7 +135,7 @@
 	fire_sound = 'sound/weapons/gunshot4.ogg'
 	damage = 40
 	SA_bonus_damage = 80 // 120 total against demons
-	SA_vulnerability = MOB_CLASS_DEMONIC
+	SA_vulnerability = MOB_CLASS_DEMONIC | MOB_CLASS_ABERRATION
 	embed_chance = -1
 	holy = TRUE
 
@@ -159,6 +159,9 @@
 /obj/item/projectile/bullet/pistol/spin // Special weak ammo for Service Spin mode.
 	fire_sound = 'sound/weapons/gunshot2.ogg'
 	damage = 5
+	SA_bonus_damage = 10 // 15 total against demons
+	SA_vulnerability = MOB_CLASS_DEMONIC | MOB_CLASS_ABERRATION
+	holy = TRUE
 
 /* shotgun projectiles */
 
@@ -198,7 +201,7 @@
 	fire_sound = 'sound/weapons/Gunshot_shotgun.ogg'
 	damage = 10
 	SA_bonus_damage = 16 // Potential 156 Damage against demons at point blank.
-	SA_vulnerability = MOB_CLASS_DEMONIC
+	SA_vulnerability = MOB_CLASS_DEMONIC | MOB_CLASS_ABERRATION
 	embed_chance = -1
 	pellets = 6
 	range_step = 1
@@ -211,7 +214,7 @@
 	damage = 50
 	armor_penetration = 15
 	SA_bonus_damage = 16 // Potential 156 Damage against demons at point blank.
-	SA_vulnerability = MOB_CLASS_DEMONIC
+	SA_vulnerability = MOB_CLASS_DEMONIC | MOB_CLASS_ABERRATION
 	holy = TRUE
 
 //EMP shotgun 'slug', it's basically a beanbag that pops a tiny emp when it hits. //Not currently used
@@ -250,6 +253,13 @@
 	damage = 30
 	armor_penetration = 50 // At 30 or more armor, this will do more damage than standard rounds.
 
+/obj/item/projectile/bullet/rifle/a762/ap/silver
+	damage = 30
+	armor_penetration = 50 // At 30 or more armor, this will do more damage than standard rounds.
+	SA_bonus_damage = 30 // 60 total against demons
+	SA_vulnerability = MOB_CLASS_DEMONIC | MOB_CLASS_ABERRATION
+	holy = TRUE
+
 /obj/item/projectile/bullet/rifle/a762/hp
 	damage = 40
 	armor_penetration = -50
@@ -262,7 +272,7 @@
 	embed_chance = -1
 
 /obj/item/projectile/bullet/rifle/a762/sniperhunter
-	damage = 25 
+	damage = 25
 	SA_bonus_damage = 45 // 70 total on animals.
 	SA_vulnerability = MOB_CLASS_ANIMAL
 	embed_chance = -1
@@ -323,6 +333,21 @@
 /obj/item/projectile/bullet/burstbullet/on_hit(var/atom/target, var/blocked = 0)
 	if(isturf(target))
 		explosion(target, -1, 0, 2)
+	..()
+
+/obj/item/projectile/bullet/burstbullet/service
+	name = "charge bullet"
+	fire_sound = 'sound/effects/Explosion1.ogg'
+	damage = 20
+	embed_chance = 0
+	edge = 1
+	SA_bonus_damage = 40 // 60 total damage against demons.
+	SA_vulnerability = MOB_CLASS_DEMONIC | MOB_CLASS_ABERRATION
+	holy = TRUE
+
+/obj/item/projectile/bullet/burstbullet/service/on_hit(var/atom/target, var/blocked = 0)
+	if(isturf(target))
+		explosion(target, 0, 1, 2)
 	..()
 
 /* Incendiary */


### PR DESCRIPTION
Recent playtesting has revealed that anti-Cult weapons and ammunition aren't doing sufficient damage to cult mobs. This rolls out some buffs and tweaks to special weapons which may become relevant in events relatively soon.