### PR TITLE
moved synth cooling check so it won't interfere with heat status icon

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -615,7 +615,7 @@ var/last_message = 0
 
 	if(is_incorporeal())
 		return
-	
+
 	if(isSynthetic()) // synth specific temperature values in the absence of a synthetic species
 		var/mob/living/carbon/human/H = src
 		if(H.species.name == "Protean")
@@ -1288,6 +1288,38 @@ var/last_message = 0
 					if(260 to 280)			bodytemp.icon_state = "temp-3"
 					else					bodytemp.icon_state = "temp-4"
 			else
+				//TODO: precalculate all of this stuff when the species datum is created
+				var/base_temperature = species.body_temperature
+				if(base_temperature == null) //some species don't have a set metabolic temperature
+					base_temperature = (species.heat_level_1 + species.cold_level_1)/2
+
+				var/temp_step
+				if (bodytemperature >= base_temperature)
+					temp_step = (species.heat_level_1 - base_temperature)/4
+
+					if (bodytemperature >= species.heat_level_1)
+						bodytemp.icon_state = "temp4"
+					else if (bodytemperature >= base_temperature + temp_step*3)
+						bodytemp.icon_state = "temp3"
+					else if (bodytemperature >= base_temperature + temp_step*2)
+						bodytemp.icon_state = "temp2"
+					else if (bodytemperature >= base_temperature + temp_step*1)
+						bodytemp.icon_state = "temp1"
+					else
+						bodytemp.icon_state = "temp0"
+				else if (bodytemperature < base_temperature)
+					temp_step = (base_temperature - species.cold_level_1)/4
+
+					if (bodytemperature <= species.cold_level_1)
+						bodytemp.icon_state = "temp-4"
+					else if (bodytemperature <= base_temperature - temp_step*3)
+						bodytemp.icon_state = "temp-3"
+					else if (bodytemperature <= base_temperature - temp_step*2)
+						bodytemp.icon_state = "temp-2"
+					else if (bodytemperature <= base_temperature - temp_step*1)
+						bodytemp.icon_state = "temp-1"
+					else
+						bodytemp.icon_state = "temp0"
 		if(bodytemperature >= 361)
 			if(isSynthetic())
 				if(world.time >= last_message || last_message == 0)
@@ -1300,39 +1332,6 @@ var/last_message = 0
 						add_modifier(/datum/modifier/synthcooling, 15 SECONDS) // enable cooling systems at cost of energy
 						src.nutrition -= 50
 					last_message = world.time + 60 SECONDS
-			//TODO: precalculate all of this stuff when the species datum is created
-			var/base_temperature = species.body_temperature
-			if(base_temperature == null) //some species don't have a set metabolic temperature
-				base_temperature = (species.heat_level_1 + species.cold_level_1)/2
-
-			var/temp_step
-			if (bodytemperature >= base_temperature)
-				temp_step = (species.heat_level_1 - base_temperature)/4
-
-				if (bodytemperature >= species.heat_level_1)
-					bodytemp.icon_state = "temp4"
-				else if (bodytemperature >= base_temperature + temp_step*3)
-					bodytemp.icon_state = "temp3"
-				else if (bodytemperature >= base_temperature + temp_step*2)
-					bodytemp.icon_state = "temp2"
-				else if (bodytemperature >= base_temperature + temp_step*1)
-					bodytemp.icon_state = "temp1"
-				else
-					bodytemp.icon_state = "temp0"
-
-			else if (bodytemperature < base_temperature)
-				temp_step = (base_temperature - species.cold_level_1)/4
-
-				if (bodytemperature <= species.cold_level_1)
-					bodytemp.icon_state = "temp-4"
-				else if (bodytemperature <= base_temperature - temp_step*3)
-					bodytemp.icon_state = "temp-3"
-				else if (bodytemperature <= base_temperature - temp_step*2)
-					bodytemp.icon_state = "temp-2"
-				else if (bodytemperature <= base_temperature - temp_step*1)
-					bodytemp.icon_state = "temp-1"
-				else
-					bodytemp.icon_state = "temp0"
 		if(blinded)
 			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Previously everything was stuck behind a check for bodytemperature >= 361, which meant you'd only see the max temperature icon, and it'd never go away.
You'll start to see the temperature icons for being cold again, too. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

sqosh bugs

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed hud thermometer sticking at maximum
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
