### PR TITLE
adds some lobby screens

### DIFF
--- a/maps/citadel_minitest/citadel_minitest_defines.dm
+++ b/maps/citadel_minitest/citadel_minitest_defines.dm
@@ -7,7 +7,7 @@
 	path = "citadel_minitest"
 
 	lobby_icon = 'icons/misc/title_vr.dmi'
-	lobby_screens = list("title1", "title2", "title3", "title4", "title5", "title6", "title7")
+	lobby_screens = list("minitest1", "minitest2")
 	id_hud_icons = 'icons/mob/hud_jobs_vr.dmi' //CITADEL CHANGE: Ignore this line because it's going to be overriden in modular_citadel\maps\tether\tether_defines.dm	//TODO Remove/Fix these unneccessary Override Overrides everywhere ffs - Zandario
 
 	admin_levels = list()

--- a/maps/nsv_triumph/triumph_defines.dm
+++ b/maps/nsv_triumph/triumph_defines.dm
@@ -43,7 +43,7 @@
 	zlevel_datum_type = /datum/map_z_level/triumph
 
 	lobby_icon = 'icons/misc/title_vr.dmi'
-	lobby_screens = list("title1", "title2", "title3", "title4", "title5", "title6", "title7", "title8")
+	lobby_screens = list("title1", "title2", "title3", "title4", "title5", "title6", "title7", "title8", "title9")
 	id_hud_icons = 'icons/mob/hud_jobs_vr.dmi' //CITADEL CHANGE: Ignore this line because it's going to be overriden in modular_citadel\maps\triumph\triumph_defines.dm	//TODO Remove/Fix these unneccessary Override Overrides everywhere ffs - Zandario
 
 	admin_levels = list()


### PR DESCRIPTION
this stops using triumph lobby screens in minitest. there will now be minitest specific lobby screens to prevent ANY confusion for a dev as to where they're at.

see: devmins hitting 'start now' on live

🆑
tweak: minitest has minitest specific lobby images now
add: 1 new rp lobby image
/:cl:
