### PR TITLE
Fixes quantum leap pad not teleporting mechs.

### DIFF
--- a/code/modules/telesci/hyper_pad.dm
+++ b/code/modules/telesci/hyper_pad.dm
@@ -147,8 +147,8 @@
 							continue
 					else
 						continue
-				if(!(istype(ROI,/obj/mecha)))
-					continue //TP mechs
+				if(!((istype(ROI,/obj/mecha)) || istype(ROI,/obj/vehicle)))
+					continue //TP things that move that are "anchored"
 			if(isobserver(ROI))
 				continue
 			var/datum/effect_system/teleport_greyscale/tele1 = new /datum/effect_system/teleport_greyscale()

--- a/code/modules/telesci/hyper_pad.dm
+++ b/code/modules/telesci/hyper_pad.dm
@@ -147,8 +147,8 @@
 							continue
 					else
 						continue
-				else if(!isobserver(ROI))
-					continue
+				if(!(istype(ROI,/obj/mecha)))
+					continue //TP mechs
 			if(isobserver(ROI))
 				continue
 			var/datum/effect_system/teleport_greyscale/tele1 = new /datum/effect_system/teleport_greyscale()


### PR DESCRIPTION
Mechs are anchored.
The leap pad doesn't teleport anchored objects.
So I just wrote an exception for mechs, because they should teleport.