### PR TITLE
removes instanced areas from Triumph

### DIFF
--- a/_maps/map_files/triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/triumph/triumph-02-deck2.dmm
@@ -283,7 +283,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "aQ" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
@@ -430,7 +430,7 @@
 "bj" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "bl" = (
 /turf/simulated/wall/r_wall,
 /area/triumph/surfacebase/bar_backroom)
@@ -1124,7 +1124,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "dH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -1743,9 +1743,6 @@
 "fj" = (
 /obj/structure/coatrack,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
 /obj/machinery/button/remote/airlock{
 	id = "Dressroom";
 	name = "Dressroom lock";
@@ -1754,7 +1751,7 @@
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet/bcarpet,
-/area/vacant/vacant_site)
+/area/vacant/vacant_shop)
 "fk" = (
 /obj/machinery/status_display/supply_display{
 	pixel_y = 32
@@ -2321,7 +2318,7 @@
 	pixel_x = -23
 	},
 /turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "gI" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -2332,7 +2329,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "gK" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2810,17 +2807,8 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/item/stool/padded,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/carpet/bcarpet,
-/area/vacant/vacant_site)
+/area/vacant/vacant_shop)
 "id" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -4358,7 +4346,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "mB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -4408,7 +4396,7 @@
 	dir = 8
 	},
 /turf/simulated/wall,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "mG" = (
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_10)
@@ -5764,7 +5752,7 @@
 	pixel_x = 30
 	},
 /turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "qn" = (
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/sleep/Dorm_7)
@@ -5995,7 +5983,7 @@
 /area/quartermaster/foyer)
 "ra" = (
 /turf/simulated/wall,
-/area/vacant/vacant_site2)
+/area/vacant/vacant_office)
 "rd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -6388,13 +6376,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "sk" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/vacant/vacant_shop)
+/turf/simulated/floor/plating,
+/area/vacant/vacant_office)
 "sl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7027,8 +7010,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/mining_ship/general)
 "tQ" = (
-/turf/simulated/wall,
-/area/vacant/vacant_site)
+/turf/simulated/floor/tiled,
+/area/vacant/vacant_office)
 "tS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -7515,7 +7498,7 @@
 "vh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "vj" = (
 /obj/machinery/power/solar_control,
 /obj/structure/cable/yellow{
@@ -7631,11 +7614,6 @@
 "vB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "vC" = (
@@ -8557,11 +8535,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "yu" = (
@@ -9345,13 +9318,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/carpet/bcarpet,
-/area/vacant/vacant_site)
+/area/vacant/vacant_shop)
 "AT" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -10067,13 +10035,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/belter)
 "CX" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/wood,
-/area/vacant/vacant_shop)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_office)
 "CY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -10256,7 +10223,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "DD" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -10291,7 +10258,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "DI" = (
 /obj/structure/stairs/north,
 /turf/simulated/floor/tiled,
@@ -10827,11 +10794,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "Fm" = (
@@ -11166,13 +11128,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/carpet/bcarpet,
-/area/vacant/vacant_site)
+/area/vacant/vacant_shop)
 "Gi" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Solar Farm - SMES 1"
@@ -12382,7 +12339,7 @@
 	name = "Vacant lobby"
 	},
 /turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "JT" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled,
@@ -12876,7 +12833,7 @@
 "Lx" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "Ly" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -14842,7 +14799,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "RV" = (
 /obj/effect/landmark/start{
 	name = "Chef"
@@ -14949,11 +14906,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
@@ -15078,13 +15030,8 @@
 	id_tag = "Dressroom";
 	name = "Dressing Room"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/wood,
-/area/vacant/vacant_site)
+/area/vacant/vacant_shop)
 "SD" = (
 /obj/structure/sink{
 	dir = 8;
@@ -15515,11 +15462,6 @@
 "TN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
@@ -16070,7 +16012,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "Vr" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -16526,7 +16468,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "Wv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -17663,7 +17605,7 @@
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/area/vacant/vacant_office)
 "Zs" = (
 /obj/machinery/chem_master/condimaster,
 /turf/simulated/floor/tiled/dark,
@@ -25055,8 +24997,8 @@ mF
 Zr
 Vq
 gH
-xj
-mQ
+sk
+ra
 oE
 iM
 oE
@@ -25193,12 +25135,12 @@ ub
 mM
 As
 Ny
-mQ
-xj
-xj
-xj
-xj
-mQ
+ra
+sk
+sk
+sk
+sk
+ra
 oE
 oE
 oE
@@ -25333,14 +25275,14 @@ AF
 SY
 pc
 Qc
-mQ
-mQ
-mQ
+ra
+ra
+ra
 vh
 gJ
 mA
 mA
-Qj
+CX
 Pm
 sl
 sl
@@ -25477,10 +25419,10 @@ jr
 kO
 JP
 DC
-xj
-GM
+sk
+tQ
 DH
-xj
+sk
 Wu
 wc
 wc
@@ -25619,11 +25561,11 @@ Vv
 mM
 bj
 RU
-xj
-GM
-GM
-GM
-GM
+sk
+tQ
+tQ
+tQ
+tQ
 wc
 gg
 xg
@@ -25759,13 +25701,13 @@ RE
 sc
 rL
 Wn
-mQ
+ra
 aO
-xj
-xj
-GM
-xj
-xj
+sk
+sk
+tQ
+sk
+sk
 wc
 kn
 km
@@ -25901,12 +25843,12 @@ vd
 gO
 Vv
 PT
-mQ
+ra
 qm
 dG
-xj
-xj
-xj
+sk
+sk
+sk
 Lx
 wc
 qG
@@ -26032,10 +25974,10 @@ Sv
 Nb
 EW
 Gx
-tQ
-tQ
-tQ
-ra
+mQ
+mQ
+mQ
+mQ
 RE
 vd
 vd
@@ -26043,13 +25985,13 @@ vd
 gO
 Vv
 mM
-mQ
-mQ
-mQ
-mQ
-mQ
-mQ
-mQ
+ra
+ra
+ra
+ra
+ra
+ra
+ra
 wc
 DA
 wc
@@ -26174,10 +26116,10 @@ Sv
 dD
 ul
 dD
-tQ
+mQ
 ib
 AR
-tQ
+mQ
 RE
 vd
 vd
@@ -26316,10 +26258,10 @@ Sv
 Hp
 yk
 dD
-tQ
+mQ
 fj
 Gf
-tQ
+mQ
 IX
 RE
 RE
@@ -26458,10 +26400,10 @@ Sv
 Sv
 Ya
 Sv
-tQ
-tQ
+mQ
+mQ
 SC
-tQ
+mQ
 mQ
 mQ
 mQ
@@ -26886,8 +26828,8 @@ gz
 sf
 mQ
 wY
-CX
-sk
+Py
+Py
 Sl
 vB
 yt

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -1647,9 +1647,7 @@
 /obj/structure/table/woodentable,
 /obj/item/toy/plushie/therapy/green,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "buX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -1979,9 +1977,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "bIX" = (
 /obj/effect/floor_decal/techfloor,
 /obj/structure/cable/green{
@@ -3275,7 +3271,7 @@
 "cLl" = (
 /obj/structure/bed/psych,
 /turf/simulated/floor/wood,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "cLo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /obj/machinery/camera/network/research{
@@ -3475,9 +3471,7 @@
 /obj/structure/table/woodentable,
 /obj/item/flashlight/lamp/green,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "cVZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3505,9 +3499,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "cWS" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -4418,9 +4410,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "dLs" = (
 /turf/simulated/wall/r_wall,
 /area/teleporter/departing)
@@ -4508,7 +4498,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "dNE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -4615,7 +4605,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "dTa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 10
@@ -6249,9 +6239,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "fnL" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	id_tag = "MedbayFoyer";
@@ -7060,7 +7048,7 @@
 	name = "Psychiatrist"
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "fSY" = (
 /obj/machinery/suspension_gen,
 /obj/machinery/light{
@@ -7796,7 +7784,7 @@
 /area/medical/patient_d)
 "gxS" = (
 /turf/simulated/floor/wood,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "gyJ" = (
 /obj/machinery/camera/network/medbay{
 	dir = 8
@@ -7867,7 +7855,7 @@
 "gzM" = (
 /obj/structure/sign/greencross,
 /turf/simulated/wall/r_wall,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "gzU" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -9492,7 +9480,7 @@
 /area/maintenance/fore)
 "hVx" = (
 /turf/simulated/wall,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "hWa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -9864,9 +9852,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "ikK" = (
 /obj/machinery/door/airlock/glass_external{
 	name = "Isolation Room 1";
@@ -10677,9 +10663,7 @@
 	name = "Psychiatrist"
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "iYU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -11047,7 +11031,7 @@
 "jrD" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "jrF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11813,7 +11797,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "jXs" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/item/roller_holder,
@@ -11924,7 +11908,7 @@
 "kcr" = (
 /obj/structure/sign/department/medbay,
 /turf/simulated/wall,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "kcx" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 4
@@ -11966,7 +11950,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "kdY" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -13227,9 +13211,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "lji" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -14116,7 +14098,7 @@
 "lZE" = (
 /obj/structure/flora/pottedplant/smallcactus,
 /turf/simulated/floor/wood,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "mak" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -14320,9 +14302,7 @@
 /area/maintenance/substation/medical)
 "mhs" = (
 /turf/simulated/wall,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "mht" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 10
@@ -14393,7 +14373,7 @@
 "mjq" = (
 /obj/structure/flora/pottedplant/tropical,
 /turf/simulated/floor/wood,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "mjN" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -14860,9 +14840,7 @@
 	},
 /obj/structure/closet/secure_closet/psych,
 /turf/simulated/floor/wood,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "mzO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance/common,
@@ -15040,7 +15018,7 @@
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "mJN" = (
 /obj/machinery/atmospherics/unary/heat_exchanger{
 	dir = 4
@@ -15101,7 +15079,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/wood,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "mKU" = (
 /turf/simulated/floor/tiled/old_cargo/purple,
 /area/assembly/robotics)
@@ -15172,7 +15150,7 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "mNl" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers,
@@ -15666,7 +15644,7 @@
 	name = "Medical Forms"
 	},
 /turf/simulated/floor/wood,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "neu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/tiled,
@@ -16297,9 +16275,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "nNT" = (
 /obj/effect/floor_decal/techfloor,
 /obj/structure/disposalpipe/segment{
@@ -16339,9 +16315,7 @@
 /area/holodeck_control)
 "nPz" = (
 /turf/simulated/floor/wood,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "nPW" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -16673,9 +16647,7 @@
 "ocR" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "odC" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
 	dir = 8
@@ -16819,7 +16791,7 @@
 	name = "Medical Records"
 	},
 /turf/simulated/floor/wood,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "ohL" = (
 /obj/machinery/light/small,
 /obj/structure/catwalk,
@@ -17579,9 +17551,7 @@
 	req_access = list(64)
 	},
 /turf/simulated/floor/wood,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "oLg" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -17660,9 +17630,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/wood,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "oNN" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -20013,7 +19981,7 @@
 	id = "psyche"
 	},
 /turf/simulated/floor/plating,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "qnK" = (
 /obj/machinery/door/airlock/medical{
 	name = "Psychiatric Ward"
@@ -20698,7 +20666,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "qOS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -21087,7 +21055,7 @@
 "rag" = (
 /obj/structure/sign/warning/nosmoking_1,
 /turf/simulated/wall,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "rat" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/borderfloorwhite,
@@ -21586,9 +21554,7 @@
 "rru" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "rrw" = (
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/airless/ceiling,
@@ -22795,7 +22761,7 @@
 /obj/machinery/camera/network/medbay,
 /obj/structure/closet/secure_closet/psych,
 /turf/simulated/floor/wood,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "sqH" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner,
@@ -23378,9 +23344,7 @@
 	name = "Medical Forms"
 	},
 /turf/simulated/floor/wood,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "sJv" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
@@ -24502,7 +24466,7 @@
 	req_access = list(64)
 	},
 /turf/simulated/floor/wood,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "twh" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -24961,7 +24925,7 @@
 /area/medical/ward)
 "tOE" = (
 /turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "tOF" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -25270,9 +25234,7 @@
 	},
 /obj/structure/bed/psych,
 /turf/simulated/floor/wood,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "tZu" = (
 /obj/structure/sink{
 	dir = 4;
@@ -25691,9 +25653,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/wood,
-/area/medical/psych{
-	name = "\improper Psych Room 2"
-	})
+/area/medical/psych/psych_2)
 "uxC" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/corner/blue/diagonal,
@@ -26141,7 +26101,7 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/wood,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "uOx" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -27242,7 +27202,7 @@
 /obj/structure/table/woodentable,
 /obj/machinery/computer/med_data/laptop,
 /turf/simulated/floor/wood,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "vIb" = (
 /obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/wood,
@@ -28546,7 +28506,7 @@
 	req_access = list()
 	},
 /turf/simulated/floor/wood,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "wHh" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	input_tag = "atmos_out";
@@ -28988,7 +28948,7 @@
 /obj/structure/table/woodentable,
 /obj/item/toy/plushie/kitten,
 /turf/simulated/floor/wood,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "wVq" = (
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
@@ -29350,7 +29310,7 @@
 /obj/item/toy/plushie/siamese_cat,
 /obj/item/toy/plushie/therapy/green,
 /turf/simulated/floor/wood,
-/area/medical/psych)
+/area/medical/psych/psych_1)
 "xmf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
@@ -34357,7 +34317,7 @@ hVx
 kcr
 mJq
 gzM
-bCW
+mur
 nhq
 eeL
 nhq

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -107,7 +107,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "acp" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -173,9 +173,7 @@
 	pixel_x = 25
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "afA" = (
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Emergecy Flood Storage";
@@ -191,7 +189,7 @@
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/machinery/scale,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "afO" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -962,7 +960,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "aMP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -1276,9 +1274,7 @@
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "bge" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -1351,9 +1347,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "bjl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -1471,9 +1465,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "bmN" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
 	dir = 1
@@ -1867,14 +1859,12 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "bEP" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "bFb" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
@@ -2131,9 +2121,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "bOg" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -2172,7 +2160,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "bPy" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2610,11 +2598,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
-"clC" = (
-/turf/simulated/wall,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
 "clG" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -2905,9 +2888,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/blue,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "cwJ" = (
 /obj/machinery/door/airlock{
 	name = "Restroom"
@@ -3016,9 +2997,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "cCe" = (
 /obj/machinery/light{
 	dir = 8;
@@ -3461,9 +3440,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "cUY" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3721,6 +3698,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay3)
+"ddh" = (
+/turf/simulated/wall,
+/area/medical/exam_room/exam_2)
 "ddE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3958,9 +3938,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "doH" = (
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/airless,
@@ -4190,9 +4168,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "dBv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
@@ -4382,9 +4358,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "dHz" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -4595,9 +4569,7 @@
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "dRj" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4660,7 +4632,7 @@
 /obj/item/bedsheet/medical,
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "dTK" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/white,
@@ -4989,9 +4961,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "eeL" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor,
@@ -5605,9 +5575,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "eHl" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -6055,7 +6023,7 @@
 /area/rnd/test_area)
 "fdT" = (
 /turf/simulated/wall,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "fdU" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/firealarm{
@@ -6346,9 +6314,7 @@
 /obj/item/clothing/head/surgery,
 /obj/item/clothing/under/rank/medical/scrubs,
 /turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "fpS" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -6901,9 +6867,7 @@
 	network = list("Research","Toxins Test Area")
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "fKa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -7655,9 +7619,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "grZ" = (
 /turf/simulated/floor/tiled,
 /area/medical/psych_ward)
@@ -7947,9 +7909,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "gAD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8127,9 +8087,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "gIt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -8513,7 +8471,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "gZq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/purple{
 	dir = 1
@@ -8734,7 +8692,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "hhX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9120,9 +9078,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/old_cargo/purple,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "hAr" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -9233,9 +9189,7 @@
 	req_access = list()
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "hHp" = (
 /obj/machinery/access_button{
 	master_tag = null;
@@ -9530,9 +9484,7 @@
 "hUs" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "hUt" = (
 /obj/random/trash,
 /obj/structure/railing,
@@ -10375,9 +10327,7 @@
 /obj/item/bedsheet/blue,
 /obj/structure/curtain/open/bed,
 /turf/simulated/floor/carpet/blue,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "iJE" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled,
@@ -10832,9 +10782,7 @@
 "jeQ" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "jfg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -10885,9 +10833,7 @@
 	req_one_access = list(47)
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "jgE" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 8
@@ -11047,9 +10993,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "jpk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -11999,9 +11943,7 @@
 "kcI" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "kcZ" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -12184,9 +12126,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "klW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -12420,7 +12360,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "kvz" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -12506,9 +12446,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "kxP" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/beige/border,
@@ -13055,9 +12993,7 @@
 /obj/machinery/light,
 /obj/item/reagent_containers/food/drinks/cup,
 /turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "kYs" = (
 /obj/machinery/alarm{
 	frequency = 1441;
@@ -13065,9 +13001,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "kYP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
@@ -13333,9 +13267,7 @@
 	name = "Robotics Operating Table"
 	},
 /turf/simulated/floor/tiled/old_cargo/purple,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "llO" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -13443,9 +13375,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "lrR" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -14149,9 +14079,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "lXD" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -14232,9 +14160,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "mdq" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 4
@@ -14525,7 +14451,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "mlt" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -14736,9 +14662,7 @@
 	},
 /obj/structure/curtain/open/shower/medical,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "mrJ" = (
 /obj/machinery/recharge_station,
 /obj/machinery/camera/network/research{
@@ -14798,9 +14722,7 @@
 	pixel_y = -31
 	},
 /turf/simulated/floor/carpet/blue,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "mvb" = (
 /obj/machinery/light{
 	dir = 1
@@ -15242,7 +15164,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "mNb" = (
 /obj/structure/table/woodentable,
 /obj/item/flashlight/lamp/green{
@@ -15280,17 +15202,13 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "mNz" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "mOL" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central6,
 /turf/simulated/floor/tiled,
@@ -15770,9 +15688,7 @@
 /obj/item/mmi/digital/posibrain,
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "nfm" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -15890,9 +15806,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "nmP" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -15947,9 +15861,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/old_cargo/purple,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "noo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16049,9 +15961,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "ntR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16378,9 +16288,7 @@
 /obj/machinery/scale,
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "nNN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16882,7 +16790,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "ogR" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	frequency = 1445;
@@ -17023,7 +16931,7 @@
 	id = "exam_1"
 	},
 /turf/simulated/floor/plating,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "olq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
@@ -17095,7 +17003,7 @@
 	name = "Exam Room 1"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "oqt" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 1;
@@ -17189,9 +17097,7 @@
 	pixel_x = -26
 	},
 /turf/simulated/floor/carpet/blue,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "ots" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloorwhite,
@@ -17307,9 +17213,7 @@
 	name = "Exam Room 2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "owX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17556,9 +17460,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "oFm" = (
 /obj/structure/bed/chair/wheelchair,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
@@ -17868,9 +17770,7 @@
 /area/medical/morgue)
 "oRt" = (
 /turf/simulated/wall/r_wall,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "oRy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18090,9 +17990,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "oYN" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18278,9 +18176,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/old_cargo/purple,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "pdO" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18671,9 +18567,7 @@
 /obj/item/clothing/under/rank/medical/scrubs,
 /obj/item/clothing/head/surgery,
 /turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "psm" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18756,9 +18650,7 @@
 "pvt" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "pvP" = (
 /turf/simulated/wall/r_wall,
 /area/medical/ward)
@@ -18978,9 +18870,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "pzW" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/research,
@@ -19007,7 +18897,7 @@
 "pAO" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "pAW" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -19043,9 +18933,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "pBu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -19837,9 +19725,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "qas" = (
 /turf/simulated/wall/r_wall,
 /area/medical/virologyaccess)
@@ -20719,9 +20605,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "qJZ" = (
 /turf/simulated/wall,
 /area/medical/chemistry)
@@ -20876,7 +20760,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "qPW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -21334,9 +21218,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "ref" = (
 /obj/machinery/light{
 	dir = 8;
@@ -21884,9 +21766,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "rxU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22303,7 +22183,7 @@
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "rPd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22594,9 +22474,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "sef" = (
 /obj/structure/toilet{
 	dir = 1
@@ -22858,9 +22736,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "smZ" = (
 /obj/machinery/camera/network/research{
 	dir = 1
@@ -23936,9 +23812,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "taT" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/effect/floor_decal/techfloor{
@@ -24420,9 +24294,7 @@
 /obj/machinery/cell_charger,
 /obj/item/surgical/bioregen,
 /turf/simulated/floor/tiled/old_cargo/purple,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "tpV" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -24838,9 +24710,7 @@
 	name = "SURGERY - AUTHORIZED PERSONNEL ONLY"
 	},
 /turf/simulated/wall,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "tCs" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
@@ -24951,9 +24821,7 @@
 /obj/item/clothing/accessory/stethoscope,
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "tJM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -24978,7 +24846,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "tKl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/purple{
 	dir = 8
@@ -25012,9 +24880,7 @@
 /area/rnd/xenobiology)
 "tLy" = (
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "tLH" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/machinery/door/blast/regular{
@@ -25728,9 +25594,7 @@
 /area/medical/medbay_primary_storage)
 "usN" = (
 /turf/simulated/wall,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "utF" = (
 /obj/structure/table/glass,
 /obj/item/backup_implanter{
@@ -25837,9 +25701,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "uxE" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -26092,9 +25954,7 @@
 /obj/item/mmi,
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "uHy" = (
 /obj/machinery/camera/network/research{
 	dir = 4;
@@ -28149,9 +28009,7 @@
 	id = "exam_2"
 	},
 /turf/simulated/floor/plating,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "wor" = (
 /turf/simulated/wall,
 /area/assembly/robotics)
@@ -28185,7 +28043,7 @@
 	name = "Medical Doctor"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "woX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -28763,9 +28621,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "wKv" = (
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/airless,
@@ -29218,9 +29074,7 @@
 	},
 /obj/item/storage/box/gloves,
 /turf/simulated/floor/tiled/old_cargo/gray,
-/area/medical/surgery{
-	name = "\improper Robotics Surgery Room"
-	})
+/area/assembly/robotics/surgery)
 "xcn" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -29252,7 +29106,7 @@
 	name = "Exam Room 1"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/exam_room/exam_1)
 "xdo" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/structure/cable/green{
@@ -29475,9 +29329,7 @@
 	name = "Exam Room 2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "xlS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29822,9 +29674,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Exam Room 2"
-	})
+/area/medical/exam_room/exam_2)
 "xAy" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -30315,9 +30165,7 @@
 /obj/item/clothing/head/surgery,
 /obj/item/clothing/under/rank/medical/scrubs,
 /turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "xUD" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -30623,9 +30471,7 @@
 /area/hallway/primary/port)
 "yhl" = (
 /turf/simulated/wall,
-/area/medical/biostorage{
-	name = "\improper Surgeon Break Room"
-	})
+/area/crew_quarters/medbreak/surgery)
 "yhu" = (
 /obj/machinery/light{
 	dir = 8
@@ -41754,13 +41600,13 @@ qJZ
 mak
 hxL
 bPy
-clC
-clC
-clC
-clC
-clC
-clC
-clC
+fdT
+fdT
+fdT
+fdT
+fdT
+fdT
+fdT
 fNm
 cbU
 tRd
@@ -41896,7 +41742,7 @@ nrB
 mak
 hxL
 vtk
-clC
+ddh
 tJn
 dQH
 eHf
@@ -42038,13 +41884,13 @@ gbb
 lUV
 fVB
 tvT
-clC
+ddh
 bEM
 oFe
 hUs
 hUs
 rdx
-clC
+ddh
 jqm
 dcC
 wMb
@@ -42180,7 +42026,7 @@ auK
 mak
 uWd
 vtk
-clC
+ddh
 kYs
 doo
 bdW
@@ -42322,13 +42168,13 @@ qJZ
 mak
 uWd
 ioo
-clC
+ddh
 gAA
 uxC
 wKj
 hUs
 hUs
-clC
+ddh
 tiM
 cbU
 tRd
@@ -42606,13 +42452,13 @@ dFO
 fZZ
 uWd
 csX
-clC
-clC
-clC
-clC
-clC
-clC
-clC
+ddh
+ddh
+ddh
+ddh
+ddh
+ddh
+ddh
 kuM
 nJe
 tRd

--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -336,9 +336,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/wood,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "aoK" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/red/border,
@@ -467,9 +465,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "aue" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -1236,16 +1232,12 @@
 	dir = 9
 	},
 /turf/simulated/floor/wood,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "bbO" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "bem" = (
 /obj/structure/table/rack,
 /obj/random/trash,
@@ -3322,9 +3314,7 @@
 	name = "Bridge"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "cDW" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3439,9 +3429,7 @@
 "cHO" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/carpet,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "cHX" = (
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
@@ -3599,9 +3587,7 @@
 /area/crew_quarters/sleep/CE_quarters)
 "cQt" = (
 /turf/simulated/wall/r_wall,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "cRe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4739,9 +4725,7 @@
 /area/triumph/surfacebase/sauna)
 "dOZ" = (
 /turf/simulated/wall/r_wall,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "dPR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/techfloor/orange{
@@ -6109,9 +6093,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "eND" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
@@ -7275,9 +7257,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/camera/network/command,
 /turf/simulated/floor/tiled/dark,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "fCb" = (
 /turf/simulated/wall/r_wall,
 /area/vacant/vacant_bar)
@@ -7514,9 +7494,7 @@
 	name = "Official Personal Storage"
 	},
 /turf/simulated/floor/wood,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "fOX" = (
 /obj/structure/sign/department/chapel,
 /turf/simulated/wall,
@@ -7705,9 +7683,7 @@
 /area/lawoffice)
 "fWb" = (
 /turf/simulated/open,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "fWZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7883,9 +7859,7 @@
 /area/bridge/hallway)
 "ggT" = (
 /turf/simulated/floor/carpet,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "ggU" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 8
@@ -9533,9 +9507,7 @@
 /area/triumph/surfacebase/sauna)
 "hrX" = (
 /turf/simulated/wall,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "hsS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/alarm/alarms_hidden{
@@ -10550,9 +10522,7 @@
 	},
 /obj/structure/flora/pottedplant/flower,
 /turf/simulated/floor/wood,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "hZS" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -10701,6 +10671,10 @@
 /obj/machinery/camera/network/exploration,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/excursion_dock)
+"ifn" = (
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/airless/ceiling,
+/area/bridge/hallway)
 "ify" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/red/border,
@@ -11189,9 +11163,7 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /turf/simulated/shuttle/floor/voidcraft,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "iyy" = (
 /obj/structure/loot_pile/maint/boxfort,
 /turf/simulated/floor/plating,
@@ -11451,9 +11423,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "iMD" = (
 /obj/structure/fitness/weightlifter,
 /turf/simulated/floor/tiled/dark,
@@ -13112,9 +13082,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/carpet,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "kgT" = (
 /obj/machinery/camera/network/outside{
 	dir = 10
@@ -13775,9 +13743,7 @@
 	pixel_x = -1
 	},
 /turf/simulated/floor/carpet,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "kMK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -13941,9 +13907,7 @@
 	},
 /obj/structure/table/marble,
 /turf/simulated/floor/wood,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "kSf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -14538,9 +14502,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "lpR" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/dark,
@@ -15027,9 +14989,7 @@
 	pixel_y = -31
 	},
 /turf/simulated/floor/tiled/dark,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "lEO" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -16347,9 +16307,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "mFS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16368,9 +16326,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/wood,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "mHf" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -16651,9 +16607,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "mRY" = (
 /obj/structure/bookcase{
 	name = "bookcase (Non-Fiction)"
@@ -17735,9 +17689,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/carpet,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "nFe" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel_grid,
@@ -17977,9 +17929,7 @@
 "nRc" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "nRf" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/structure/closet/secure_closet/guncabinet/excursion,
@@ -19086,9 +19036,7 @@
 "oIa" = (
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/wood,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "oIi" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -19245,9 +19193,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "oOP" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
@@ -21658,9 +21604,7 @@
 /obj/structure/table/marble,
 /obj/item/flashlight/lamp/green,
 /turf/simulated/floor/wood,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "qsQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22848,9 +22792,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "rhT" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/lino,
@@ -23232,9 +23174,7 @@
 /area/hydroponics/garden)
 "ruN" = (
 /turf/simulated/floor/wood,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "ruS" = (
 /turf/simulated/floor/wood/broken,
 /area/maintenance/central)
@@ -24200,9 +24140,7 @@
 "siD" = (
 /obj/machinery/computer/communications,
 /turf/simulated/floor/wood,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "sju" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
@@ -24620,9 +24558,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "szd" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -25303,9 +25239,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "sPq" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -25364,9 +25298,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "sRA" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -26592,9 +26524,7 @@
 "tUY" = (
 /obj/structure/sign/deck/fourth,
 /turf/simulated/wall,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "tVk" = (
 /obj/machinery/ai_slipper,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -26695,9 +26625,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "tZn" = (
 /obj/machinery/camera/network/civilian{
 	dir = 4
@@ -28343,9 +28271,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "vil" = (
 /obj/structure/table/reinforced,
 /obj/item/stamp/denied,
@@ -28398,9 +28324,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/dark,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "vlb" = (
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 8
@@ -28637,9 +28561,7 @@
 /area/triumph/surfacebase/tram)
 "vtG" = (
 /turf/simulated/floor/tiled/dark,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "vtY" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -28988,9 +28910,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "vFI" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -29614,9 +29534,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/dark,
-/area/station/stairs_one{
-	name = "\improper Station Stairwell Fourth Floor"
-	})
+/area/triumph/station/stairs_four)
 "vVM" = (
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
@@ -29931,9 +29849,7 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /turf/simulated/shuttle/floor/voidcraft,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "wfD" = (
 /turf/simulated/floor/tiled/dark,
 /area/gateway)
@@ -30604,6 +30520,15 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/central)
+"wFA" = (
+/obj/machinery/porta_turret/crescent{
+	density = 1;
+	faction = "neutral"
+	},
+/turf/simulated/floor/plating{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/bridge/hallway)
 "wFO" = (
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
@@ -30975,9 +30900,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/wood,
-/area/bridge{
-	name = "\improper Official On-Site Office"
-	})
+/area/bridge/office)
 "wUd" = (
 /obj/machinery/camera/network/exploration,
 /obj/structure/table/bench/steel,
@@ -48655,7 +48578,7 @@ nIK
 clY
 nIK
 dff
-dOZ
+dSw
 dSw
 lfI
 jgZ
@@ -48797,7 +48720,7 @@ nIK
 clY
 nIK
 dff
-dOZ
+dSw
 dSw
 icR
 oqg
@@ -48939,7 +48862,7 @@ nIK
 clY
 pkc
 dff
-dOZ
+dSw
 dSw
 gTD
 bFf
@@ -50217,7 +50140,7 @@ nIK
 clY
 nIK
 nIK
-rYN
+wFA
 dOZ
 iyp
 dOZ
@@ -50359,7 +50282,7 @@ nIK
 clY
 nIK
 nIK
-cBE
+ifn
 nIK
 nIK
 pkc

--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -662,9 +662,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "aCV" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/wood,
@@ -869,9 +867,7 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/taser,
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/taser,
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "aMF" = (
 /obj/structure/closet,
 /obj/random/maintenance/clean,
@@ -7805,9 +7801,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "gdJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -8230,9 +8224,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "gub" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -14921,9 +14913,7 @@
 "lCw" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "lCP" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -15098,9 +15088,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "lIz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -16124,9 +16112,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "myb" = (
 /obj/structure/closet/crate/mimic/cointoss,
 /obj/random/maintenance/security,
@@ -16950,9 +16936,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "nfb" = (
 /obj/machinery/light/small/emergency{
 	dir = 8
@@ -17388,9 +17372,7 @@
 	phorontanks = 0
 	},
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "nuT" = (
 /obj/machinery/door/airlock/glass_external{
 	name = "Public Airlock"
@@ -21505,9 +21487,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "qpa" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_security{
@@ -22049,9 +22029,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "qIu" = (
 /obj/structure/closet/hydrant{
 	pixel_x = 32
@@ -23043,9 +23021,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "rqT" = (
 /obj/effect/landmark/start{
 	name = "AI"
@@ -24333,9 +24309,7 @@
 /obj/item/clothing/head/helmet/space/void/security,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "spo" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/floor_decal/grass_edge{
@@ -26041,9 +26015,7 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "txO" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/security,
@@ -26455,9 +26427,7 @@
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide,
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "tSR" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -27447,9 +27417,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "uAw" = (
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/heads/hos)
@@ -27842,9 +27810,7 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/phase,
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/phase,
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "uRN" = (
 /obj/structure/toilet{
 	dir = 8
@@ -28384,9 +28350,7 @@
 /area/hydroponics/garden)
 "vnf" = (
 /turf/simulated/wall/r_wall,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "vnk" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/corner/red{
@@ -29660,9 +29624,7 @@
 /obj/item/clothing/head/helmet/space/void/security,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "vZU" = (
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ai)
@@ -31859,15 +31821,11 @@
 /obj/item/suit_cooling_unit,
 /obj/item/suit_cooling_unit,
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "xDT" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "xEu" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/structure/railing{
@@ -32102,9 +32060,7 @@
 /area/shuttle/excursion/general)
 "xMj" = (
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "xMk" = (
 /turf/simulated/wall,
 /area/maintenance/central)
@@ -32511,9 +32467,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "ycR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -32523,9 +32477,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "ydn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -32687,9 +32639,7 @@
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled,
-/area/security/recstorage{
-	name = "\improper Brig EVA Storage"
-	})
+/area/security/eva)
 "yjS" = (
 /obj/item/radio/intercom{
 	dir = 8;

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -1276,12 +1276,18 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "bridge"
 	music = "signal"
 
-/area/bridge_hallway
+/area/bridge/bridge_hallway
 	name = "Bridge Hallway"
 	icon_state = "bridge"
 
 /area/bridge/meeting_room
 	name = "Heads of Staff Meeting Room"
+	icon_state = "bridge"
+	music = null
+	sound_env = MEDIUM_SOFTFLOOR
+
+/area/bridge/office
+	name = "Official On-Site Office"
 	icon_state = "bridge"
 	music = null
 	sound_env = MEDIUM_SOFTFLOOR
@@ -2054,6 +2060,10 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "\improper Robotics Lab"
 	icon_state = "robotics"
 
+/area/assembly/robotics/surgery
+	name = "\improper Robotics Surgery"
+	icon_state = "surgery"
+
 /area/assembly/assembly_line //Derelict Assembly Line
 	name = "\improper Assembly Line"
 	icon_state = "ass_line"
@@ -2132,10 +2142,20 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "\improper Psych Room"
 	icon_state = "medbay3"
 
+/area/medical/psych/psych_1
+	name = "\improper Psych Room 1"
+
+/area/medical/psych/psych_2
+	name = "\improper Psych Room 2"
+
 /area/crew_quarters/medbreak
 	name = "\improper Break Room"
 	icon_state = "medbay3"
 	music = 'sound/ambience/signal.ogg'
+
+/area/crew_quarters/medbreak/surgery
+	name = "\improper Surgeon Break Room"
+	icon_state = "medbay2"
 
 /area/crew_quarters/medical_restroom
 	name = "\improper Medbay Restroom"
@@ -2219,6 +2239,9 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "\improper Operation Observation Room"
 	icon_state = "surgery"
 
+/area/medical/genetics
+	name = "\improper Genetics Lab"
+	icon_state = "genetics"
 /area/medical/surgeryprep
 	name = "\improper Pre-Op Prep Room"
 	icon_state = "surgery"
@@ -2239,9 +2262,11 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "\improper Exam Room"
 	icon_state = "exam_room"
 
-/area/medical/genetics
-	name = "\improper Genetics Lab"
-	icon_state = "genetics"
+/area/medical/exam_room/exam_1
+	name = "\improper Exam Room 1"
+
+/area/medical/exam_room/exam_2
+	name = "\improper Exam Room 2"
 
 /area/medical/genetics_cloning
 	name = "\improper Cloning Lab"
@@ -3406,6 +3431,10 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "dk_yellow"
 /area/triumph/station/stairs_three
 	name = "\improper Station Stairwell Third Floor"
+	icon_state = "dk_yellow"
+
+/area/triumph/station/stairs_four
+	name = "\improper Station Stairwell Fourth Floor"
 	icon_state = "dk_yellow"
 /area/triumph/station/dock_one
 	name = "\improper Dock One"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This purges all(?) varedited instances of areas from Triumph .dmms. Hopefully. @silicons be sure to double-check with linter in case I missed any.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
In *general* this is bad practice, because there are area-specific events (radiation storm, brig virus, any potential new ones) that can inadvertently affect an area you never intended it to, simply because you were a lazy mapper and instanced instead of adding 2-3 lines of new code.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:FreeStylaLT
fix:Area errors. You won't know where, trust me.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
