### PR TITLE
Fixes lights obscuring cameras, missing atmos pipes on Triumph.

### DIFF
--- a/_maps/map_files/triumph/triumph-01-deck1.dmm
+++ b/_maps/map_files/triumph/triumph-01-deck1.dmm
@@ -6129,6 +6129,28 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/engineering/foyer_mezzenine)
+"tR" = (
+/obj/structure/catwalk,
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/hallway/lower)
 "tS" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -29240,7 +29262,7 @@ FC
 Cf
 YJ
 by
-NG
+tR
 eP
 ZW
 La

--- a/_maps/map_files/triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/triumph/triumph-02-deck2.dmm
@@ -955,6 +955,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/eva)
+"di" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
 "dj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -8056,6 +8068,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "wS" = (
@@ -11010,8 +11024,6 @@
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/refinery)
 "FL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Bar Backroom";
@@ -11621,6 +11633,8 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "HB" = (
@@ -12966,6 +12980,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "LB" = (
@@ -16646,6 +16662,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/coffee_shop)
 "Wx" = (
@@ -17693,6 +17715,8 @@
 /obj/machinery/computer/security/telescreen{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "Zn" = (
@@ -22561,7 +22585,7 @@ Um
 Um
 Um
 dN
-QG
+di
 Hz
 wQ
 Zm

--- a/_maps/map_files/triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/triumph/triumph-02-deck2.dmm
@@ -955,12 +955,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/eva)
-"di" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
 "dj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -2052,9 +2046,6 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "fW" = (
@@ -2856,6 +2847,9 @@
 	},
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_x = -32
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
@@ -4393,9 +4387,6 @@
 	layer = 3.3;
 	pixel_x = -27
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "mz" = (
@@ -4547,9 +4538,6 @@
 /obj/item/reagent_containers/glass/rag,
 /obj/machinery/camera/network/civilian{
 	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
@@ -6077,6 +6065,9 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "rj" = (
@@ -7251,6 +7242,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "ul" = (
@@ -8181,6 +8173,9 @@
 /area/crew_quarters/showers)
 "xh" = (
 /obj/machinery/vending/boozeomat,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "xi" = (
@@ -8697,7 +8692,6 @@
 /obj/machinery/computer/security/telescreen{
 	pixel_y = -32
 	},
-/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "yI" = (
@@ -13437,6 +13431,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
 	},
+/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/station/stairs_two)
 "Nn" = (
@@ -16473,6 +16468,7 @@
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_y = -37
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "Wd" = (
@@ -28673,7 +28669,7 @@ GJ
 GJ
 XZ
 dJ
-di
+XZ
 Uy
 Uy
 Uy

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -1179,9 +1179,6 @@
 /obj/item/clothing/suit/space/anomaly,
 /obj/item/clothing/head/helmet/space/anomaly,
 /obj/item/clothing/mask/breath,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/item/storage/belt/archaeology,
 /obj/item/clothing/mask/breath,
 /obj/structure/window/reinforced{
@@ -1545,9 +1542,6 @@
 /obj/item/clothing/suit/space/anomaly,
 /obj/item/clothing/head/helmet/space/anomaly,
 /obj/item/clothing/mask/breath,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/item/storage/belt/archaeology,
 /obj/item/clothing/suit/space/anomaly,
 /obj/item/clothing/head/helmet/space/anomaly,
@@ -8391,8 +8385,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/assembly/chargebay)
 "gYn" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "gYs" = (
@@ -12402,9 +12400,6 @@
 /obj/item/clothing/suit/space/anomaly,
 /obj/item/clothing/head/helmet/space/anomaly,
 /obj/item/clothing/mask/breath,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/item/storage/belt/archaeology,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/suit/bio_suit/anomaly,
@@ -15118,12 +15113,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "mLJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	layer = 3.3;

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -9887,6 +9887,9 @@
 /obj/structure/closet/hydrant{
 	pixel_x = -32
 	},
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
 "imh" = (
@@ -10690,6 +10693,7 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/blue/border,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
 "jaT" = (
@@ -10987,9 +10991,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/recoveryrestroom)
@@ -12867,9 +12868,7 @@
 /area/maintenance/research)
 "kSR" = (
 /obj/machinery/recharge_station,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/white,
 /area/medical/recoveryrestroom)
 "kTk" = (
@@ -16958,6 +16957,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/recoveryrestroom)
 "onK" = (
@@ -19268,9 +19270,6 @@
 /obj/effect/floor_decal/corner/green/border{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
 "pLS" = (
@@ -20954,11 +20953,11 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "qXr" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/toilet{
 	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/recoveryrestroom)
@@ -21692,11 +21691,11 @@
 /turf/simulated/floor/plating,
 /area/medical/patient_c)
 "ruB" = (
-/obj/machinery/camera/network/civilian{
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/holodeck_control)
+/turf/simulated/floor/wood,
+/area/crew_quarters/medbreak)
 "rvf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/techfloor{
@@ -26155,10 +26154,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "uQl" = (
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -29759,12 +29754,6 @@
 /obj/structure/closet/l3closet/scientist/double,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
-"xGA" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/recoveryrestroom)
 "xGN" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/blue/border,
@@ -35567,7 +35556,7 @@ vwF
 jpk
 omY
 lcc
-xGA
+aIW
 aIW
 ooG
 mmU
@@ -43511,7 +43500,7 @@ rzy
 ltR
 oIJ
 szb
-yhM
+ruB
 yhM
 eeY
 dYE
@@ -43930,7 +43919,7 @@ hMA
 wtS
 uQl
 ilk
-ruB
+wqC
 qWm
 nPh
 mBS

--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -3981,13 +3981,6 @@
 /obj/effect/floor_decal/rust/mono_rusted1,
 /turf/simulated/floor/tiled,
 /area/security/brig)
-"cOZ" = (
-/obj/structure/closet/crate/secure/weapon,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/exploration/excursion_dock)
 "cPE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4247,12 +4240,6 @@
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/tiled,
 /area/security/interrogation)
-"dfd" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/teleporter)
 "dff" = (
 /turf/simulated/wall/r_wall,
 /area/space)
@@ -4501,12 +4488,8 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -4954,9 +4937,6 @@
 /turf/simulated/floor/tiled,
 /area/security/security_equiptment_storage)
 "dFk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
 	},
@@ -7313,12 +7293,6 @@
 /turf/simulated/floor,
 /area/maintenance/tool_storage)
 "fgf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -8733,6 +8707,12 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
+"gnw" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/teleporter)
 "gnz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine{
@@ -9132,6 +9112,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/triumph/surfacebase/tram)
+"gBV" = (
+/obj/structure/closet/crate/secure/weapon,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/exploration/excursion_dock)
 "gBY" = (
 /obj/machinery/suit_cycler/medical,
 /turf/simulated/floor/tiled,
@@ -12815,7 +12802,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /obj/structure/dispenser{
 	phorontanks = 0
 	},
@@ -23739,8 +23728,6 @@
 	},
 /area/shuttle/civvie/cockpit)
 "qzT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -25217,7 +25204,6 @@
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/shuttle/civvie/general)
 "rtF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -27605,8 +27591,6 @@
 /area/maintenance/tool_storage)
 "sXf" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -31971,7 +31955,6 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -34285,12 +34268,6 @@
 /area/security/warden)
 "xDT" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -39518,7 +39495,7 @@ egk
 eQf
 iwe
 qVA
-cOZ
+gBV
 hqy
 dls
 mAF
@@ -52310,7 +52287,7 @@ gef
 trR
 trR
 hEB
-dfd
+gnw
 tYh
 gef
 jEx

--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -3981,6 +3981,13 @@
 /obj/effect/floor_decal/rust/mono_rusted1,
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"cOZ" = (
+/obj/structure/closet/crate/secure/weapon,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/exploration/excursion_dock)
 "cPE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4240,6 +4247,12 @@
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/tiled,
 /area/security/interrogation)
+"dfd" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/teleporter)
 "dff" = (
 /turf/simulated/wall/r_wall,
 /area/space)
@@ -10718,9 +10731,6 @@
 /obj/structure/dispenser{
 	phorontanks = 0
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/teleporter)
 "hEC" = (
@@ -10943,7 +10953,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals5,
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -16152,7 +16164,7 @@
 "lvR" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/exploration/showers)
@@ -17171,13 +17183,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "mfa" = (
-/obj/machinery/light/small,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals5,
 /obj/machinery/recharge_station,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/sauna)
 "mfn" = (
@@ -22130,9 +22144,6 @@
 /area/security/security_bathroom)
 "pCc" = (
 /obj/machinery/camera/network/exploration,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/exploration/excursion_dock)
 "pCf" = (
@@ -28226,12 +28237,12 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/exploration/showers)
@@ -39507,7 +39518,7 @@ egk
 eQf
 iwe
 qVA
-pLf
+cOZ
 hqy
 dls
 mAF
@@ -52299,7 +52310,7 @@ gef
 trR
 trR
 hEB
-czx
+dfd
 tYh
 gef
 jEx


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#2815 was made using layers that excluded airlocks and cameras, resulting in situations like these:
![image](https://user-images.githubusercontent.com/11361525/111130959-73cc2980-8580-11eb-96cd-b9b082a09f51.png)

This PR:
- Fixes those cameras hidden by lights
- Fixes missing / copy pasted atmos pipes
- Fixes a single instance of a door-camera
- Adds an additional light to Medbay's break room (2dark)


## Why It's Good For The Game
Cameras should be immediately visible and recognizable, not obscured by lights.

## Changelog
:cl:
fix: Lights obscuring cameras
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
