### PR TITLE
makes minor rad weakness actually cause 25% more rads like it says instead of 35% more

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
@@ -100,7 +100,7 @@
 	name = "Radiation Weakness"
 	desc = "You take 25% more radition damage"
 	cost = -1
-	var_changes = list("radiation_mod" = 1.35)
+	var_changes = list("radiation_mod" = 1.25)
 
 /datum/trait/rad_weak_plus
 	name = "Major Radiation Weakness"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
consistency and accuracy = poggers
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: made the minor rad trait mechanically accurate to its description
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
