### PR TITLE
fixes antimagic components, gives inversion beams 0.66x damage if someone is antimagic shielded

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -78,3 +78,5 @@
 #define isbot(A) istype(A, /mob/living/bot)
 
 #define isxeno(A) istype(A, /mob/living/simple_mob/xeno)
+
+#define issimple(A) istype(A, /mob/living/simple_mob)

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -75,13 +75,11 @@ var/const/tk_maxrange = 15
 	var/mob/living/host = null
 
 /obj/item/tk_grab/dropped(mob/user as mob)
+	. = ..()
 	if(focus && user && loc != user && loc != user.loc) // drop_item() gets called when you tk-attack a table/closet with an item
 		if(focus.Adjacent(loc))
-			focus.loc = loc
-	loc = null
-	spawn(1)
-		qdel(src)
-	return
+			focus.forceMove(loc)
+	qdel(src)
 
 //stops TK grabs being equipped anywhere but into hands
 /obj/item/tk_grab/equipped(var/mob/user, var/slot)

--- a/code/game/gamemodes/changeling/powers/armblade.dm
+++ b/code/game/gamemodes/changeling/powers/armblade.dm
@@ -75,18 +75,17 @@
 		src.creator = loc
 
 /obj/item/melee/changeling/dropped(mob/user)
+	. = ..()
 	visible_message("<span class='warning'>With a sickening crunch, [creator] reforms their arm!</span>",
 	"<span class='notice'>We assimilate the weapon back into our body.</span>",
 	"<span class='italics'>You hear organic matter ripping and tearing!</span>")
 	playsound(src, 'sound/effects/blobattack.ogg', 30, 1)
-	spawn(1)
-		if(src)
-			qdel(src)
+	qdel(src)
 
 /obj/item/melee/changeling/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	creator = null
-	..()
+	return ..()
 
 /obj/item/melee/changeling/suicide_act(mob/user)
 	var/datum/gender/T = gender_datums[user.get_visible_gender()]

--- a/code/game/gamemodes/changeling/powers/armor.dm
+++ b/code/game/gamemodes/changeling/powers/armor.dm
@@ -49,6 +49,7 @@
 		"<span class='italics'>You hear organic matter ripping and tearing!</span>")
 
 /obj/item/clothing/suit/space/changeling/dropped()
+	. = ..()
 	qdel(src)
 
 /obj/item/clothing/head/helmet/space/changeling
@@ -61,6 +62,7 @@
 	canremove = 0
 
 /obj/item/clothing/head/helmet/space/changeling/dropped()
+	. = ..()
 	qdel(src)
 
 /obj/item/clothing/shoes/magboots/changeling

--- a/code/game/gamemodes/changeling/powers/bioelectrogenesis.dm
+++ b/code/game/gamemodes/changeling/powers/bioelectrogenesis.dm
@@ -123,9 +123,8 @@
 		new /obj/effect/effect/sparks(T)
 
 /obj/item/electric_hand/dropped(mob/user)
-	spawn(1)
-		if(src)
-			qdel(src)
+	. = ..()
+	qdel(src)
 
 /obj/item/electric_hand/afterattack(var/atom/target, var/mob/living/carbon/human/user, proximity)
 	if(!target)

--- a/code/game/gamemodes/changeling/powers/electric_lockpick.dm
+++ b/code/game/gamemodes/changeling/powers/electric_lockpick.dm
@@ -38,10 +38,9 @@
 		to_chat(loc, "<span class='notice'>We shape our finger to fit inside electronics, and are ready to force them open.</span>")
 
 /obj/item/finger_lockpick/dropped(mob/user)
+	. = ..()
 	to_chat(user, "<span class='notice'>We discreetly shape our finger back to a less suspicious form.</span>")
-	spawn(1)
-		if(src)
-			qdel(src)
+	qdel(src)
 
 /obj/item/finger_lockpick/afterattack(var/atom/target, var/mob/living/user, proximity)
 	if(!target)

--- a/code/game/gamemodes/cult/construct_spells.dm
+++ b/code/game/gamemodes/cult/construct_spells.dm
@@ -578,7 +578,7 @@ proc/findNullRod(var/atom/target)
 	light_power = -2
 	light_color = "#FFFFFF"
 	antimagic_check = TRUE
-	antimagic_damage_factor = 0.25
+	antimagic_damage_factor = 0.66
 
 	muzzle_type = /obj/effect/projectile/muzzle/inversion
 	tracer_type = /obj/effect/projectile/tracer/inversion

--- a/code/game/gamemodes/cult/construct_spells.dm
+++ b/code/game/gamemodes/cult/construct_spells.dm
@@ -577,6 +577,8 @@ proc/findNullRod(var/atom/target)
 	light_range = 2
 	light_power = -2
 	light_color = "#FFFFFF"
+	antimagic_check = TRUE
+	antimagic_damage_factor = 0.25
 
 	muzzle_type = /obj/effect/projectile/muzzle/inversion
 	tracer_type = /obj/effect/projectile/tracer/inversion

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -41,7 +41,8 @@
 
 	return 1
 
-/obj/item/melee/cultblade/pickup(mob/living/user as mob)
+/obj/item/melee/cultblade/pickup(mob/user)
+	. = ..()
 	if(!iscultist(user) && !istype(user, /mob/living/simple_mob/construct))
 		to_chat(user, "<span class='warning'>An overwhelming feeling of dread comes over you as you pick up the cultist's sword. It would be wise to be rid of this blade quickly.</span>")
 		user.make_dizzy(120)

--- a/code/game/gamemodes/technomancer/spell_objs.dm
+++ b/code/game/gamemodes/technomancer/spell_objs.dm
@@ -285,9 +285,8 @@
 // Parameters: 0
 // Description: Deletes the spell object immediately.
 /obj/item/spell/dropped()
-	spawn(1)
-		if(src)
-			qdel(src)
+	. = ..()
+	qdel(src)
 
 // Proc: throw_impact()
 // Parameters: 1 (hit_atom - the atom that got hit by the spell as it was thrown)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -342,7 +342,7 @@
 /obj/item/proc/pickup(mob/user)
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user)
-	item_flags |= IN_INVENTORY
+	// item_flags |= IN_INVENTORY
 
 // called when this item is removed from a storage item, which is passed on as S. The loc variable is already set to the new destination before this is called.
 /obj/item/proc/on_exit_storage(obj/item/storage/S as obj)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -321,6 +321,7 @@
 
 // apparently called whenever an item is removed from a slot, container, or anything else.
 /obj/item/proc/dropped(mob/user as mob)
+	SHOULD_CALL_PARENT(TRUE)
 	if(zoom)
 		zoom() //binoculars, scope, etc
 	appearance_flags &= ~NO_CLIENT_COLOR

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -319,16 +319,30 @@
 	else
 		playsound(src, drop_sound, 30, preference = /datum/client_preference/drop_sounds)
 
-// apparently called whenever an item is removed from a slot, container, or anything else.
-/obj/item/proc/dropped(mob/user as mob)
+/// Called when a mob drops an item.
+/obj/item/proc/dropped(mob/user, silent = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
+/*
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.Remove(user)
+	if(item_flags & DROPDEL)
+		qdel(src)
+	item_flags &= ~IN_INVENTORY
+*/
+	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)
+	// if(!silent)
+	// 	playsound(src, drop_sound, DROP_SOUND_VOLUME, ignore_walls = FALSE)
+	// user?.update_equipment_speed_mods()
 	if(zoom)
 		zoom() //binoculars, scope, etc
 	appearance_flags &= ~NO_CLIENT_COLOR
 
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)
-	return
+	SHOULD_CALL_PARENT(TRUE)
+	SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user)
+	item_flags |= IN_INVENTORY
 
 // called when this item is removed from a storage item, which is passed on as S. The loc variable is already set to the new destination before this is called.
 /obj/item/proc/on_exit_storage(obj/item/storage/S as obj)

--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -131,6 +131,7 @@
 	user_client = new_client
 
 /obj/item/t_scanner/dropped(mob/user)
+	. = ..()
 	set_user_client(null)
 
 /obj/item/t_scanner/upgraded

--- a/code/game/objects/items/storage/_storage.dm
+++ b/code/game/objects/items/storage/_storage.dm
@@ -462,9 +462,6 @@
 	W.add_fingerprint(user)
 	return handle_item_insertion(W)
 
-/obj/item/storage/dropped(mob/user as mob)
-	return
-
 /obj/item/storage/attack_hand(mob/user as mob)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/code/game/objects/items/storage/laundry_basket.dm
+++ b/code/game/objects/items/storage/laundry_basket.dm
@@ -81,7 +81,7 @@
 	name = "second hand"
 	use_to_pickup = 0
 
-/obj/item/storage/laundry_basket/offhand/dropped(mob/user as mob)
+/obj/item/storage/laundry_basket/offhand/dropped(mob/user)
+	. = ..()
 	user.drop_from_inventory(linked)
-	return
 

--- a/code/game/objects/items/storage/laundry_basket.dm
+++ b/code/game/objects/items/storage/laundry_basket.dm
@@ -42,21 +42,19 @@
 	return ..()
 
 /obj/item/storage/laundry_basket/pickup(mob/user)
+	. = ..()
 	var/obj/item/storage/laundry_basket/offhand/O = new(user)
 	O.name = "[name] - second hand"
 	O.desc = "Your second grip on the [name]."
 	O.linked = src
 	user.put_in_inactive_hand(O)
 	linked = O
-	return
 
-/obj/item/storage/laundry_basket/update_icon()
+/obj/item/storage/laundry_basket/update_icon_state()
 	if(contents.len)
 		icon_state = "laundry-full"
 	else
 		icon_state = "laundry-empty"
-	return
-
 
 /obj/item/storage/laundry_basket/MouseDrop(obj/over_object as obj)
 	if(over_object == usr)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -313,6 +313,7 @@ var/last_chew = 0
 		return 1
 
 /obj/item/handcuffs/legcuffs/bola/dropped()
+	. = ..()
 	visible_message("<span class='notice'>\The [src] falls apart!</span>")
 	qdel(src)
 

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -160,6 +160,7 @@
 	var/obj/item/rig_module/armblade/storing_module
 
 /obj/item/material/knife/machete/armblade/rig/dropped(mob/user)
+	. = ..()
 	if(storing_module)
 		src.forceMove(storing_module)
 		user.visible_message(

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -518,10 +518,11 @@
 
 /obj/item/melee/energy/blade/attack_self(mob/user as mob)
 	user.drop_from_inventory(src)
-	spawn(1) if(src) qdel(src)
+	qdel(src)
 
 /obj/item/melee/energy/blade/dropped()
-	spawn(1) if(src) qdel(src)
+	. = ..()
+	qdel(src)
 
 /obj/item/melee/energy/blade/process(delta_time)
 	if(!creator || loc != creator || !creator.item_is_in_hands(src))

--- a/code/game/objects/items/weapons/mop_deploy.dm
+++ b/code/game/objects/items/weapons/mop_deploy.dm
@@ -54,10 +54,11 @@
 
 /obj/item/mop_deploy/attack_self(mob/user as mob)
 	user.drop_from_inventory(src)
-	spawn(1) if(!QDELETED(src)) qdel(src)
+	qdel(src)
 
 /obj/item/mop_deploy/dropped()
-	spawn(1) if(!QDELETED(src)) qdel(src)
+	. = ..()
+	qdel(src)
 
 /obj/item/mop_deploy/process(delta_time)
 	if(!creator || loc != creator || !creator.item_is_in_hands(src))

--- a/code/game/objects/items/weapons/nullrod.dm
+++ b/code/game/objects/items/weapons/nullrod.dm
@@ -40,7 +40,6 @@
 		if(SA_vulnerability & tm.mob_class)
 			tm.apply_damage(SA_bonus_damage) // fuck em
 
-
 /obj/item/nullrod/attack_self(mob/user)
 	if(user && (user.mind.isholy) && !reskinned)
 		reskin_holy_weapon(user)

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -167,6 +167,7 @@
 	return val
 
 /obj/item/tray/pickup(mob/user)
+	. = ..()
 
 	if(!isturf(loc))
 		return
@@ -183,7 +184,7 @@
 			if(calc_carry() + add >= max_carry)
 				break
 			var/image/Img = new(src.icon)
-			I.loc = src
+			I.forceMove(src)
 			carrying.Add(I)
 			Img.icon = I.icon
 			Img.icon_state = I.icon_state

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -195,6 +195,7 @@
 			overlays += Img
 
 /obj/item/tray/dropped(mob/user)
+	. = ..()
 	var/noTable = null
 
 	spawn() //Allows the tray to udpate location, rather than just checking against mob's location

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -8,8 +8,8 @@
 	var/net_type = /obj/effect/energy_net
 
 /obj/item/energy_net/dropped()
-	spawn(10)
-		if(src) qdel(src)
+	. = ..()
+	QDEL_IN(src, 10)
 
 /obj/item/energy_net/throw_impact(atom/hit_atom)
 	..()

--- a/code/modules/artifice/deadringer.dm
+++ b/code/modules/artifice/deadringer.dm
@@ -20,13 +20,13 @@
 /obj/item/deadringer/Destroy() //just in case some smartass tries to stay invisible by destroying the watch
 	uncloak()
 	STOP_PROCESSING(SSobj, src)
-	..()
+	return ..()
 
 /obj/item/deadringer/dropped()
+	. = ..()
 	if(timer > 20)
 		uncloak()
 		watchowner = null
-	return
 
 /obj/item/deadringer/attack_self(var/mob/living/user as mob)
 	var/mob/living/H = src.loc

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -74,11 +74,8 @@
 
 
 /obj/item/assembly/prox_sensor/dropped()
-	spawn(0)
-		sense()
-		return
-	return
-
+	. = ..()
+	INVOKE_ASYNC(src, .proc/sense)
 
 /obj/item/assembly/prox_sensor/proc/toggle_scan()
 	if(!secured)	return 0

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -128,9 +128,9 @@
 
 	switch(Proj.damage_type)
 		if(BRUTE)
-			take_damage(Proj.damage / brute_resist)
+			take_damage(Proj.get_fianl_damage(src))
 		if(BURN)
-			take_damage(Proj.damage / fire_resist)
+			take_damage(Proj.get_final_damage(src))
 	return 0
 
 /obj/effect/blob/attackby(var/obj/item/W, var/mob/user)

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -128,7 +128,7 @@
 
 	switch(Proj.damage_type)
 		if(BRUTE)
-			take_damage(Proj.get_fianl_damage(src))
+			take_damage(Proj.get_final_damage(src))
 		if(BURN)
 			take_damage(Proj.get_final_damage(src))
 	return 0

--- a/code/modules/clothing/gloves/gauntlets.dm
+++ b/code/modules/clothing/gloves/gauntlets.dm
@@ -40,6 +40,7 @@
 	return 1
 
 /obj/item/clothing/gloves/gauntlets/dropped()
+	. = ..()
 	var/mob/living/carbon/human/H = wearer
 	if(gloves)
 		if(!H.equip_to_slot_if_possible(gloves, slot_gloves))

--- a/code/modules/clothing/suits/hooded.dm
+++ b/code/modules/clothing/suits/hooded.dm
@@ -42,6 +42,7 @@
 	hood.forceMove(src)
 
 /obj/item/clothing/suit/storage/hooded/dropped()
+	. = ..()
 	RemoveHood()
 
 /obj/item/clothing/suit/storage/hooded/proc/ToggleHood()

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -535,6 +535,7 @@
 	..(S, user)
 
 /obj/item/clothing/accessory/collar/dropped()
+	. = ..()
 	icon_override = icon_previous_override
 //ywedit end
 

--- a/code/modules/economy/retail_scanner.dm
+++ b/code/modules/economy/retail_scanner.dm
@@ -42,20 +42,18 @@
 
 // Reset dir when picked back up
 /obj/item/retail_scanner/pickup(mob/user)
-	src.dir = SOUTH
-	src.pixel_y = 0
-
+	. = ..()
+	setDir(SOUTH)
+	pixel_y = 0
 
 /obj/item/retail_scanner/attack_self(mob/user as mob)
 	user.set_machine(src)
 	interact(user)
 
-
 /obj/item/retail_scanner/AltClick(var/mob/user)
 	if(Adjacent(user))
 		user.set_machine(src)
 		interact(user)
-
 
 /obj/item/retail_scanner/interact(mob/user as mob)
 	var/dat = "<h2>Retail Scanner<hr></h2>"

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -453,10 +453,11 @@
 		i++
 
 /obj/item/hand/dropped(mob/user as mob)
+	. = ..()
 	if(locate(/obj/structure/table, loc))
-		src.update_icon(user.dir)
+		update_icon(user.dir)
 	else
 		update_icon()
 
 /obj/item/hand/pickup(mob/user as mob)
-	src.update_icon()
+	update_icon()

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -452,12 +452,13 @@
 		overlays += I
 		i++
 
-/obj/item/hand/dropped(mob/user as mob)
+/obj/item/hand/dropped(mob/user)
 	. = ..()
 	if(locate(/obj/structure/table, loc))
 		update_icon(user.dir)
 	else
 		update_icon()
 
-/obj/item/hand/pickup(mob/user as mob)
+/obj/item/hand/pickup(mob/user)
+	. = ..()
 	update_icon()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -9,7 +9,6 @@ emp_act
 */
 
 /mob/living/carbon/human/bullet_act(var/obj/item/projectile/P, var/def_zone)
-
 	def_zone = check_zone(def_zone)
 	if(!has_organ(def_zone))
 		return PROJECTILE_FORCE_MISS //if they don't have the organ in question then the projectile just passes by.
@@ -44,7 +43,7 @@ emp_act
 				SP.loc = organ
 				organ.embed(SP)
 
-	return (..(P , def_zone))
+	return ..()
 
 /mob/living/carbon/human/stun_effect_act(var/stun_amount, var/agony_amount, var/def_zone)
 	var/obj/item/organ/external/affected = get_organ(check_zone(def_zone))

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -165,8 +165,7 @@
 	return
 
 /mob/living/carbon/slime/bullet_act(var/obj/item/projectile/Proj)
-	attacked
-		+= 10
+	attacked += 10
 	..(Proj)
 	return 0
 

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -165,7 +165,8 @@
 	return
 
 /mob/living/carbon/slime/bullet_act(var/obj/item/projectile/Proj)
-	attacked += 10
+	attacked
+		+= 10
 	..(Proj)
 	return 0
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1198,9 +1198,9 @@ default behaviour is:
 	return default_pixel_y
 
 //Adds the anti-magic check back in.
-/mob/living/proc/anti_magic_check(magic = TRUE, holy = FALSE, chargecost = 1, self = FALSE)
-//	. = ..()
-//	if(.)
-//		return
+/mob/living/anti_magic_check(magic = TRUE, holy = FALSE, chargecost = 1, self = FALSE)
+	. = ..()
+	if(.)
+		return
 	if((magic && HAS_TRAIT(src, TRAIT_ANTIMAGIC)) || (holy && HAS_TRAIT(src, TRAIT_HOLY)))
 		return src

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1196,11 +1196,3 @@ default behaviour is:
   */
 /mob/living/proc/get_standard_pixel_y_offset(lying = 0)
 	return default_pixel_y
-
-//Adds the anti-magic check back in.
-/mob/living/anti_magic_check(magic = TRUE, holy = FALSE, chargecost = 1, self = FALSE)
-	. = ..()
-	if(.)
-		return
-	if((magic && HAS_TRAIT(src, TRAIT_ANTIMAGIC)) || (holy && HAS_TRAIT(src, TRAIT_HOLY)))
-		return src

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -117,6 +117,7 @@
 	var/absorb = run_armor_check(def_zone, P.check_armour, P.armor_penetration)
 	var/proj_sharp = is_sharp(P)
 	var/proj_edge = has_edge(P)
+	var/final_damage = P.get_final_damage(src)
 
 	if ((proj_sharp || proj_edge) && (soaked >= round(P.damage*0.8)))
 		proj_sharp = 0
@@ -131,12 +132,12 @@
 		stun_effect_act(0, P.agony, def_zone, P)
 		to_chat(src, "<font color='red'>You have been hit by [P]!</font>")
 		if(!P.nodamage)
-			apply_damage(P.damage, P.damage_type, def_zone, absorb, soaked, 0, P, sharp=proj_sharp, edge=proj_edge)
+			apply_damage(final_damage, P.damage_type, def_zone, absorb, soaked, 0, P, sharp=proj_sharp, edge=proj_edge)
 		qdel(P)
 		return
 
 	if(!P.nodamage)
-		apply_damage(P.damage, P.damage_type, def_zone, absorb, soaked, 0, P, sharp=proj_sharp, edge=proj_edge)
+		apply_damage(final_damage, P.damage_type, def_zone, absorb, soaked, 0, P, sharp=proj_sharp, edge=proj_edge)
 	P.on_hit(src, absorb, soaked, def_zone)
 
 	if(absorb == 100)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -455,7 +455,8 @@
 
 /mob/living/silicon/robot/bullet_act(var/obj/item/projectile/Proj)
 	..(Proj)
-	if(prob(75) && Proj.damage > 0) spark_system.start()
+	if(prob(75) && Proj.damage > 0)
+		spark_system.start()
 	return 2
 
 /mob/living/silicon/robot/attackby(obj/item/W as obj, mob/user as mob)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -106,9 +106,9 @@
 	if(!Proj.nodamage)
 		switch(Proj.damage_type)
 			if(BRUTE)
-				adjustBruteLoss(Proj.damage)
+				adjustBruteLoss(Proj.get_final_damage(src))
 			if(BURN)
-				adjustFireLoss(Proj.damage)
+				adjustFireLoss(Proj.get_final_damage(src))
 
 	Proj.on_hit(src,2)
 	updatehealth()

--- a/code/modules/mob/living/simple_mob/defense.dm
+++ b/code/modules/mob/living/simple_mob/defense.dm
@@ -1,14 +1,3 @@
-// Hit by a projectile.
-/mob/living/simple_mob/bullet_act(var/obj/item/projectile/P)
-	//Projectiles with bonus SA damage
-	if(!P.nodamage)
-	//	if(!P.SA_vulnerability || P.SA_vulnerability == intelligence_level)
-		if(P.SA_vulnerability & mob_class)
-			P.damage += P.SA_bonus_damage
-
-	. = ..()
-
-
 // When someone clicks us with an empty hand
 /mob/living/simple_mob/attack_hand(mob/living/L)
 	..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1191,3 +1191,26 @@ mob/proc/yank_out_object()
 		return
 
 	to_chat(src, "<span class='notice'>Diceroll result: <b>[rand(1, n)]</b></span>")
+
+/**
+ * Checks for anti magic sources.
+ *
+ * @params
+ * - magic - wizard-type magic
+ * - holy - cult-type magic, stuff chaplains/nullrods/similar should be countering
+ * - chargecost - charges to remove from antimagic if applicable/not a permanent source
+ * - self - check if the antimagic is ourselves
+ *
+ * @return The datum source of the antimagic
+ */
+/mob/proc/anti_magic_check(magic = TRUE, holy = FALSE, chargecost = 1, self = FALSE)
+	if(!magic && !holy && !tinfoil)
+		return
+	var/list/protection_sources = list()
+	if(SEND_SIGNAL(src, COMSIG_MOB_RECEIVE_MAGIC, src, magic, holy, chargecost, self, protection_sources) & COMPONENT_BLOCK_MAGIC)
+		if(protection_sources.len)
+			return pick(protection_sources)
+		else
+			return src
+	if((magic && HAS_TRAIT(src, TRAIT_ANTIMAGIC)) || (holy && HAS_TRAIT(src, TRAIT_HOLY)))
+		return src

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1204,7 +1204,7 @@ mob/proc/yank_out_object()
  * @return The datum source of the antimagic
  */
 /mob/proc/anti_magic_check(magic = TRUE, holy = FALSE, chargecost = 1, self = FALSE)
-	if(!magic && !holy && !tinfoil)
+	if(!magic && !holy)
 		return
 	var/list/protection_sources = list()
 	if(SEND_SIGNAL(src, COMSIG_MOB_RECEIVE_MAGIC, src, magic, holy, chargecost, self, protection_sources) & COMPONENT_BLOCK_MAGIC)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -340,9 +340,8 @@
 		devour(affecting, assailant)
 
 /obj/item/grab/dropped()
-	loc = null
-	if(!QDELETED(src))
-		qdel(src)
+	. = ..()
+	qdel(src)
 
 /obj/item/grab/proc/reset_kill_state()
 	if(state == GRAB_KILL)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -119,6 +119,8 @@
 	var/modifier_type_to_apply = null // If set, will apply a modifier to mobs that are hit by this projectile.
 	var/modifier_duration = null // How long the above modifier should last for. Leave null to be permanent.
 	var/excavation_amount = 0 // How much, if anything, it drills from a mineral turf.
+	/// If this projectile is holy. Silver bullets, etc. Currently no effects.
+	var/holy = FALSE
 
 	// Antimagic
 	/// Should we check for antimagic effects?
@@ -769,11 +771,11 @@
 	if(isliving(target))
 		var/mob/living/L = target
 		if(issimple(target))
-			var/mob/living/simple_mob/SM = M
+			var/mob/living/simple_mob/SM = L
 			if(SM.mob_class & SA_vulnerability)
 				final_damage += SA_bonus_damage
-	if(target.anti_magic_check(TRUE, TRUE, antimagic_charges_used, FALSE))
-		final_damage *= antimagic_damage_factor
+		if(L.anti_magic_check(TRUE, TRUE, antimagic_charges_used, FALSE))
+			final_damage *= antimagic_damage_factor
 	return final_damage
 
 /**

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -119,7 +119,14 @@
 	var/modifier_type_to_apply = null // If set, will apply a modifier to mobs that are hit by this projectile.
 	var/modifier_duration = null // How long the above modifier should last for. Leave null to be permanent.
 	var/excavation_amount = 0 // How much, if anything, it drills from a mineral turf.
-	var/holy = FALSE
+
+	// Antimagic
+	/// Should we check for antimagic effects?
+	var/antimagic_check = FALSE
+	/// Antimagic charges to use, if any
+	var/antimagic_charges_used = 0
+	/// Multiplier for damage if antimagic is on the target
+	var/antimagic_damage_factor = 0
 
 	embed_chance = 0	//Base chance for a projectile to embed
 
@@ -578,8 +585,10 @@
 
 //TODO: make it so this is called more reliably, instead of sometimes by bullet_act() and sometimes not
 /obj/item/projectile/proc/on_hit(atom/target, blocked = 0, def_zone)
-	if(blocked >= 100)		return 0//Full block
-	if(!isliving(target))	return 0
+	if(blocked >= 100)
+		return 0//Full block
+	if(!isliving(target))
+		return 0
 //	if(isanimal(target))	return 0
 	var/mob/living/L = target
 	L.apply_effects(stun, weaken, paralyze, irradiate, stutter, eyeblur, drowsy, agony, blocked, incendiary, flammability) // add in AGONY!
@@ -745,3 +754,31 @@
 
 	preparePixelProjectile(target, get_turf(src), params, forced_spread)
 	return fire(angle_override, direct_target)
+
+/**
+ * Standard proc to determine damage when impacting something. This does not affect the special damage variables/effect variables, only damage and damtype.
+ * May or may not be called before/after armor calculations.
+ *
+ * @params
+ * - target The atom hit
+ *
+ * @return Damage to apply to target.
+ */
+/obj/item/projectile/proc/run_damage_vulnerability(atom/target)
+	var/final_damage = damage
+	if(isliving(target))
+		var/mob/living/L = target
+		if(issimple(target))
+			var/mob/living/simple_mob/SM = M
+			if(SM.mob_class & SA_vulnerability)
+				final_damage += SA_bonus_damage
+	if(target.anti_magic_check(TRUE, TRUE, antimagic_charges_used, FALSE))
+		final_damage *= antimagic_damage_factor
+	return final_damage
+
+/**
+ * Probably isn't needed but saves me the time and I can regex this later:
+ * Gets the final `damage` that should be used on something
+ */
+/obj/item/projectile/proc/get_final_damage(atom/target)
+	return run_damage_vulnerability(target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

i have zero attachment to the latter but i'm fixing the former so
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

ask @Mount0 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: inversion beams get dampened by antimagic
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
