### PR TITLE
[Review Needed]Moves floor decals from LateInitialize() to Initialize(), fixing floorpainter

### DIFF
--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -176,7 +176,6 @@ var/list/flooring_types
 	icon = 'icons/turf/flooring/techfloor_vr.dmi'
 	icon_base = "techfloor_gray"
 	build_type = /obj/item/stack/tile/floor/techgrey
-	can_paint = null
 
 /decl/flooring/tiling/tech/grid
 	icon_base = "techfloor_grid"

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -18,7 +18,7 @@ var/list/floor_decals = list()
 	. = ..()
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/effect/floor_decal/LateInitialize()
+/obj/effect/floor_decal/Initialize()
 	add_to_turf_decals()
 	qdel(src)
 
@@ -43,7 +43,7 @@ var/list/floor_decals = list()
 /obj/effect/floor_decal/reset
 	name = "reset marker"
 
-/obj/effect/floor_decal/reset/LateInitialize()
+/obj/effect/floor_decal/reset/Initialize()
 	var/turf/T = get_turf(src)
 	if(T.decals && T.decals.len)
 		T.decals.Cut()

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -15,10 +15,6 @@ var/list/floor_decals = list()
 	..(newloc)
 
 /obj/effect/floor_decal/Initialize()
-	. = ..()
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/effect/floor_decal/Initialize()
 	add_to_turf_decals()
 	qdel(src)
 

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -16,7 +16,7 @@ var/list/floor_decals = list()
 
 /obj/effect/floor_decal/Initialize()
 	add_to_turf_decals()
-	qdel(src)
+	return INITIALIZE_HINT_QDEL
 
 // This is a separate proc from initialize() to facilitiate its caching and other stuff.  Look into it someday.
 /obj/effect/floor_decal/proc/add_to_turf_decals()
@@ -44,7 +44,7 @@ var/list/floor_decals = list()
 	if(T.decals && T.decals.len)
 		T.decals.Cut()
 		T.update_icon()
-	qdel(src)
+	return INITIALIZE_HINT_QDEL
 
 /obj/effect/floor_decal/corner
 	icon_state = "corner_white"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
From my **limited** understanding, the `LateInitialize()` of the decals was simply never called, swapping them back to `Initialize()` fixed it with no apparent issues, but I did not do a full code dive into the initialization subsystem.

This should **definitely** be looked at by someone who understands the current decal system / mapload order / atom initialization system better, as every decal is now initialized regularly, not late.

## Why It's Good For The Game
Fixes a rather fun tool for those who enjoy customization:
![ezgif-1-a13fa12f807b](https://user-images.githubusercontent.com/11361525/109430475-4de44800-7a0a-11eb-8884-13298d0a370d.gif)


## Changelog
:cl:FreeStylaLT
fix:Fixed the floor painter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
