### PR TITLE
How to piss off engineers in one simple step

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -129,7 +129,7 @@ var/global/list/rad_collectors = list()
 /obj/machinery/power/rad_collector/proc/receive_pulse(var/pulse_strength)
 	if(P && active)
 		var/power_produced = 0
-		power_produced = /* P.air_contents.gas[/datum/gas/phoron]* */ pulse_strength*300
+		power_produced = (min(P.air_contents.gas[/datum/gas/phoron], 1000)) * pulse_strength * 20
 		add_avail(power_produced)
 		last_power_new = power_produced
 		return

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -129,7 +129,7 @@ var/global/list/rad_collectors = list()
 /obj/machinery/power/rad_collector/proc/receive_pulse(var/pulse_strength)
 	if(P && active)
 		var/power_produced = 0
-		power_produced = /* P.air_contents.gas[/datum/gas/phoron]* */ pulse_strength*120
+		power_produced = /* P.air_contents.gas[/datum/gas/phoron]* */ pulse_strength*300
 		add_avail(power_produced)
 		last_power_new = power_produced
 		return

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -129,7 +129,7 @@ var/global/list/rad_collectors = list()
 /obj/machinery/power/rad_collector/proc/receive_pulse(var/pulse_strength)
 	if(P && active)
 		var/power_produced = 0
-		power_produced = /* P.air_contents.gas[/datum/gas/phoron]* */ pulse_strength*20
+		power_produced = /* P.air_contents.gas[/datum/gas/phoron]* */ pulse_strength*120
 		add_avail(power_produced)
 		last_power_new = power_produced
 		return

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -129,7 +129,7 @@ var/global/list/rad_collectors = list()
 /obj/machinery/power/rad_collector/proc/receive_pulse(var/pulse_strength)
 	if(P && active)
 		var/power_produced = 0
-		power_produced = P.air_contents.gas[/datum/gas/phoron]*pulse_strength*20
+		power_produced = /* P.air_contents.gas[/datum/gas/phoron]* */ pulse_strength*20
 		add_avail(power_produced)
 		last_power_new = power_produced
 		return

--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -12,8 +12,8 @@
 	var/locked = 0
 	var/average_field_strength = 0
 	var/strengthen_rate = 0.2
-	var/max_strengthen_rate = 0.5	//the maximum rate that the generator can increase the average field strength
-	var/dissipation_rate = 0.030	//the percentage of the shield strength that needs to be replaced each second
+	var/max_strengthen_rate = 0.9	//the maximum rate that the generator can increase the average field strength
+	var/dissipation_rate = 0.070	//the percentage of the shield strength that needs to be replaced each second
 	var/min_dissipation = 0.01		//will dissipate by at least this rate in renwicks per field tile (otherwise field would never dissipate completely as dissipation is a percentage)
 	var/powered = 0
 	var/check_powered = 1
@@ -28,7 +28,7 @@
 /obj/machinery/shield_gen/advanced
 	name = "advanced bubble shield generator"
 	desc = "A machine that generates a field of energy optimized for blocking meteorites when activated.  This version comes with a more efficent shield matrix."
-	energy_conversion_rate = 0.0012
+	energy_conversion_rate = 0.0020
 
 /obj/machinery/shield_gen/Initialize(mapload)
 	if(anchored)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This needs some real round testing.

This PR removes the actual gas content from the math related to how much power a collector produces. Granted, this will take a  lot of tweaking to make ideal but- the general goal is to make it impossible for a set of collectors to 10x your power generation. They should be helpful to boost your power, but not to the absolutely ludicrous degree they are now.

It ALSO makes shields a lot more power-heavy. A fully charged, 10 RW hull shield now draws 1.6 MWs, while also increasing the max charge rate from 0.5/s to 0.9/s to allow it to more easily be set at lower levels, and boosted in times of higher risk. This will also likely need further tweaking after live tests.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Engineers who powergame the fuck out of the engine and shields at the start of every round basically remove a ton of mechanics from existence. This is aimed at hamstringing that slightly, while still allowing some freedom for being stupid sometimes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

tweak: gas moles no longer factor in rad collector output
tweak: shields are now about 2.5x more power-heavy.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
