### PR TITLE
Protean rad immunity, because it makes sense

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
@@ -332,7 +332,7 @@ A best case sev 1 emp will do 11 pre-mitigation damage. This is 17.6 damage.
 	holder.adjustBruteLoss(-9 ,include_robo = TRUE) //Looks high, but these are modified by species resistances to equal out at 3hp/sec.
 	holder.adjustFireLoss(-2.14,include_robo = TRUE) //Looks high, but these are modified by species resistances to equal out at 3hp/sec.
 	holder.adjustToxLoss(-3)
-	holder.radiation = max(holder.radiation - 15, 0) // I'm keeping this in and increasing it, just in the off chance the protean gets some rads, so that there's way to get rid of them
+	holder.radiation = max(holder.radiation - 30, 0) // I'm keeping this in and increasing it, just in the off chance the protean gets some rads, so that there's way to get rid of them
 
 
 

--- a/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
@@ -332,7 +332,7 @@ A best case sev 1 emp will do 11 pre-mitigation damage. This is 17.6 damage.
 	holder.adjustBruteLoss(-9 ,include_robo = TRUE) //Looks high, but these are modified by species resistances to equal out at 3hp/sec.
 	holder.adjustFireLoss(-2.14,include_robo = TRUE) //Looks high, but these are modified by species resistances to equal out at 3hp/sec.
 	holder.adjustToxLoss(-3)
-	// holder.radiation = max(holder.radiation - 15, 0)  As they now have rad immunity, this is a bit redundant
+	holder.radiation = max(holder.radiation - 15, 0) // I'm keeping this in and increasing it, just in the off chance the protean gets some rads, so that there's way to get rid of them
 
 
 

--- a/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
@@ -34,6 +34,7 @@
 	brute_mod =		0.30 // 70% brute reduction
 	burn_mod =		1.4 //60% burn weakness
 	oxy_mod =		0
+	radiation_mod = 0 // Their blobforms have rad immunity, so it only makes sense that their humanoid forms do too
  /*
 These values assume all limbs are hit by the damage. To get individual limb damages divide by 11.
 A worst-case sev 4 emp will do 88 damage pre-mitigation, and 140.8 post-mitigation (as resist is negative) spread out over all the limbs.
@@ -331,7 +332,7 @@ A best case sev 1 emp will do 11 pre-mitigation damage. This is 17.6 damage.
 	holder.adjustBruteLoss(-9 ,include_robo = TRUE) //Looks high, but these are modified by species resistances to equal out at 3hp/sec.
 	holder.adjustFireLoss(-2.14,include_robo = TRUE) //Looks high, but these are modified by species resistances to equal out at 3hp/sec.
 	holder.adjustToxLoss(-3)
-	holder.radiation = max(holder.radiation - 15, 0)
+	// holder.radiation = max(holder.radiation - 15, 0)  As they now have rad immunity, this is a bit redundant
 
 
 


### PR DESCRIPTION
As protean blobs are rad immune and their humanoid forms aren't, I though it made little sense for a species with 2 forms to have differing resistances, so here I am, making them more similar.

The entire PR is me editing two lines of code, with the express purpose to make proteans more OP.




Also, a personal gripe, there're too many protean apps right now and I will spare a lot of effort due to my laziness to reduce the amount and freely given acceptance of them.
![Protein](https://user-images.githubusercontent.com/66063955/104940197-12da0800-59ba-11eb-8f76-94bf6f2cbefe.PNG)


-Ashet
<3