### PR TITLE
masks no longer block your ability to use swabkits on hands

### DIFF
--- a/code/modules/detectivework/tools/swabs.dm
+++ b/code/modules/detectivework/tools/swabs.dm
@@ -22,14 +22,6 @@
 	var/mob/living/carbon/human/H = M
 	var/sample_type
 
-	if(H.wear_mask)
-		to_chat(user, "<span class='warning'>\The [H] is wearing a mask.</span>")
-		return
-
-	if(!H.dna || !H.dna.unique_enzymes)
-		to_chat(user, "<span class='warning'>They don't seem to have DNA!</span>")
-		return
-
 	if(user != H && H.a_intent != "help" && !H.lying)
 		user.visible_message("<span class='danger'>\The [user] tries to take a swab sample from \the [H], but they move away.</span>")
 		return
@@ -38,6 +30,15 @@
 		if(!H.organs_by_name[BP_HEAD])
 			to_chat(user, "<span class='warning'>They don't have a head.</span>")
 			return
+
+		if(H.wear_mask)
+			to_chat(user, "<span class='warning'>Something is blocking \the [H]'s mouth.</span>")
+			return
+
+		if(!H.dna || !H.dna.unique_enzymes)
+			to_chat(user, "<span class='warning'>They don't seem to have DNA!</span>")
+			return
+
 		if(!H.check_has_mouth())
 			to_chat(user, "<span class='warning'>They don't have a mouth.</span>")
 			return
@@ -58,7 +59,7 @@
 			to_chat(user, "<span class='warning'>They don't have any hands.</span>")
 			return
 		user.visible_message("[user] swabs [H]'s palm for a sample.")
-		sample_type = "GSR"
+		sample_type = "residue"
 		gsr = H.gunshot_residue
 	else
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Swab kits are a little munted, though mostly in weird fiddly ways that could really do with a general overhaul.
Either way, this fixes something that could end up really bad in the 'this vox/plasmaman needs to take off his mask or else i can't check his palms for gunshot residue' kind of way

I've also slightly adjusted the text for a mouth swab being blocked by a mask since that also includes cigarettes and other items, and changed the sample_type of palm swabs from 'GSR' to 'residue' which implied there was gunshot residue to be found even if there wasn't.

It's worth reworking them somewhere down the line: currently full-face helmets don't block swab kits, you can swab a synth's mouth and get a DNA string (though synths bleed and have fingerprints so ???), and you need a target to be on help intent or prone or else you can't swab them. Most of this is unlikely to have any major impact though.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

bugfix good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Masks no longer block your ability to use swab kits on hands.
tweak: Slightly altered swab kit text
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
