### PR TITLE
Adds an emote cooldown system. Adds a 3 second cooldown to every emote that plays a sound.

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -31,3 +31,7 @@
 /datum/config_entry/number/client_error_build
 	config_entry_value = null
 	min_val = 0
+
+/datum/config_entry/number/sound_emote_cooldown
+	config_entry_value = 30
+	min_val = 0

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,20 +1,13 @@
-#define EMOTE_COOLDOWN 30		//Time in deciseconds that the cooldown lasts
-
 //Emote Cooldown System
-/mob/proc/handle_emote_CD(cooldown = EMOTE_COOLDOWN)
-	if(emote_cd == 3) //Spam those emotes
-		return FALSE
-	if(emote_cd == 2) // Cooldown emotes were disabled by an admin, prevent use
+/mob/proc/handle_emote_cd(cooldown)
+	if(!cooldown)
+		cooldown = CONFIG_GET(number/sound_emote_cooldown)	//Default 30 deciseconds (3 seconds)
+	if(!emote_cd)
+		emote_cd = TRUE	// Starting cooldown
+		addtimer(VARSET_CALLBACK(src, emote_cd, FALSE),cooldown)
+		return FALSE // Proceed with emote
+	else
 		return TRUE
-	if(emote_cd == 1)  // Already on CD, prevent use
-		return TRUE
-
-	emote_cd = TRUE	// Starting cooldown
-	spawn(cooldown)
-		if(emote_cd == 2)
-			return // Don't reset if cooldown emotes were disabled by an admin during the cooldown
-		emote_cd = FALSE // Cooldown complete, ready for more!
-	return FALSE // Proceed with emote
 
 // All mobs should have custom emote, really..
 //m_type == 1 --> visual.

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,6 +1,6 @@
 #define EMOTE_COOLDOWN 30		//Time in deciseconds that the cooldown lasts
 
-//Emote Cooldown System (it's so simple!)
+//Emote Cooldown System
 /mob/proc/handle_emote_CD(cooldown = EMOTE_COOLDOWN)
 	if(emote_cd == 3) //Spam those emotes
 		return FALSE

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,3 +1,21 @@
+#define EMOTE_COOLDOWN 30		//Time in deciseconds that the cooldown lasts
+
+//Emote Cooldown System (it's so simple!)
+/mob/proc/handle_emote_CD(cooldown = EMOTE_COOLDOWN)
+	if(emote_cd == 3) //Spam those emotes
+		return FALSE
+	if(emote_cd == 2) // Cooldown emotes were disabled by an admin, prevent use
+		return TRUE
+	if(emote_cd == 1)  // Already on CD, prevent use
+		return TRUE
+
+	emote_cd = TRUE	// Starting cooldown
+	spawn(cooldown)
+		if(emote_cd == 2)
+			return // Don't reset if cooldown emotes were disabled by an admin during the cooldown
+		emote_cd = FALSE // Cooldown complete, ready for more!
+	return FALSE // Proceed with emote
+
 // All mobs should have custom emote, really..
 //m_type == 1 --> visual.
 //m_type == 2 --> audible

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -36,11 +36,21 @@
 				on_CD = handle_emote_CD()		//proc located in code\modules\mob\emote.dm'
 			else
 				return
-		if("clap","cough","coughs","crack","sneeze","sneezes","slap","slaps","aslap","aslaps","scream","screams","squeak","squeaks","meow","meows","snap","snaps","whistle","whistles","qwhistle","flip")
+		if("clap","crack","slap","slaps","aslap","aslaps","flip")
 			if(!src.restrained())
 				on_CD = handle_emote_CD()		//proc located in code\modules\mob\emote.dm'
 			else
 				return
+		if("cough","coughs","sneeze","sneezes","scream","screams","squeak","squeaks","meow","meows","whistle","whistles","qwhistle")
+			if(!muzzled)
+				on_CD = handle_emote_CD()		//proc located in code\modules\mob\emote.dm'
+			else
+				return
+		if("snap","snaps")
+			if(!src.restrained())
+				on_CD = handle_emote_CD(5)		//0.5s. People like to snap quickly.
+				return
+
 	if(on_CD == 1)	//Check if we need to suppress the emote
 		return		//Suppress the emote
 	if(attempt_vr(src,"handle_emote_vr",list(act,m_type,message))) return //VOREStation Add - Custom Emote Handler

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -2,7 +2,7 @@
 	var/param = null
 
 	//Emote Cooldown System
-	//handle_emote_CD() located in [code\modules\mob\emote.dm]
+	/handle_emote_cd() located in [code\modules\mob\emote.dm]
 	var/on_CD = FALSE
 	var/datum/gender/T = gender_datums[get_visible_gender()]
 
@@ -28,19 +28,19 @@
 	switch(act)
 		if("squish")
 			if(species.bump_flag == SLIME)
-				on_CD = handle_emote_CD()		//proc located in code\modules\mob\emote.dm'
+				on_CD =handle_emote_cd()		//proc located in code\modules\mob\emote.dm'
 		if("shriekloud","shriekshort")
 			if(src.species.name == SPECIES_VOX)
-				on_CD = handle_emote_CD()		//proc located in code\modules\mob\emote.dm'
+				on_CD =handle_emote_cd()		//proc located in code\modules\mob\emote.dm'
 		if("clap","crack","slap","slaps","aslap","aslaps","flip")
 			if(!src.restrained())
-				on_CD = handle_emote_CD()		//proc located in code\modules\mob\emote.dm'
+				on_CD =handle_emote_cd()		//proc located in code\modules\mob\emote.dm'
 		if("cough","coughs","sneeze","sneezes","scream","screams","squeak","squeaks","meow","meows","whistle","whistles","qwhistle")
 			if(!muzzled)
-				on_CD = handle_emote_CD()		//proc located in code\modules\mob\emote.dm'
+				on_CD =handle_emote_cd()		//proc located in code\modules\mob\emote.dm'
 		if("snap","snaps")
 			if(!src.restrained())
-				on_CD = handle_emote_CD(5)		//0.5s. People like to snap quickly.
+				on_CD =handle_emote_cd(5)		//0.5s. People like to snap quickly.
 
 	if(on_CD == 1)	//Check if we need to suppress the emote
 		return		//Suppress the emote
@@ -58,7 +58,7 @@
 			if(!isSynthetic())
 				to_chat(src, "<span class='warning'>You are not a synthetic.</span>")
 				return
-			on_CD = handle_emote_CD()	//proc located in code\modules\mob\emote.dm'
+			on_CD =handle_emote_cd()	//proc located in code\modules\mob\emote.dm'
 			var/M = null
 			if(param)
 				for (var/mob/A in view(null, null))
@@ -898,7 +898,7 @@
 	var/on_CD = FALSE
 	switch(act)
 		if("awoo","nya","peep","chirp","weh","merp","bark","hiss","squeak","purr")
-			on_CD = handle_emote_CD()	//proc located in code\modules\mob\emote.dm'
+			on_CD =handle_emote_cd()	//proc located in code\modules\mob\emote.dm'
 	if(on_CD == 1)	//Check if we need to suppress the emote
 		return		//Suppress the emote
 	switch(act)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -36,7 +36,7 @@
 				on_CD = handle_emote_CD()		//proc located in code\modules\mob\emote.dm'
 			else
 				return
-		if("clap","cough","coughs","crack","sneeze","sneezes","slap","slaps","aslap","aslaps","scream","screams","squeak","squeaks","meow","meows","snap","snaps","whistle","whistles","qwhistle")
+		if("clap","cough","coughs","crack","sneeze","sneezes","slap","slaps","aslap","aslaps","scream","screams","squeak","squeaks","meow","meows","snap","snaps","whistle","whistles","qwhistle","flip")
 			if(!src.restrained())
 				on_CD = handle_emote_CD()		//proc located in code\modules\mob\emote.dm'
 			else

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -2,7 +2,7 @@
 	var/param = null
 
 	//Emote Cooldown System
-	/handle_emote_cd() located in [code\modules\mob\emote.dm]
+	//handle_emote_cd() located in [code\modules\mob\emote.dm]
 	var/on_CD = FALSE
 	var/datum/gender/T = gender_datums[get_visible_gender()]
 
@@ -28,16 +28,16 @@
 	switch(act)
 		if("squish")
 			if(species.bump_flag == SLIME)
-				on_CD =handle_emote_cd()		//proc located in code\modules\mob\emote.dm'
+				on_CD = handle_emote_cd()		//proc located in code\modules\mob\emote.dm'
 		if("shriekloud","shriekshort")
 			if(src.species.name == SPECIES_VOX)
-				on_CD =handle_emote_cd()		//proc located in code\modules\mob\emote.dm'
+				on_CD = handle_emote_cd()		//proc located in code\modules\mob\emote.dm'
 		if("clap","crack","slap","slaps","aslap","aslaps","flip")
 			if(!src.restrained())
-				on_CD =handle_emote_cd()		//proc located in code\modules\mob\emote.dm'
+				on_CD = handle_emote_cd()		//proc located in code\modules\mob\emote.dm'
 		if("cough","coughs","sneeze","sneezes","scream","screams","squeak","squeaks","meow","meows","whistle","whistles","qwhistle")
 			if(!muzzled)
-				on_CD =handle_emote_cd()		//proc located in code\modules\mob\emote.dm'
+				on_CD = handle_emote_cd()		//proc located in code\modules\mob\emote.dm'
 		if("snap","snaps")
 			if(!src.restrained())
 				on_CD =handle_emote_cd(5)		//0.5s. People like to snap quickly.

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -29,28 +29,18 @@
 		if("squish")
 			if(species.bump_flag == SLIME)
 				on_CD = handle_emote_CD()		//proc located in code\modules\mob\emote.dm'
-			else
-				return
 		if("shriekloud","shriekshort")
 			if(src.species.name == SPECIES_VOX)
 				on_CD = handle_emote_CD()		//proc located in code\modules\mob\emote.dm'
-			else
-				return
 		if("clap","crack","slap","slaps","aslap","aslaps","flip")
 			if(!src.restrained())
 				on_CD = handle_emote_CD()		//proc located in code\modules\mob\emote.dm'
-			else
-				return
 		if("cough","coughs","sneeze","sneezes","scream","screams","squeak","squeaks","meow","meows","whistle","whistles","qwhistle")
 			if(!muzzled)
 				on_CD = handle_emote_CD()		//proc located in code\modules\mob\emote.dm'
-			else
-				return
 		if("snap","snaps")
 			if(!src.restrained())
 				on_CD = handle_emote_CD(5)		//0.5s. People like to snap quickly.
-			else
-				return
 
 	if(on_CD == 1)	//Check if we need to suppress the emote
 		return		//Suppress the emote

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -49,6 +49,7 @@
 		if("snap","snaps")
 			if(!src.restrained())
 				on_CD = handle_emote_CD(5)		//0.5s. People like to snap quickly.
+			else
 				return
 
 	if(on_CD == 1)	//Check if we need to suppress the emote

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -1,6 +1,9 @@
 /mob/living/carbon/human/emote(var/act,var/m_type=1,var/message = null)
 	var/param = null
 
+	//Emote Cooldown System
+	//handle_emote_CD() located in [code\modules\mob\emote.dm]
+	var/on_CD = FALSE
 	var/datum/gender/T = gender_datums[get_visible_gender()]
 
 	if (findtext(act, "-", 1, null))
@@ -21,6 +24,25 @@
 
 	if(src.stat == 2.0 && (act != "deathgasp"))
 		return
+
+	switch(act)
+		if("squish")
+			if(species.bump_flag == SLIME)
+				on_CD = handle_emote_CD()		//proc located in code\modules\mob\emote.dm'
+			else
+				return
+		if("shriekloud","shriekshort")
+			if(src.species.name == SPECIES_VOX)
+				on_CD = handle_emote_CD()		//proc located in code\modules\mob\emote.dm'
+			else
+				return
+		if("clap","cough","coughs","crack","sneeze","sneezes","slap","slaps","aslap","aslaps","scream","screams","squeak","squeaks","meow","meows","snap","snaps","whistle","whistles","qwhistle")
+			if(!src.restrained())
+				on_CD = handle_emote_CD()		//proc located in code\modules\mob\emote.dm'
+			else
+				return
+	if(on_CD == 1)	//Check if we need to suppress the emote
+		return		//Suppress the emote
 	if(attempt_vr(src,"handle_emote_vr",list(act,m_type,message))) return //VOREStation Add - Custom Emote Handler
 	switch(act)
 
@@ -35,7 +57,7 @@
 			if(!isSynthetic())
 				to_chat(src, "<span class='warning'>You are not a synthetic.</span>")
 				return
-
+			on_CD = handle_emote_CD()	//proc located in code\modules\mob\emote.dm'
 			var/M = null
 			if(param)
 				for (var/mob/A in view(null, null))
@@ -44,6 +66,8 @@
 						break
 			if(!M)
 				param = null
+			if(on_CD == 1)		//Check if we need to suppress the emote
+				return			//Suppress the emote
 
 			var/display_msg = "beeps"
 			var/use_sound = 'sound/machines/twobeep.ogg'
@@ -870,7 +894,12 @@
 	src << browse(HTML, "window=flavor_changes;size=430x300")
 
 /mob/living/carbon/human/proc/handle_emote_vr(var/act,var/m_type=1,var/message = null)
-
+	var/on_CD = FALSE
+	switch(act)
+		if("awoo","nya","peep","chirp","weh","merp","bark","hiss","squeak","purr")
+			on_CD = handle_emote_CD()	//proc located in code\modules\mob\emote.dm'
+	if(on_CD == 1)	//Check if we need to suppress the emote
+		return		//Suppress the emote
 	switch(act)
 		if ("vwag")
 			if(toggle_tail_vr(message = 1))

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -137,6 +137,7 @@
 	var/m_int = null//Living
 	var/lastKnownIP = null
 	var/obj/buckled = null//Living
+	var/emote_cd = 0		// Used to supress emote spamming. 1 if on CD, 2 if disabled by admin (manually set), else 0
 
 	var/seer = 0 //for cult//Carbon, probably Human
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -137,7 +137,7 @@
 	var/m_int = null//Living
 	var/lastKnownIP = null
 	var/obj/buckled = null//Living
-	var/emote_cd = 0		// Used to supress emote spamming. 1 if on CD, 2 if disabled by admin (manually set), else 0
+	var/emote_cd = 0		// Used to supress emote spamming. 1 if on CD, 0 if not
 
 	var/seer = 0 //for cult//Carbon, probably Human
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This limits the macro-spamming players from being annoying and allows admins to set `emote_cd` on mobs to 2 to mute them from audible emotes entirely.

Ported from Paradise.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The less spam, the better.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:FreeStylaLT
add:Emote cooldown for every audible emote
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
