### PR TITLE
i'm not sure why the "power all apcs" button also drains the SMES but i'm annoyed enough to fix it

### DIFF
--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -12,6 +12,7 @@
 		S.last_charge			= S.charge
 		S.last_output_attempt	= S.output_attempt
 		S.last_input_attempt 	= S.input_attempt
+		S.powerout_holders_used = TRUE
 		S.charge = 0
 		S.inputting(0)
 		S.outputting(0)
@@ -35,11 +36,13 @@
 		var/area/current_area = get_area(S)
 		if(current_area.type in skipped_areas || isNotStationLevel(S.z))
 			continue
-		S.charge = S.last_charge
-		S.output_attempt = S.last_output_attempt
-		S.input_attempt = S.last_input_attempt
-		S.update_icon()
-		S.power_change()
+		if(S.powerout_holders_used)
+			S.charge = S.last_charge
+			S.output_attempt = S.last_output_attempt
+			S.input_attempt = S.last_input_attempt
+			S.powerout_holders_used = FALSE
+			S.update_icon()
+			S.power_change()
 
 /proc/power_restore_quick(var/announce = 1)
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -30,6 +30,7 @@
 	var/output_used = 0				// amount of power actually outputted. may be less than output_level if the powernet returns excess power
 
 	//Holders for powerout event.
+	var/powerout_holders_used = FALSE
 	var/last_output_attempt	= 0
 	var/last_input_attempt	= 0
 	var/last_charge			= 0


### PR DESCRIPTION
now it stores if it used powerout holders and is only restored to the values if it's, y'know, actually SET.