### PR TITLE
Station lighting tubes are now very slightly less white.

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -77,7 +77,7 @@
 #define LIGHT_COLOR_HALOGEN    "#F0FAFA" //Barely visible cyan-ish hue, as the doctor prescribed. rgb(240, 250, 250)
 
 //Lighting values used by the station lights
-#define LIGHT_COLOR_FLUORESCENT_TUBE "#E0EFFF"
+#define LIGHT_COLOR_FLUORESCENT_TUBE "#B3D7FF"
 #define LIGHT_COLOR_FLUORESCENT_FLASHLIGHT "#CDDDFF"
 #define LIGHT_COLOR_INCANDESCENT_TUBE "#E0EFF0"
 #define LIGHT_COLOR_INCANDESCENT_BULB "#FFFEB8"


### PR DESCRIPTION
E.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the hex value of station lighting tubes from 
#E0EFFF
to
#B3D7FF
which is about 11% more blue, making the lighting slightly less straining on the eyes.
I would have gone with orange which is technically better, but would also make the station look like piss.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

why is this station so fucking bright
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaks the lighting color for tubes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
