### PR TITLE
Returns the missing core eject button to Bridge

### DIFF
--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -1695,6 +1695,10 @@
 /area/triumph/surfacebase/sauna)
 "bup" = (
 /obj/structure/closet/emcloset,
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "buK" = (
@@ -3838,18 +3842,29 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/civilian_hallway_mid)
 "djA" = (
-/obj/machinery/camera/network/command{
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = -24
+/obj/machinery/button/remote/driver{
+	dir = 4;
+	id = "enginecore";
+	name = "Emergency Core Eject";
+	pixel_x = -22
 	},
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/folder/red,
-/obj/item/folder/blue,
-/obj/item/pen,
+/obj/effect/floor_decal/industrial/danger/cee{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "EngineVent";
+	name = "Reactor Ventillatory Control";
+	pixel_x = -33;
+	req_access = list(10)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "djR" = (
@@ -16118,6 +16133,14 @@
 /obj/random/maintenance/security,
 /turf/simulated/floor/plating,
 /area/maintenance/security/starboard)
+"mym" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/folder/red,
+/obj/item/folder/blue,
+/obj/item/pen,
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "myH" = (
 /obj/machinery/door/window/brigdoor/westright{
 	dir = 4;
@@ -50409,7 +50432,7 @@ duy
 dqW
 pox
 iTO
-pox
+mym
 hYd
 pox
 kzW


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I have no concrete clue how this was removed in the sec remap, but it was entirely unintentional.

![image](https://user-images.githubusercontent.com/11361525/113255804-efdca600-92d0-11eb-8c8e-b763d8543a75.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Command should probably be able to make emergency engine calls from bridge. In case of, you know, an _imminent explosion._
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: FreeStylaLT
fix: Missing core ejection button from Bridge
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
