### PR TITLE
makes explorer pins work anywhere off station, not just on explorer levels sue me

### DIFF
--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -185,7 +185,7 @@
 	var/turf/T = get_turf(src)
 	if(!locked)
 		return TRUE
-	if(T.z in GLOB.using_map.map_levels)
+	if(T.z in GLOB.using_map.station_levels)
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

using this on lavaland/beltmining is based, if i wanted to commit homicide i'd use a kinetic accelerator anyways 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: explorer pins now work on lavaland/anywhere off station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
