### PR TITLE
Parts Lathe GUI update.

### DIFF
--- a/nano/templates/partslathe.tmpl
+++ b/nano/templates/partslathe.tmpl
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 Title: Parts Lathe UI
 Used In File(s): \code\game\machinery\partslathe.dm
  -->
@@ -11,7 +11,7 @@ Used In File(s): \code\game\machinery\partslathe.dm
 	{{for data.materials }}
 		<div class="line">
 			<div class="statusLabel">{{:value.display.toTitleCase()}}</div>
-			<div class="statusValue">{{:helper.displayBar(value.percent, 0, 100, 
+			<div class="statusValue">{{:helper.displayBar(value.percent, 0, 100,
 				(value.percent < 25) ? 'bad' : (value.percent < 50) ? 'average' : 'good',
 				value.qty + "/" + value.max )}}</div>
 			<div class="statusValue">{{:helper.link("Eject", 'eject', {'ejectMaterial' : value.name })}}</div>
@@ -41,6 +41,14 @@ Used In File(s): \code\game\machinery\partslathe.dm
 	</div>
 {{/if}}
 
+
+<h3>Recipies</h3>
+{{for data.recipies}}
+	<div class="clearRight">
+		{{:helper.link(value.name.toTitleCase(), 'plus', {'queue' : value.type})}}
+	</div>
+{{/for}}
+
 {{if data.building }}
 	<h3>Currently Building</h3>
 	<div class="line">
@@ -67,10 +75,3 @@ Used In File(s): \code\game\machinery\partslathe.dm
 		{{/for}}
 	{{/if}}
 </div>
-
-<h3>Recipies</h3>
-{{for data.recipies}}
-	<div class="line">
-		{{:helper.link(value.name.toTitleCase(), 'plus', {'queue' : value.type})}}
-	</div>
-{{/for}}


### PR DESCRIPTION
makes parts lathe not terrible to use.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Parts lathe UI gets a little CSS change and layout reordering to be less jumpy. 

## Why It's Good For The Game

Parts lathe moves the buttons around every time you click one currently, and has too much wasted space, enough that you have to scroll multiple times to make parts. We don't have TGUI for this machine yet, so this makes it less painful to use until then. 

## Changelog
:cl:

tweak: Parts Lathe GUI is improved slightly. 

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
