### PR TITLE
Following an unfortunate incident where an employee was found drowned in a pool, NT has added appropriate safety measures.

### DIFF
--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -570,6 +570,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"ayC" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/hydroponics/garden)
 "aza" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2529,10 +2538,7 @@
 	dir = 4
 	},
 /obj/structure/railing,
-/obj/effect/floor_decal/grass_edge{
-	dir = 1
-	},
-/turf/simulated/floor/grass,
+/turf/simulated/wall,
 /area/hydroponics/garden)
 "bXv" = (
 /obj/structure/filingcabinet/filingcabinet,
@@ -3682,6 +3688,12 @@
 	},
 /obj/structure/lightpost,
 /turf/simulated/floor/grass,
+/area/hydroponics/garden)
+"cVg" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
 /area/hydroponics/garden)
 "cVO" = (
 /turf/simulated/floor/tiled,
@@ -9198,6 +9210,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
@@ -17108,6 +17123,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/structure/flora/pottedplant/orientaltree,
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "nls" = (
@@ -21192,6 +21208,7 @@
 	dir = 1
 	},
 /obj/structure/table/bench/wooden,
+/obj/item/clothing/shoes/swimmingfins,
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
 "qgO" = (
@@ -21917,6 +21934,9 @@
 	dir = 1
 	},
 /obj/machinery/shield_diffuser,
+/obj/structure/sign/warning/falling{
+	pixel_y = 34
+	},
 /turf/simulated/floor/outdoors/water,
 /area/hydroponics/garden)
 "qEc" = (
@@ -22172,6 +22192,12 @@
 /obj/item/reagent_containers/food/snacks/fishandchips,
 /turf/simulated/floor/plating,
 /area/maintenance/security/starboard)
+"qMT" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/hydroponics/garden)
 "qNn" = (
 /obj/machinery/light{
 	dir = 1
@@ -23161,6 +23187,9 @@
 "rtS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
@@ -31572,7 +31601,7 @@
 	},
 /obj/structure/railing,
 /obj/effect/floor_decal/grass_edge{
-	dir = 1
+	dir = 5
 	},
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/firealarm{
@@ -31946,7 +31975,7 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/railing,
 /obj/effect/floor_decal/grass_edge{
-	dir = 1
+	dir = 9
 	},
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
@@ -32125,6 +32154,13 @@
 /obj/machinery/vending/fishing,
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
+"xOL" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/hydroponics/garden)
 "xOV" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -32186,7 +32222,9 @@
 "xQh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/flora/pottedplant/orientaltree,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
 "xQn" = (
@@ -42893,7 +42931,7 @@ hLJ
 lFS
 bjU
 wdF
-nen
+ayC
 xJI
 hGE
 fuD
@@ -43035,7 +43073,7 @@ bfm
 xqQ
 gkx
 cKH
-xJI
+cVg
 qXg
 wzj
 vmR
@@ -43177,7 +43215,7 @@ xsj
 btG
 rZq
 vWU
-xJI
+cVg
 xJI
 wns
 ecI
@@ -43319,7 +43357,7 @@ bXk
 qDS
 iNL
 oxG
-eqv
+xOL
 xJI
 wns
 ccJ
@@ -43461,7 +43499,7 @@ xIk
 prc
 iSJ
 wkS
-xJI
+cVg
 xJI
 wns
 rSA
@@ -43603,7 +43641,7 @@ sXD
 xQh
 hgh
 rtS
-xJI
+qMT
 xJI
 xJI
 qXg


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Nanotrasen's Human Resources division was left disturbed by an incident where an employee was found drowned inside a pool. Preliminary investigation found it to likely have been an accident.

Due to this, appropriate measures have been taken:
![image](https://user-images.githubusercontent.com/11361525/113862976-c1b80400-97b1-11eb-949a-aab3a96070fb.png)
- The exterior of the railing has been covered by a hazard line, indicating potential danger
- A falling hazard sign has been added, to signify potential dangers of falling inside the pool
- A pair of swimming fins were added to aid in rescue.

## Why It's Good For The Game
With these added measures Nanotrasen hopes the crew can feel safe and their morale reinvigorated, knowing that the corporation is willing to take every precaution necessary to avoid any further tragedies. We Care:tm:


## Changelog
:cl:FreeStylaLT
add: Safety features around the pool
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
