### PR TITLE
Adds a long rang analyzer to the game. 

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -340,6 +340,19 @@ HALOGEN COUNTER	- Radcount on mobs
 	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 20)
 
 	origin_tech = list(TECH_MAGNET = 1, TECH_ENGINEERING = 1)
+/obj/item/analyzer/longrange
+	name = "long-range analyzer"
+	desc = "A hand-held environmental scanner which reports current gas levels. This one uses bluespace technology."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "atmos"
+	item_state = "analyzer"
+	w_class = ITEMSIZE_SMALL
+	slot_flags = SLOT_BELT
+	throwforce = 5
+	throw_speed = 4
+	throw_range = 20
+	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 20)
+	origin_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 3)
 
 /obj/item/analyzer/atmosanalyze(var/mob/user)
 	var/air = user.return_air()
@@ -363,6 +376,9 @@ HALOGEN COUNTER	- Radcount on mobs
 		analyze_gases(O, user)
 	return
 
+/obj/item/analyzer/longrange/afterattack(var/obj/O, var/mob/user, var/proximity)
+	analyze_gases(O, user)
+	return
 
 /obj/item/mass_spectrometer
 	name = "mass spectrometer"

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -109,7 +109,7 @@
 		/obj/item/multitool,
 		/obj/item/stack/cable_coil/random_belt,
 		/obj/item/extinguisher/mini,
-		/obj/item/analyzer
+		/obj/item/analyzer/longrange
 	)
 
 /obj/item/storage/belt/medical

--- a/code/modules/research/designs/engineering.dm
+++ b/code/modules/research/designs/engineering.dm
@@ -74,10 +74,19 @@
 	sort_string = "NBAAC"
 
 /datum/design/item/engineering/atmosanalyzer
-	name = "Analyzer"
+	name = "Atmospheric Analyzer"
 	desc = "A hand-held environmental scanner which reports current gas levels."
 	id = "atmosanalyzer"
 	req_tech = list(TECH_ENGINEERING = 2)
 	materials = list(DEFAULT_WALL_MATERIAL = 200, "glass" = 100)
 	build_path = /obj/item/analyzer
 	sort_string = "NBABA"
+
+/datum/design/item/engineering/atmosanalyzerlongrange
+	name = "Long Range Atmospheric Analyzer"
+	desc = "A hand-held environmental scanner which reports current gas levels from a distance."
+	id = "atmosanalyzerlr"
+	req_tech = list(TECH_ENGINEERING = 4)
+	materials = list(DEFAULT_WALL_MATERIAL = 200, "glass" = 200)
+	build_path = /obj/item/analyzer/longrange
+	sort_string = "NBABB"

--- a/code/modules/research/designs/engineering.dm
+++ b/code/modules/research/designs/engineering.dm
@@ -87,6 +87,6 @@
 	desc = "A hand-held environmental scanner which reports current gas levels from a distance."
 	id = "atmosanalyzerlr"
 	req_tech = list(TECH_ENGINEERING = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 200, "glass" = 200)
+	materials = list(DEFAULT_WALL_MATERIAL = 300, "glass" = 300)
 	build_path = /obj/item/analyzer/longrange
 	sort_string = "NBABB"


### PR DESCRIPTION
adds a long range analyzer to the game, available from RnD

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds a long-range analyzer to the game, printable by RnD. Balance may be needed for the tech levels and materials. 

## Why It's Good For The Game

It's another engineer upgrade, like the better t-rays and tools. Useful when building rooms or fixing destroyed areas. 

## Changelog
:cl:
add: long-range analyzer to RnD for engineering.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
