### PR TITLE
Phoron Bores start with a capacitor and a manipulator

### DIFF
--- a/code/modules/projectiles/guns/magnetic/bore.dm
+++ b/code/modules/projectiles/guns/magnetic/bore.dm
@@ -6,6 +6,9 @@
 	description_info = "The projectile of this tool will travel six tiles before dissipating, excavating mineral walls as it does so. It can be reloaded with phoron sheets."
 
 
+	capacitor = new /obj/item/stock_parts/capacitor
+	manipulator = new /obj/item/stock_parts/manipulator
+
 	icon_state = "bore"
 	item_state = "bore"
 	wielded_item_state = "bore-wielded"
@@ -175,3 +178,5 @@
 	projectile_type = /obj/item/projectile/bullet/magnetic/bore/powerful
 	power_cost = 1000
 	max_mat_storage = 20000
+	manipulator = null 
+	capacitor = null

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -63,7 +63,7 @@
 		if(!affecting)
 			to_chat(user, "<span class='warning'>The limb is missing!</span>")
 			return
-		
+
 		if(affecting.robotic >= ORGAN_ROBOT)
 			to_chat(user, "<span class='notice'>\The [src] won't work on a robotic limb!</span>")
 			return

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -240,12 +240,6 @@
 				<li class="bugfix">Chemical Patches can no longer be placed on surgical sites.</li>
 				<li class="bugfix">Chemical Patches now correctly check for robotic limbs.</li>
 			</ul>
-
-			<h2 class="date">10 December 2020</h2>
-			<h3 class="author">Kraseo updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">Gradients on hairstyles.</li>
-			</ul>
 		</div>
 
 <br><b>Baystation 12 Credit List</b>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The standard Phoron bore starts with a capacitor and manipulator.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The standard Phoron bore can only be aquired via the mining and the exploration vendor and is only used if science isnt around, or exploration forgot and/or lost other equipment on the go. Meaning in both use cases the people wanting to use it dont have access to proper parts, which is stupid.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Vendor Phoron Bores only need phoron and a powercell.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
