### PR TITLE
Adds moles to gas analyzer & allows ghosts to analyze pipes

### DIFF
--- a/code/__HELPERS/atmospherics.dm
+++ b/code/__HELPERS/atmospherics.dm
@@ -13,16 +13,28 @@
 	to_chat(user, "<span class='warning'>Your [src] flashes a red light as it fails to analyze \the [A].</span>")
 	return 0
 
+/obj/proc/analyze_gases_ghost(var/atom/A, var/mob/user)
+	var/list/result = A.atmosanalyze(user)
+	if(result && result.len)
+		to_chat(user, "<span class='notice'>Results of the analysis[src == A ? "" : " of \the [A]"]</span>")
+		for(var/line in result)
+			to_chat(user, "<span class='notice'>[line]</span>")
+		return 1
+
+	to_chat(user, "<span class='warning'>That [A] does not contain atmosphere.</span>")
+	return 0
+
 /proc/atmosanalyzer_scan(var/atom/target, var/datum/gas_mixture/mixture, var/mob/user)
 	var/list/results = list()
 
 	if (mixture && mixture.total_moles > 0)
 		var/pressure = mixture.return_pressure()
 		var/total_moles = mixture.total_moles
-		results += "<span class='notice'>Pressure: [round(pressure,0.1)] kPa</span>"
+		results += "<span class='notice'>Pressure: [round(pressure,0.01)] kPa</span>"
 		for(var/mix in mixture.gas)
 			results += "<span class='notice'>[GLOB.meta_gas_names[mix]]: [round((mixture.gas[mix] / total_moles) * 100)]%</span>"
 		results += "<span class='notice'>Temperature: [round(mixture.temperature-T0C)]&deg;C</span>"
+		results += "<span class='notice'>Total Moles: [round(total_moles,0.01)]</span>"
 	else
 		results += "<span class='notice'>\The [target] is empty!</span>"
 

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -275,6 +275,7 @@ update_flag
 	data["canLabel"] = can_label ? 1 : 0
 	data["portConnected"] = connected_port ? 1 : 0
 	data["tankPressure"] = round(air_contents.return_pressure() ? air_contents.return_pressure() : 0)
+	data["tankMoles"] = round(air_contents.total_moles, 0.01)
 	data["releasePressure"] = round(release_pressure ? release_pressure : 0)
 	data["minReleasePressure"] = round(ONE_ATMOSPHERE/10)
 	data["maxReleasePressure"] = round(10*ONE_ATMOSPHERE)

--- a/code/modules/atmospherics/pipes/pipe_base.dm
+++ b/code/modules/atmospherics/pipes/pipe_base.dm
@@ -139,3 +139,10 @@
 		..()
 	else
 		. = PROCESS_KILL
+
+/obj/machinery/atmospherics/pipe/attack_ghost(mob/user)
+	. = ..()
+	if(user.client && user.client.inquisitive_ghost)
+		analyze_gases_ghost(src, user)
+	else
+		to_chat(user, "<span class='warning'>[src] doesn't have a pipenet, which is probably a bug.</span>")

--- a/nano/templates/canister.tmpl
+++ b/nano/templates/canister.tmpl
@@ -13,7 +13,8 @@
 		Tank Pressure:
 	</div>
 	<div class="itemContent">
-		{{:data.tankPressure}} kPa
+		{{:data.tankPressure}} kPa </br>
+		{{:data.tankMoles}} Moles
 	</div>
 </div>
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You get to see moles in your pipenets and cannisters, as opposed to just relative KPA. Ghosts can also analyze pipes now!

## Why It's Good For The Game

KPA leaves out a lot of information and is relative to area. Moles is an absolute measurement of how much gas is available before other factors. Main shows this information (to ghosts too), and it's immensely helpful there, so I think we should too. 

## Changelog
:cl:
add: Moles measurement to pipes and cannisters
add: Ghosts can inspect pipes

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
