### PR TITLE
disruptor blade in mining borg emag modules (read: scrambled equips)

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station/cargo.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/cargo.dm
@@ -34,3 +34,4 @@
 	src.modules += new /obj/item/mining_scanner(src)
 	src.emag = new /obj/item/pickaxe/plasmacutter(src)
 	src.emag = new /obj/item/pickaxe/diamonddrill(src)
+	src.emag = new /obj/item/melee/disruptor/borg(src)


### PR DESCRIPTION
## About The Pull Request
see title
## Why It's Good For The Game
funny knife heho :)
(knife with moderate effectiveness for jabbing shit, but **50** force against animals and aberrations, intended purpose "stabbing whatever's hiding out in the belt")
## Changelog
:cl:
add: Mining-module equipped stationbound synthetics now get a disruptor blade when given a scrambled module. What's a disruptor blade? Who knows.
/:cl: