### PR TITLE
Protean de-jello-fication project

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/protean/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean/protean_blob.dm
@@ -171,8 +171,8 @@
 /mob/living/simple_mob/protean_blob/Life()
 	. = ..()
 	if(. && istype(refactory) && humanform)
-		if(!healing && health < maxHealth && refactory.get_stored_material(DEFAULT_WALL_MATERIAL) >= 100)
-			healing = humanform.add_modifier(/datum/modifier/protean/steel, origin = refactory)
+		if(!healing && health < maxHealth && refactory.get_stored_material(DEFAULT_WALL_MATERIAL) >= 50)
+			healing = humanform.add_modifier(/datum/modifier/protean/steelBlob, origin = refactory)
 		else if(healing && health == maxHealth)
 			healing.expire()
 			healing = null
@@ -519,3 +519,31 @@
 		if("Plain")
 			icon_living = "puddle0"
 			update_icon()
+/datum/modifier/protean/steelBlob
+	name = "Protean Blob Effect - Steel"
+	desc = "You're affected by the presence of steel."
+
+	on_created_text = "<span class='notice'>You feel new nanites being produced from your stockpile of steel, healing you.</span>"
+	on_expired_text = "<span class='notice'>Your steel supply has either run out, or is no longer needed, and your healing stops.</span>"
+
+	material_name = MAT_STEEL
+
+/datum/modifier/protean/steelBlob/tick()
+
+	..()
+	holder.adjustBruteLoss(-11.1 ,include_robo = TRUE) //This is for the blob-regen. As there's now non-blob regen, I've increased it to have a reason to blob other than ventcrawling
+	holder.adjustFireLoss(-7.7 ,include_robo = TRUE) // Both brute and burn are ~10/s for blob regen
+	holder.adjustToxLoss(-36) // Still keeping these in, for the just-in-case scenario
+	holder.radiation = max(holder.radiation - 90, 0)
+
+
+	var/mob/living/carbon/human/H = holder
+	for(var/organ in H.internal_organs)
+		var/obj/item/organ/O = organ
+		// Fix internal damage
+		if(O.damage > 0)
+			O.damage = max(0,O.damage-3) // The major part of blob regen. The quick organ repair, compared to non-blob regen
+		// If not damaged, but dead, fix it
+		else if(O.status & ORGAN_DEAD)
+			O.status &= ~ORGAN_DEAD //Unset dead if we repaired it entirely
+

--- a/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
@@ -38,7 +38,7 @@
 	
 	total_health =	175  // With the increased limb health, this is necessary to not have inexplicable blobbings when you appear generally okay.
 
-	brute_mod =		0.9 // 10% brute reduction, changed with the increase in limb health so they're not near-immune to brute. Also'd make sense as the nanites would still get damaged akin to organic cells
+	brute_mod =		0.8 // 20% brute reduction, changed with the increase in limb health so they're not near-immune to brute. Also'd make sense as the nanites would still get damaged akin to organic cells
 	burn_mod =		1.3 //30% burn weakness. This, combined with the increased total health makes them able to survive more than 1 laser shot before being blobbed. The cap's still 2 shots, though -- The previous value of 1.4 was 40% weakness, not 60%
 	oxy_mod =		0
 	radiation_mod = 0 // Their blobforms have rad immunity, so it only makes sense that their humanoid forms do too

--- a/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
@@ -210,7 +210,7 @@ I redid the calculations, as the burn weakness has been changed. This should be 
 			H.gib()
 
 /datum/species/protean/handle_environment_special(var/mob/living/carbon/human/H)
-	if((H.getActualBruteLoss() + H.getActualFireLoss()) > H.maxHealth*0.8 && isturf(H.loc)) //So, only if we're not a blob (we're in nullspace) or in someone (or a locker, really, but whatever). The decimal point (0.8 as of now) is the autoblob %hp threshold. Right, quick maths lesson: making the autoblob threshold 35% does not mean that proteans will blob at 35% health. It means that they'll blob at 65% health, because it's checking if the total damage is higher than the threshold. I've made it that they blob at 20% health now, so they don't instantly blob to everything.
+	if((H.getActualBruteLoss() + H.getActualFireLoss()) > H.maxHealth*0.9 && isturf(H.loc)) //So, only if we're not a blob (we're in nullspace) or in someone (or a locker, really, but whatever). The decimal point (0.9 as of now) is the autoblob %hp threshold. This means a protean will blob at 10% health. I've lowered it still, due to the increase in limb health.
 		H.nano_intoblob()
 		return ..() //Any instakill shot runtimes since there are no organs after this. No point to not skip these checks, going to nullspace anyway.
 

--- a/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
@@ -218,7 +218,7 @@ I redid the calculations, as the burn weakness has been changed. This should be 
 	if(refactory && !(refactory.status & ORGAN_DEAD) && refactory.processingbuffs)
 		
 		//Steel adds regen
-		if(H.health < H.maxHealth && refactory.get_stored_material(DEFAULT_WALL_MATERIAL) >= METAL_PER_TICK)  //  A test to see if I can make regen work without blobform
+		if(H.health < H.maxHealth && refactory.get_stored_material(DEFAULT_WALL_MATERIAL) >= METAL_PER_TICK)  //  Regen without blobform, though relatively slow compared to blob regen
 			H.add_modifier(/datum/modifier/protean/steel, origin = refactory)
 		
 		//MHydrogen adds speeeeeed

--- a/code/modules/organs/subtypes/nano.dm
+++ b/code/modules/organs/subtypes/nano.dm
@@ -2,67 +2,67 @@
 /obj/item/organ/external/chest/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 50 // <-- This is different from the rest
+	max_damage = 125 // All limb health is increased to prevent instant delimbing via weak EMPs, lasers, etc.
 	min_broken_damage = 1000
 	vital = TRUE // <-- This is different from the rest
 /obj/item/organ/external/groin/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 30 // <-- This is different from the rest
+	max_damage = 125 // All limb health is increased to prevent instant delimbing via weak EMPs, lasers, etc.
 	min_broken_damage = 1000 //Multiple
 	vital = FALSE
 /obj/item/organ/external/head/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 10
+	max_damage = 75
 	min_broken_damage = 1000 //Inheritance
 	vital = FALSE
 /obj/item/organ/external/arm/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 10
+	max_damage = 75
 	min_broken_damage = 1000 //Please
 	vital = FALSE
 /obj/item/organ/external/arm/right/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 10
+	max_damage = 75
 	min_broken_damage = 1000
 	vital = FALSE
 /obj/item/organ/external/leg/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 10
+	max_damage = 75
 	min_broken_damage = 1000
 	vital = FALSE
 /obj/item/organ/external/leg/right/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 10
+	max_damage = 75
 	min_broken_damage = 1000
 	vital = FALSE
 /obj/item/organ/external/hand/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 10
+	max_damage = 75
 	min_broken_damage = 1000
 	vital = FALSE
 /obj/item/organ/external/hand/right/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 10
+	max_damage = 75
 	min_broken_damage = 1000
 	vital = FALSE
 /obj/item/organ/external/foot/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 10
+	max_damage = 75
 	min_broken_damage = 1000
 	vital = FALSE
 /obj/item/organ/external/foot/right/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 10
+	max_damage = 75
 	min_broken_damage = 1000
 	vital = FALSE
 

--- a/code/modules/vore/appearance/sprite_accessories_vr.dm
+++ b/code/modules/vore/appearance/sprite_accessories_vr.dm
@@ -159,6 +159,21 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 
+/datum/sprite_accessory/ears/demon_horns3
+	name = "demon horns, colorable(upward)"
+	desc = ""
+	icon_state = "demon-horns3"
+	do_colouration = 1
+	color_blend_mode = ICON_MULTIPLY
+
+/datum/sprite_accessory/ears/demon_horns4
+	name = "demon horns, colorable ring(upward)"
+	desc = ""
+	icon_state = "demon-horns4"
+	do_colouration = 1
+	color_blend_mode = ICON_MULTIPLY
+	extra_overlay = "demon-horns4-ring"
+
 /datum/sprite_accessory/ears/dragon_horns
 	name = "dragon horns, colorable"
 	desc = ""
@@ -642,6 +657,13 @@ datum/sprite_accessory/ears/tesh_pattern_ear_male
     icon_state = "frosted_tips"
     ckeys_allowed = list("tucker0666")
 
+/datum/sprite_accessory/ears/peekinghuman
+	name = "peeking ears"
+	desc = ""
+	icon_state = "earpeek"
+	do_colouration = 1
+	color_blend_mode = ICON_MULTIPLY
+
 /*
 ////////////////////////////
 /  =--------------------=  /
@@ -656,6 +678,7 @@ datum/sprite_accessory/ears/tesh_pattern_ear_male
 
 	var/color_blend_mode = ICON_ADD // Only appliciable if do_coloration = 1
 	var/extra_overlay // Icon state of an additional overlay to blend in.
+	var/extra_overlay2
 	var/clothing_can_hide = 1 // If true, clothing with HIDETAIL hides it. If the clothing is bulky enough to hide a tail, it should also hide wings.
 	// var/show_species_tail = 1 // Just so // TODO - Seems not needed ~Leshana
 	var/desc = "You should not see this..."
@@ -902,6 +925,75 @@ datum/sprite_accessory/ears/tesh_pattern_ear_male
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 
+/datum/sprite_accessory/wing/liquidfirefly_gazer
+	name = "gazer eyestalks"
+	desc = ""
+	icon_state = "liquidfirefly-eyestalks"
+
+/datum/sprite_accessory/wing/nevrean
+	name = "nevrean wings/fantail"
+	desc = ""
+	icon_state = "nevrean_s"
+	do_colouration = 1
+	color_blend_mode = ICON_MULTIPLY
+
+/datum/sprite_accessory/wing/sepulchre_c_yw
+	name = "demon wings (colorable)"
+	desc = ""
+	icon_state = "sepulchre_wingsc"
+	do_colouration = 1
+
+/datum/sprite_accessory/wing/cyberdragon
+	name = "Cyber dragon wing (colorable)"
+	desc = ""
+	icon_state = "cyberdragon_s"
+	do_colouration = 1
+	color_blend_mode = ICON_MULTIPLY
+
+/datum/sprite_accessory/wing/cyberdragon_red
+	name = "Cyber dragon wing (red)"
+	desc = ""
+	icon_state = "cyberdragon_red_s"
+	do_colouration = 0
+
+/datum/sprite_accessory/wing/cyberdoe
+	name = "Cyber doe wing"
+	desc = ""
+	icon_state = "cyberdoe_s"
+	do_colouration = 0
+
+/datum/sprite_accessory/wing/drago_wing
+	name = "Cybernetic Dragon wings"
+	desc = ""
+	icon_state = "drago_wing"
+	do_colouration = 1
+	color_blend_mode = ICON_MULTIPLY
+	extra_overlay = "drago_wing_2"
+
+/datum/sprite_accessory/wing/harpywings
+	name = "harpy wings, colorable"
+	desc = ""
+	icon_state = "harpywings"
+	do_colouration = 1
+	color_blend_mode = ICON_MULTIPLY
+
+/datum/sprite_accessory/wing/Harpywings_alt
+	name = "harpy wings alt, archeopteryx"
+	desc = ""
+	icon_state = "Harpywings_alt"
+	do_colouration = 1
+	color_blend_mode = ICON_MULTIPLY
+	extra_overlay = "Neckfur"
+	extra_overlay2 = "Harpywings_altmarkings"
+
+/datum/sprite_accessory/wing/Harpywings_Bat
+	name = "harpy wings, bat"
+	desc = ""
+	icon_state = "Harpywings_Bat"
+	do_colouration = 1
+	color_blend_mode = ICON_MULTIPLY
+	extra_overlay = "Neckfur"
+	extra_overlay2 = "Harpywings_BatMarkings"
 
 /*
 ////////////////////////////
@@ -926,6 +1018,10 @@ datum/sprite_accessory/ears/tesh_pattern_ear_male
 	var/icon/clip_mask_icon = null //Icon file used for clip mask.
 	var/clip_mask_state = null //Icon state to generate clip mask. Clip mask is used to 'clip' off the lower part of clothing such as jumpsuits & full suits.
 	var/icon/clip_mask = null //Instantiated clip mask of given icon and state
+
+	//Loafing vars
+	var/can_loaf = FALSE
+	var/loaf_offset = 0
 
 /datum/sprite_accessory/tail/New()
 	. = ..()
@@ -1269,6 +1365,24 @@ datum/sprite_accessory/ears/tesh_pattern_ear_male
 	desc = ""
 	icon_state = "tamamo-kitsunetails"
 	extra_overlay = "tamamo-kitsunetails-tips"
+	do_colouration = 1
+	color_blend_mode = ICON_MULTIPLY
+
+/datum/sprite_accessory/tail/foxtail
+	name = "Fox"
+	desc = ""	//leaving this just in case i break something if i just don't include a blank description because this codebase is akin to a house of cards
+	icon_state = "foxtail_but_good"
+	extra_overlay = "foxtail_but_good-tips"
+	do_colouration = TRUE
+	color_blend_mode = ICON_MULTIPLY
+	ani_state = "foxtail_but_good_w"
+	extra_overlay_w = "foxtail_but_good-tips_w"
+
+/datum/sprite_accessory/tail/triple_kitsune
+	name = "Triple Kitsune Tails"
+	desc = ""
+	icon_state = "triple-kitsunetails"
+	extra_overlay = "triple-kitsunetails-tips"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 


### PR DESCRIPTION
## About The Pull Request

So, Protean limbs were 10 hp per limb, meaning a misplaced candle flame or the like would've ashed it. This annoyed me to no end, so I changed it.
I also added a rather minor regen effect to non-blob Proteans (2/s), and buffed the blob regen to 10/s, so that people would have a reason other than ventcrawling/tentacle erp/near-death to go to blobform.


As I am incredibly balance-blind, people will probably think that either the blob regen is too much, or that the entire existence of non-blob regen, a la prommies, is too OP.


## Why It's Good For The Game

Makes the Protean limbs not made of jello. This change also makes them not turn to limbless torsos when exposed to weak EMPs, and makes the limbs able to survive 2 laser rifle shots.
The Protean in general will be able to survive 2 ion rifle shots or 1 medium EMP before blobbing. A heavy EMP, also known as sitting on the grenade, will still kill them very dead.


Also, I'm a bad coder, so you'll have to disable material modifiers to turn off the regen, or it'll tick over to zero. If anyone can tell me how to prevent that, please do.

## Changelog
:cl:
add: Protean non-blob regen, similar to prommies
tweak: Tweaked Protean limb HP to make them not made of nano-jello
tweak: Reduced Protean brute resist as a cause of them not being made of nano-jello
balance: Buffed blobform regen
/:cl: