### PR TITLE
Speeds warming up of cooking machines & fixes "it is switched off." always appearing bug

### DIFF
--- a/code/modules/food/kitchen/cooking_machines/_appliance.dm
+++ b/code/modules/food/kitchen/cooking_machines/_appliance.dm
@@ -15,8 +15,8 @@
 
 	use_power = 0
 	idle_power_usage = 5			// Power used when turned on, but not processing anything
-	active_power_usage = 1000		// Power used when turned on and actively cooking something
-	var/initial_active_power_usage = 1000
+	active_power_usage = 5000		// Power used when turned on and actively cooking something
+	var/initial_active_power_usage = 5000
 
 	var/cooking_power  = 1
 	var/initial_cooking_power = 1

--- a/code/modules/food/kitchen/cooking_machines/_cooker.dm
+++ b/code/modules/food/kitchen/cooking_machines/_cooker.dm
@@ -1,7 +1,7 @@
 /obj/machinery/appliance/cooker
 	var/temperature = T20C
 	var/min_temp = 80 + T0C	//Minimum temperature to do any cooking
-	var/optimal_temp = 200 + T0C	//Temperature at which we have 100% efficiency. efficiency is lowered on either side of this
+	var/optimal_temp = 200 + T0C	//Temperature at which we have 100% efficiency. - Edit, efficiency is not lowered anymore for being too hot, because why would that slow down cooking?
 	var/optimal_power = 0.1//cooking power at 100%
 
 	var/loss = 1	//Temp lost per proc when equalising
@@ -89,8 +89,11 @@
 			else
 				temp_scale = 1 - (temp_scale - 1)
 
+	if(temperature > optimal_temp)
+		cooking_power = optimal_power
+	else
+		cooking_power = optimal_power * temp_scale
 
-	cooking_power = optimal_power * temp_scale
 	//RefreshParts()
 
 /obj/machinery/appliance/cooker/proc/heat_up()

--- a/code/modules/food/kitchen/cooking_machines/_cooker.dm
+++ b/code/modules/food/kitchen/cooking_machines/_cooker.dm
@@ -5,7 +5,7 @@
 	var/optimal_power = 0.1//cooking power at 100%
 
 	var/loss = 1	//Temp lost per proc when equalising
-	var/resistance = 162000	//Resistance to heating. combines with active power usage to determine how long heating takes
+	var/resistance = 81000	//Resistance to heating. combines with active power usage to determine how long heating takes
 
 	var/light_x = 0
 	var/light_y = 0
@@ -21,7 +21,8 @@
 				. += span("notice", "It is running at [round(get_efficiency(), 0.1)]% efficiency!")
 			. += "Temperature: [round(temperature - T0C, 0.1)]C / [round(optimal_temp - T0C, 0.1)]C"
 		else
-	. += span("warning", "It is switched off.")
+			if(stat)
+				. += span("warning", "It is switched off.")
 
 /obj/machinery/appliance/cooker/list_contents(var/mob/user)
 	if (cooking_objs.len)
@@ -98,7 +99,7 @@
 			playsound(src, 'sound/machines/click.ogg', 20, 1)
 			use_power = 2.//If we're heating we use the active power
 			update_icon()
-		temperature += active_power_usage / resistance
+		temperature += active_power_usage / (resistance/2)
 		update_cooking_power()
 		return 1
 	else


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #3032
Speeds up the cooking machines significantly, and makes them not lose half their heat just by opening them. 
Feels, to me, realistic in speed and behaviour now. 


## Why It's Good For The Game
It's well known how agonizing the oven is to use, this fixes a few of these issues. 

## Changelog
:cl:
tweak: Oven heat momentum sped up almost 8x. They don't lose their heat when opened, too. 
fix: Machines no longer say they're off upon inspect when they're on. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
