### PR TITLE
Various aesthetic fixes and tweaks to Triumph, especially Security and D4.

### DIFF
--- a/_maps/map_files/triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/triumph/triumph-02-deck2.dmm
@@ -330,6 +330,12 @@
 	dir = 8
 	},
 /obj/machinery/light,
+/obj/item/deck/unus{
+	pixel_x = 7
+	},
+/obj/item/deck/cah{
+	pixel_x = -8
+	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "aU" = (
@@ -2821,6 +2827,9 @@
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_x = -32
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "ig" = (
@@ -2941,9 +2950,6 @@
 /area/maintenance/bar/lower)
 "iv" = (
 /obj/machinery/vending/hydronutrients,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/hydroponics)
 "iw" = (
@@ -4328,9 +4334,6 @@
 /obj/machinery/newscaster{
 	layer = 3.3;
 	pixel_x = -27
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
@@ -5746,6 +5749,7 @@
 /obj/machinery/newscaster{
 	pixel_x = 30
 	},
+/obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_office)
 "qn" = (

--- a/_maps/map_files/triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/triumph/triumph-02-deck2.dmm
@@ -325,15 +325,11 @@
 "aT" = (
 /obj/structure/table/marble,
 /obj/item/storage/pill_bottle/dice_nerd,
-/obj/item/deck/cards{
-	pixel_x = 6
-	},
+/obj/item/deck/cards,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/obj/item/deck/unus{
-	pixel_x = -7
-	},
+/obj/machinery/light,
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "aU" = (
@@ -2043,9 +2039,6 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "fW" = (
@@ -3343,7 +3336,7 @@
 /area/crew_quarters/recreation_area)
 "jB" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/metal{
+/obj/machinery/door/airlock/multi_tile/glass{
 	name = "Crew Cryo Bay"
 	},
 /obj/structure/cable/green{
@@ -4491,9 +4484,6 @@
 /obj/machinery/camera/network/civilian{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "mQ" = (
@@ -5260,13 +5250,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/refinery)
-"oO" = (
-/obj/machinery/chemical_dispenser/bar_soft/full{
-	dir = 1;
-	pixel_y = -1
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
 "oQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5763,7 +5746,6 @@
 /obj/machinery/newscaster{
 	pixel_x = 30
 	},
-/obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_office)
 "qn" = (
@@ -7235,6 +7217,9 @@
 /obj/item/retail_scanner/civilian,
 /obj/item/retail_scanner/civilian,
 /obj/item/clothing/accessory/hawaii/random,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/triumph/surfacebase/bar_backroom)
 "up" = (
@@ -7479,18 +7464,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
-"va" = (
-/obj/structure/table/marble,
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	id = "bar";
-	layer = 3.3;
-	name = "Bar Shutters"
-	},
-/obj/machinery/door/firedoor/glass/hidden/steel,
-/obj/item/material/ashtray/glass,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/bar)
 "vb" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -8665,7 +8638,6 @@
 /obj/machinery/computer/security/telescreen{
 	pixel_y = -32
 	},
-/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "yI" = (
@@ -9225,6 +9197,9 @@
 	dir = 4;
 	pixel_x = -11
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "AA" = (
@@ -9749,9 +9724,6 @@
 "Cc" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/triumph/surfacebase/bar_backroom)
@@ -13376,6 +13348,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"Nu" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/vacant/vacant_office)
 "Nv" = (
 /obj/machinery/camera/network/cargo{
 	dir = 4
@@ -14385,9 +14361,6 @@
 "QI" = (
 /obj/structure/dogbed,
 /obj/machinery/camera/network/civilian,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom (General)";
@@ -14474,6 +14447,9 @@
 	pixel_x = 32
 	},
 /obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -16491,7 +16467,6 @@
 /obj/machinery/camera/network/civilian{
 	dir = 1
 	},
-/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_office)
 "Wv" = (
@@ -16503,7 +16478,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/triumph/surfacebase/bar_backroom)
 "Ww" = (
@@ -21174,13 +21148,13 @@ Ts
 lK
 KS
 Om
-va
+TZ
 Ub
 TZ
-va
+TZ
 Ub
 CG
-va
+TZ
 FG
 HJ
 HJ
@@ -24300,7 +24274,7 @@ rI
 aU
 HZ
 kr
-oO
+kr
 Zy
 Zy
 Nw
@@ -25590,7 +25564,7 @@ sk
 tQ
 tQ
 tQ
-tQ
+Nu
 wc
 gg
 xg

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -242,10 +242,7 @@
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/green/bordercorner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/green/bordercorner{
+/obj/effect/floor_decal/corner/green/border{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -10050,10 +10047,9 @@
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/green/bordercorner{
+/obj/effect/floor_decal/corner/green/border{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/green/bordercorner,
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyisolation)
 "isK" = (
@@ -19161,10 +19157,9 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/green/bordercorner{
+/obj/effect/floor_decal/corner/green/border{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/green/bordercorner,
 /turf/simulated/floor/tiled,
 /area/medical/virology)
 "pKT" = (
@@ -20796,6 +20791,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/cmo)
 "qUP" = (

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -229,6 +229,9 @@
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
 	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "ahz" = (
@@ -1629,6 +1632,9 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/beige/border{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -7294,11 +7300,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "gdJ" = (
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/green/bordercorner{
-	dir = 4
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
@@ -7361,10 +7367,10 @@
 	pixel_x = -23
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
+	dir = 9
 	},
 /obj/effect/floor_decal/corner/green/border{
-	dir = 8
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
@@ -7424,6 +7430,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -10696,6 +10705,9 @@
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "jbe" = (
@@ -12164,6 +12176,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -13975,6 +13990,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "lVQ" = (
@@ -15281,12 +15299,6 @@
 /obj/random/drinkbottle,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
-"mRt" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
 "mRW" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -15588,6 +15600,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "ndN" = (
@@ -15856,6 +15871,9 @@
 	tag_interior_door = "virology_airlock_interior"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -16821,6 +16839,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "okm" = (
@@ -16920,6 +16941,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -17361,6 +17385,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/beige/border,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "oEF" = (
@@ -18223,6 +18248,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/beige/border,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "phN" = (
@@ -19193,9 +19219,6 @@
 /obj/effect/floor_decal/corner/green/border{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
 "pLS" = (
@@ -19490,10 +19513,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay_primary_storage)
-"pUp" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
 "pVD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -19981,6 +20000,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "qpL" = (
@@ -21334,6 +21354,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/corner/lightorange/border,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "rna" = (
@@ -22234,6 +22255,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "rYj" = (
@@ -22751,10 +22773,7 @@
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/lightorange/bordercorner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
+/obj/effect/floor_decal/corner/blue/border{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -23470,17 +23489,6 @@
 "sQl" = (
 /turf/simulated/floor/plating,
 /area/maintenance/research)
-"sQL" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloorwhite,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "sRb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -24559,10 +24567,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"tAA" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
 "tAD" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -28413,6 +28417,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "wHf" = (
@@ -28962,6 +28967,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
@@ -34381,7 +34389,7 @@ uHP
 lsY
 oAn
 bTp
-pUp
+jSL
 qnK
 hKH
 grZ
@@ -36373,7 +36381,7 @@ pdk
 gvS
 gyO
 pdO
-sQL
+gwM
 rKV
 axg
 dBv
@@ -37083,7 +37091,7 @@ gvk
 vEc
 mgw
 lpT
-sQL
+gwM
 sxO
 pGx
 tlB
@@ -37793,7 +37801,7 @@ fjW
 qas
 jXs
 lpT
-sQL
+gwM
 wxf
 iVP
 lzM
@@ -39920,7 +39928,7 @@ rzF
 mjd
 lSR
 fIW
-tAA
+tRd
 upH
 vca
 tRQ
@@ -41054,7 +41062,7 @@ rPc
 pAO
 pAO
 opZ
-mRt
+mHH
 cbU
 nVa
 wEZ
@@ -41340,7 +41348,7 @@ hhy
 okO
 fNm
 cbU
-tAA
+tRd
 iVN
 xND
 eUH
@@ -41906,7 +41914,7 @@ bdW
 hUs
 hUs
 xlO
-mRt
+mHH
 cbU
 tRd
 sMj

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -229,9 +229,6 @@
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
 	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 5
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "ahz" = (
@@ -759,9 +756,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/medbreak)
 "aDo" = (
@@ -1227,7 +1221,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "bcq" = (
-/obj/item/roller_holder,
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 8
@@ -1236,6 +1229,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
+/obj/structure/bed/roller,
 /turf/simulated/floor/tiled/monotile,
 /area/medical/surgeryprep)
 "bcG" = (
@@ -4625,6 +4619,7 @@
 /area/medical/exam_room/exam_1)
 "dTK" = (
 /obj/structure/table/steel_reinforced,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "dUt" = (
@@ -5057,15 +5052,16 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer)
 "ekF" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 4;
-	pixel_y = -4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/port)
 "emb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7347,11 +7343,11 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer_auxiliary)
 "ggX" = (
-/obj/item/roller_holder,
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 8
 	},
+/obj/structure/bed/roller,
 /turf/simulated/floor/tiled/monotile,
 /area/medical/surgeryprep)
 "ghe" = (
@@ -7429,12 +7425,6 @@
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/medical/surgeryprep)
@@ -10706,12 +10696,6 @@
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "jbe" = (
@@ -12182,24 +12166,18 @@
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
 "kpH" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
@@ -13412,6 +13390,7 @@
 /area/rnd/test_area)
 "ltR" = (
 /obj/structure/table/woodentable,
+/obj/item/reagent_containers/food/drinks/metaglass,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/medbreak)
 "lwA" = (
@@ -13986,12 +13965,6 @@
 /area/medical/morgue)
 "lUV" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightorange/bordercorner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightorange/bordercorner{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14929,6 +14902,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "mDI" = (
+/obj/structure/table/steel_reinforced,
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "O- Blood Locker";
 	pixel_x = 32;
@@ -14938,6 +14912,7 @@
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "mDZ" = (
@@ -15310,12 +15285,6 @@
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "mRW" = (
@@ -15380,9 +15349,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -15613,10 +15579,6 @@
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -15894,12 +15856,6 @@
 	tag_interior_door = "virology_airlock_interior"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/green/bordercorner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/green/bordercorner{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -16865,10 +16821,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "okm" = (
@@ -17409,7 +17361,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/beige/bordercorner,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "oEF" = (
@@ -17512,8 +17463,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "oIJ" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/food/drinks/metaglass,
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/medbreak)
 "oIP" = (
@@ -18271,9 +18223,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/beige/bordercorner{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "phN" = (
@@ -19543,10 +19492,6 @@
 /area/medical/medbay_primary_storage)
 "pUp" = (
 /obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/beige/bordercorner,
-/obj/effect/floor_decal/corner/beige/bordercorner{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "pVD" = (
@@ -19870,14 +19815,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/anomaly_lab/containment_one)
 "qib" = (
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
 /obj/structure/table/steel_reinforced,
+/obj/item/stack/nanopaste{
+	amount = 30
+	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -20040,10 +19981,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/blue/bordercorner,
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "qpL" = (
@@ -20834,10 +20771,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/blue/bordercorner,
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -21396,10 +21329,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/lightorange/bordercorner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightorange/bordercorner,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -22305,10 +22234,6 @@
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "rYj" = (
@@ -23074,22 +22999,17 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyisolation)
 "szb" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blue,
-/area/crew_quarters/medbreak)
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "szd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -23551,13 +23471,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "sQL" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/stack/nanopaste{
-	amount = 30
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloorwhite,
 /turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
+/area/medical/ward)
 "sRb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -24638,10 +24561,6 @@
 /area/medical/medbay4)
 "tAA" = (
 /obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/blue/bordercorner,
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "tAD" = (
@@ -28494,10 +28413,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "wHf" = (
@@ -28543,7 +28458,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/roller_holder,
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/light{
 	dir = 8
@@ -28551,6 +28465,7 @@
 /obj/structure/sign/greencross{
 	pixel_x = -32
 	},
+/obj/structure/bed/roller,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "wJC" = (
@@ -29041,12 +28956,6 @@
 /area/assembly/robotics/surgery)
 "xcn" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
 	dir = 1
 	},
 /obj/structure/cable/green{
@@ -33890,7 +33799,7 @@ dmX
 bXb
 bXb
 bXb
-bXb
+ekF
 dmX
 bXb
 bXb
@@ -36464,7 +36373,7 @@ pdk
 gvS
 gyO
 pdO
-gwM
+sQL
 rKV
 axg
 dBv
@@ -37174,7 +37083,7 @@ gvk
 vEc
 mgw
 lpT
-gwM
+sQL
 sxO
 pGx
 tlB
@@ -37884,7 +37793,7 @@ fjW
 qas
 jXs
 lpT
-gwM
+sQL
 wxf
 iVP
 lzM
@@ -40291,7 +40200,7 @@ rpF
 hrW
 sin
 vMK
-ekF
+vMK
 poz
 nkn
 ugG
@@ -40433,7 +40342,7 @@ hrW
 mos
 tFP
 nEu
-sQL
+vMK
 uio
 mHH
 yhL
@@ -40717,7 +40626,7 @@ gyJ
 bJh
 oXa
 mDI
-vMK
+szb
 poz
 tiM
 cbU
@@ -43544,9 +43453,9 @@ twu
 rzy
 rzy
 rzy
-ltR
 oIJ
-szb
+oIJ
+sre
 yhM
 gDg
 eeY

--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -708,6 +708,9 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "aEz" = (
@@ -980,6 +983,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3963,6 +3969,9 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "doe" = (
@@ -5269,6 +5278,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "eiZ" = (
@@ -13547,6 +13557,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "kGG" = (
@@ -13873,6 +13884,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -15584,6 +15598,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -19832,6 +19849,9 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "pjg" = (
@@ -20358,6 +20378,9 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "pHP" = (
@@ -20759,6 +20782,9 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -21165,6 +21191,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -22335,6 +22364,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "qSA" = (
@@ -22409,6 +22439,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "qUK" = (
@@ -22732,6 +22763,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "rgM" = (
@@ -22918,6 +22950,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "rmO" = (
@@ -25167,6 +25200,9 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "sPc" = (
@@ -26474,6 +26510,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -28539,6 +28578,9 @@
 	},
 /obj/machinery/computer/prisoner{
 	dir = 1
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -31121,9 +31163,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "xdr" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -32
-	},
 /obj/item/storage/box/handcuffs{
 	pixel_x = 1;
 	pixel_y = 2

--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -337,13 +337,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/bridge/office)
-"aoA" = (
-/obj/machinery/computer/shuttle_control/explore/excursion{
-	dir = 4;
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled,
-/area/shuttle/excursion/cockpit)
 "aoK" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/red/border,
@@ -702,8 +695,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
-/area/shuttle/excursion/cargo)
+/turf/simulated/shuttle/wall/voidcraft/blue,
+/area/shuttle/excursion/general)
 "aEx" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -713,9 +706,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -729,13 +719,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "aEY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/catwalk,
 /obj/structure/cable/cyan{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/cargo)
 "aFu" = (
@@ -990,9 +980,6 @@
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1082,32 +1069,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/security/security_lockerroom)
-"aWv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/red/bordercorner,
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/hallway)
 "aWA" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_security{
 	layer = 2.8;
-	name = "Security Maintenance";
+	name = "Security Tool Storage";
 	req_one_access = list(1,38)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1372,15 +1338,16 @@
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/sauna)
 "bhO" = (
-/obj/machinery/computer/prisoner{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/floor_decal/corner/red/full{
-	dir = 4
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -1410,7 +1377,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "biV" = (
-/obj/machinery/light,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/glass_security{
+	layer = 2.8;
+	name = "Security Tool Storage";
+	req_one_access = list(1,38)
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/lobby)
 "bjf" = (
@@ -1702,10 +1681,6 @@
 /area/triumph/surfacebase/sauna)
 "bup" = (
 /obj/structure/closet/emcloset,
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = -24
-	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "buK" = (
@@ -1772,7 +1747,7 @@
 	dir = 8
 	},
 /turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/excursion/cargo)
+/area/shuttle/excursion/general)
 "bwx" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1917,6 +1892,7 @@
 /area/hydroponics/garden)
 "bDy" = (
 /obj/structure/table/steel,
+/obj/item/clothing/gloves/black,
 /obj/item/clothing/glasses/welding,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/lobby)
@@ -2051,12 +2027,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
-"bHL" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/shuttle/excursion/general)
 "bHY" = (
 /obj/structure/railing{
 	dir = 4
@@ -2165,6 +2135,9 @@
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hop)
@@ -2368,8 +2341,14 @@
 /turf/simulated/floor/lino,
 /area/security/detectives_office)
 "bSA" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -2448,29 +2427,16 @@
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
 "bWc" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/accessory/armor/armguards,
-/obj/item/clothing/accessory/armor/armguards,
-/obj/item/clothing/accessory/armor/armguards,
-/obj/item/clothing/accessory/armor/armguards,
-/obj/item/clothing/accessory/armor/armguards,
-/obj/item/clothing/accessory/armor/armguards,
-/obj/item/clothing/accessory/armor/armguards,
-/obj/item/clothing/accessory/armor/armguards,
-/obj/item/shield_projector,
-/obj/item/shield_projector,
-/obj/item/shield_projector,
-/obj/item/shield_projector,
-/obj/item/shield_projector,
 /obj/machinery/firealarm{
 	dir = 4;
 	layer = 3.3;
 	pixel_x = 26
 	},
+/obj/machinery/camera/network/security,
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/mech_recharger,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "bWp" = (
@@ -2753,24 +2719,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/tool_storage)
-"chi" = (
-/obj/machinery/door/airlock/voidcraft/vertical{
-	icon_state = "door_locked";
-	id_tag = "expshuttle_door_L";
-	locked = 1
-	},
-/obj/machinery/button/remote/airlock{
-	desiredstate = 1;
-	dir = 1;
-	id = "expshuttle_door_L";
-	name = "hatch bolt control";
-	pixel_y = -28;
-	req_one_access = list(19,43,67);
-	specialfunctions = 4
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
-/area/shuttle/excursion/cargo)
 "chw" = (
 /obj/item/radio/intercom{
 	pixel_y = -24
@@ -2799,8 +2747,17 @@
 /turf/simulated/floor/tiled,
 /area/exploration)
 "cjs" = (
+/obj/structure/closet/hydrant{
+	pixel_x = 32
+	},
 /obj/structure/table/steel,
-/obj/item/clothing/gloves/black,
+/obj/item/radio{
+	pixel_x = -4
+	},
+/obj/item/radio{
+	pixel_x = 4;
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/lobby)
 "cjA" = (
@@ -3044,8 +3001,8 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/secondary/civilian_hallway_mid)
 "ctm" = (
-/obj/machinery/chemical_dispenser/bar_coffee,
 /obj/structure/table/woodentable,
+/obj/machinery/chemical_dispenser/bar_coffee/full,
 /turf/simulated/floor/wood,
 /area/maintenance/security/starboard)
 "ctv" = (
@@ -3157,11 +3114,8 @@
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "cvW" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
+/obj/structure/bed/chair/shuttle{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
@@ -3325,6 +3279,9 @@
 	},
 /obj/structure/table/steel,
 /obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/structure/closet/hydrant{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "cDx" = (
@@ -3395,9 +3352,6 @@
 "cEr" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/cargo)
 "cEx" = (
@@ -3805,6 +3759,10 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "des" = (
@@ -3831,9 +3789,6 @@
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/plating,
 /area/maintenance/security/starboard)
-"dfy" = (
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
-/area/shuttle/excursion/cargo)
 "dfZ" = (
 /obj/structure/railing{
 	dir = 1
@@ -3882,29 +3837,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/civilian_hallway_mid)
 "djA" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/camera/network/command{
 	dir = 4
 	},
-/obj/machinery/button/remote/driver{
-	dir = 4;
-	id = "enginecore";
-	name = "Emergency Core Eject";
-	pixel_x = -22
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/effect/floor_decal/industrial/danger/cee{
-	dir = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 4;
-	id = "EngineVent";
-	name = "Reactor Ventillatory Control";
-	pixel_x = -33;
-	req_access = list(10)
-	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/folder/red,
+/obj/item/folder/blue,
+/obj/item/pen,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "djR" = (
@@ -3993,13 +3937,11 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
 	},
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 8
+/obj/effect/floor_decal/corner/red{
+	dir = 10
 	},
-/obj/item/book/manual/security_space_law,
-/obj/structure/closet/secure_closet/warden,
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/red/full,
+/obj/structure/table/steel_reinforced,
+/obj/item/retail_scanner/security,
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "dnw" = (
@@ -4021,12 +3963,6 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "doe" = (
@@ -4037,11 +3973,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/gateway)
 "dpF" = (
-/obj/machinery/mech_recharger,
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 5
 	},
-/obj/effect/floor_decal/techfloor,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -4054,6 +3988,9 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/autolathe{
+	hacked = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "dpQ" = (
@@ -4150,7 +4087,7 @@
 /obj/machinery/door/blast/regular{
 	dir = 2;
 	id = "armoryriot";
-	name = "Riot Control Armory Access"
+	name = "Emergency Armory Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4290,6 +4227,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
+"dwl" = (
+/obj/machinery/door/airlock/voidcraft/vertical{
+	icon_state = "door_locked";
+	id_tag = "expshuttle_door_L";
+	locked = 1
+	},
+/obj/machinery/button/remote/airlock{
+	desiredstate = 1;
+	dir = 1;
+	id = "expshuttle_door_L";
+	name = "hatch bolt control";
+	pixel_y = -28;
+	req_one_access = list(19,43,67);
+	specialfunctions = 4
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/excursion/general)
 "dxa" = (
 /turf/simulated/floor/tiled,
 /area/exploration/showers)
@@ -4335,8 +4289,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security/port)
 "dzk" = (
-/turf/simulated/shuttle/wall/voidcraft/blue,
-/area/shuttle/excursion/cargo)
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/excursion/cockpit)
 "dzz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/borderfloorblack{
@@ -4405,7 +4364,7 @@
 	dir = 6
 	},
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
-/area/shuttle/excursion/cargo)
+/area/shuttle/excursion/general)
 "dBL" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/super;
@@ -4514,11 +4473,13 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -22
 	},
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs{
+	pixel_y = 7
+	},
 /obj/structure/table/steel,
 /obj/effect/floor_decal/corner/red/full,
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/item/storage/box/flashbangs,
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)
 "dFO" = (
@@ -4656,13 +4617,13 @@
 /turf/simulated/floor/tiled/old_cargo/white,
 /area/security/forensics)
 "dKK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/cargo)
 "dKL" = (
@@ -4862,8 +4823,8 @@
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "dUu" = (
-/obj/structure/table/steel,
-/obj/machinery/light/small,
+/obj/random/maintenance,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/security/starboard)
 "dUV" = (
@@ -5046,14 +5007,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/aft)
 "eau" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 32
-	},
 /obj/structure/cable/cyan{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
@@ -5172,7 +5129,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/civilian_hallway_mid)
 "edy" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
@@ -5313,10 +5269,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/red/bordercorner,
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "eiZ" = (
@@ -5623,7 +5575,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/gateway)
 "eyk" = (
-/obj/structure/table/steel_reinforced,
+/obj/structure/table/rack/shelf/steel,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/glasses/goggles,
 /obj/structure/window/reinforced{
@@ -5765,18 +5717,6 @@
 	cur_coils = 3
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
-/area/shuttle/excursion/general)
-"eDu" = (
-/obj/machinery/door/airlock/voidcraft/vertical,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
 "eDN" = (
@@ -6124,6 +6064,7 @@
 /area/crew_quarters/sleep/CMO_quarters)
 "eMU" = (
 /obj/item/handcuffs,
+/obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/plating,
 /area/maintenance/security/starboard)
 "eNu" = (
@@ -6193,6 +6134,9 @@
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 6
+	},
+/obj/structure/sign/department/armory{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
@@ -6292,6 +6236,13 @@
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
+/turf/simulated/floor/plating,
+/area/maintenance/security/starboard)
+"eSm" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
 /turf/simulated/floor/plating,
 /area/maintenance/security/starboard)
 "eSo" = (
@@ -6400,15 +6351,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
-"eWr" = (
-/obj/effect/floor_decal/industrial/warning/full,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/vehicle/train/engine/quadbike,
-/obj/machinery/mech_recharger,
-/turf/simulated/floor/plating,
-/area/shuttle/excursion/cargo)
 "eWD" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -6818,9 +6760,6 @@
 /area/hydroponics/garden)
 "fkE" = (
 /obj/structure/table/bench/steel,
-/obj/structure/window/basic{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -7184,12 +7123,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/HOP_quarters)
-"fza" = (
-/obj/machinery/door/airlock/maintenance/common{
-	req_access = list(38)
-	},
-/turf/simulated/floor/plating,
-/area/lawoffice)
 "fzn" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
@@ -7222,6 +7155,10 @@
 	},
 /turf/simulated/floor/tiled/old_cargo/red,
 /area/security/security_processing)
+"fzE" = (
+/obj/machinery/computer/ship/engines,
+/turf/simulated/floor/tiled,
+/area/shuttle/excursion/cockpit)
 "fzI" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7260,23 +7197,11 @@
 /turf/simulated/floor/tiled,
 /area/chapel/main)
 "fzX" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/excursion/cargo)
+/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/area/shuttle/excursion/general)
 "fAu" = (
 /obj/structure/table/steel,
 /obj/item/flashlight/lamp,
@@ -7295,7 +7220,7 @@
 /area/security/warden)
 "fAN" = (
 /obj/structure/table/woodentable,
-/obj/machinery/chemical_dispenser/bar_soft{
+/obj/machinery/chemical_dispenser/bar_soft/full{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -7742,6 +7667,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/exploration/pathfinder_office)
+"fVV" = (
+/obj/structure/table/woodentable,
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "fVZ" = (
 /obj/machinery/camera/network/security{
 	dir = 1
@@ -7752,14 +7681,6 @@
 "fWb" = (
 /turf/simulated/open,
 /area/triumph/station/stairs_four)
-"fWo" = (
-/obj/structure/closet/walllocker/emerglocker{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/shuttle/excursion/general)
 "fWZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8032,8 +7953,8 @@
 /turf/simulated/floor/tiled,
 /area/exploration/pathfinder_office)
 "gmK" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
+/obj/structure/railing{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security/starboard)
@@ -8189,13 +8110,6 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/firstaid/regular,
-/obj/item/radio{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/radio{
-	pixel_x = -4
-	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "grG" = (
@@ -8456,7 +8370,7 @@
 	dir = 4
 	},
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
-/area/shuttle/excursion/cargo)
+/area/shuttle/excursion/general)
 "gya" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -8465,10 +8379,8 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/excursion_dock)
 "gyv" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood,
+/obj/random/trash,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/security/starboard)
 "gzz" = (
@@ -8479,13 +8391,30 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "gzM" = (
-/obj/machinery/autolathe{
-	hacked = 1
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/cell/device/weapon{
+	pixel_x = 3
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 3
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 3
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 3
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 3
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 3
+	},
+/obj/item/gun/energy/phasegun/cannon,
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)
 "gzW" = (
@@ -8745,6 +8674,28 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/item/clothing/accessory/armor/legguards,
+/obj/item/clothing/accessory/armor/legguards,
+/obj/item/clothing/accessory/armor/legguards,
+/obj/item/clothing/accessory/armor/legguards{
+	pixel_x = 8
+	},
+/obj/item/clothing/accessory/armor/legguards{
+	pixel_x = -6
+	},
+/obj/item/clothing/accessory/armor/legguards{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/clothing/accessory/armor/legguards{
+	pixel_y = 8
+	},
+/obj/item/clothing/accessory/armor/legguards{
+	pixel_x = -5;
+	pixel_y = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "gMN" = (
@@ -8836,22 +8787,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/cargo)
-"gQL" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/dark,
-/area/security/armoury)
 "gQP" = (
 /obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/tiled,
@@ -8926,8 +8861,12 @@
 /turf/simulated/floor/tiled/white,
 /area/exploration/medical)
 "gTt" = (
-/obj/machinery/shipsensors,
-/turf/simulated/floor/plating,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
 "gTD" = (
 /obj/effect/floor_decal/borderfloor{
@@ -9363,13 +9302,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/lawoffice)
+"hjg" = (
+/obj/structure/bed/chair/shuttle{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/excursion/cockpit)
 "hjI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/structure/shuttle/engine/heater{
 	dir = 4
 	},
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
-/area/shuttle/excursion/cargo)
+/area/shuttle/excursion/general)
 "hjL" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 10;
@@ -9450,9 +9395,7 @@
 /area/security/warden)
 "hmc" = (
 /obj/structure/table/steel,
-/obj/item/material/ashtray/glass{
-	pixel_y = 48
-	},
+/obj/item/material/ashtray/glass,
 /turf/simulated/floor/plating,
 /area/maintenance/security/starboard)
 "hmi" = (
@@ -10050,7 +9993,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/storage/box/empslite,
+/obj/item/storage/box/empslite{
+	pixel_y = 6
+	},
 /obj/item/storage/box/empslite,
 /obj/effect/floor_decal/corner/red/full{
 	dir = 4
@@ -10105,13 +10050,6 @@
 /obj/item/flame/candle/candelabra/everburn,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/chapel/main)
-"hLF" = (
-/obj/structure/catwalk,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/excursion/cargo)
 "hLJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10178,13 +10116,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/aft)
-"hNo" = (
-/obj/structure/closet/walllocker/emerglocker{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled,
-/area/shuttle/excursion/general)
 "hNz" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -11076,9 +11007,6 @@
 /turf/simulated/floor/tiled,
 /area/exploration)
 "ira" = (
-/obj/effect/landmark/start{
-	name = "Security Officer"
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central5{
 	dir = 1
 	},
@@ -11118,11 +11046,6 @@
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/security/lobby)
@@ -11196,15 +11119,14 @@
 /turf/simulated/floor/carpet/tealcarpet,
 /area/shuttle/civvie/general)
 "iwU" = (
-/obj/item/radio/intercom{
-	pixel_y = -24
+/obj/item/gps/internal/base{
+	desc = "A tracking beacon embedded in the shuttle systems, to help explorers find where they landed.";
+	gps_tag = "SHUTTLE";
+	name = "shuttle beacon"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 32
+/obj/machinery/computer/ship/helm{
+	dir = 4
 	},
-/obj/structure/cable/cyan,
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/cockpit)
 "iwY" = (
@@ -11294,6 +11216,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "iCL" = (
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/white,
 /area/security/warden)
 "iCQ" = (
@@ -11653,10 +11576,14 @@
 /area/chapel/office)
 "iRC" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/shuttle/excursion/general)
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/shuttle/excursion/cargo)
 "iSk" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector,
@@ -11914,7 +11841,7 @@
 /turf/simulated/floor/bluegrid,
 /area/ai_upload)
 "jeD" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -11961,12 +11888,6 @@
 /area/exploration/excursion_dock)
 "jgx" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/gunbox,
-/obj/item/gunbox,
-/obj/item/gunbox,
-/obj/item/gunbox,
-/obj/item/gunbox,
-/obj/item/gunbox,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -12271,6 +12192,11 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
 /area/security/security_lockerroom)
 "jrs" = (
@@ -12306,6 +12232,9 @@
 "jsY" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = -32
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -12382,12 +12311,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hop)
 "jxo" = (
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -24
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/cargo)
 "jxs" = (
@@ -12417,10 +12344,14 @@
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "jxu" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 32
+	},
 /obj/structure/cable/cyan{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
@@ -12503,18 +12434,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals9,
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/prison/cell_block)
@@ -12589,8 +12514,8 @@
 /turf/simulated/floor/tiled,
 /area/bridge/hallway)
 "jED" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/voidcraft/vertical,
+/turf/simulated/floor/tiled,
 /area/shuttle/excursion/cargo)
 "jFj" = (
 /obj/structure/cable/green{
@@ -12682,7 +12607,9 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/item/storage/box/teargas,
+/obj/item/storage/box/teargas{
+	pixel_y = 6
+	},
 /obj/item/storage/box/teargas,
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -12734,7 +12661,9 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
-/obj/machinery/vending/sovietsoda,
+/obj/machinery/vending/sovietsoda{
+	name = "Water Dispenser"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/brig)
 "jKM" = (
@@ -12816,12 +12745,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/machinery/button/remote/airlock{
-	id = "BrigFoyer";
-	name = "Lobby Door Control";
-	pixel_x = 27;
-	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -13004,7 +12927,10 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
 "jYA" = (
-/obj/item/bone/skull,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/security/starboard)
 "jZa" = (
@@ -13177,6 +13103,13 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "khB" = (
@@ -13185,7 +13118,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/shuttle/wall/voidcraft/blue,
-/area/shuttle/excursion/cargo)
+/area/shuttle/excursion/general)
 "kim" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/glasses/meta,
@@ -13197,10 +13130,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/CE_quarters)
 "kiY" = (
-/obj/machinery/sleep_console,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/mineral/equipment_vendor/survey,
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
 "kjd" = (
@@ -13469,12 +13399,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "kwq" = (
-/obj/machinery/door/airlock/voidcraft/vertical,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/computer/ship/sensors,
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/cockpit)
 "kzc" = (
@@ -13622,10 +13547,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/red/bordercorner,
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "kGG" = (
@@ -13682,8 +13603,16 @@
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "kJf" = (
-/obj/effect/wingrille_spawn/reinforced_phoron,
-/turf/simulated/shuttle/floor/voidcraft,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 32
+	},
+/obj/structure/cable/cyan,
+/turf/simulated/floor/tiled,
 /area/shuttle/excursion/cockpit)
 "kJr" = (
 /obj/item/radio/intercom{
@@ -13944,10 +13873,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/bordercorner,
-/obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -14338,6 +14263,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = -32
+	},
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 4;
@@ -14694,6 +14622,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "ltW" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -14748,7 +14681,6 @@
 "luA" = (
 /obj/structure/grille/broken,
 /obj/item/material/shard,
-/obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/maintenance/security/starboard)
 "luJ" = (
@@ -14764,6 +14696,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals9,
 /obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -15019,11 +14954,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)
 "lEt" = (
+/obj/structure/stasis_cage,
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/light,
-/obj/vehicle/train/engine/quadbike,
-/obj/machinery/mech_recharger,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/shuttle/excursion/cargo)
 "lEu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -15205,7 +15139,9 @@
 /area/maintenance/central)
 "lKF" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/gun/energy/ionrifle,
+/obj/item/gun/energy/ionrifle{
+	pixel_y = 5
+	},
 /obj/item/gun/energy/ionrifle,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15505,9 +15441,6 @@
 	pixel_y = 6
 	},
 /obj/item/megaphone,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/camera/network/command,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -15651,10 +15584,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/bordercorner,
-/obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -15894,7 +15823,7 @@
 	dir = 4
 	},
 /turf/simulated/shuttle/wall/voidcraft/blue,
-/area/shuttle/excursion/cargo)
+/area/shuttle/excursion/general)
 "mmU" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
@@ -16189,14 +16118,6 @@
 /obj/random/maintenance/security,
 /turf/simulated/floor/plating,
 /area/maintenance/security/starboard)
-"mym" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/folder/red,
-/obj/item/folder/blue,
-/obj/item/pen,
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
 "myH" = (
 /obj/machinery/door/window/brigdoor/westright{
 	dir = 4;
@@ -16527,18 +16448,36 @@
 /area/exploration/medical)
 "mMh" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/accessory/armor/legguards,
-/obj/item/clothing/accessory/armor/legguards,
-/obj/item/clothing/accessory/armor/legguards,
-/obj/item/clothing/accessory/armor/legguards,
-/obj/item/clothing/accessory/armor/legguards,
-/obj/item/clothing/accessory/armor/legguards,
-/obj/item/clothing/accessory/armor/legguards,
-/obj/item/clothing/accessory/armor/legguards,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/item/clothing/suit/armor/pcarrier/medium/nt,
+/obj/item/clothing/suit/armor/pcarrier/medium/nt,
+/obj/item/clothing/suit/armor/pcarrier/medium/nt{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/item/clothing/suit/armor/pcarrier/medium/nt{
+	pixel_x = 1;
+	pixel_y = -4
+	},
+/obj/item/clothing/suit/armor/pcarrier/medium/nt{
+	pixel_x = -3;
+	pixel_y = -4
+	},
+/obj/item/clothing/suit/armor/pcarrier/medium/nt{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/pcarrier/medium/nt{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/pcarrier/medium/nt{
+	pixel_x = -3;
+	pixel_y = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "mMm" = (
@@ -16563,6 +16502,13 @@
 /obj/item/book/custom_library/reference,
 /turf/simulated/floor/wood,
 /area/library)
+"mNU" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/security/starboard)
 "mOm" = (
 /obj/structure/flora/pottedplant,
 /obj/item/radio/intercom{
@@ -17222,11 +17168,9 @@
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
 "nmi" = (
-/obj/structure/bed/chair/shuttle{
-	dir = 8
-	},
+/obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled,
-/area/shuttle/excursion/general)
+/area/shuttle/excursion/cockpit)
 "nmY" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -17338,27 +17282,16 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/lounge)
 "nrI" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/cell/device/weapon{
-	pixel_x = 3
-	},
-/obj/item/cell/device/weapon{
-	pixel_x = 3
-	},
-/obj/item/cell/device/weapon{
-	pixel_x = 3
-	},
-/obj/item/cell/device/weapon{
-	pixel_x = 3
-	},
-/obj/item/melee/baton/stunsword,
-/obj/item/melee/baton/stunsword,
+/obj/structure/table/steel,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/camera/network/security,
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
@@ -17638,21 +17571,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "nAj" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/storage/box/handcuffs{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/book/manual/security_space_law,
-/obj/item/book/manual/security_space_law,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/melee/baton/stunsword,
+/obj/item/melee/baton/stunsword{
+	pixel_x = 3;
+	pixel_y = -4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "nAS" = (
@@ -17840,11 +17768,6 @@
 /obj/item/book/codex/lore/news,
 /turf/simulated/floor/wood,
 /area/library)
-"nKN" = (
-/obj/effect/floor_decal/industrial/warning/full,
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plating,
-/area/shuttle/excursion/cargo)
 "nLj" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -18372,11 +18295,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/civilian_hallway_mid)
 "oik" = (
-/obj/machinery/computer/ship/sensors{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/shuttle/excursion/cockpit)
+/area/shuttle/excursion/general)
 "oiq" = (
 /obj/effect/floor_decal/corner/black{
 	dir = 9
@@ -18446,6 +18372,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
+"okw" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled,
+/area/shuttle/excursion/general)
 "okA" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -18515,6 +18445,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/exploration/showers)
+"oln" = (
+/obj/machinery/sleep_console,
+/turf/simulated/floor/tiled,
+/area/shuttle/excursion/general)
 "olP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -18926,6 +18860,11 @@
 	},
 /obj/effect/floor_decal/corner/red/full,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/security/security_lockerroom)
 "oCE" = (
@@ -18963,14 +18902,6 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/security/interrogation)
-"oDm" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 32;
-	pixel_y = 2
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/excursion/cargo)
 "oEc" = (
 /obj/machinery/door/airlock/glass_external{
 	frequency = null;
@@ -19409,7 +19340,6 @@
 /area/crew_quarters/captain)
 "oUS" = (
 /obj/structure/table/steel,
-/obj/item/storage/lockbox,
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 24
@@ -19420,6 +19350,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
+/obj/item/storage/lockbox,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "oVi" = (
@@ -19616,19 +19547,8 @@
 /turf/simulated/shuttle/floor/voidcraft,
 /area/bridge)
 "pak" = (
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 8
-	},
 /obj/structure/table/steel_reinforced,
-/obj/item/retail_scanner/security,
 /obj/item/folder/red,
-/obj/item/clipboard,
-/obj/item/tool/wrench,
-/obj/item/tool/crowbar,
-/obj/item/hand_labeler,
-/obj/effect/floor_decal/corner/red{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "pat" = (
@@ -19912,12 +19832,6 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "pjg" = (
@@ -20029,6 +19943,29 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/brig)
+"pnk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/hallway)
 "pno" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
@@ -20300,13 +20237,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
-"pBL" = (
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 32;
-	pixel_y = 3
-	},
-/turf/simulated/floor/tiled,
-/area/shuttle/excursion/general)
 "pCc" = (
 /obj/machinery/camera/network/exploration,
 /obj/machinery/light{
@@ -20347,6 +20277,9 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -20425,12 +20358,6 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "pHP" = (
@@ -20465,7 +20392,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "pJC" = (
-/obj/structure/table/steel_reinforced,
+/obj/structure/table/rack/shelf/steel,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/glasses/goggles,
 /obj/structure/window/reinforced{
@@ -20529,9 +20456,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "pKw" = (
-/obj/machinery/computer/ship/engines,
+/obj/machinery/door/airlock/voidcraft/vertical,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
-/area/shuttle/excursion/cockpit)
+/area/shuttle/excursion/general)
 "pKG" = (
 /turf/simulated/shuttle/wall/voidcraft/blue,
 /area/hallway/primary/aft)
@@ -20768,6 +20700,9 @@
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
 "pTM" = (
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/effect/overmap/visitable/ship/landable/excursion,
 /obj/effect/shuttle_landmark/triumph/deck4/excursion,
 /turf/simulated/floor/tiled,
@@ -20825,12 +20760,6 @@
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
@@ -21092,6 +21021,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = -32
+	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -21235,9 +21167,6 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "qgG" = (
@@ -21248,7 +21177,6 @@
 	dir = 1
 	},
 /obj/structure/table/bench/wooden,
-/obj/item/deck/unus,
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
 "qgO" = (
@@ -21294,6 +21222,10 @@
 "qhg" = (
 /obj/structure/table/woodentable,
 /obj/item/book/manual/security_space_law,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -5;
+	pixel_y = 2
+	},
 /turf/simulated/floor/carpet,
 /area/security/warden)
 "qid" = (
@@ -21426,6 +21358,11 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/security/security_lockerroom)
 "qkp" = (
@@ -21650,6 +21587,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
+"qsk" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/excursion/general)
 "qss" = (
 /obj/machinery/fitness/heavy/lifter,
 /turf/simulated/floor/tiled/dark,
@@ -21701,9 +21644,6 @@
 "qvi" = (
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/machinery/computer/ship/sensors{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
@@ -21902,13 +21842,10 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "qBb" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/old_tile/red,
-/area/security/range)
+/obj/structure/table/bench/steel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/monotile,
+/area/security/security_lockerroom)
 "qBs" = (
 /obj/structure/flora/pottedplant/minitree,
 /obj/machinery/firealarm{
@@ -21948,11 +21885,8 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "qCU" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/random/trash_pile,
-/turf/simulated/floor/plating,
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled/old_tile/gray,
 /area/maintenance/security/starboard)
 "qDf" = (
 /obj/effect/floor_decal/spline/plain{
@@ -21975,18 +21909,26 @@
 /area/hydroponics/garden)
 "qEc" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/suit/armor/pcarrier/medium/nt,
-/obj/item/clothing/suit/armor/pcarrier/medium/nt,
-/obj/item/clothing/suit/armor/pcarrier/medium/nt,
-/obj/item/clothing/suit/armor/pcarrier/medium/nt,
-/obj/item/clothing/suit/armor/pcarrier/medium/nt,
-/obj/item/clothing/suit/armor/pcarrier/medium/nt,
-/obj/item/clothing/suit/armor/pcarrier/medium/nt,
-/obj/item/clothing/suit/armor/pcarrier/medium/nt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/item/clothing/accessory/armor/armguards{
+	pixel_y = 4
+	},
+/obj/item/clothing/accessory/armor/armguards,
+/obj/item/clothing/accessory/armor/armguards{
+	pixel_y = -4
+	},
+/obj/item/clothing/accessory/armor/armguards{
+	pixel_y = -9
+	},
+/obj/item/clothing/accessory/armor/armguards{
+	pixel_y = -9
+	},
+/obj/item/clothing/accessory/armor/armguards,
+/obj/item/clothing/accessory/armor/armguards,
+/obj/item/clothing/accessory/armor/armguards,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "qEu" = (
@@ -22044,7 +21986,9 @@
 /area/bridge)
 "qGf" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/security,
+/obj/machinery/door/airlock/security{
+	name = "Private Quarters"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "qGx" = (
@@ -22391,9 +22335,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "qSA" = (
@@ -22468,7 +22409,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/red/bordercorner,
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "qUK" = (
@@ -22488,7 +22428,7 @@
 /turf/simulated/floor/airless,
 /area/shuttle/civvie/cockpit)
 "qVj" = (
-/obj/machinery/chemical_dispenser/bar_soft{
+/obj/machinery/chemical_dispenser/bar_soft/full{
 	dir = 8
 	},
 /obj/structure/table/woodentable,
@@ -22556,9 +22496,6 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4;
 	name = "Engine Fuel Port"
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/cargo)
@@ -22758,14 +22695,13 @@
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "reI" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/walllocker/emerglocker{
-	pixel_y = 32
+/obj/machinery/light,
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -23
 	},
 /turf/simulated/floor/tiled,
-/area/shuttle/excursion/general)
+/area/shuttle/excursion/cockpit)
 "reN" = (
 /turf/simulated/floor/outdoors/water/indoors,
 /area/triumph/surfacebase/sauna)
@@ -22796,7 +22732,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/red/bordercorner,
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "rgM" = (
@@ -22983,9 +22918,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "rmO" = (
@@ -23200,9 +23132,6 @@
 "rsS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "rtC" = (
@@ -23464,6 +23393,8 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
+/obj/structure/closet/secure_closet/warden,
+/obj/item/book/manual/security_space_law,
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "rEY" = (
@@ -23509,13 +23440,13 @@
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
@@ -23542,6 +23473,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "rGT" = (
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/machinery/autolathe{
 	hacked = 1
 	},
@@ -23917,7 +23851,7 @@
 	dir = 4
 	},
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
-/area/shuttle/excursion/cargo)
+/area/shuttle/excursion/general)
 "rXj" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24010,6 +23944,9 @@
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
+	},
+/obj/structure/sign/department/prison{
+	pixel_y = 31
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
@@ -24177,6 +24114,7 @@
 /area/hallway/secondary/civilian_hallway_mid)
 "shs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals_central6,
 /turf/simulated/floor/tiled/monotile,
 /area/security/security_lockerroom)
 "shG" = (
@@ -24714,30 +24652,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "sBq" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/cell/device/weapon{
-	pixel_x = 3
-	},
-/obj/item/cell/device/weapon{
-	pixel_x = 3
-	},
-/obj/item/cell/device/weapon{
-	pixel_x = 3
-	},
-/obj/item/cell/device/weapon{
-	pixel_x = 3
-	},
-/obj/item/cell/device/weapon{
-	pixel_x = 3
-	},
-/obj/item/cell/device/weapon{
-	pixel_x = 3
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/item/gun/energy/phasegun/cannon,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/deployable/barrier,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "sBU" = (
@@ -25055,11 +24974,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "sKx" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/cockpit)
 "sKy" = (
@@ -25093,8 +25007,10 @@
 /obj/item/radio/intercom{
 	pixel_y = -24
 	},
+/obj/structure/bed/chair/shuttle{
+	dir = 1
+	},
 /obj/machinery/light,
-/obj/machinery/sleep_console,
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
 "sNf" = (
@@ -25133,9 +25049,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -25143,6 +25056,12 @@
 	},
 /obj/machinery/status_display{
 	pixel_y = 32
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -25246,12 +25165,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -25568,13 +25481,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/civilian_hallway_mid)
 "tab" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 32
 	},
 /obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/cargo)
@@ -25909,6 +25826,9 @@
 	dir = 8;
 	pixel_x = -26
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/lobby)
 "tpw" = (
@@ -25981,7 +25901,12 @@
 /turf/simulated/floor,
 /area/security/hanger)
 "tsv" = (
-/obj/machinery/light/small,
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "tsJ" = (
@@ -26052,7 +25977,11 @@
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "tuX" = (
-/turf/simulated/shuttle/wall/voidcraft/blue,
+/obj/machinery/computer/shuttle_control/explore/excursion{
+	dir = 4;
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled,
 /area/shuttle/excursion/cockpit)
 "tvx" = (
 /obj/structure/flora/skeleton,
@@ -26094,15 +26023,6 @@
 /obj/random/maintenance/security,
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/maintenance/security/starboard)
-"tym" = (
-/obj/machinery/light,
-/obj/machinery/alarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -23
-	},
-/obj/structure/table/rack/shelf,
-/turf/simulated/floor/tiled,
-/area/shuttle/excursion/cockpit)
 "tyT" = (
 /turf/simulated/wall/r_wall,
 /area/ai/foyer)
@@ -26423,10 +26343,10 @@
 /area/security/hallway)
 "tLZ" = (
 /obj/structure/table/bench/steel,
-/obj/structure/window/basic{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/security_lockerroom)
 "tMK" = (
@@ -26524,9 +26444,6 @@
 /area/crew_quarters/heads/hos)
 "tTk" = (
 /obj/structure/table/bench/steel,
-/obj/structure/window/basic{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -26559,14 +26476,16 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/bordercorner,
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "tUB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/table/steel_reinforced,
+/obj/machinery/photocopier/faxmachine{
+	department = "Warden's Office"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "tUV" = (
@@ -26605,7 +26524,6 @@
 /area/triumph/surfacebase/tram)
 "tVJ" = (
 /obj/structure/table/steel,
-/obj/item/storage/box/flashbangs,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
 "tVK" = (
@@ -26619,10 +26537,12 @@
 /turf/simulated/floor/wood,
 /area/lawoffice)
 "tWp" = (
-/obj/structure/catwalk,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/cargo)
 "tXa" = (
@@ -26977,6 +26897,11 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
+/obj/structure/table/steel_reinforced,
+/obj/item/clipboard,
+/obj/item/tool/wrench,
+/obj/item/tool/crowbar,
+/obj/item/hand_labeler,
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "ujJ" = (
@@ -27172,7 +27097,7 @@
 "upV" = (
 /obj/machinery/button/remote/blast_door{
 	id = "armoryriot";
-	name = "Riot Armory Access";
+	name = "Emergency Armory Access";
 	pixel_x = 25;
 	pixel_y = -6;
 	req_access = list(3)
@@ -27210,9 +27135,8 @@
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "urq" = (
-/obj/machinery/door/airlock/multi_tile/metal/mait{
-	dir = 2
-	},
+/obj/effect/decal/cleanable/blood/drip,
+/obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/security/starboard)
 "urK" = (
@@ -27286,17 +27210,13 @@
 "uue" = (
 /obj/machinery/button/remote/blast_door{
 	id = "armoryriot";
-	name = "Riot Armory Access";
+	name = "Emergency Armory Access";
 	pixel_x = -25;
 	pixel_y = -6;
 	req_access = list(3)
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 9
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -22;
-	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)
@@ -27558,8 +27478,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "uDH" = (
-/obj/effect/wingrille_spawn/reinforced_phoron,
-/turf/simulated/shuttle/floor/voidcraft,
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
 "uEc" = (
 /obj/machinery/button/remote/airlock{
@@ -27597,7 +27523,9 @@
 /area/security/forensics)
 "uGS" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/security,
+/obj/machinery/door/airlock/security{
+	name = "Private Quarters"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "uHZ" = (
@@ -27855,12 +27783,13 @@
 /turf/simulated/floor/plating,
 /area/security/brig)
 "uQV" = (
-/obj/structure/table/woodentable,
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -26
 	},
-/obj/item/book/manual/security_space_law,
 /turf/simulated/floor/wood,
 /area/security/breakroom)
 "uQZ" = (
@@ -27925,18 +27854,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
-"uTz" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/obj/structure/closet/hydrant{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/hallway)
 "uTH" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -27999,8 +27916,12 @@
 /turf/simulated/wall/r_wall,
 /area/ai_upload)
 "uWs" = (
-/turf/simulated/wall,
-/area/security/interrogation)
+/obj/structure/closet/emcloset,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security/starboard)
 "uXe" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -28150,6 +28071,12 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -28344,10 +28271,25 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/CE_quarters)
 "vjU" = (
-/obj/random/trash,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/security/starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/hallway)
 "vjX" = (
 /obj/structure/sink{
 	pixel_y = 30
@@ -28592,14 +28534,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "vsQ" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
-/obj/effect/landmark/start{
-	name = "Warden"
+/obj/machinery/computer/prisoner{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -28900,16 +28839,11 @@
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "vBq" = (
-/obj/structure/table/bench/steel,
-/obj/structure/window/basic{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/effect/landmark/start{
-	name = "Security Officer"
-	},
+/obj/structure/table/steel,
+/obj/item/storage/box/donut,
 /turf/simulated/floor/tiled/monotile,
 /area/security/security_lockerroom)
 "vBD" = (
@@ -28921,11 +28855,14 @@
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
 "vCh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/wall/voidcraft/blue,
-/area/shuttle/excursion/cargo)
+/obj/machinery/door/airlock/voidcraft/vertical,
+/turf/simulated/shuttle/plating,
+/area/shuttle/excursion/general)
 "vDp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -29008,6 +28945,10 @@
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/security/security_lockerroom)
 "vGG" = (
@@ -29086,10 +29027,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "vIU" = (
-/obj/structure/table/bench/steel,
-/obj/structure/window/basic{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -29098,22 +29035,19 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/table/steel,
+/obj/item/book/manual/security_space_law,
+/obj/item/book/manual/standard_operating_procedure{
+	pixel_x = -5
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/security_lockerroom)
 "vJe" = (
-/obj/structure/table/steel,
-/obj/fiftyspawner/glass,
-/obj/fiftyspawner/glass,
-/obj/fiftyspawner/steel,
-/obj/fiftyspawner/steel,
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
-	},
 /obj/effect/floor_decal/corner/red/full{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/table/steel,
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)
 "vJi" = (
@@ -29224,7 +29158,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central6,
 /turf/simulated/floor/tiled/monotile,
 /area/security/security_lockerroom)
 "vMP" = (
@@ -29310,8 +29243,6 @@
 /area/maintenance/tool_storage)
 "vOb" = (
 /obj/structure/table/steel,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -29320,6 +29251,11 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/item/shield_projector,
+/obj/item/shield_projector,
+/obj/item/shield_projector,
+/obj/item/shield_projector,
+/obj/item/shield_projector,
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)
 "vPg" = (
@@ -29587,17 +29523,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/triumph/station/stairs_four)
 "vVM" = (
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 8
-	},
 /obj/structure/table/steel_reinforced,
 /obj/item/stamp/denied{
 	pixel_x = 5
 	},
 /obj/item/stamp/ward,
-/obj/effect/floor_decal/corner/red{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "vWa" = (
@@ -29632,8 +29562,8 @@
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
 "vXo" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/structure/bed/chair/office/dark{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -29856,11 +29786,11 @@
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "wem" = (
+/obj/machinery/door/airlock/voidcraft/vertical,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
+	dir = 4
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/shuttle/excursion/cargo)
 "wer" = (
 /obj/machinery/firealarm{
@@ -29927,9 +29857,6 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/hallway/secondary/civilian_hallway_mid)
 "whn" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "Warden's Office"
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
@@ -29995,19 +29922,32 @@
 /turf/simulated/floor/plating,
 /area/maintenance/central)
 "wkz" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/accessory/armor/helmcover/nt,
-/obj/item/clothing/accessory/armor/helmcover/nt,
-/obj/item/clothing/accessory/armor/helmcover/nt,
-/obj/item/clothing/accessory/armor/helmcover/nt,
-/obj/item/clothing/accessory/armor/helmcover/nt,
-/obj/item/clothing/accessory/armor/helmcover/nt,
-/obj/item/clothing/accessory/armor/helmcover/nt,
-/obj/item/clothing/accessory/armor/helmcover/nt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/cell/device/weapon{
+	pixel_x = -8
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = -4
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = -1
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 3
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 8
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 3
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 3
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "wkS" = (
@@ -30204,6 +30144,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "wrw" = (
@@ -30233,6 +30175,10 @@
 /obj/item/pen,
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = 30
 	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
@@ -30291,7 +30237,7 @@
 /obj/machinery/door/blast/regular{
 	dir = 2;
 	id = "armoryriot";
-	name = "Riot Control Armory Access"
+	name = "Emergency Armory Access"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -30779,13 +30725,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/forensics)
-"wNH" = (
-/obj/machinery/mineral/equipment_vendor/survey,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/shuttle/excursion/general)
 "wNX" = (
 /obj/machinery/light_switch{
 	name = "light switch ";
@@ -30878,7 +30817,15 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
 "wRr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "wRC" = (
@@ -31174,12 +31121,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "xdr" = (
-/obj/structure/table/steel_reinforced,
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -32
 	},
-/obj/effect/floor_decal/corner/red/full,
+/obj/item/storage/box/handcuffs{
+	pixel_x = 1;
+	pixel_y = 2
+	},
 /obj/item/megaphone,
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "xdv" = (
@@ -31289,16 +31245,9 @@
 /turf/simulated/wall/r_wall,
 /area/security/breakroom)
 "xhB" = (
-/obj/item/gps/internal/base{
-	desc = "A tracking beacon embedded in the shuttle systems, to help explorers find where they landed.";
-	gps_tag = "SHUTTLE";
-	name = "shuttle beacon"
-	},
-/obj/machinery/computer/ship/helm{
-	dir = 4
-	},
+/obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/tiled,
-/area/shuttle/excursion/cockpit)
+/area/shuttle/excursion/general)
 "xhF" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -31399,7 +31348,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "xlj" = (
-/obj/structure/table/steel_reinforced,
+/obj/structure/table/rack/shelf/steel,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/glasses/goggles,
 /obj/structure/window/reinforced{
@@ -31493,14 +31442,28 @@
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/cargo)
 "xnz" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/accessory/armor/helmcover/nt,
+/obj/item/clothing/accessory/armor/helmcover/nt,
+/obj/item/clothing/accessory/armor/helmcover/nt,
+/obj/item/clothing/accessory/armor/helmcover/nt,
+/obj/item/clothing/accessory/armor/helmcover/nt,
+/obj/item/clothing/accessory/armor/helmcover/nt,
+/obj/item/clothing/accessory/armor/helmcover/nt,
+/obj/item/clothing/accessory/armor/helmcover/nt,
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "xoa" = (
-/obj/structure/bed/chair/shuttle{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/shuttle/excursion/cockpit)
+/obj/machinery/shipsensors,
+/turf/simulated/floor/plating,
+/area/shuttle/excursion/general)
 "xox" = (
 /obj/item/clothing/shoes/black,
 /turf/simulated/floor/plating,
@@ -31846,7 +31809,7 @@
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
-/obj/machinery/newscaster/security_unit{
+/obj/structure/sign/department/interrogation{
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
@@ -31906,7 +31869,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/red/bordercorner,
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "xBR" = (
@@ -31930,12 +31892,28 @@
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "xEu" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/railing{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/security/starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/sign/department/interrogation{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/hallway)
 "xFn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -32008,7 +31986,7 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/red/border{
+/obj/effect/floor_decal/corner/blue/border{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -32176,7 +32154,6 @@
 /area/security/armoury)
 "xNa" = (
 /obj/item/material/shard,
-/obj/effect/decal/remains,
 /turf/simulated/floor/plating,
 /area/maintenance/security/starboard)
 "xOb" = (
@@ -32190,8 +32167,9 @@
 /turf/simulated/floor/tiled,
 /area/security/hanger)
 "xOw" = (
-/turf/simulated/floor/tiled,
-/area/shuttle/excursion/cockpit)
+/obj/effect/wingrille_spawn/reinforced_phoron,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/shuttle/excursion/general)
 "xOD" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -32443,29 +32421,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
-"xWT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/obj/structure/closet/hydrant{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/hallway)
 "xXe" = (
 /obj/structure/table/woodentable,
 /obj/machinery/chemical_dispenser/bar_soft/full,
@@ -32550,7 +32505,7 @@
 /obj/machinery/door/blast/regular{
 	dir = 2;
 	id = "armoryriot";
-	name = "Riot Control Armory Access"
+	name = "Emergency Armory Access"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/red{
@@ -32718,6 +32673,9 @@
 /turf/simulated/wall/r_wall,
 /area/security/evidence_storage)
 "yhh" = (
+/obj/structure/bed/chair/shuttle{
+	dir = 1
+	},
 /obj/machinery/alarm/alarms_hidden{
 	dir = 1;
 	pixel_y = -23
@@ -34328,12 +34286,12 @@ mAF
 xsI
 xsI
 xsI
-tuX
-tuX
-kJf
-kJf
-tuX
-tuX
+xsI
+xsI
+xsI
+xsI
+xsI
+xsI
 xsI
 xsI
 xsI
@@ -34470,12 +34428,12 @@ mAF
 xsI
 xsI
 xsI
-tuX
-oik
-xhB
-aoA
-tym
-tuX
+xsI
+xsI
+xsI
+xsI
+xsI
+xsI
 xsI
 xsI
 xsI
@@ -34612,14 +34570,14 @@ mAF
 bPa
 xsI
 xsI
-kJf
-xOw
-xoa
-xOw
-xOw
-kJf
 xsI
 xsI
+hYe
+hYe
+xOw
+xOw
+hYe
+hYe
 xsI
 xsI
 eLD
@@ -34754,14 +34712,14 @@ mAF
 xsI
 xsI
 xsI
-tuX
-pKw
-xoa
+xsI
+xsI
+hYe
 sKx
 iwU
 tuX
-xsI
-xsI
+nmi
+hYe
 xsI
 mAF
 iWU
@@ -34896,14 +34854,14 @@ mAF
 ouB
 xsI
 xsI
-tuX
-tuX
-kJf
+xsI
+xsI
+hYe
 kwq
-tuX
-tuX
-xsI
-xsI
+hjg
+hjg
+reI
+hYe
 oJL
 mAF
 iWU
@@ -35037,15 +34995,15 @@ mAF
 mAF
 xsI
 xsI
-gTt
-hYe
-qvi
-ieD
-jxu
-wNH
-hYe
-hYe
 xsI
+xsI
+xsI
+hYe
+fzE
+sKx
+dzk
+kJf
+hYe
 xsI
 mAF
 iWU
@@ -35179,15 +35137,15 @@ mAF
 mAF
 xsI
 xsI
-bYS
-bYS
-nmi
-ieD
-jxu
-hNo
-bYS
-hYe
 xsI
+xsI
+xsI
+hYe
+hYe
+hYe
+pKw
+hYe
+hYe
 xsI
 mAF
 iWU
@@ -35321,15 +35279,15 @@ mAF
 mAF
 xsI
 xsI
-uDH
-nmi
-ieD
-ieD
-jxu
-ieD
-nmi
-uDH
 xsI
+xsI
+xsI
+hYe
+qsk
+qvi
+eau
+uDH
+hYe
 xsI
 mAF
 iWU
@@ -35463,15 +35421,15 @@ mAF
 mAF
 bPa
 xsI
-uDH
-nmi
-ieD
-ieD
-jxu
-ieD
-nmi
-uDH
 xsI
+xsI
+xsI
+xOw
+oln
+ieD
+eau
+oln
+hYe
 xsI
 mAF
 iWU
@@ -35605,15 +35563,15 @@ mAF
 mAF
 alS
 xsI
-uDH
-nmi
-ieD
-ieD
-jxu
-ieD
-nmi
-uDH
 xsI
+xsI
+xoa
+hYe
+okw
+ieD
+eau
+okw
+xOw
 uKG
 mAF
 iWU
@@ -35749,13 +35707,13 @@ ouB
 hYe
 hYe
 hYe
-reI
+hYe
+bYS
 ieD
-jxu
-fWo
-hYe
-hYe
-hYe
+ieD
+eau
+cvW
+xOw
 oJL
 mAF
 iWU
@@ -35894,10 +35852,10 @@ lks
 qby
 jsY
 rGn
-ieD
-ieD
+oik
+gTt
 cvW
-hYe
+xOw
 xsI
 mAF
 iWU
@@ -36178,7 +36136,7 @@ cqx
 dXI
 bYS
 hdl
-ieD
+xhB
 ieD
 yhh
 hYe
@@ -36322,8 +36280,8 @@ pSB
 dvW
 mpE
 ieD
-bHL
-hYe
+cvW
+xOw
 xsI
 mAF
 iWU
@@ -36457,15 +36415,15 @@ eEl
 skC
 xsI
 hYe
-iRC
+ieD
 tii
 kln
 hYe
 jxu
 eau
-pBL
+ieD
 kiY
-hYe
+xOw
 xsI
 mAF
 iWU
@@ -36603,11 +36561,11 @@ oZY
 obo
 ula
 hYe
-eDu
+hYe
+vCh
 hYe
 hYe
-hYe
-hYe
+xOw
 xsI
 mAF
 iWU
@@ -36740,16 +36698,16 @@ aQk
 vil
 mAF
 utL
-dzk
+hYe
 pAV
-pAV
+iRC
 cEr
 rGT
 jxo
 tWp
-nKN
 vIe
-dzk
+vIe
+hYe
 xsI
 mAF
 iWU
@@ -36882,7 +36840,7 @@ hqy
 mjJ
 mAF
 ouB
-dzk
+hYe
 qXa
 sfl
 tab
@@ -36891,7 +36849,7 @@ aEY
 ltW
 ntt
 qyn
-dzk
+hYe
 xsI
 mAF
 iWU
@@ -37024,16 +36982,16 @@ hqy
 gxG
 mAF
 xsI
-dzk
+hYe
 gQk
 xnp
 fzX
-oDm
-jED
-hLF
+hYe
+dwl
+hYe
 wem
 jED
-dzk
+hYe
 uKG
 mAF
 iWU
@@ -37166,16 +37124,16 @@ hqy
 dls
 mAF
 ifm
-dzk
+hYe
 rFX
 fse
 aDO
-dzk
-chi
-dfy
-eWr
+xsI
+xsI
+hYe
+bbp
 lEt
-dzk
+hYe
 xsI
 mAF
 iWU
@@ -37308,16 +37266,16 @@ gaT
 rsy
 mAF
 xsI
-dzk
+hYe
 lTt
 lTt
-vCh
+aDO
 xsI
 xsI
-dzk
+hYe
 bbp
 dZg
-dzk
+hYe
 xsI
 mAF
 iWU
@@ -37627,14 +37585,14 @@ lPS
 lst
 eGK
 uAw
-vAk
+vjU
 xSR
 ooz
 sab
 vYq
 vYq
 jeD
-jeD
+gXR
 gXR
 qkS
 xhp
@@ -37778,7 +37736,7 @@ vYq
 xSo
 hvq
 xKG
-kQE
+fVV
 bkw
 pkc
 pkc
@@ -38189,13 +38147,13 @@ iAb
 iWU
 iWU
 hQJ
-lPS
-lPS
-lPS
-lPS
+ybe
+ybe
+ybe
+ybe
 hQd
 tSR
-vAk
+vjU
 xSR
 gxV
 gxV
@@ -38337,7 +38295,7 @@ ybe
 ybe
 wzg
 uAw
-vAk
+vjU
 xSR
 uNU
 rUN
@@ -38749,7 +38707,7 @@ xPq
 ssI
 ePg
 bWp
-xxQ
+vma
 cDe
 jPB
 eBw
@@ -39047,7 +39005,7 @@ iLa
 iNN
 ooZ
 oAG
-xWT
+vAk
 xSR
 qQW
 mZU
@@ -39191,7 +39149,7 @@ oAG
 oAG
 vAk
 xSR
-npe
+vny
 sEs
 tLl
 shs
@@ -39337,7 +39295,7 @@ rCz
 sEL
 tLZ
 vBq
-tLZ
+qBb
 aWe
 rGX
 qke
@@ -39617,7 +39575,7 @@ tDq
 glH
 vAk
 xSR
-npe
+vny
 sIp
 ira
 vMM
@@ -40310,8 +40268,8 @@ dHb
 vma
 ogC
 iBZ
+iBZ
 biV
-vLR
 czV
 xzh
 xzE
@@ -40324,7 +40282,7 @@ xzE
 kVu
 fnC
 qUK
-uWs
+xIX
 vAk
 ify
 tDn
@@ -40473,7 +40431,7 @@ rDs
 vbY
 wRr
 bSA
-trF
+tsv
 qGf
 uSv
 uSv
@@ -40608,7 +40566,7 @@ xzE
 xek
 spt
 xek
-uWs
+xIX
 vAk
 xSR
 tDn
@@ -40618,7 +40576,7 @@ vVM
 dnp
 tDn
 tbC
-tsv
+trF
 tDn
 tDn
 nIK
@@ -40750,8 +40708,8 @@ xzE
 llb
 fxw
 oDb
-uWs
-vAk
+xIX
+xEu
 xSR
 nBV
 pEd
@@ -41034,8 +40992,8 @@ xzE
 loy
 lQc
 jrL
-uWs
-vAk
+xIX
+pnk
 seW
 tDn
 hlA
@@ -41176,14 +41134,14 @@ xzE
 loH
 lRG
 oyw
-uWs
+xIX
 vAk
 rsu
 plC
 lUE
 eFy
 sBq
-gQL
+sBq
 tCO
 tCO
 nzO
@@ -41306,7 +41264,7 @@ tLP
 msd
 mYQ
 mYQ
-uTz
+czV
 xzh
 xzE
 xzE
@@ -41315,10 +41273,10 @@ xzE
 gRj
 xzE
 xzE
-uWs
-uWs
-uWs
-uWs
+xIX
+xIX
+xIX
+xIX
 qgT
 rsS
 rEZ
@@ -41586,7 +41544,7 @@ brg
 dHb
 mQR
 xIg
-aWv
+kRv
 sKJ
 sKJ
 sKJ
@@ -43023,7 +42981,7 @@ kmI
 mWi
 kmI
 kmI
-qBb
+mWi
 kmI
 qvQ
 xAC
@@ -43722,19 +43680,19 @@ lsu
 dft
 lsu
 lsu
-gMN
+fnm
 lsu
 lsu
 lsu
-gMN
-gMN
+jYA
+tMV
 lsu
-gMN
-gMN
-gMN
-gMN
-gMN
-gMN
+tMV
+tMV
+tMV
+tMV
+tMV
+tMV
 xAC
 xAC
 xAC
@@ -43861,20 +43819,20 @@ gMN
 lsu
 gMN
 fnm
-gMN
-gMN
-gMN
-ifk
-gMN
-fnm
-lsu
+ugw
+ugw
+ugw
+dUu
+ugw
+gyv
+ugw
 ugw
 ugw
 aBk
 ugw
 ugw
-lsu
-gMN
+ugw
+ugw
 ugw
 ugw
 ugw
@@ -44003,22 +43961,22 @@ gMN
 lsu
 gMN
 gMN
-gMN
-lsu
-lsu
-lsu
-lsu
-gMN
-lsu
-ugw
-gMN
-lsu
-pww
-ugw
-ugw
-ugw
 ugw
 lsu
+gmK
+gmK
+gmK
+gmK
+lsu
+gmK
+gmK
+lsu
+uWs
+gmK
+gmK
+gmK
+gmK
+eSm
 ugw
 iWf
 gMN
@@ -44146,13 +44104,13 @@ lsu
 eIN
 gMN
 ugw
-ugw
-ugw
-ugw
-ugw
-ugw
-ugw
-ugw
+iWf
+gMN
+gMN
+gMN
+gMN
+gMN
+gMN
 gMN
 lsu
 hzP
@@ -44288,7 +44246,7 @@ lsu
 lJa
 gMN
 ugw
-fnm
+qfo
 lsu
 hzP
 wXE
@@ -44582,7 +44540,7 @@ mPl
 ecG
 mPl
 gMN
-mWl
+gMN
 mPl
 mPl
 lsu
@@ -45146,7 +45104,7 @@ gMN
 xMt
 gYA
 lUj
-mPl
+qCU
 lsu
 lsu
 mWl
@@ -45433,7 +45391,7 @@ iat
 gMN
 lsu
 gMN
-lsu
+gMN
 lsu
 mPl
 gMN
@@ -45572,10 +45530,10 @@ rjU
 gMN
 nVn
 ovY
+qCU
+lsu
 mPl
-gMN
-mPl
-dUu
+dIf
 lsu
 lsu
 gFZ
@@ -45724,7 +45682,7 @@ gMN
 lsu
 hzP
 ugw
-iWf
+mNU
 lsu
 gMN
 fnm
@@ -45866,7 +45824,7 @@ mPl
 lsu
 gMN
 ugw
-qCU
+ugw
 bVJ
 gMN
 pww
@@ -46008,7 +45966,7 @@ lsu
 lsu
 gMN
 ugw
-lsu
+iWf
 lsu
 gMN
 lJa
@@ -46291,7 +46249,7 @@ lsu
 lsu
 lsu
 gMN
-ugw
+jjG
 iWf
 lsu
 gMN
@@ -46429,10 +46387,10 @@ fnm
 gMN
 fNw
 lsu
-ugw
-ugw
-ugw
-ugw
+fnm
+gMN
+lJa
+gMN
 ugw
 iWf
 lsu
@@ -46572,9 +46530,9 @@ ugw
 ugw
 ugw
 ugw
-gMN
-lsu
-fnm
+ugw
+ugw
+ugw
 ugw
 iWf
 lsu
@@ -46706,9 +46664,9 @@ ugw
 myb
 lsu
 lsu
-gMN
 gmK
-gMN
+gmK
+gmK
 lsu
 lJa
 gMN
@@ -46716,12 +46674,12 @@ fnm
 lJa
 hzP
 lsu
-gMN
-vjU
+fnm
+ugw
 iWf
 lsu
-gMN
 lJa
+gMN
 aSO
 aSO
 nIK
@@ -46863,7 +46821,7 @@ ugw
 qfo
 lsu
 lsu
-lsu
+gMN
 aSO
 aSO
 nIK
@@ -46991,7 +46949,7 @@ gMN
 lsu
 gMN
 qZU
-gyv
+nXq
 gMN
 lsu
 ydT
@@ -47127,7 +47085,7 @@ udf
 upm
 xqf
 wBy
-fza
+fre
 ugw
 tZH
 lsu
@@ -47276,7 +47234,7 @@ lsu
 dbt
 eOC
 hmc
-jYA
+lJa
 lsu
 rbu
 bjY
@@ -47417,8 +47375,8 @@ fvd
 lsu
 nXq
 eRm
-gyv
-qZU
+nXq
+urq
 lsu
 dlI
 tzG
@@ -47569,8 +47527,8 @@ lsu
 lsu
 lsu
 lsu
-ugw
-urq
+aBk
+lsu
 lsu
 lsu
 lsu
@@ -47703,13 +47661,13 @@ lsu
 lJa
 wnC
 tMV
-xEu
+tMV
 gIU
 ctx
 fuM
 tMV
 wnC
-aSO
+lsu
 gMN
 ugw
 gMN
@@ -50531,7 +50489,7 @@ duy
 dqW
 pox
 iTO
-mym
+pox
 hYd
 pox
 kzW

--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -7195,6 +7195,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/prison/cell_block)
 "fzM" = (
@@ -12451,6 +12454,9 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/prison/cell_block)
 "jAN" = (
@@ -12764,6 +12770,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/prison/cell_block)
@@ -15524,6 +15533,9 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/prison/cell_block)
@@ -38476,7 +38488,7 @@ kIp
 lAD
 nXp
 uAw
-vAk
+vjU
 nbt
 uNU
 sfo


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lots of minor fixes, but major-ish ones include:
- Flattening out the layout of D4's maint, also removes blood and skulls
- Redoes Warden's office
- Reshuffles some equipment around the armories
- Standardizes department stripes
- Fixes cameras under lights (as many as I could locate)
- Fills up certain coffee / drink dispensers

Warden's office:
![image](https://user-images.githubusercontent.com/11361525/116090493-9cc9f900-a6ac-11eb-8245-e10bb312fcbe.png)


### FOR CHANGES, LOOK AT CHECKS -> MAPDIFFBOT. THEY ARE TOO FEW AND SCATTERED TO ILLUSTRATE PROPERLY MANUALLY.

## Why It's Good For The Game

Essentially just addressing various complaints / concerns and establishing (or following) standards.

## Changelog
:cl:FreeStylaLT
tweak: Minor changes to Security and armories.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
