### PR TITLE
fixes modular weapons not updating after generatefiremodes somehow writing 5 lines of code to fix this doesn't change the fact this entire fire deserves to go in a trash fire

### DIFF
--- a/code/modules/projectiles/guns/energy/modular/modulargun.dm
+++ b/code/modules/projectiles/guns/energy/modular/modulargun.dm
@@ -1,6 +1,8 @@
 //modular weapons 2. shitcode ahead, be warned.
 //i'd just like to say nitsah is annoying as FUCK but also sometimes nice
 
+// if i have to maintain this perfect example of why we shouldn't just merge code just because someone made it and instead we should enforce some modicrum of fucking code standards one more time, i'm going to remove it entirely because fuck off.
+
 /obj/item/gun/energy/modular
 	name = "the very concept of a modular weapon"
 	desc = "An idea, given physical form? Contact your God, the Maker has made a mistake."
@@ -41,7 +43,12 @@
 	if(circuit)
 		. += "The modular weapon has a [circuit.name] installed in the fire control slot."
 
-/obj/item/gun/energy/modular/proc/generatefiremodes() //Accepts no args. Checks the gun's current components and generates projectile types, firemode costs and max burst. Should be called after changing parts or part values.
+/obj/item/gun/energy/modular/proc/generatefiremodes()
+	do_generatefiremodes()
+	var/datum/firemode/new_mode = firemodes[1]
+	new_mode.apply_to(src)
+
+/obj/item/gun/energy/modular/proc/do_generatefiremodes() //Accepts no args. Checks the gun's current components and generates projectile types, firemode costs and max burst. Should be called after changing parts or part values.
 	if(!circuit)
 		return FALSE
 	if(!primarycore)
@@ -152,8 +159,6 @@
 
 /obj/item/gun/energy/modular/AltClick(mob/user)
 	generatefiremodes()
-	var/datum/firemode/new_mode = firemodes[1]
-	new_mode.apply_to(src)
 	to_chat(user, "You hit the reset on the weapon's internal checking system.")
 
 

--- a/code/modules/projectiles/guns/energy/modular/modulargun.dm
+++ b/code/modules/projectiles/guns/energy/modular/modulargun.dm
@@ -43,6 +43,7 @@
 	if(circuit)
 		. += "The modular weapon has a [circuit.name] installed in the fire control slot."
 
+// hilariously snowflake proc to force a firemode switch because i can't be assed to do it properly holy shit fuck you
 /obj/item/gun/energy/modular/proc/generatefiremodes()
 	do_generatefiremodes()
 	var/datum/firemode/new_mode = firemodes[1]


### PR DESCRIPTION
can we just remove them already if no one can be assed to maintain their own work