### PR TITLE
Reduces the ungodly amount of lights on Triumph across all four decks

### DIFF
--- a/_maps/map_files/triumph/triumph-01-deck1.dmm
+++ b/_maps/map_files/triumph/triumph-01-deck1.dmm
@@ -968,11 +968,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
 "dl" = (
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Engineering Hallway";
-	req_one_access = null
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -1520,11 +1518,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/starboardnacelle)
 "fn" = (
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Engineering Hallway";
-	req_one_access = null
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 10
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
@@ -4256,7 +4252,6 @@
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/techfloor/orange,
-/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
 "nP" = (
@@ -6659,9 +6654,6 @@
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering Hallway";
 	req_one_access = null
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
@@ -9075,6 +9067,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 5
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
@@ -13349,6 +13344,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
 "Rc" = (
@@ -25693,7 +25689,7 @@ DE
 XP
 Lv
 xv
-GQ
+dl
 Zv
 qW
 MK
@@ -27967,7 +27963,7 @@ ON
 YJ
 LE
 QX
-fn
+LE
 Tx
 Tx
 Tx
@@ -28109,7 +28105,7 @@ Pf
 YJ
 MT
 FE
-di
+fn
 Tx
 fI
 fI
@@ -31231,7 +31227,7 @@ OD
 OD
 OD
 OD
-dl
+LE
 Fj
 LE
 em

--- a/_maps/map_files/triumph/triumph-01-deck1.dmm
+++ b/_maps/map_files/triumph/triumph-01-deck1.dmm
@@ -1518,11 +1518,26 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/starboardnacelle)
 "fn" = (
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 10
+/obj/structure/catwalk,
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
 	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/engineering/hallway/lower)
 "fo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -1566,7 +1581,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "fx" = (
-/obj/effect/floor_decal/techfloor/orange,
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 10
+	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
@@ -2443,9 +2460,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "hY" = (
+/obj/effect/floor_decal/techfloor/orange,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/engine_airlock)
+/turf/simulated/floor/tiled,
+/area/engineering/hallway/lower)
 "hZ" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -3023,18 +3041,9 @@
 /turf/simulated/floor/plating,
 /area/engineering/hallway/lower)
 "jQ" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
-	},
-/turf/simulated/floor/tiled/white,
-/area/engineering/foyer_mezzenine)
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/engine_airlock)
 "jT" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -3389,14 +3398,18 @@
 /turf/simulated/floor/plating,
 /area/station/stairs_one)
 "la" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 8
+/obj/structure/toilet{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/engineering/atmos)
+/obj/effect/landmark{
+	name = "xeno_spawn";
+	pixel_x = -1
+	},
+/turf/simulated/floor/tiled/white,
+/area/engineering/foyer_mezzenine)
 "lb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -3787,8 +3800,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/storage/tech)
 "my" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 8
@@ -4650,6 +4663,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engi_engine)
+"ph" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/atmos)
 "pi" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil{
@@ -5995,7 +6017,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 1
 	},
-/obj/structure/disposalpipe/junction,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
 "tx" = (
@@ -7103,8 +7128,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/network/outside{
-	dir = 10
+/obj/machinery/camera/network/engineering{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23710,7 +23735,7 @@ IN
 sZ
 HN
 Tf
-hY
+jQ
 IN
 mc
 ke
@@ -26273,7 +26298,7 @@ Vf
 YF
 WJ
 cK
-la
+ph
 WJ
 Bq
 Tm
@@ -28105,7 +28130,7 @@ Pf
 YJ
 MT
 FE
-fn
+fx
 Tx
 fI
 fI
@@ -29240,7 +29265,7 @@ FC
 Cf
 YJ
 by
-NG
+fn
 eP
 ZW
 La
@@ -29951,7 +29976,7 @@ Ai
 gh
 Ji
 bt
-fx
+hY
 Tx
 OM
 OM
@@ -30384,7 +30409,7 @@ oG
 em
 ea
 em
-jQ
+la
 UQ
 iu
 qb

--- a/_maps/map_files/triumph/triumph-01-deck1.dmm
+++ b/_maps/map_files/triumph/triumph-01-deck1.dmm
@@ -548,7 +548,6 @@
 /obj/structure/dispenser{
 	phorontanks = 0
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
 "bK" = (
@@ -793,9 +792,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/machinery/light/small/emergency{
-	dir = 8
-	},
 /obj/structure/railing{
 	dir = 4
 	},
@@ -972,14 +968,16 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
 "dl" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Engineering Hallway";
+	req_one_access = null
 	},
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/engineering/hallway)
+/area/engineering/hallway/lower)
 "dm" = (
 /obj/machinery/status_display{
 	pixel_y = 30
@@ -1004,9 +1002,6 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/storage)
@@ -1199,9 +1194,7 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/small,
 /obj/effect/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
@@ -1232,7 +1225,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_monitoring)
 "eg" = (
@@ -1316,9 +1308,6 @@
 /obj/item/clothing/glasses/welding/superior,
 /obj/structure/closet/hydrant{
 	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
@@ -1531,12 +1520,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/starboardnacelle)
 "fn" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Engineering Hallway";
+	req_one_access = null
 	},
-/obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/tiled/techfloor,
-/area/engineering/engine_room)
+/obj/machinery/door/firedoor,
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/engineering/hallway/lower)
 "fo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -1579,14 +1570,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "fx" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/bluegrid{
-	initial_gas_mix = "n2=100;TEMP=80";
-	name = "Mainframe Base"
-	},
-/area/tcommsat/chamber)
+/obj/effect/floor_decal/techfloor/orange,
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/engineering/hallway/lower)
 "fy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1995,6 +1982,9 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 9
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/station/stairs_one)
 "gC" = (
@@ -2111,9 +2101,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
@@ -2144,7 +2131,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "hg" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/recharge_station,
@@ -2235,9 +2222,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "hv" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 4
@@ -2464,8 +2448,8 @@
 /area/engineering/locker_room)
 "hY" = (
 /obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/engineering/hallway/lower)
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/engine_airlock)
 "hZ" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -2670,7 +2654,7 @@
 /area/engineering/portnacelle)
 "iN" = (
 /obj/machinery/telecomms/relay/preset/triumph/deck_two,
-/obj/machinery/light,
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -3043,10 +3027,18 @@
 /turf/simulated/floor/plating,
 /area/engineering/hallway/lower)
 "jQ" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/techfloor/orange,
-/turf/simulated/floor/tiled,
-/area/engineering/hallway/lower)
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/landmark{
+	name = "xeno_spawn";
+	pixel_x = -1
+	},
+/turf/simulated/floor/tiled/white,
+/area/engineering/foyer_mezzenine)
 "jT" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -3317,6 +3309,9 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
 "kL" = (
@@ -3398,15 +3393,14 @@
 /turf/simulated/floor/plating,
 /area/station/stairs_one)
 "la" = (
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 8
 	},
-/turf/simulated/floor/bluegrid{
-	initial_gas_mix = "n2=100;TEMP=80";
-	name = "Mainframe Base"
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/area/tcommsat/chamber)
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/atmos)
 "lb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -3791,6 +3785,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/storage/tech)
 "my" = (
@@ -3892,9 +3889,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos/storage)
 "mJ" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/table/rack{
 	dir = 8;
 	layer = 2.6
@@ -4146,9 +4140,6 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "nB" = (
@@ -4265,6 +4256,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/techfloor/orange,
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
 "nP" = (
@@ -4500,7 +4492,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_smes)
 "oC" = (
-/obj/machinery/light,
 /obj/structure/table/standard,
 /obj/machinery/recharger,
 /obj/effect/floor_decal/techfloor/orange,
@@ -4664,16 +4655,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engi_engine)
-"ph" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/techfloor/orange,
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/engineering/hallway/lower)
 "pi" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil{
@@ -5037,9 +5018,6 @@
 /turf/space,
 /area/space)
 "qs" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 4
@@ -5050,9 +5028,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor,
@@ -5431,11 +5406,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/carpet/blucarpet,
 /area/crew_quarters/heads/chief)
-"rF" = (
-/obj/effect/floor_decal/techfloor/orange,
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/engineering/hallway/lower)
 "rG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -5489,9 +5459,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "rM" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/closet/hydrant{
 	pixel_x = 32
 	},
@@ -5711,6 +5678,9 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
 "sA" = (
@@ -5751,9 +5721,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engi_engine)
 "sF" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -6049,9 +6016,6 @@
 "tz" = (
 /obj/machinery/shieldgen,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/storage)
 "tA" = (
@@ -6158,15 +6122,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
-"tM" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway/lower)
 "tP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -6190,6 +6145,9 @@
 "tT" = (
 /obj/structure/table/standard,
 /obj/item/multitool,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tcommsat/computer)
 "tU" = (
@@ -6503,6 +6461,10 @@
 	pixel_x = -26
 	},
 /obj/machinery/vending/cola,
+/obj/machinery/light{
+	dir = 8;
+	light_range = 12
+	},
 /turf/simulated/floor/wood,
 /area/engineering/hallway/lower)
 "uW" = (
@@ -6670,6 +6632,7 @@
 /obj/machinery/power/thermoregulator,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/rust,
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
 "vw" = (
@@ -6696,6 +6659,9 @@
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering Hallway";
 	req_one_access = null
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
@@ -6901,6 +6867,9 @@
 /obj/item/healthanalyzer,
 /obj/item/analyzer,
 /obj/item/analyzer,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "wp" = (
@@ -7135,9 +7104,6 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/vending/assist,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
@@ -7199,13 +7165,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_smes)
-"xa" = (
-/obj/structure/catwalk,
-/obj/machinery/light/small/emergency{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/engi_engine)
 "xb" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
@@ -7341,9 +7300,6 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -7351,14 +7307,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
-"xE" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/techfloor/orange,
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway/lower)
 "xF" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -7677,9 +7625,6 @@
 	pixel_x = 5;
 	pixel_y = -5
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -7702,6 +7647,9 @@
 	dir = 4
 	},
 /obj/structure/table/rack/shelf/steel,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_monitoring)
 "yH" = (
@@ -7890,9 +7838,6 @@
 /area/engineering/engine_room)
 "zi" = (
 /obj/machinery/atmospherics/binary/pump,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "zl" = (
@@ -8241,6 +8186,7 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 10
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/station/stairs_one)
 "AL" = (
@@ -8291,15 +8237,6 @@
 /obj/item/clothing/gloves/yellow,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
-"AY" = (
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
 "AZ" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -8374,6 +8311,9 @@
 	dir = 4;
 	layer = 3.3;
 	pixel_x = 26
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
@@ -8526,9 +8466,6 @@
 "BP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -8878,9 +8815,6 @@
 /area/engineering/atmos)
 "CR" = (
 /obj/structure/closet/secure_closet/engineering_chief,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/clothing/accessory/poncho/roles/cloak/ce,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
@@ -8995,18 +8929,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/engi_engine)
-"Dq" = (
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos/storage)
 "Ds" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -9061,6 +8983,9 @@
 "Dy" = (
 /obj/machinery/ntnet_relay,
 /obj/machinery/camera/network/tcomms,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
@@ -9138,10 +9063,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
+/obj/effect/floor_decal/techfloor/orange{
 	dir = 8
 	},
-/obj/effect/floor_decal/techfloor/orange{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -9287,9 +9212,6 @@
 /turf/simulated/floor/reinforced/n20,
 /area/engineering/atmos)
 "El" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/table/standard,
 /obj/item/storage/box/donkpockets{
 	pixel_y = 3
@@ -9312,6 +9234,9 @@
 /area/engineering/engine_room)
 "Eo" = (
 /obj/machinery/telecomms/bus/preset_three,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -9367,6 +9292,7 @@
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/techfloor/orange,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_monitoring)
 "Ez" = (
@@ -9381,10 +9307,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/station/stairs_one)
-"EA" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
-/area/tcommsat/computer)
 "EC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/catwalk,
@@ -10211,7 +10133,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/workshop)
 "GF" = (
@@ -10294,9 +10215,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - Engine Output";
@@ -10598,19 +10516,6 @@
 	},
 /turf/simulated/floor,
 /area/storage/tech)
-"HG" = (
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway/lower)
 "HI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11239,16 +11144,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
-"JX" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/techfloor/orange,
-/turf/simulated/floor/tiled,
-/area/engineering/hallway/lower)
 "JY" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
@@ -11370,9 +11265,6 @@
 /area/engineering/atmos)
 "Kx" = (
 /obj/machinery/power/grid_checker,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -11460,7 +11352,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "KN" = (
@@ -11527,7 +11418,6 @@
 /area/maintenance/engi_engine)
 "KW" = (
 /obj/effect/floor_decal/techfloor/orange,
-/obj/machinery/light,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "KX" = (
@@ -12080,7 +11970,6 @@
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/storage)
 "MJ" = (
@@ -12122,19 +12011,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/portnacelle)
-"MP" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/techfloor/orange,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/engineering/hallway/lower)
 "MS" = (
 /obj/machinery/light{
 	dir = 1
@@ -12197,7 +12073,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/storage)
 "MZ" = (
-/obj/machinery/light,
 /obj/structure/table/reinforced,
 /obj/item/tool/crowbar,
 /obj/item/tool/screwdriver,
@@ -12217,6 +12092,9 @@
 	},
 /obj/structure/sign/warning/radioactive{
 	pixel_x = -32
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_smes)
@@ -12440,11 +12318,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/lower)
-"NH" = (
-/obj/machinery/light,
-/obj/structure/table/woodentable,
-/turf/simulated/floor/wood,
-/area/engineering/hallway/lower)
 "NI" = (
 /obj/machinery/status_display{
 	pixel_y = 30
@@ -12506,20 +12379,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"NR" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
 "NS" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
@@ -12750,10 +12609,6 @@
 "OD" = (
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/heads/chief)
-"OG" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/engine_airlock)
 "OH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -13150,7 +13005,6 @@
 /area/engineering/engine_room)
 "PW" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/purple,
-/obj/machinery/light,
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
@@ -13521,14 +13375,12 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "Rf" = (
-/obj/machinery/light,
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
 	},
@@ -13977,15 +13829,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
-"Sq" = (
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
 "Sr" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -14010,7 +13853,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
 "Sw" = (
@@ -14276,7 +14118,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "Tk" = (
-/obj/machinery/light,
 /obj/machinery/keycard_auth{
 	pixel_y = -28
 	},
@@ -14289,9 +14130,6 @@
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -23
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -14466,9 +14304,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
 "TM" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -14479,7 +14314,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -14637,6 +14472,9 @@
 /area/engineering/engine_room)
 "Uu" = (
 /obj/machinery/vending/snack,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/engineering/break_room)
 "Uv" = (
@@ -14658,9 +14496,6 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom (General)";
@@ -14668,20 +14503,8 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
-"Uy" = (
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
 "Uz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -14799,6 +14622,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_smes)
@@ -15045,9 +14871,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engi_engine)
 "VA" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/table/bench/padded,
 /obj/effect/landmark/start{
 	name = "Station Engineer"
@@ -15154,10 +14977,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
-"VM" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/engineering/engine_room)
 "VN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -15210,7 +15029,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/engineering/foyer_mezzenine)
 "VW" = (
@@ -15297,6 +15115,10 @@
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -23
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_range = 12
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tcommsat/entrance)
@@ -15425,6 +15247,9 @@
 /area/engineering/atmos)
 "WK" = (
 /obj/machinery/telecomms/bus/preset_one,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -15800,9 +15625,6 @@
 /area/maintenance/engineering)
 "Yd" = (
 /obj/machinery/telecomms/processor/preset_four,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -16035,10 +15857,6 @@
 /area/engineering/portnacelle)
 "YH" = (
 /obj/machinery/telecomms/processor/preset_two,
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
-	},
 /turf/simulated/floor/tiled/dark{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -16069,20 +15887,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
-"YR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
 "YS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 5
@@ -16090,12 +15894,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
-"YT" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/workshop)
 "YU" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -16257,7 +16055,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "Zt" = (
-/obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -22343,7 +22140,7 @@ GW
 hN
 ny
 RL
-VM
+tg
 xl
 aN
 Vm
@@ -23775,7 +23572,7 @@ IN
 Rq
 Vx
 Tf
-OG
+TR
 IN
 mc
 ke
@@ -23907,7 +23704,7 @@ Gi
 zz
 so
 sA
-fn
+so
 so
 so
 zz
@@ -23917,7 +23714,7 @@ IN
 sZ
 HN
 Tf
-TR
+hY
 IN
 mc
 ke
@@ -24338,7 +24135,7 @@ MT
 QM
 di
 BS
-hY
+BS
 WV
 pr
 ZJ
@@ -24764,7 +24561,7 @@ GQ
 jv
 bv
 RB
-NH
+RB
 WV
 uW
 Gj
@@ -25178,7 +24975,7 @@ ID
 oX
 hi
 ep
-YR
+tH
 Lt
 Mr
 tH
@@ -25464,11 +25261,11 @@ vd
 jx
 uy
 uy
-dl
+uy
 uy
 CP
 Zm
-Uy
+vi
 gc
 Kd
 Zh
@@ -25766,7 +25563,7 @@ Dv
 xi
 ft
 wH
-xa
+wH
 xv
 Yp
 Kq
@@ -25896,9 +25693,9 @@ DE
 XP
 Lv
 xv
-Xc
+GQ
 Zv
-MP
+qW
 MK
 JQ
 Fw
@@ -26324,7 +26121,7 @@ dj
 YJ
 aT
 nl
-ph
+am
 MK
 LM
 Fw
@@ -26480,7 +26277,7 @@ Vf
 YF
 WJ
 cK
-YF
+la
 WJ
 Bq
 Tm
@@ -26750,7 +26547,7 @@ MB
 yl
 GQ
 nl
-ph
+am
 MK
 MK
 MK
@@ -27164,7 +26961,7 @@ UX
 yC
 yC
 yC
-NR
+Mf
 hj
 YJ
 uH
@@ -27296,7 +27093,7 @@ YH
 WK
 AT
 wK
-la
+PQ
 tD
 kd
 Nh
@@ -27460,12 +27257,12 @@ NF
 YJ
 Xc
 nl
-JX
+am
 ow
 Lj
-YT
 Zz
-YT
+Zz
+Zz
 oH
 Mj
 uK
@@ -28014,7 +27811,7 @@ CO
 CO
 xk
 TJ
-EA
+TJ
 yC
 VK
 UU
@@ -28148,7 +27945,7 @@ Yd
 Eo
 PQ
 bu
-fx
+PQ
 EV
 yC
 oK
@@ -28170,7 +27967,7 @@ ON
 YJ
 LE
 QX
-LE
+fn
 Tx
 Tx
 Tx
@@ -28310,7 +28107,7 @@ aL
 UT
 Pf
 YJ
-tM
+MT
 FE
 di
 Tx
@@ -28603,7 +28400,7 @@ Ps
 Ps
 Lb
 Wj
-Dq
+Wj
 Qj
 bw
 zu
@@ -28726,7 +28523,7 @@ dv
 nF
 US
 dv
-Sq
+RT
 yu
 YJ
 YJ
@@ -29017,7 +28814,7 @@ Pn
 Oq
 uy
 FB
-AY
+uy
 vi
 NB
 GQ
@@ -30016,7 +29813,7 @@ KW
 yk
 et
 XY
-xE
+Ka
 Tx
 Fv
 ml
@@ -30158,7 +29955,7 @@ Ai
 gh
 Ji
 bt
-bv
+fx
 Tx
 OM
 OM
@@ -30440,7 +30237,7 @@ Hd
 OD
 OD
 OD
-HG
+ku
 Ud
 bv
 Tx
@@ -30584,14 +30381,14 @@ St
 OD
 Gn
 pp
-jQ
+bv
 em
 hg
 oG
 em
 ea
 em
-ea
+jQ
 UQ
 iu
 qb
@@ -31152,7 +30949,7 @@ Tk
 OD
 SX
 JE
-rF
+bv
 em
 Ex
 Bw
@@ -31434,7 +31231,7 @@ OD
 OD
 OD
 OD
-LE
+dl
 Fj
 LE
 em

--- a/_maps/map_files/triumph/triumph-01-deck1.dmm
+++ b/_maps/map_files/triumph/triumph-01-deck1.dmm
@@ -1518,26 +1518,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/starboardnacelle)
 "fn" = (
-/obj/structure/catwalk,
-/obj/effect/floor_decal/spline/fancy/wood,
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
 "fo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -1581,9 +1566,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "fx" = (
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 10
-	},
+/obj/effect/floor_decal/techfloor/orange,
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
@@ -2460,10 +2443,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "hY" = (
-/obj/effect/floor_decal/techfloor/orange,
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/engineering/hallway/lower)
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/engine_airlock)
 "hZ" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -3041,9 +3023,18 @@
 /turf/simulated/floor/plating,
 /area/engineering/hallway/lower)
 "jQ" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/engine_airlock)
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/landmark{
+	name = "xeno_spawn";
+	pixel_x = -1
+	},
+/turf/simulated/floor/tiled/white,
+/area/engineering/foyer_mezzenine)
 "jT" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -3398,18 +3389,14 @@
 /turf/simulated/floor/plating,
 /area/station/stairs_one)
 "la" = (
-/obj/structure/toilet{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
-	},
-/turf/simulated/floor/tiled/white,
-/area/engineering/foyer_mezzenine)
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/atmos)
 "lb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -3800,8 +3787,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/storage/tech)
 "my" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 8
@@ -4663,15 +4650,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engi_engine)
-"ph" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/engineering/atmos)
 "pi" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil{
@@ -6017,10 +5995,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 1
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
 "tx" = (
@@ -7128,8 +7103,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/network/engineering{
-	dir = 1
+/obj/machinery/camera/network/outside{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23735,7 +23710,7 @@ IN
 sZ
 HN
 Tf
-jQ
+hY
 IN
 mc
 ke
@@ -26298,7 +26273,7 @@ Vf
 YF
 WJ
 cK
-ph
+la
 WJ
 Bq
 Tm
@@ -28130,7 +28105,7 @@ Pf
 YJ
 MT
 FE
-fx
+fn
 Tx
 fI
 fI
@@ -29265,7 +29240,7 @@ FC
 Cf
 YJ
 by
-fn
+NG
 eP
 ZW
 La
@@ -29976,7 +29951,7 @@ Ai
 gh
 Ji
 bt
-hY
+fx
 Tx
 OM
 OM
@@ -30409,7 +30384,7 @@ oG
 em
 ea
 em
-la
+jQ
 UQ
 iu
 qb

--- a/_maps/map_files/triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/triumph/triumph-02-deck2.dmm
@@ -16650,12 +16650,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/coffee_shop)
 "Wx" = (

--- a/_maps/map_files/triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/triumph/triumph-02-deck2.dmm
@@ -16650,6 +16650,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/coffee_shop)
 "Wx" = (

--- a/_maps/map_files/triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/triumph/triumph-02-deck2.dmm
@@ -19,7 +19,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "ae" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -166,7 +166,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "az" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -267,9 +267,6 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/quartermaster/foyer)
 "aO" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -361,7 +358,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "aZ" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -392,17 +389,15 @@
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/refinery)
 "be" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
 	},
-/obj/structure/mirror{
-	pixel_x = -28
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
+/turf/simulated/floor/plating,
+/area/vacant/vacant_shop)
 "bg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -487,7 +482,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "bG" = (
 /obj/structure/cable/green{
@@ -497,9 +492,6 @@
 	dir = 4;
 	name = "east bump";
 	pixel_x = 28
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -796,17 +788,15 @@
 	pixel_y = 32
 	},
 /obj/structure/closet/l3closet/janitor,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
 "cz" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/table/rack/shelf,
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/bar/lower)
+/area/vacant/vacant_shop)
 "cB" = (
 /obj/machinery/camera/network/outside{
 	dir = 10
@@ -833,9 +823,6 @@
 /area/hallway/primary/port)
 "cE" = (
 /obj/structure/closet/wardrobe/white,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_5)
 "cF" = (
@@ -869,7 +856,6 @@
 /turf/simulated/floor/wood,
 /area/station/stairs_two)
 "cJ" = (
-/obj/machinery/light,
 /obj/structure/bed/chair/comfy/teal{
 	dir = 4
 	},
@@ -940,9 +926,6 @@
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
 "dd" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
 	},
@@ -973,7 +956,8 @@
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/eva)
 "di" = (
-/obj/effect/floor_decal/techfloor,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
@@ -1014,7 +998,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "do" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -1067,6 +1051,9 @@
 	},
 /obj/structure/bed/padded,
 /obj/item/bedsheet/blue,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_1)
 "du" = (
@@ -1075,7 +1062,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
 /obj/item/radio/intercom{
 	pixel_y = -24
 	},
@@ -1215,7 +1201,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
 "dV" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 8
 	},
 /obj/structure/ladder/up,
@@ -1273,9 +1259,6 @@
 	pixel_x = 26;
 	pixel_y = -4;
 	specialfunctions = 4
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /obj/item/instrument/recorder,
 /turf/simulated/floor/wood,
@@ -1800,9 +1783,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "fo" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -1854,7 +1834,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -2072,6 +2052,9 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "fW" = (
@@ -2223,7 +2206,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "gn" = (
@@ -2511,9 +2493,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_7)
 "hf" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/table/marble,
 /obj/machinery/microwave,
 /turf/simulated/floor/tiled,
@@ -2599,6 +2578,7 @@
 	tag_exterior_door = "mining_fore_outer";
 	tag_interior_door = "mining_fore_inner"
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningdock)
 "ho" = (
@@ -2606,6 +2586,9 @@
 /obj/item/bedsheet/blue,
 /obj/machinery/newscaster{
 	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_2)
@@ -2638,9 +2621,6 @@
 "hr" = (
 /obj/machinery/alarm{
 	pixel_y = 22
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 9
@@ -2741,9 +2721,6 @@
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
 "hE" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
@@ -2796,12 +2773,10 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "hQ" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/area/hallway/primary/starboard)
 "hR" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -2825,7 +2800,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
 "hW" = (
-/obj/machinery/light,
 /obj/item/radio/intercom{
 	pixel_y = -24
 	},
@@ -2853,7 +2827,7 @@
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
 "ib" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -3048,9 +3022,6 @@
 	name = "north bump";
 	pixel_y = 28
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
@@ -3224,8 +3195,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/wood,
+/area/crew_quarters/recreation_area)
 "jf" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3275,7 +3246,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green,
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -3481,9 +3452,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
 "jM" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -3563,7 +3531,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/light,
 /obj/machinery/media/jukebox,
 /turf/simulated/floor/wood,
 /area/crew_quarters/fitness)
@@ -3689,9 +3656,6 @@
 /area/station/stairs_two)
 "kq" = (
 /obj/machinery/appliance/cooker/grill,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "kr" = (
@@ -4279,9 +4243,6 @@
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_9)
 "md" = (
@@ -4432,6 +4393,9 @@
 	layer = 3.3;
 	pixel_x = -27
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "mz" = (
@@ -4496,9 +4460,6 @@
 /turf/simulated/wall,
 /area/vacant/vacant_shop)
 "mG" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_10)
 "mH" = (
@@ -4561,8 +4522,8 @@
 /area/crew_quarters/coffee_shop)
 "mL" = (
 /obj/machinery/recharge_station,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
@@ -4571,11 +4532,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
 "mO" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel,
@@ -4586,6 +4547,9 @@
 /obj/item/reagent_containers/glass/rag,
 /obj/machinery/camera/network/civilian{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
@@ -4978,7 +4942,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "nJ" = (
 /obj/structure/grille,
@@ -5152,9 +5116,6 @@
 	pixel_x = -28
 	},
 /obj/structure/cable/green,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
 "og" = (
@@ -5384,7 +5345,7 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -5510,7 +5471,7 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -5821,7 +5782,7 @@
 /obj/structure/toilet{
 	dir = 1
 	},
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -6038,9 +5999,11 @@
 /turf/simulated/floor/tiled,
 /area/station/stairs_two)
 "qW" = (
-/obj/machinery/light,
-/turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/toilet)
 "qX" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	cycle_to_external_air = 1;
@@ -6110,9 +6073,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -6234,6 +6194,10 @@
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "mining_interior"
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_range = 12
 	},
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/refinery)
@@ -6366,6 +6330,9 @@
 /area/shuttle/belter)
 "rV" = (
 /obj/structure/closet/firecloset,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
 "rW" = (
@@ -6510,9 +6477,6 @@
 "sq" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = -28;
@@ -6880,18 +6844,19 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/triumph/surfacebase/mining_main/refinery)
 "th" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/toilet{
+	dir = 1
 	},
-/obj/structure/table/rack/shelf,
-/turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/toilet)
 "tk" = (
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -28
 	},
-/obj/machinery/light,
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
@@ -6922,9 +6887,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
 "tn" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -7254,7 +7216,6 @@
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/station/stairs_two)
 "uj" = (
@@ -7338,7 +7299,7 @@
 /obj/structure/toilet{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
 "uv" = (
@@ -7439,7 +7400,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "uI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -7577,7 +7538,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/light,
 /obj/item/radio/intercom{
 	pixel_y = -24
 	},
@@ -7752,18 +7712,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
-"vG" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/status_display/supply_display{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
 "vH" = (
 /turf/simulated/floor/airless,
 /area/space)
@@ -7937,9 +7885,6 @@
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
@@ -7977,9 +7922,6 @@
 "wr" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_7)
@@ -8347,7 +8289,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
 "xx" = (
-/obj/machinery/light,
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_4)
@@ -8357,6 +8298,7 @@
 	pixel_y = -24
 	},
 /obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "xB" = (
@@ -8400,9 +8342,6 @@
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -23
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
@@ -8758,6 +8697,7 @@
 /obj/machinery/computer/security/telescreen{
 	pixel_y = -32
 	},
+/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "yI" = (
@@ -8786,7 +8726,7 @@
 /area/crew_quarters/sleep/Dorm_2)
 "yM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -8875,7 +8815,6 @@
 /area/crew_quarters/bar)
 "zf" = (
 /obj/structure/table/woodentable,
-/obj/machinery/light,
 /obj/item/instrument/harmonica,
 /obj/machinery/recharger,
 /turf/simulated/floor/wood,
@@ -8935,10 +8874,10 @@
 /obj/machinery/status_display/supply_display{
 	pixel_y = 32
 	},
+/obj/machinery/vending/loadout/accessory,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/vending/loadout/accessory,
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
 "zo" = (
@@ -9054,6 +8993,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
 "zD" = (
@@ -9074,6 +9016,9 @@
 "zG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/closet/wardrobe,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_10)
 "zH" = (
@@ -9321,9 +9266,6 @@
 /obj/structure/sink/kitchen{
 	dir = 4;
 	pixel_x = -11
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
@@ -9637,9 +9579,6 @@
 /area/hallway/primary/port)
 "Bx" = (
 /obj/structure/table/woodentable,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/item/instrument/accordion,
 /obj/machinery/computer/security/telescreen{
 	pixel_y = 32
@@ -9658,6 +9597,9 @@
 "Bz" = (
 /obj/structure/bed/chair/comfy/teal{
 	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
@@ -9719,6 +9661,9 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_3)
 "BG" = (
@@ -9742,18 +9687,14 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad2"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "BK" = (
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
@@ -9821,9 +9762,6 @@
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "Ca" = (
@@ -9882,9 +9820,6 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "Cf" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
@@ -10453,16 +10388,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "DS" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -10485,7 +10417,6 @@
 /turf/simulated/floor/plating,
 /area/vacant/vacant_shop)
 "DX" = (
-/obj/machinery/light,
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_y = -37
 	},
@@ -10928,6 +10859,9 @@
 /area/vacant/vacant_shop)
 "Fm" = (
 /obj/structure/undies_wardrobe,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_11)
 "Fq" = (
@@ -10968,9 +10902,6 @@
 	dir = 8;
 	pixel_y = 24
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/wood,
 /area/hallway/primary/port)
 "Fw" = (
@@ -10992,6 +10923,9 @@
 	},
 /obj/machinery/atm{
 	pixel_y = 30
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
@@ -11097,9 +11031,6 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_1)
 "FN" = (
@@ -11177,7 +11108,6 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/warehouse)
 "FT" = (
-/obj/machinery/light,
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
@@ -11342,15 +11272,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/showers)
-"Gs" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/quartermaster/foyer)
 "Gt" = (
 /turf/simulated/floor/carpet/sblucarpet,
 /area/quartermaster/foyer)
@@ -11360,7 +11281,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -11517,6 +11438,9 @@
 /obj/structure/bed/chair/comfy/teal{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_5)
 "GW" = (
@@ -11634,7 +11558,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/freezer)
 "Hp" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -11728,9 +11652,6 @@
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin,
 /obj/random/soap,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	pixel_y = -24
 	},
@@ -11802,6 +11723,9 @@
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -12074,18 +11998,12 @@
 	frequency = 1379;
 	id_tag = "mining_fore_pump"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningdock)
 "IE" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -12137,9 +12055,6 @@
 /area/maintenance/dormitory)
 "IL" = (
 /obj/structure/bed/chair/comfy/teal,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -12186,13 +12101,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
-"IS" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lime/border,
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/hydroponics)
 "IT" = (
 /obj/structure/sign/deck/second,
 /turf/simulated/wall,
@@ -12244,15 +12152,6 @@
 "IX" = (
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/hallway/primary/port)
-"IY" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
 "IZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -12373,6 +12272,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -12613,14 +12515,14 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 5
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/tank/jetpack/oxygen,
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom (General)";
 	pixel_y = 26
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/storage)
@@ -12683,9 +12585,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_3)
 "Kr" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/computer/security/telescreen{
 	pixel_y = 32
 	},
@@ -13068,9 +12967,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "LA" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -13167,9 +13063,6 @@
 /area/hallway/primary/port)
 "LY" = (
 /obj/structure/bed/chair/comfy/teal,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_3)
 "LZ" = (
@@ -13181,9 +13074,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/status_display/supply_display{
@@ -13297,17 +13187,11 @@
 	mode = 99;
 	pixel_y = 32
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
-"Mv" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
 "My" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -13422,9 +13306,6 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /obj/structure/closet/wardrobe,
 /turf/simulated/floor/wood,
@@ -13556,7 +13437,6 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
 	},
-/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/station/stairs_two)
 "Nn" = (
@@ -13566,9 +13446,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_7)
 "Np" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom (General)";
@@ -13703,9 +13580,6 @@
 	frequency = 1379;
 	id_tag = "mining_fore_pump"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningdock)
 "NK" = (
@@ -13774,12 +13648,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/station/stairs_two)
-"NV" = (
-/obj/effect/floor_decal/techfloor,
-/obj/machinery/light,
-/obj/machinery/computer/timeclock/premade/south,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
 "NX" = (
 /turf/simulated/floor/carpet/sblucarpet,
 /area/crew_quarters/sleep/Dorm_2)
@@ -13861,6 +13729,9 @@
 	name = "Bar Shutters"
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "On" = (
@@ -14278,7 +14149,7 @@
 	name = "Annex Dock"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "PF" = (
 /obj/effect/floor_decal/techfloor{
@@ -14322,7 +14193,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "PK" = (
 /obj/machinery/mineral/processing_unit_console{
@@ -14515,7 +14386,6 @@
 /turf/simulated/floor/plating,
 /area/vacant/vacant_shop)
 "Ql" = (
-/obj/machinery/light,
 /obj/structure/bed/chair/comfy/teal{
 	dir = 4
 	},
@@ -14570,10 +14440,6 @@
 /obj/machinery/mineral/unloading_machine,
 /turf/simulated/floor/tiled/steel_grid,
 /area/triumph/surfacebase/mining_main/refinery)
-"Qx" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/Dorm_11)
 "Qy" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -14655,9 +14521,6 @@
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -14667,7 +14530,7 @@
 /obj/structure/toilet{
 	pixel_y = 10
 	},
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -14804,9 +14667,6 @@
 /turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "Rn" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/closet/hydrant{
 	pixel_x = -32
 	},
@@ -15000,9 +14860,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
@@ -15138,7 +14995,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "Sf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -15353,6 +15210,9 @@
 /obj/machinery/light_switch{
 	pixel_x = -25
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_4)
 "SI" = (
@@ -15418,9 +15278,6 @@
 /area/crew_quarters/kitchen)
 "SS" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central6{
-	dir = 4
-	},
-/obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/requests_console/preset/cargo{
@@ -15627,13 +15484,6 @@
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/sleep/Dorm_9)
-"Tv" = (
-/obj/machinery/fitness/punching_bag,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/fitness)
 "Tw" = (
 /obj/structure/closet/chefcloset,
 /obj/item/glass_jar,
@@ -15651,7 +15501,6 @@
 /area/crew_quarters/kitchen)
 "Tx" = (
 /obj/machinery/computer/timeclock/premade/south,
-/obj/machinery/light,
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/port)
@@ -15693,9 +15542,6 @@
 	},
 /obj/structure/sign/double/barsign{
 	pixel_y = 30
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/bar_alc/full,
@@ -15883,6 +15729,7 @@
 	icon_state = "superjuke-nopower";
 	state_base = "superjuke"
 	},
+/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
 "Ud" = (
@@ -15951,9 +15798,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
 "Uq" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/bed/chair/sofa/right{
 	icon_state = "sofaend_right"
 	},
@@ -16280,8 +16124,8 @@
 /area/vacant/vacant_shop)
 "Vr" = (
 /obj/machinery/recharge_station,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
@@ -16371,7 +16215,6 @@
 /turf/simulated/floor/tiled,
 /area/station/stairs_two)
 "VB" = (
-/obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -16467,7 +16310,7 @@
 /area/station/stairs_two)
 "VO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "VP" = (
 /obj/structure/cable/green{
@@ -16749,6 +16592,7 @@
 /obj/machinery/camera/network/civilian{
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_shop)
 "Wv" = (
@@ -17014,7 +16858,7 @@
 /obj/structure/toilet{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/small,
 /obj/effect/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
@@ -17104,9 +16948,6 @@
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
 "Xn" = (
@@ -17122,6 +16963,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1379;
 	id_tag = "mining_fore_pump"
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningdock)
@@ -17335,6 +17179,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/sleep/cryo)
 "XN" = (
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_9)
 "XO" = (
@@ -17570,7 +17417,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "Yy" = (
 /obj/machinery/door/firedoor,
@@ -17611,7 +17458,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -17725,9 +17572,6 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 28
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -17928,12 +17772,12 @@
 /area/crew_quarters/fitness)
 "Zw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/refinery)
 "Zx" = (
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_8)
 "Zy" = (
@@ -18030,9 +17874,6 @@
 	dir = 4;
 	pixel_x = -25;
 	pixel_y = -1
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /obj/machinery/button/remote/blast_door{
 	dir = 4;
@@ -22590,7 +22431,7 @@ CD
 JX
 SD
 Dy
-be
+Dy
 Dm
 ai
 ai
@@ -23431,7 +23272,7 @@ ZP
 LR
 LR
 LR
-jd
+LR
 LR
 WU
 sU
@@ -23871,7 +23712,7 @@ CR
 Vo
 CR
 WE
-IS
+dx
 Ki
 oE
 gC
@@ -24865,7 +24706,7 @@ zj
 Tt
 jw
 Uh
-IS
+dx
 Ki
 oE
 gC
@@ -25268,7 +25109,7 @@ Bd
 iu
 Rr
 Nh
-cz
+Nh
 Nh
 dV
 Nh
@@ -25999,7 +25840,7 @@ xj
 xj
 GM
 xj
-qW
+xj
 wc
 kn
 km
@@ -26420,7 +26261,7 @@ sU
 Vv
 mM
 VL
-iq
+jd
 LJ
 Jf
 NK
@@ -27141,7 +26982,7 @@ mL
 Dn
 Yq
 Dn
-qi
+th
 MF
 uQ
 uQ
@@ -27707,7 +27548,7 @@ GT
 MF
 Bk
 Bk
-Kv
+qW
 VP
 HC
 MF
@@ -28403,7 +28244,7 @@ bI
 HE
 zH
 LU
-Mv
+HE
 vI
 Vv
 mM
@@ -28571,7 +28412,7 @@ Uz
 vD
 Pu
 gX
-Qx
+AH
 Yu
 Er
 Xr
@@ -28832,7 +28673,7 @@ GJ
 GJ
 XZ
 dJ
-XZ
+di
 Uy
 Uy
 Uy
@@ -28960,7 +28801,7 @@ KE
 yc
 AO
 pt
-Gs
+Ln
 Ln
 AT
 rV
@@ -29283,7 +29124,7 @@ Kl
 CA
 Ov
 Yu
-Tv
+pr
 dm
 yn
 cn
@@ -29398,7 +29239,7 @@ pX
 dj
 Kx
 GJ
-vG
+rY
 oc
 hT
 Uy
@@ -29512,7 +29353,7 @@ Ux
 rJ
 kk
 kk
-kk
+aQ
 OY
 Mt
 kk
@@ -29794,7 +29635,7 @@ ii
 cB
 rP
 Mq
-hQ
+JT
 JT
 JT
 BI
@@ -29805,7 +29646,7 @@ DF
 qR
 Nj
 kk
-aQ
+kk
 et
 zl
 QE
@@ -30110,7 +29951,7 @@ zf
 GJ
 Fz
 uZ
-di
+hT
 cX
 BD
 yr
@@ -30815,10 +30656,10 @@ lu
 VR
 NB
 Rn
-gH
+be
 Nq
 sD
-IY
+nM
 FC
 Lm
 zk
@@ -31388,7 +31229,7 @@ eM
 CJ
 vb
 mr
-hT
+hQ
 zk
 zy
 OO
@@ -31670,7 +31511,7 @@ cN
 Hu
 by
 mQ
-IY
+nM
 Gl
 cH
 jB
@@ -32376,8 +32217,8 @@ Rj
 aC
 mQ
 fP
-th
 fP
+cz
 fP
 mQ
 lf
@@ -32666,7 +32507,7 @@ oQ
 SW
 HM
 FC
-NV
+VV
 zk
 zk
 zk

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -3526,8 +3526,12 @@
 /obj/machinery/atm{
 	pixel_x = -33
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
 "cXI" = (
@@ -8391,8 +8395,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/assembly/chargebay)
 "gYn" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "gYs" = (
@@ -15119,12 +15127,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "mLJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	layer = 3.3;
@@ -45773,7 +45775,7 @@ trY
 oSC
 uRN
 cXI
-uGD
+wZI
 uGD
 abu
 ruk

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -6,6 +6,9 @@
 	pixel_y = 26
 	},
 /mob/living/simple_mob/slime/xenobio/rainbow/kendrick,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/rdoffice)
 "aab" = (
@@ -183,7 +186,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer_auxiliary)
 "afL" = (
-/obj/machinery/light,
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/machinery/scale,
 /turf/simulated/floor/tiled/white,
@@ -845,7 +847,6 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 6
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer)
 "aIW" = (
@@ -1299,7 +1300,7 @@
 /obj/structure/toilet{
 	pixel_y = 10
 	},
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -1314,7 +1315,7 @@
 /area/assembly/robotics)
 "bhf" = (
 /obj/machinery/recharge_station,
-/obj/machinery/light,
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "bhi" = (
@@ -1398,7 +1399,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/light,
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
@@ -1597,6 +1597,7 @@
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/rnd/test_area)
 "btk" = (
@@ -1723,6 +1724,9 @@
 /area/medical/morgue)
 "bzz" = (
 /obj/machinery/photocopier,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/rdoffice)
 "bAa" = (
@@ -1992,9 +1996,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
 "bJh" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/table/steel_reinforced,
 /obj/item/defib_kit/loaded{
 	pixel_y = 3
@@ -2241,9 +2242,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/washing_machine,
 /obj/machinery/computer/cryopod{
 	pixel_y = 32
@@ -2322,7 +2320,6 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
 "bWQ" = (
-/obj/machinery/light,
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_y = -37
 	},
@@ -2387,7 +2384,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "bZI" = (
-/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
@@ -2841,7 +2837,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/rnd/rdoffice)
 "ctY" = (
@@ -2910,6 +2905,9 @@
 /obj/structure/sign/directions/cargo{
 	dir = 1;
 	pixel_y = 30
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
@@ -3012,21 +3010,10 @@
 /area/rnd/xenobiology)
 "cCD" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 4
 	},
-/obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = 24;
-	req_access = list()
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
+/turf/simulated/floor/tiled/dark,
+/area/rnd/research/testingrange)
 "cCL" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1
@@ -3183,18 +3170,19 @@
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
 "cHU" = (
 /turf/simulated/wall,
 /area/maintenance/fore)
 "cIi" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/vending/snack,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/port)
+/area/rnd/storage)
 "cIH" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
@@ -3414,7 +3402,6 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "cSV" = (
@@ -3667,6 +3654,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer)
 "dct" = (
@@ -3877,9 +3867,14 @@
 /turf/simulated/floor/tiled,
 /area/medical/surgery)
 "dmT" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/rnd/xenobiology)
+/obj/structure/morgue{
+	dir = 2
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
 "dmV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -4088,15 +4083,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
-"dvJ" = (
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/mauve/border,
-/turf/simulated/floor/tiled,
-/area/rnd/research_foyer_auxiliary)
 "dvY" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -4195,9 +4181,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
 "dCC" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom (General)";
@@ -4294,7 +4277,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
 /turf/simulated/floor/tiled,
@@ -4395,7 +4377,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/beige/border,
 /turf/simulated/floor/tiled/white,
@@ -4411,9 +4392,6 @@
 	dir = 4
 	},
 /obj/structure/closet/l3closet/virology,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 9
 	},
@@ -4555,9 +4533,6 @@
 /area/crew_quarters/medbreak)
 "dPR" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
 	},
@@ -4841,9 +4816,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/rnd/test_area)
 "ecz" = (
@@ -4952,13 +4924,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
-"edK" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/tiled,
-/area/rnd/xenobiology)
 "edS" = (
 /obj/effect/floor_decal/steeldecal/steel_decals9,
 /obj/effect/floor_decal/steeldecal/steel_decals9{
@@ -5064,19 +5029,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
-"eiW" = (
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
 "ejv" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/old_cargo/purple,
@@ -5831,7 +5783,7 @@
 /obj/structure/toilet{
 	pixel_y = 10
 	},
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -6479,7 +6431,9 @@
 /turf/simulated/floor/tiled,
 /area/rnd/test_area)
 "ful" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_restroom)
@@ -6584,6 +6538,9 @@
 	dir = 1
 	},
 /obj/item/beach_ball,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/grass,
 /area/medical/psych_ward)
 "fxL" = (
@@ -6782,11 +6739,6 @@
 	name = "Server Base"
 	},
 /area/rnd/research)
-"fGL" = (
-/obj/machinery/cryopod/robot,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/old_cargo/purple,
-/area/assembly/robotics)
 "fHa" = (
 /obj/structure/sign/department/robo,
 /turf/simulated/wall,
@@ -6920,9 +6872,6 @@
 /area/triumph/station/stairs_three)
 "fKp" = (
 /obj/item/reagent_containers/food/snacks/monkeycube/wrapped,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/table/standard,
 /obj/item/storage/box/monkeycubes{
 	starts_with = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped = 10)
@@ -7060,7 +7009,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/testingrange)
 "fRC" = (
@@ -7083,9 +7031,6 @@
 /obj/item/clothing/shoes/black,
 /obj/item/clothing/shoes/black,
 /obj/item/clothing/shoes/black,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/medical/resleeving)
@@ -8122,12 +8067,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyaccess)
-"gHF" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/medbreak)
 "gHQ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/alarm{
@@ -8138,9 +8077,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/medical/surgery{
 	name = "\improper Robotics Surgery Room"
@@ -8153,9 +8089,6 @@
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
 "gIx" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
@@ -8364,29 +8297,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/xenobiology)
-"gTl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/research_foyer_auxiliary)
 "gUR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -8433,7 +8343,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
 "gWq" = (
-/obj/machinery/light,
 /obj/machinery/computer/diseasesplicer{
 	dir = 1
 	},
@@ -8701,9 +8610,6 @@
 /area/rnd/research_foyer_auxiliary)
 "hek" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -9106,9 +9012,6 @@
 /turf/simulated/floor/tiled,
 /area/medical/reception)
 "hwt" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
@@ -9305,7 +9208,7 @@
 	dir = 8;
 	pixel_x = 25
 	},
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/washing_machine,
@@ -9675,7 +9578,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyaccess)
 "hZY" = (
-/obj/machinery/light,
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled,
 /area/rnd/anomaly_lab)
@@ -9874,7 +9776,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "ifT" = (
-/obj/machinery/light,
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
@@ -10159,9 +10060,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/test_area)
 "isM" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 1
 	},
@@ -10220,14 +10118,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/anomaly_lab/containment_one)
 "ivz" = (
-/obj/machinery/light,
+/obj/machinery/light/small,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
 "ivY" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 6
 	},
@@ -10459,7 +10354,6 @@
 	pixel_y = -28
 	},
 /obj/structure/cable/green,
-/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/rnd/anomaly_lab)
 "iKB" = (
@@ -10998,7 +10892,6 @@
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
 "jiJ" = (
-/obj/machinery/light,
 /obj/machinery/vending/wallmed1{
 	name = "Emergency NanoMed";
 	pixel_y = -30
@@ -11436,13 +11329,6 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
-"jFO" = (
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
-	},
-/turf/simulated/floor/tiled,
-/area/medical/psych_ward)
 "jGr" = (
 /obj/machinery/atmospherics/unary/freezer{
 	dir = 1;
@@ -11680,12 +11566,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer_auxiliary)
-"jQp" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
 "jQw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -11746,7 +11626,7 @@
 /turf/simulated/floor/tiled,
 /area/medical/medbay_primary_storage)
 "jRB" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -12037,9 +11917,6 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/medical/psych_ward)
 "kcI" = (
@@ -12111,6 +11988,9 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer)
@@ -12433,9 +12313,6 @@
 /area/rnd/research_foyer_auxiliary)
 "kve" = (
 /obj/structure/flora/pottedplant/tropical,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
 	},
@@ -12497,7 +12374,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/testingrange)
 "kwO" = (
@@ -13292,13 +13168,6 @@
 	name = "Server Base"
 	},
 /area/rnd/research)
-"lhT" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/storage)
 "lhX" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -13319,9 +13188,6 @@
 /area/rnd/anomaly_lab/containment_two)
 "liu" = (
 /obj/machinery/mecha_part_fabricator,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/old_cargo/purple,
 /area/assembly/robotics)
 "liw" = (
@@ -13379,9 +13245,6 @@
 /obj/machinery/optable{
 	name = "Robotics Operating Table"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/old_cargo/purple,
 /area/medical/surgery{
 	name = "\improper Robotics Surgery Room"
@@ -13423,7 +13286,7 @@
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
 "lnZ" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -13598,9 +13461,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "lAA" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/table/rack,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/suit/storage/hooded/wintercoat/science,
@@ -13763,9 +13623,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /obj/machinery/computer/timeclock/premade/west,
 /turf/simulated/floor/tiled,
@@ -14691,7 +14548,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/light,
 /obj/machinery/camera/network/research{
 	dir = 1
 	},
@@ -14802,9 +14658,6 @@
 	})
 "mrJ" = (
 /obj/machinery/recharge_station,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/camera/network/research{
 	dir = 8;
 	network = list("Research","Toxins Test Area")
@@ -14949,16 +14802,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer_auxiliary)
-"myi" = (
-/obj/machinery/light,
-/obj/machinery/computer/general_air_control/large_tank_control{
-	input_tag = "atmos_out";
-	name = "Atmos Intake Control";
-	output_tag = "atmos_in";
-	sensors = list("atmos_intake" = "Tank")
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/test_area)
 "mym" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 5
@@ -15195,9 +15038,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/test_area)
 "mJW" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
@@ -15222,9 +15062,8 @@
 	pixel_x = -28
 	},
 /obj/structure/cable/green{
-	d2 = 2;
-	dir = 4;
-	icon_state = "0-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled,
 /area/medical/virology)
@@ -15663,9 +15502,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medbay/fore)
 "mYv" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 10
 	},
@@ -16959,6 +16795,10 @@
 /obj/structure/window/phoronreinforced{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 8;
+	light_range = 12
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/test_area)
 "ogS" = (
@@ -17801,9 +17641,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
 "oNI" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/button/remote/airlock{
 	desc = "A remote control switch for the medbay recovery room door.";
 	dir = 8;
@@ -18126,9 +17963,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay_emt_bay)
 "oYa" = (
@@ -18306,7 +18140,7 @@
 /turf/simulated/floor/tiled,
 /area/rnd/reception_desk)
 "pdv" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -18677,20 +18511,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/virologyaccess)
-"ppX" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/port)
 "pqs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18818,9 +18638,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "puT" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 5
 	},
@@ -18892,6 +18709,7 @@
 	pixel_y = -37
 	},
 /obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
 "pwM" = (
@@ -19016,9 +18834,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/cmo)
 "pzs" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -19604,7 +19419,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_restroom)
 "pRL" = (
@@ -19906,12 +19720,6 @@
 /area/medical/surgery{
 	name = "\improper Robotics Surgery Room"
 	})
-"qac" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/mauve/border,
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/rnd/research_foyer_auxiliary)
 "qas" = (
 /turf/simulated/wall/r_wall,
 /area/medical/virologyaccess)
@@ -20069,7 +19877,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/light,
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
@@ -20277,15 +20084,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
-"qrh" = (
-/obj/structure/morgue{
-	dir = 2
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
 "qrl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -20573,18 +20371,6 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled,
 /area/medical/medbay_emt_bay)
-"qBZ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/triumph/station/stairs_three)
 "qCC" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -20834,13 +20620,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central4,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
-"qMl" = (
-/obj/effect/floor_decal/industrial/warning/dust,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
 "qMC" = (
 /obj/structure/toilet{
 	dir = 1
@@ -20853,14 +20632,6 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/medical/virologyisolation)
-"qMR" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "xenobiocoldroom"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/bluegrid,
-/area/rnd/xenobiology)
 "qMY" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -21346,9 +21117,6 @@
 /turf/simulated/floor/plating,
 /area/rnd/anomaly_lab/containment_two)
 "rbt" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 9
 	},
@@ -21541,6 +21309,9 @@
 "rgW" = (
 /obj/machinery/light_switch{
 	pixel_x = 25
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/rnd/breakroom)
@@ -21807,7 +21578,7 @@
 /obj/structure/toilet{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
 "rsx" = (
@@ -21846,7 +21617,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "rty" = (
-/obj/machinery/light,
+/obj/machinery/light/small,
 /obj/structure/toilet{
 	dir = 1
 	},
@@ -21935,9 +21706,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
@@ -22135,23 +21903,6 @@
 /obj/machinery/atmospherics/binary/passive_gate/on,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
-"rEH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/mauve/border,
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/rnd/hallway)
 "rFu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22216,6 +21967,9 @@
 "rHO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/medical/psych_ward)
 "rHU" = (
@@ -22259,7 +22013,7 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "rJn" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -22576,9 +22330,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "rYN" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled,
 /area/medical/resleeving)
@@ -22712,7 +22463,9 @@
 /obj/structure/toilet{
 	dir = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /obj/effect/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
@@ -22775,6 +22528,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
 "sgQ" = (
@@ -23190,7 +22946,6 @@
 /obj/fiftyspawner/steel,
 /obj/fiftyspawner/glass,
 /obj/structure/table/reinforced,
-/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
 /turf/simulated/floor/tiled,
@@ -23559,9 +23314,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "sGq" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -24101,9 +23853,6 @@
 "tcO" = (
 /obj/structure/table/steel,
 /obj/item/electronic_assembly/large/default,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 5
 	},
@@ -24388,9 +24137,8 @@
 	id = "cmo_office"
 	},
 /obj/structure/cable/green{
-	d2 = 2;
-	dir = 4;
-	icon_state = "0-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/cmo)
@@ -24411,6 +24159,9 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/rnd/breakroom)
@@ -25408,7 +25159,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/light,
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/research)
@@ -25688,9 +25438,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "uld" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 10
 	},
@@ -25854,9 +25601,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -26462,15 +26206,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer_auxiliary)
-"uRq" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
-	scrub_id = "rnd_can_store"
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/storage)
 "uRF" = (
 /obj/machinery/atmospherics/unary/heater{
 	icon_state = "heater"
@@ -26618,7 +26353,6 @@
 /turf/simulated/wall/r_wall,
 /area/medical/medbay_emt_bay)
 "uXn" = (
-/obj/machinery/light,
 /obj/structure/sign/directions/cryo{
 	pixel_y = -24
 	},
@@ -27380,7 +27114,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/light,
 /obj/structure/table/glass,
 /obj/machinery/microwave,
 /turf/simulated/floor/wood,
@@ -27412,6 +27145,9 @@
 /obj/machinery/alarm{
 	frequency = 1441;
 	pixel_y = 22
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/testingrange)
@@ -27462,9 +27198,6 @@
 "vHg" = (
 /obj/structure/table/woodentable,
 /obj/machinery/computer/med_data/laptop,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "vIb" = (
@@ -27509,10 +27242,6 @@
 "vMg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5
-	},
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/test_area)
@@ -27601,10 +27330,6 @@
 /area/maintenance/fpmaint2)
 "vOF" = (
 /obj/structure/cable/green,
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -27891,9 +27616,6 @@
 /area/rnd/xenobiology)
 "wcL" = (
 /obj/machinery/transhuman/resleever,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 9
 	},
@@ -27942,18 +27664,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay_emt_bay)
-"wfd" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
 "wfk" = (
 /obj/structure/morgue{
 	dir = 2
@@ -28178,7 +27888,6 @@
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
-/obj/machinery/light,
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
 	},
@@ -28218,9 +27927,6 @@
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
 "wnE" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
@@ -28341,9 +28047,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
 "wpT" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -28764,9 +28467,6 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = -28;
@@ -28793,9 +28493,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "wHM" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/tiled,
 /area/rnd/test_area)
@@ -29658,9 +29355,6 @@
 	frequency = 1441;
 	pixel_y = 22
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/assembly/chargebay)
 "xqp" = (
@@ -29908,9 +29602,6 @@
 	pixel_x = 25
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room{
 	name = "\improper Exam Room 2"
@@ -29925,9 +29616,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/closet/l3closet/scientist/double,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
 	},
@@ -30421,9 +30109,6 @@
 	name = "west bump";
 	pixel_x = -28
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
@@ -30519,10 +30204,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/shuttle/emt/general)
-"xYH" = (
-/obj/machinery/light,
-/turf/simulated/floor/plating,
-/area/maintenance/research)
 "xYU" = (
 /obj/machinery/light_switch{
 	pixel_x = 25
@@ -30651,9 +30332,6 @@
 /area/maintenance/medbay/fore)
 "ydh" = (
 /obj/machinery/papershredder,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
@@ -32628,7 +32306,7 @@ piZ
 kaR
 bAu
 oHo
-jQp
+cOK
 cOK
 cOK
 cOK
@@ -34176,7 +33854,7 @@ bXb
 bXb
 dmX
 bXb
-ppX
+bXb
 uUU
 jxi
 jPl
@@ -34758,7 +34436,7 @@ bTp
 pUp
 qnK
 hKH
-jFO
+grZ
 grZ
 grZ
 rFu
@@ -34994,16 +34672,16 @@ xDW
 jYb
 rdi
 vSH
-qMR
+pDJ
 jYb
 mXp
 tCD
-dmT
+xDW
 slN
 ezT
 hHY
 lUU
-qrh
+wfk
 wpJ
 vnE
 uJg
@@ -35179,7 +34857,7 @@ lQz
 dHK
 gzL
 qFM
-eiW
+dHK
 xhl
 gGA
 dHK
@@ -35429,7 +35107,7 @@ slN
 ezT
 sQl
 lUU
-wfk
+dmT
 suM
 qxB
 xND
@@ -35566,7 +35244,7 @@ jYb
 jYb
 trj
 jkM
-dmT
+xDW
 slN
 fDL
 sQl
@@ -35581,7 +35259,7 @@ vGq
 rxU
 eus
 vGq
-fGL
+wgM
 wor
 vrf
 wfK
@@ -35700,7 +35378,7 @@ lSq
 lSq
 xDW
 orO
-dmT
+xDW
 rmJ
 eTh
 ejM
@@ -35836,7 +35514,7 @@ pYD
 gVh
 nhp
 jYb
-edK
+tPc
 xDW
 lSq
 lSq
@@ -35988,7 +35666,7 @@ moi
 ipv
 edp
 bge
-qac
+wpE
 boQ
 jYb
 jYb
@@ -36034,7 +35712,7 @@ ooG
 dDt
 hnC
 nQm
-wfd
+uTE
 uTE
 scf
 kxP
@@ -36297,7 +35975,7 @@ isq
 gsQ
 nAL
 nOd
-cIi
+xxY
 ydf
 aDX
 ykq
@@ -36554,7 +36232,7 @@ otR
 pSz
 ose
 laR
-aWV
+xgE
 shT
 wpE
 boQ
@@ -36710,7 +36388,7 @@ bQu
 tpO
 pZI
 sed
-qMl
+kcI
 sGT
 xqe
 jEz
@@ -37006,7 +36684,7 @@ oSS
 nSl
 noo
 nSl
-qBZ
+oSS
 foy
 fxx
 xZU
@@ -37836,7 +37514,7 @@ eze
 cNT
 ouV
 uTg
-dvJ
+rNa
 hoC
 hoC
 hoC
@@ -38259,10 +37937,10 @@ dBd
 oje
 oZO
 oEZ
-anU
+cNT
 ouV
 kuR
-kfs
+wpE
 hoC
 iMu
 mjN
@@ -38399,7 +38077,7 @@ tvo
 gvg
 imB
 dXj
-uRq
+hBB
 oEZ
 cNT
 ouV
@@ -38543,7 +38221,7 @@ hCu
 dXj
 lDq
 oEZ
-oIP
+cIi
 ouV
 kuR
 wpE
@@ -38687,7 +38365,7 @@ lDq
 oEZ
 oIP
 ouV
-gTl
+kuR
 ggF
 suR
 efJ
@@ -39161,7 +38839,7 @@ hZG
 sAO
 gdJ
 iFz
-vrg
+kWH
 vhx
 tmj
 fsl
@@ -39537,7 +39215,7 @@ xMc
 fUI
 jJh
 tiX
-lhT
+jJh
 ouV
 xom
 aQp
@@ -39547,7 +39225,7 @@ gvu
 wHM
 qpE
 qpE
-myi
+wHh
 gvu
 pPV
 pPV
@@ -40720,7 +40398,7 @@ sQL
 uio
 mHH
 yhL
-jlQ
+tRd
 udR
 dPR
 uJT
@@ -41539,7 +41217,7 @@ myx
 bKS
 vOJ
 bKS
-myx
+hhg
 bcG
 ifT
 pPC
@@ -42101,7 +41779,7 @@ vQH
 pGa
 hja
 ugl
-rEH
+fDD
 izT
 bSK
 kiR
@@ -42422,7 +42100,7 @@ wKj
 hUs
 hUs
 clC
-cCD
+tiM
 cbU
 tRd
 krf
@@ -43091,7 +42769,7 @@ niJ
 sIP
 slN
 tWd
-xYH
+hnF
 slN
 xkT
 tnM
@@ -43102,7 +42780,7 @@ rgW
 bcG
 gzU
 izT
-lwA
+btG
 mfs
 hNx
 mBS
@@ -43511,7 +43189,7 @@ oCz
 sIP
 vFJ
 vFJ
-vFJ
+cCD
 vFJ
 vFJ
 sIP
@@ -43830,7 +43508,7 @@ rzy
 ltR
 oIJ
 szb
-gHF
+yhM
 yhM
 eeY
 dYE
@@ -44950,7 +44628,7 @@ gVh
 jCw
 btG
 mfs
-inc
+hNx
 mBS
 frZ
 frZ
@@ -45518,7 +45196,7 @@ gVh
 ioO
 kFx
 kzI
-inc
+hNx
 mBS
 frZ
 frZ
@@ -47236,7 +46914,7 @@ iJE
 uGD
 uGD
 efH
-nmW
+uGD
 ioO
 gVh
 gVh
@@ -47517,7 +47195,7 @@ goC
 uGD
 uGD
 eOy
-kGm
+uGD
 uGD
 ndV
 ndV

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -1581,12 +1581,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
 "bso" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/turf/simulated/floor/plating,
-/area/medical/virologyisolation)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/research/testingrange)
 "bsO" = (
 /obj/machinery/atmospherics/unary/heat_exchanger{
 	dir = 8
@@ -3009,11 +3008,10 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "cCD" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/research/testingrange)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled,
+/area/rnd/storage)
 "cCL" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1
@@ -3179,10 +3177,14 @@
 /turf/simulated/wall,
 /area/maintenance/fore)
 "cIi" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled,
-/area/rnd/storage)
+/obj/structure/morgue{
+	dir = 2
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
 "cIH" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
@@ -3413,7 +3415,9 @@
 /turf/simulated/floor/tiled/old_cargo/purple,
 /area/assembly/robotics)
 "cTT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/medical{
 	name = "Virology Labs"
@@ -3870,15 +3874,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/surgery)
-"dmT" = (
-/obj/structure/morgue{
-	dir = 2
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
 "dmV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -23072,8 +23067,8 @@
 /turf/simulated/floor/tiled,
 /area/medical/medbay3)
 "syP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23729,6 +23724,9 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyisolation)
@@ -35112,7 +35110,7 @@ slN
 ezT
 sQl
 lUU
-dmT
+cIi
 suM
 qxB
 xND
@@ -36565,7 +36563,7 @@ vEc
 vEc
 vEc
 vEc
-bso
+qMI
 cTT
 mcT
 qMI
@@ -38226,7 +38224,7 @@ hCu
 dXj
 lDq
 oEZ
-cIi
+cCD
 ouV
 kuR
 wpE
@@ -43194,7 +43192,7 @@ oCz
 sIP
 vFJ
 vFJ
-cCD
+bso
 vFJ
 vFJ
 sIP

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -1581,11 +1581,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
 "bso" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/research/testingrange)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/medical/virologyisolation)
 "bsO" = (
 /obj/machinery/atmospherics/unary/heat_exchanger{
 	dir = 8
@@ -3008,10 +3009,11 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "cCD" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled,
-/area/rnd/storage)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/research/testingrange)
 "cCL" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1
@@ -3177,14 +3179,10 @@
 /turf/simulated/wall,
 /area/maintenance/fore)
 "cIi" = (
-/obj/structure/morgue{
-	dir = 2
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled,
+/area/rnd/storage)
 "cIH" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
@@ -3415,9 +3413,7 @@
 /turf/simulated/floor/tiled/old_cargo/purple,
 /area/assembly/robotics)
 "cTT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/medical{
 	name = "Virology Labs"
@@ -3530,12 +3526,8 @@
 /obj/machinery/atm{
 	pixel_x = -33
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
 "cXI" = (
@@ -3874,6 +3866,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/surgery)
+"dmT" = (
+/obj/structure/morgue{
+	dir = 2
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
 "dmV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -8390,12 +8391,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/assembly/chargebay)
 "gYn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "gYs" = (
@@ -15122,6 +15119,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "mLJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/machinery/firealarm{
 	dir = 4;
 	layer = 3.3;
@@ -23067,8 +23070,8 @@
 /turf/simulated/floor/tiled,
 /area/medical/medbay3)
 "syP" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/black{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23724,9 +23727,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyisolation)
@@ -35110,7 +35110,7 @@ slN
 ezT
 sQl
 lUU
-cIi
+dmT
 suM
 qxB
 xND
@@ -36563,7 +36563,7 @@ vEc
 vEc
 vEc
 vEc
-qMI
+bso
 cTT
 mcT
 qMI
@@ -38224,7 +38224,7 @@ hCu
 dXj
 lDq
 oEZ
-cCD
+cIi
 ouV
 kuR
 wpE
@@ -43192,7 +43192,7 @@ oCz
 sIP
 vFJ
 vFJ
-bso
+cCD
 vFJ
 vFJ
 sIP
@@ -45773,7 +45773,7 @@ trY
 oSC
 uRN
 cXI
-wZI
+uGD
 uGD
 abu
 ruk

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -11972,6 +11972,9 @@
 "kfy" = (
 /obj/structure/table/steel,
 /obj/item/storage/toolbox/mechanical,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay/fore)
 "kfH" = (

--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -1771,6 +1771,7 @@
 "bok" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -2464,6 +2465,19 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood,
 /area/lawoffice)
+"bOG" = (
+/obj/effect/floor_decal/chapel,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "bOS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -4474,8 +4488,12 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -5434,6 +5452,17 @@
 /obj/effect/floor_decal/techfloor/hole,
 /turf/simulated/floor/tiled/dark,
 /area/station/stairs_one)
+"dVU" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "chapel"
+	},
+/turf/simulated/floor/plating,
+/area/chapel/office)
 "dWA" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
@@ -12774,9 +12803,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/dispenser{
 	phorontanks = 0
 	},
@@ -14155,7 +14182,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 5
 	},
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -19226,6 +19253,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass_security{
 	name = "Equipment Storage";
 	req_one_access = list(2)
@@ -21305,6 +21333,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance/engi,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/command)
@@ -21486,6 +21515,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance/engi,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/command)
@@ -25176,6 +25206,7 @@
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/shuttle/civvie/general)
 "rtF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -29353,6 +29384,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"ush" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/library)
 "usl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -31920,6 +31960,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -33001,6 +33042,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"wMP" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/library)
 "wNw" = (
 /obj/machinery/computer/security/telescreen{
 	pixel_y = -128
@@ -34224,6 +34274,12 @@
 /area/security/warden)
 "xDT" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -42566,7 +42622,7 @@ gvP
 cgH
 bpv
 sfA
-lZt
+wMP
 uEJ
 xim
 wFO
@@ -42708,7 +42764,7 @@ bra
 cgH
 xZu
 qVU
-wFO
+ush
 mMK
 wFO
 sNf
@@ -42850,7 +42906,7 @@ sTa
 cgH
 wFO
 riS
-wFO
+ush
 jjh
 wFO
 sNf
@@ -45407,7 +45463,7 @@ qSQ
 bok
 cqg
 ntW
-uLz
+bOG
 xTl
 iPv
 uLz
@@ -45546,7 +45602,7 @@ uyK
 ksm
 hgG
 hgG
-ucJ
+dVU
 caf
 sqe
 apN

--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -153,9 +153,6 @@
 /turf/simulated/floor/tiled,
 /area/exploration/showers)
 "agn" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/table/woodentable,
 /obj/machinery/recharger,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -242,6 +239,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/security/security_bathroom)
 "ajg" = (
@@ -645,19 +643,11 @@
 /turf/simulated/wall/r_wall,
 /area/chapel/main)
 "azW" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
 /obj/machinery/light{
-	dir = 8
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/secondary/civilian_hallway_mid)
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
 "aAg" = (
 /obj/structure/table/woodentable,
 /obj/item/paper{
@@ -924,7 +914,6 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
 /obj/structure/table/steel,
-/obj/machinery/light,
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -1159,7 +1148,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/dark,
@@ -1237,6 +1225,9 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/turretid/lethal{
 	pixel_x = -35
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
@@ -1435,17 +1426,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "baW" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/aft)
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/exploration/explorer_prep)
 "bbd" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance Access"
@@ -1722,21 +1707,17 @@
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "bky" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
-/obj/machinery/shower{
-	pixel_y = 16
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals5,
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 6
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/security/security_bathroom)
+/area/security/hallway)
 "bkB" = (
 /obj/machinery/station_map{
 	pixel_y = 32
@@ -1784,9 +1765,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
@@ -1814,24 +1792,20 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/captain)
 "boK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/security/hallway)
+/obj/machinery/light,
+/turf/simulated/floor/carpet/bcarpet,
+/area/security/training)
 "boN" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/tiled/freezer,
@@ -1956,12 +1930,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "bsQ" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/blue/border,
 /obj/machinery/light,
-/obj/structure/bed/chair/shuttle{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/tealcarpet,
-/area/shuttle/civvie/general)
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "btG" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -2172,32 +2145,11 @@
 /turf/simulated/floor/tiled,
 /area/exploration)
 "bBw" = (
-/obj/structure/closet/secure_closet/explorer,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/obj/effect/floor_decal/steeldecal/steel_decals9{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/tank/jetpack/oxygen,
-/obj/item/reagent_containers/hypospray/autoinjector/biginjector/healing_nanites,
-/obj/item/reagent_containers/hypospray/autoinjector/biginjector/stimm,
-/obj/item/clothing/suit/space/void/exploration{
-	armor = list("melee" = 50, "bullet" = 40, "laser" = 45, "energy" = 45, "bomb" = 30, "bio" = 100, "rad" = 70);
-	desc = "A heavier varient of the radiation-resistant voidsuit for explorations. This one features increased armor protection against small and medium arms fire, but comes at the cost of extra weight.";
-	move_speed = 7;
-	name = "heavy exploration voidsuit"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/exploration/explorer_prep)
+/turf/simulated/floor/tiled,
+/area/security/brig)
 "bBP" = (
 /obj/structure/railing{
 	dir = 4
@@ -2213,7 +2165,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/red/border,
 /obj/machinery/power/apc{
@@ -2445,7 +2396,6 @@
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "bKU" = (
-/obj/machinery/light,
 /obj/structure/closet/crate/freezer/rations,
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -2622,14 +2572,14 @@
 /turf/simulated/floor/wood,
 /area/triumph/surfacebase/sauna)
 "bQT" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
 	},
 /obj/structure/table/rack/shelf/steel,
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "bRn" = (
@@ -2919,9 +2869,6 @@
 	pixel_y = 24;
 	req_access = list()
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
 "bZp" = (
@@ -3207,9 +3154,6 @@
 /obj/machinery/gateway{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/gateway)
 "clY" = (
@@ -3362,29 +3306,6 @@
 /obj/item/duct_tape_roll,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
-"crn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/security/hallway)
 "crC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4024,9 +3945,6 @@
 /turf/simulated/open,
 /area/exploration/explorer_prep)
 "cNd" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
@@ -4185,19 +4103,6 @@
 "cVO" = (
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
-"cWo" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/teleporter)
-"cYi" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table/bench/wooden,
-/turf/simulated/floor/tiled/freezer,
-/area/hallway/secondary/civilian_hallway_mid)
 "cYJ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4560,7 +4465,6 @@
 	pixel_y = -25;
 	req_access = list(3)
 	},
-/obj/machinery/light,
 /obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
@@ -5345,12 +5249,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
-"dOv" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/aft)
 "dOX" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light,
@@ -5913,9 +5811,6 @@
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
@@ -6486,14 +6381,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"eEj" = (
-/obj/effect/floor_decal/steeldecal/steel_decals5,
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
-	},
-/turf/simulated/floor/tiled,
-/area/exploration/showers)
 "eEl" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_external{
@@ -6700,9 +6587,6 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/civilian_hallway_mid)
 "eJn" = (
@@ -6887,9 +6771,6 @@
 /obj/item/gun/projectile/automatic/wt550,
 /obj/item/gun/projectile/automatic/wt550,
 /obj/item/gun/projectile/automatic/wt550,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
 	},
@@ -7727,7 +7608,6 @@
 	pixel_x = 4;
 	pixel_y = -32
 	},
-/obj/machinery/light,
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled,
 /area/security/interrogation)
@@ -8497,9 +8377,6 @@
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "fVL" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
 	},
@@ -8809,9 +8686,6 @@
 /turf/simulated/floor/tiled,
 /area/bridge/hallway)
 "glO" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/table/woodentable,
 /obj/machinery/photocopier/faxmachine{
 	department = "Pathfinder's Office"
@@ -8835,9 +8709,6 @@
 	layer = 3.3;
 	pixel_x = 4;
 	pixel_y = 26
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/machinery/fitness/punching_bag,
 /turf/simulated/floor/carpet/bcarpet,
@@ -8874,7 +8745,7 @@
 	pixel_y = 10
 	},
 /obj/machinery/light/small{
-	dir = 4
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/security_bathroom)
@@ -9301,12 +9172,6 @@
 	},
 /turf/simulated/shuttle/wall/voidcraft/blue,
 /area/shuttle/excursion/general)
-"gFO" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/maintenance/substation/command)
 "gHc" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -9442,9 +9307,6 @@
 /area/exploration/explorer_prep)
 "gLs" = (
 /obj/structure/closet/wardrobe/chaplain_black,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/lino,
 /area/chapel/office)
 "gLy" = (
@@ -9582,9 +9444,6 @@
 /turf/simulated/floor/tiled,
 /area/security/hanger)
 "gQP" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/tiled,
 /area/exploration)
@@ -9840,7 +9699,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/exploration/showers)
 "hag" = (
@@ -10367,12 +10225,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/interrogation)
-"hsN" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/lounge)
 "hsS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/alarm/alarms_hidden{
@@ -10433,6 +10285,7 @@
 	},
 /obj/item/book/manual/security_space_law,
 /obj/structure/closet/secure_closet/warden,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "hur" = (
@@ -10812,7 +10665,6 @@
 	dir = 9
 	},
 /obj/structure/table/rack/shelf/steel,
-/obj/machinery/light,
 /obj/item/clothing/accessory/holster/waist,
 /obj/item/clothing/accessory/holster/waist,
 /obj/item/clothing/accessory/holster/leg,
@@ -10865,6 +10717,9 @@
 	},
 /obj/structure/dispenser{
 	phorontanks = 0
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/teleporter)
@@ -11088,7 +10943,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals5,
-/obj/machinery/light,
+/obj/machinery/light/small,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -11513,9 +11368,6 @@
 /area/crew_quarters/sleep/CE_quarters)
 "hXL" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
 	},
@@ -11605,9 +11457,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "iai" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/fitness/weightlifter,
 /turf/simulated/floor/carpet/bcarpet,
 /area/security/training)
@@ -12371,9 +12220,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -12439,9 +12285,6 @@
 /turf/simulated/floor/tiled,
 /area/security/riot_control)
 "iGl" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -12457,9 +12300,6 @@
 /turf/simulated/wall/r_wall,
 /area/security/riot_control)
 "iGE" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/bed/chair/sofa{
 	icon_state = "sofamiddle"
 	},
@@ -12478,7 +12318,6 @@
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
 "iIE" = (
-/obj/machinery/light,
 /obj/structure/bed/chair/office{
 	dir = 1
 	},
@@ -12597,9 +12436,6 @@
 	layer = 3.3;
 	pixel_x = 4;
 	pixel_y = 26
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/exploration/meeting)
@@ -13272,7 +13108,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/light{
+/obj/machinery/light/small/emergency{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -13336,19 +13172,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
-"jlt" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/closet/crate/freezer/rations,
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/exploration/explorer_prep)
 "jlA" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -13568,6 +13391,7 @@
 /area/security/armoury)
 "jwb" = (
 /obj/machinery/vending/cigarette,
+/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/security/breakroom)
 "jwX" = (
@@ -13677,9 +13501,6 @@
 /obj/machinery/light_switch{
 	name = "light switch ";
 	pixel_y = 26
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -13801,9 +13622,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/megaphone,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -13914,6 +13732,7 @@
 "jIK" = (
 /obj/machinery/chemical_dispenser/bar_soft/full,
 /obj/structure/table/woodentable,
+/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/security/breakroom)
 "jJc" = (
@@ -14381,9 +14200,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/civilian_hallway_mid)
 "kbb" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
 	},
@@ -14422,9 +14238,6 @@
 /area/hallway/secondary/docking_hallway)
 "kcg" = (
 /obj/structure/flora/pottedplant/minitree,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "kcp" = (
@@ -14626,6 +14439,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/security/security_equiptment_storage)
 "kmY" = (
@@ -14937,7 +14751,6 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/light,
 /obj/machinery/computer/aifixer{
 	dir = 1
 	},
@@ -15419,12 +15232,6 @@
 /obj/structure/bookcase/legal/combo,
 /turf/simulated/floor/wood,
 /area/library)
-"kQn" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/exploration/excursion_dock)
 "kQF" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monofloor{
@@ -15546,9 +15353,6 @@
 	icon_state = "0-4"
 	},
 /obj/structure/closet/secure_closet/security,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
 "kTX" = (
@@ -16071,6 +15875,9 @@
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_y = 27
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "lpe" = (
@@ -16144,7 +15951,6 @@
 	name = "\improper Official On-Site Office"
 	})
 "lpR" = (
-/obj/machinery/light,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
@@ -16345,9 +16151,8 @@
 /area/crew_quarters/sleep/HOS_quarters)
 "lvR" = (
 /obj/machinery/recharge_station,
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/exploration/showers)
@@ -16588,9 +16393,6 @@
 /turf/simulated/floor/tiled,
 /area/security/interrogation)
 "lFc" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
@@ -16847,7 +16649,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/aft)
 "lOF" = (
-/obj/machinery/light,
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
@@ -16878,9 +16679,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/table/reinforced,
 /obj/item/book/manual/security_space_law,
 /obj/item/book/manual/security_space_law,
@@ -16906,6 +16704,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -16935,18 +16736,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/interrogation)
-"lQQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/bridge/hallway)
 "lRG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16959,7 +16748,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
 /obj/structure/sign/warning/secure_area/armory{
@@ -17292,6 +17080,9 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
 "mcm" = (
@@ -17380,7 +17171,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "mfa" = (
-/obj/machinery/light,
+/obj/machinery/light/small,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -17461,7 +17252,6 @@
 /turf/simulated/floor/tiled,
 /area/security/hallway)
 "mjJ" = (
-/obj/machinery/light,
 /obj/item/paper_bin,
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled,
@@ -17822,13 +17612,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge)
-"mwd" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/crate/secure/weapon,
-/turf/simulated/floor/tiled,
-/area/exploration/excursion_dock)
 "mwp" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
@@ -17872,6 +17655,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -17960,12 +17746,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
-"mBY" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled,
-/area/security/hallway)
 "mCI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18047,12 +17827,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
-"mEx" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/triumph/surfacebase/tram)
 "mFh" = (
 /obj/structure/window/phoronreinforced{
 	dir = 8
@@ -18368,6 +18142,10 @@
 	},
 /obj/machinery/recharger,
 /obj/item/book/manual/security_space_law,
+/obj/machinery/light{
+	dir = 8;
+	light_range = 12
+	},
 /turf/simulated/floor/tiled,
 /area/security/interrogation)
 "mRl" = (
@@ -18532,18 +18310,6 @@
 "mVr" = (
 /turf/simulated/wall/durasteel,
 /area/ai)
-"mVN" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/exploration)
 "mVX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -18883,13 +18649,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/gateway)
-"niQ" = (
-/obj/structure/closet/coffin/comfy,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/chapel/main)
 "nkd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
@@ -18938,10 +18697,6 @@
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "nla" = (
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
-	},
 /obj/machinery/vending/cola,
 /turf/simulated/floor/wood,
 /area/security/training)
@@ -19070,7 +18825,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/light{
+/obj/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -19121,7 +18876,6 @@
 /turf/simulated/floor/tiled,
 /area/security/hallway)
 "nrn" = (
-/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
 	},
@@ -19943,12 +19697,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/aft)
-"nWe" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/security/training)
 "nWP" = (
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/CE_quarters)
@@ -20219,6 +19967,7 @@
 /area/maintenance/central)
 "ogm" = (
 /obj/machinery/papershredder,
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
 "ogC" = (
@@ -20412,6 +20161,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_range = 12
 	},
 /turf/simulated/floor/tiled,
 /area/exploration/showers)
@@ -20800,9 +20553,6 @@
 /obj/item/radio/intercom{
 	pixel_y = -24
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -20845,6 +20595,9 @@
 /obj/item/radio/intercom/department/security{
 	dir = 4;
 	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
@@ -21175,18 +20928,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
-"oNE" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/exploration/pathfinder_office)
 "oNU" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -21275,9 +21016,6 @@
 /area/security/evidence_storage)
 "oQD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -21496,9 +21234,6 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -21635,7 +21370,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled,
@@ -21938,6 +21672,9 @@
 /obj/item/clothing/shoes/magboots,
 /obj/item/tank/oxygen,
 /obj/item/clothing/mask/breath,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "pjn" = (
@@ -22393,6 +22130,9 @@
 /area/security/security_bathroom)
 "pCc" = (
 /obj/machinery/camera/network/exploration,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/exploration/excursion_dock)
 "pCf" = (
@@ -22524,9 +22264,6 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/hallway/secondary/civilian_hallway_mid)
 "pJe" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/exploration/meeting)
@@ -23015,6 +22752,9 @@
 	dir = 4
 	},
 /obj/machinery/recharger,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "pXl" = (
@@ -23782,9 +23522,6 @@
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
 "qss" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -24242,9 +23979,6 @@
 /obj/structure/table/reinforced,
 /obj/item/suit_cooling_unit,
 /obj/item/suit_cooling_unit,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/security/security_equiptment_storage)
 "qGF" = (
@@ -25190,18 +24924,6 @@
 /obj/machinery/computer/timeclock/premade/south,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/aft)
-"rlm" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/security/hallway)
 "rlI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -25251,7 +24973,6 @@
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "rnG" = (
-/obj/machinery/light/small,
 /obj/structure/table/bench/wooden,
 /obj/effect/mist,
 /turf/simulated/floor/wood,
@@ -25328,9 +25049,6 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
 	pixel_y = 20
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
@@ -25484,12 +25202,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
-"rto" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/triumph/surfacebase/tram)
 "rtC" = (
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/shuttle/civvie/general)
@@ -25747,9 +25459,6 @@
 	dir = 1;
 	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/camera/network/security,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
@@ -25923,12 +25632,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"rFK" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ai_upload)
 "rFX" = (
 /obj/structure/closet/hydrant{
 	pixel_y = 32
@@ -25970,7 +25673,6 @@
 	pixel_y = -25;
 	req_access = list(3)
 	},
-/obj/machinery/light,
 /obj/structure/table/steel,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -26031,9 +25733,6 @@
 	name = "east bump";
 	pixel_x = 28
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/porta_turret/stationary{
 	health = 200
 	},
@@ -26083,9 +25782,6 @@
 "rLm" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
@@ -26161,9 +25857,6 @@
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "rPo" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/bed/chair{
 	dir = 8
 	},
@@ -26332,6 +26025,9 @@
 /obj/item/clothing/suit/space/void/exploration,
 /obj/item/clothing/head/helmet/space/void/exploration,
 /obj/machinery/camera/network/exploration,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "rWr" = (
@@ -26442,6 +26138,9 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
@@ -27032,9 +26731,6 @@
 /turf/simulated/floor/wood,
 /area/library)
 "sxI" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -27496,9 +27192,6 @@
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
 "sKJ" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/computer/security/wooden_tv,
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
@@ -27654,9 +27347,6 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 5
 	},
@@ -27774,14 +27464,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/tool_storage)
-"sRL" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
 "sRO" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/structure/cable/green{
@@ -27844,9 +27526,6 @@
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "sTb" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
 	},
@@ -28159,9 +27838,6 @@
 /obj/item/aiModule/corp,
 /obj/item/aiModule/paladin,
 /obj/item/aiModule/robocop,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload)
 "tgF" = (
@@ -28377,6 +28053,9 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/civilian_hallway_mid)
 "trB" = (
@@ -28488,7 +28167,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled,
@@ -28548,9 +28226,8 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
+/obj/machinery/light/small{
+	dir = 8
 	},
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -28560,9 +28237,6 @@
 /area/exploration/showers)
 "tzx" = (
 /obj/structure/table/marble,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "tzJ" = (
@@ -28906,16 +28580,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/secondary/civilian_hallway_mid)
 "tOq" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "tQm" = (
-/obj/machinery/light,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled,
 /area/security/brig)
@@ -28923,12 +28593,13 @@
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
+/obj/machinery/light{
+	dir = 8;
+	light_range = 12
+	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/security/training)
 "tQv" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/adv,
 /obj/item/roller,
@@ -28938,9 +28609,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
 "tSj" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/mech_recharger,
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
@@ -29546,9 +29214,6 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/security,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
@@ -29684,10 +29349,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
-"upX" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/security/interrogation)
 "uqj" = (
 /obj/machinery/light{
 	dir = 1
@@ -30446,10 +30107,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
-"uQT" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/exploration/meeting)
 "uQV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
@@ -30860,6 +30517,7 @@
 /obj/item/radio/intercom{
 	pixel_y = -24
 	},
+/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/exploration/meeting)
 "vfk" = (
@@ -30936,19 +30594,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
-"vgY" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/directions/evac{
-	dir = 8;
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/secondary/civilian_hallway_mid)
 "vhw" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/cyan{
@@ -30994,11 +30639,6 @@
 /obj/item/pen,
 /turf/simulated/floor/tiled,
 /area/exploration/excursion_dock)
-"viA" = (
-/obj/machinery/light,
-/obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/white,
-/area/security/security_bathroom)
 "viQ" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -31302,9 +30942,6 @@
 "vsQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -31778,9 +31415,6 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/chapel/main)
 "vIl" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32;
 	pixel_y = 32
@@ -31874,14 +31508,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"vKj" = (
-/obj/machinery/shieldwallgen,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/teleporter)
 "vKo" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
@@ -32054,7 +31680,6 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/random/tech_supply,
-/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/maintenance/tool_storage)
 "vOb" = (
@@ -32130,9 +31755,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/security/hallway)
 "vQy" = (
@@ -33189,9 +32811,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/table/reinforced,
 /obj/item/gun/projectile/garand,
 /turf/simulated/floor/tiled/dark,
@@ -33201,9 +32820,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "wDx" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/table/standard,
 /obj/item/ano_scanner,
 /turf/simulated/floor/tiled,
@@ -33742,7 +33358,6 @@
 "wXS" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/captaindouble,
-/obj/machinery/light,
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/captain)
 "wXT" = (
@@ -34144,6 +33759,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/white,
 /area/security/security_bathroom)
 "xmc" = (
@@ -34597,6 +34213,9 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "xAB" = (
@@ -34747,7 +34366,6 @@
 /area/security/hallway)
 "xHY" = (
 /obj/structure/flora/pottedplant/stoutbush,
-/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled,
@@ -35011,7 +34629,6 @@
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
 "xQn" = (
-/obj/machinery/light,
 /obj/structure/table/reinforced,
 /obj/item/stamp/denied,
 /obj/item/stamp{
@@ -35153,9 +34770,6 @@
 "xWe" = (
 /obj/structure/table/standard,
 /obj/item/aiModule/reset,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload)
 "xWo" = (
@@ -35410,9 +35024,6 @@
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "yfn" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
@@ -37191,7 +36802,7 @@ pJe
 gKC
 lsL
 afM
-eEj
+icG
 izb
 lsL
 tzd
@@ -37330,7 +36941,7 @@ xRN
 kzc
 xRN
 xRN
-uQT
+bFl
 lsL
 vUE
 icG
@@ -38040,7 +37651,7 @@ xRN
 xRN
 xRN
 xRN
-uQT
+bFl
 bFL
 egr
 iCQ
@@ -39029,7 +38640,7 @@ kCH
 gCM
 gCM
 gCM
-vYs
+wfD
 roa
 eXq
 vYs
@@ -39042,7 +38653,7 @@ xOb
 xOb
 yeU
 cVO
-pYB
+baW
 sJC
 cVO
 cVO
@@ -39325,7 +38936,7 @@ rHk
 pXd
 maj
 pFV
-jlt
+maj
 bKU
 sJC
 eee
@@ -39371,7 +38982,7 @@ hur
 hur
 hur
 nZM
-oKe
+aIm
 tZM
 aIm
 jmY
@@ -39606,7 +39217,7 @@ wdI
 pOX
 dGy
 xqV
-oNE
+llF
 lau
 hGo
 llF
@@ -39797,7 +39408,7 @@ xxK
 jLC
 cIW
 nZM
-aIm
+bBw
 lbX
 xFn
 aIm
@@ -39896,7 +39507,7 @@ egk
 eQf
 iwe
 qVA
-mwd
+pLf
 hqy
 dls
 mAF
@@ -40456,7 +40067,7 @@ apk
 bim
 uYS
 vQy
-mVN
+lyG
 lyG
 nsE
 eJn
@@ -40464,7 +40075,7 @@ shG
 lyG
 bBr
 jbl
-kQn
+hqy
 hqy
 eXs
 mXx
@@ -40635,14 +40246,14 @@ iRi
 iRi
 iRi
 iRi
-mEx
+iRi
 gcP
 iWU
 iWU
 nIK
 nIK
 wrw
-crn
+uGS
 oVv
 oVv
 luu
@@ -40912,7 +40523,7 @@ lNr
 fFW
 fFW
 fFW
-rto
+fFW
 fFW
 fFW
 wvW
@@ -41045,7 +40656,7 @@ nrx
 rDr
 rTa
 rTa
-hsN
+rTa
 dDM
 qgG
 ejc
@@ -41211,7 +40822,7 @@ nIK
 nIK
 wrw
 uGS
-mBY
+pks
 wzg
 uAw
 vAk
@@ -41300,7 +40911,7 @@ nIK
 clY
 nIK
 sJC
-bBw
+bAe
 cVO
 bnm
 aIn
@@ -41358,7 +40969,7 @@ wzg
 tSw
 tSw
 nbt
-viA
+hjG
 pLq
 wVd
 xGD
@@ -41637,7 +41248,7 @@ wrw
 wrw
 wrw
 uGS
-pks
+hsW
 wzg
 tSw
 tSw
@@ -41921,7 +41532,7 @@ oVv
 fvA
 oVv
 qpW
-hsW
+pks
 wzg
 dRB
 uYh
@@ -42058,7 +41669,7 @@ aue
 vuL
 ecs
 cVy
-rlm
+xzh
 oVv
 fvA
 oVv
@@ -42190,7 +41801,7 @@ eyp
 hMJ
 jcn
 hNz
-baW
+hNz
 dZT
 mVX
 apP
@@ -42212,7 +41823,7 @@ urm
 rgE
 cAS
 urm
-esl
+urm
 urm
 urm
 urm
@@ -42297,7 +41908,7 @@ sJC
 rWp
 cVO
 cot
-sdO
+cVO
 cgH
 ufH
 vPh
@@ -42359,7 +41970,7 @@ oVv
 oVv
 oVv
 qpW
-mBY
+hsW
 wrw
 wrw
 nIK
@@ -42488,12 +42099,12 @@ fgT
 oVv
 oVv
 sBU
-boK
+nrj
 nrj
 gdX
 nrj
 nrj
-usF
+nrj
 pOP
 ptW
 vSI
@@ -42906,7 +42517,7 @@ ufw
 ufw
 vma
 gth
-xzh
+bky
 oVv
 pks
 nbp
@@ -43038,7 +42649,7 @@ pVs
 quD
 bDG
 hvu
-dOv
+uNu
 brg
 eXj
 gwZ
@@ -43050,7 +42661,7 @@ alq
 gth
 xzh
 oVv
-hsW
+pks
 nbp
 iGt
 mwp
@@ -43175,7 +42786,7 @@ quD
 noW
 quD
 quD
-gFO
+quD
 quD
 quD
 fOb
@@ -44001,7 +43612,7 @@ sJC
 sJC
 cVO
 vcE
-sdO
+cVO
 fCb
 kRt
 kRt
@@ -44040,7 +43651,7 @@ dUE
 tLP
 msd
 iZw
-upX
+ufw
 gth
 vQd
 eAR
@@ -44770,7 +44381,7 @@ uWb
 hwU
 lLc
 wzg
-bky
+umi
 gMF
 xpv
 sxI
@@ -45462,7 +45073,7 @@ dFV
 dFV
 dFV
 dFV
-xcc
+jiv
 igD
 umM
 wZd
@@ -45750,11 +45361,11 @@ sEL
 igD
 vWr
 wZd
-nWe
 nwd
 nwd
 nwd
-sGq
+nwd
+boK
 wZd
 bch
 xlj
@@ -46413,7 +46024,7 @@ noI
 eUU
 jJc
 azG
-niQ
+xdN
 xdN
 oYZ
 xdN
@@ -46870,7 +46481,7 @@ nIw
 mIQ
 mIQ
 mIQ
-vgY
+eFC
 mIF
 tmj
 lAq
@@ -47003,7 +46614,7 @@ obh
 ldg
 trz
 xtN
-azW
+nMr
 nMr
 nMr
 cce
@@ -47533,7 +47144,7 @@ rBC
 uxk
 tmH
 lba
-hSs
+ctC
 nPD
 nIK
 nIK
@@ -49237,7 +48848,7 @@ nIK
 nPD
 urK
 uyA
-hSs
+ctC
 nPD
 nIK
 nIK
@@ -49309,7 +48920,7 @@ vgx
 kOZ
 dGE
 vMM
-pfJ
+bsQ
 vgx
 lpa
 hJV
@@ -49540,7 +49151,7 @@ clY
 nIK
 dff
 dff
-cYi
+boN
 rri
 uXQ
 lZG
@@ -51084,7 +50695,7 @@ fbp
 llC
 vlp
 gIS
-bsQ
+axc
 qvL
 nIK
 nIK
@@ -51156,7 +50767,7 @@ aSO
 bNI
 xcj
 vZU
-fuU
+vZU
 jcH
 fuU
 vZU
@@ -51818,7 +51429,7 @@ lpP
 dOZ
 dOZ
 nYA
-lQQ
+gTD
 oet
 moZ
 oet
@@ -51858,7 +51469,7 @@ usH
 usH
 usH
 usH
-rFK
+rxh
 gDS
 gCB
 ily
@@ -52667,13 +52278,13 @@ dOZ
 dOZ
 fOc
 bbJ
-sRL
+ruN
 oIa
 nYA
 kcg
 sQg
 lfm
-lfm
+azW
 lfm
 lfm
 tzx
@@ -52686,9 +52297,9 @@ hSQ
 vRU
 gef
 trR
-vKj
+trR
 hEB
-cWo
+czx
 tYh
 gef
 jEx

--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -1771,7 +1771,6 @@
 "bok" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -2465,19 +2464,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood,
 /area/lawoffice)
-"bOG" = (
-/obj/effect/floor_decal/chapel,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/chapel/main)
 "bOS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -4488,12 +4474,8 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -5452,17 +5434,6 @@
 /obj/effect/floor_decal/techfloor/hole,
 /turf/simulated/floor/tiled/dark,
 /area/station/stairs_one)
-"dVU" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment,
-/obj/structure/window/reinforced/polarized{
-	dir = 10;
-	icon_state = "fwindow";
-	id = "chapel"
-	},
-/turf/simulated/floor/plating,
-/area/chapel/office)
 "dWA" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
@@ -12803,7 +12774,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /obj/structure/dispenser{
 	phorontanks = 0
 	},
@@ -14182,7 +14155,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 6
 	},
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -19253,7 +19226,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass_security{
 	name = "Equipment Storage";
 	req_one_access = list(2)
@@ -21333,7 +21305,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance/engi,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/command)
@@ -21515,7 +21486,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance/engi,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/command)
@@ -25206,7 +25176,6 @@
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/shuttle/civvie/general)
 "rtF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -29384,15 +29353,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"ush" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/library)
 "usl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -31960,7 +31920,6 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -33042,15 +33001,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"wMP" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/library)
 "wNw" = (
 /obj/machinery/computer/security/telescreen{
 	pixel_y = -128
@@ -34274,12 +34224,6 @@
 /area/security/warden)
 "xDT" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -42622,7 +42566,7 @@ gvP
 cgH
 bpv
 sfA
-wMP
+lZt
 uEJ
 xim
 wFO
@@ -42764,7 +42708,7 @@ bra
 cgH
 xZu
 qVU
-ush
+wFO
 mMK
 wFO
 sNf
@@ -42906,7 +42850,7 @@ sTa
 cgH
 wFO
 riS
-ush
+wFO
 jjh
 wFO
 sNf
@@ -45463,7 +45407,7 @@ qSQ
 bok
 cqg
 ntW
-bOG
+uLz
 xTl
 iPv
 uLz
@@ -45602,7 +45546,7 @@ uyK
 ksm
 hgG
 hgG
-dVU
+ucJ
 caf
 sqe
 apN


### PR DESCRIPTION
## About The Pull Request
This PR does four things:
- Trims all the abundant lights.
- Re-distributes some lights for better coverage.
- Replaces maintenance / toilet / shower area lights with small fixture lights.
- Also fixes a minor Virology cable bug causing it to be depowered.
## Why It's Good For The Game
This is purely aesthetic, but reduces map clutter and makes Shadekins less prone to breaking down in tears (though some consider that a good thing)

This is also a difficult PR to showcase in images, just, uh, trust me. There are way fewer lights everywhere now.

## Changelog
:cl:FreeStylaLT
del: Abundant lights on Triumph
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
