### PR TITLE
makes dice cups able to hold 6 dice instead of 5

### DIFF
--- a/code/modules/games/dice.dm
+++ b/code/modules/games/dice.dm
@@ -117,7 +117,7 @@
 	icon = 'icons/obj/dice.dmi'
 	icon_state = "dicecup"
 	w_class = ITEMSIZE_SMALL
-	storage_slots = 5
+	storage_slots = 6
 	can_hold = list(
 		/obj/item/dice,
 		)
@@ -157,5 +157,5 @@
 
 
 /obj/item/storage/dicecup/loaded/PopulateContents()
-	for(var/i = 1 to 5)
+	for(var/i = 1 to 6)
 		new /obj/item/dice( src )


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
it is what it says on the tin
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
you can play the dice game from KCD now if you want need i say more that's right i needn't
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: dice cups hold 6 dice now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
