### PR TITLE
fixes #2701

### DIFF
--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -370,7 +370,7 @@ GLOBAL_LIST_INIT(nif_id_lookup, init_nif_id_lookup())
 	if(!human || stat == NIF_TEMPFAIL) return
 
 	to_chat(human,"<b>\[[icon2html(thing = src.big_icon, target = human)]NIF\]</b> displays, \"<span class='[alert ? "danger" : "notice"]'>[message]</span>\"")
-	if(prob(25)) human.visible_message("<span class='notice'>\The [human.real_name] [pick(look_messages)].</span>")
+	if(prob(1)) human.visible_message("<span class='notice'>\The [human.real_name] [pick(look_messages)].</span>")
 	if(alert)
 		SEND_SOUND(human, bad_sound)
 	else

--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -90,8 +90,9 @@ GLOBAL_LIST_INIT(nif_id_lookup, init_nif_id_lookup())
 
 	//If given a human on spawn (probably from persistence)
 	if(ishuman(loc))
+		var/mob/living/carbon/human/H = loc
 		if(!quick_implant(H))
-			WARNING("NIF spawned in [human.real_name] failed to implant")
+			WARNING("NIF spawned in [H] failed to implant")
 			spawn(0)
 				qdel(src)
 			return FALSE

--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -90,9 +90,8 @@ GLOBAL_LIST_INIT(nif_id_lookup, init_nif_id_lookup())
 
 	//If given a human on spawn (probably from persistence)
 	if(ishuman(loc))
-		var/mob/living/carbon/human/H = loc
 		if(!quick_implant(H))
-			WARNING("NIF spawned in [H] failed to implant")
+			WARNING("NIF spawned in [human.real_name] failed to implant")
 			spawn(0)
 				qdel(src)
 			return FALSE
@@ -370,7 +369,7 @@ GLOBAL_LIST_INIT(nif_id_lookup, init_nif_id_lookup())
 	if(!human || stat == NIF_TEMPFAIL) return
 
 	to_chat(human,"<b>\[[icon2html(thing = src.big_icon, target = human)]NIF\]</b> displays, \"<span class='[alert ? "danger" : "notice"]'>[message]</span>\"")
-	if(prob(1)) human.visible_message("<span class='notice'>\The [human] [pick(look_messages)].</span>")
+	if(prob(25)) human.visible_message("<span class='notice'>\The [human.real_name] [pick(look_messages)].</span>")
 	if(alert)
 		SEND_SOUND(human, bad_sound)
 	else
@@ -440,7 +439,7 @@ GLOBAL_LIST_INIT(nif_id_lookup, init_nif_id_lookup())
 	if(stat != NIF_WORKING) return FALSE
 
 	if(human)
-		if(prob(5)) human.visible_message("<span class='notice'>\The [human] [pick(look_messages)].</span>")
+		if(prob(5)) human.visible_message("<span class='notice'>\The [human.real_name] [pick(look_messages)].</span>")
 		var/applies_to = soft.applies_to
 		var/synth = human.isSynthetic()
 		if(synth && !(applies_to & NIF_SYNTHETIC))
@@ -468,7 +467,7 @@ GLOBAL_LIST_INIT(nif_id_lookup, init_nif_id_lookup())
 /obj/item/nif/proc/deactivate(var/datum/nifsoft/soft)
 	if(human)
 		if(prob(5))
-			human.visible_message("<span class='notice'>\The [human] [pick(look_messages)].</span>")
+			human.visible_message("<span class='notice'>\The [human.real_name] [pick(look_messages)].</span>")
 		SEND_SOUND(human, click_sound)
 
 	if(soft.tick_flags == NIF_ACTIVETICK)


### PR DESCRIPTION
just using [human] here will make it return blank space, so we force it to use human.real_name to pull the real_name var from the mob/living/carbon/human

closes #2701 