### PR TITLE
Adds wirecutters to sciencehound

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
@@ -95,6 +95,7 @@
 	src.modules += new /obj/item/storage/part_replacer(src)
 	src.modules += new /obj/item/card/robot(src)
 	src.modules += new /obj/item/shockpaddles/robot/jumper(src)
+	src.modules += new /obj/item/tool/wirecutters/cyborg(src)
 	src.emag = new /obj/item/hand_tele(src)
 	src.modules += new /obj/item/dogborg/jaws/small(src)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
@@ -88,6 +88,7 @@
 	src.modules += new /obj/item/tool/screwdriver/cyborg(src)
 	src.modules += new /obj/item/tool/wrench/cyborg(src)
 	src.modules += new /obj/item/robotanalyzer(src)
+	src.modules += new /obj/item/tool/wirecutters/cyborg(src)
 	src.modules += new /obj/item/stack/cable_coil/cyborg(src)
 	src.modules += new /obj/item/weldingtool/electric/mounted/cyborg(src)
 	src.modules += new /obj/item/multitool(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
@@ -88,7 +88,6 @@
 	src.modules += new /obj/item/tool/screwdriver/cyborg(src)
 	src.modules += new /obj/item/tool/wrench/cyborg(src)
 	src.modules += new /obj/item/robotanalyzer(src)
-	src.modules += new /obj/item/tool/wirecutters/cyborg(src)
 	src.modules += new /obj/item/stack/cable_coil/cyborg(src)
 	src.modules += new /obj/item/weldingtool/electric/mounted/cyborg(src)
 	src.modules += new /obj/item/multitool(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
One new module available for the sciencehound, the wirecutters.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is another case where the base non-dogborg option has certain equipment while the dogborg does not.  Wirecutters are necessary for mech construction and borg repair, the lack of them alone restricting the sciencehound's uses.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Adds some wirecutters to scihound
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
