### PR TITLE
[RTM] Battery_Modules no longer override their battery on charge_to_full()

### DIFF
--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -74,6 +74,5 @@
 	return ..()
 
 /obj/item/computer_hardware/battery_module/proc/charge_to_full()
-	if(ispath(battery))
-		battery = new battery
+	if(battery)//nolonger checks for a valid path, instead checks if battery is set.
 		battery.charge = battery.maxcharge


### PR DESCRIPTION
Ready to (Test)Merge

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Now properly, fixes an override that shouldnt have existed
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Things now work as intended(hopefully) only tested it with loadout tablets, but unless someone did a lazy on the vandor tablets it should be fine.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Tablets now spawn with their proper Battery modules.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
