### PR TITLE
Fix: Sleep Indicator being stuck after Surgery

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -189,7 +189,7 @@
 				M.visible_message("<span class='notice'>[M] shakes [src] trying to wake [T.him] up!</span>", \
 				"<span class='notice'>You shake [src], but [T.he] [T.does] not respond... Maybe [T.he] [T.has] S.S.D?</span>")
 			else if(lying || src.sleeping)
-				src.sleeping = max(0,src.sleeping-5)
+				AdjustSleeping(-5)
 				if(src.sleeping == 0)
 					src.resting = 0
 				if(H) H.in_stasis = 0 //VOREStation Add - Just In Case
@@ -306,7 +306,7 @@
 		to_chat(usr, "<font color='red'>You are already sleeping</font>")
 		return
 	if(alert(src,"You sure you want to sleep for a while?","Sleep","Yes","No") == "Yes")
-		usr.sleeping = 20 //Short nap
+		usr.AdjustSleeping(20)
 
 /mob/living/carbon/Bump(atom/A)
 	if(now_pushing)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1277,9 +1277,17 @@
 						bodytemp.icon_state = "temp-1"
 					else
 						bodytemp.icon_state = "temp0"
+		if(blinded)
+			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 
-		if(blinded)		overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
-		else			clear_fullscreens()
+		else
+			clear_fullscreens()
+
+		if(blinded)
+			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
+
+		else if(!machine)
+			clear_fullscreens()
 
 		if(disabilities & NEARSIGHTED)	//this looks meh but saves a lot of memory by not requiring to add var/prescription
 			if(glasses)					//to every /obj/item

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1009,7 +1009,7 @@ default behaviour is:
 	var/matrix/M = matrix()
 	M.Scale(desired_scale_x, desired_scale_y)
 	M.Translate(0, 16*(desired_scale_y-1))
-	//animate(src, transform = M, time = 10) //VOREStation edit
+	animate(src, transform = M, time = 10)
 	handle_status_indicators()
 
 // This handles setting the client's color variable, which makes everything look a specific color.


### PR DESCRIPTION
## About The Pull Request

So after a while of trying to understand why and how things do. I've opted to just compare the port of Polaris' indicators to that of Chomps, and added in the differences. This in high hopes, fixes the floating sleep icon after surgery. If not, I uh - I'll keep looking into it.

## Why It's Good For The Game

Fixes the stuck status of Sleeping when coming out of surgery.[Hopefully]

## Changelog
:cl:
fix: Fixes the 'stuck' Sleeping indicator after surgery.
/:cl:


## Comments

So while doing this I have discovered, and more harrowing - there is no way to toggle off the indicators. I however am just a simple caveman who doesn't understand how Byond is coded and how it works in general. I would encourage someone with better knowledge and skill to look into this. If not well, get cozy with the icons. ^^'

Sadly no pictures, as it's a fix.