### PR TITLE
max mob size reduced to 150% from 200%

### DIFF
--- a/code/modules/client/preference_setup/vore/02_size.dm
+++ b/code/modules/client/preference_setup/vore/02_size.dm
@@ -59,8 +59,8 @@
 
 /datum/category_item/player_setup_item/vore/size/OnTopic(var/href, var/list/href_list, var/mob/user)
 	if(href_list["size_multiplier"])
-		var/new_size = input(user, "Choose your character's size, ranging from 25% to 200%", "Set Size") as num|null
-		if (!ISINRANGE(new_size,25,200))
+		var/new_size = input(user, "Choose your character's size, ranging from 25% to 150%", "Set Size") as num|null
+		if (!ISINRANGE(new_size,25,150))
 			pref.size_multiplier = 1
 			to_chat(user, "<span class='notice'>Invalid size.</span>")
 			return TOPIC_REFRESH_UPDATE_PREVIEW

--- a/code/modules/clothing/under/miscellaneous_vr.dm
+++ b/code/modules/clothing/under/miscellaneous_vr.dm
@@ -62,7 +62,7 @@
 		to_chat(H,"<span class='warning'>You must be WEARING the uniform to change your size.</span>")
 		return
 
-	var/new_size = input("Put the desired size (25-200%)", "Set Size", 200) as num|null
+	var/new_size = input("Put the desired size (25-150%)", "Set Size", 200) as num|null
 
 	//Check AGAIN because we accepted user input which is blocking.
 	if (src != H.w_uniform)
@@ -78,7 +78,7 @@
 		H.update_icons() //Just want the matrix transform
 		return
 
-	if (!ISINRANGE(new_size,25,200))
+	if (!ISINRANGE(new_size,25,150))
 		to_chat(H,"<span class='notice'>The safety features of the uniform prevent you from choosing this size.</span>")
 		return
 

--- a/code/modules/mob/living/carbon/human/species/station/protean/protean_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean/protean_powers.dm
@@ -302,9 +302,9 @@
 		to_chat(user,"<span class='warning'>You don't have a working refactory module!</span>")
 		return
 
-	var/nagmessage = "Adjust your mass to be a size between 25 to 200%. Up-sizing consumes metal, downsizing returns metal."
+	var/nagmessage = "Adjust your mass to be a size between 25 to 150%. Up-sizing consumes metal, downsizing returns metal."
 	var/new_size = input(user, nagmessage, "Pick a Size", user.size_multiplier*100) as num|null
-	if(!new_size || !ISINRANGE(new_size,25,200))
+	if(!new_size || !ISINRANGE(new_size,25,150))
 		return
 
 	var/size_factor = new_size/100

--- a/code/modules/nifsoft/software/15_misc.dm
+++ b/code/modules/nifsoft/software/15_misc.dm
@@ -133,9 +133,9 @@
 
 	activate()
 		if((. = ..()))
-			var/new_size = input("Put the desired size (25-200%)", "Set Size", 200) as num
+			var/new_size = input("Put the desired size (25-150%)", "Set Size", 200) as num
 
-			if (!ISINRANGE(new_size,25,200))
+			if (!ISINRANGE(new_size,25,150))
 				to_chat(nif.human,"<span class='notice'>The safety features of the NIF Program prevent you from choosing this size.</span>")
 				return
 			else

--- a/code/modules/resleeving/designer.dm
+++ b/code/modules/resleeving/designer.dm
@@ -311,8 +311,8 @@
 		return
 
 	if(href_list["size_multiplier"])
-		var/new_size = input(user, "Choose your character's size, ranging from 25% to 200%", "Character Preference") as num|null
-		if(new_size && ISINRANGE(new_size,25,200))
+		var/new_size = input(user, "Choose your character's size, ranging from 25% to 150%", "Character Preference") as num|null
+		if(new_size && ISINRANGE(new_size,25,150))
 			active_br.sizemult = (new_size/100)
 			preview_icon = null
 		return 1

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -107,9 +107,9 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 	set name = "Adjust Mass"
 	set category = "Abilities" //Seeing as prometheans have an IC reason to be changing mass.
 
-	var/nagmessage = "Adjust your mass to be a size between 25 to 200% (DO NOT ABUSE)"
+	var/nagmessage = "Adjust your mass to be a size between 25 to 150% (DO NOT ABUSE)"
 	var/new_size = input(nagmessage, "Pick a Size") as num|null
-	if(new_size && ISINRANGE(new_size,25,200))
+	if(new_size && ISINRANGE(new_size,25,150))
 		src.resize(new_size/100, TRUE)
 		message_admins("[key_name(src)] used the resize command in-game to be [new_size]% size. \
 			([src ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>" : "null"])")


### PR DESCRIPTION

## About The Pull Request

max mob size reduced to 150% from 200%

## Why It's Good For The Game

mobs shouldn't be 3 tiles long or tall considering for headgear and different turf layers. dog borgs (and normal player mobs) at 200% can take up an entire hallway and no longer interact with things predictably; they enter doors above their sprite, couches can cover parts of them, etc

## Changelog
tweak: max mob size reduced to 150% from 200%
