### PR TITLE
Ports black-eyed shadekins from Virgo (WHITELIST ONLY)

### DIFF
--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -28,7 +28,8 @@
 #define IS_SLIME   8
 #define IS_ZADDAT  9
 #define IS_CHIMERA 12
-#define IS_ALRAUNE 13
+#define IS_SHADEKIN 13
+#define IS_ALRAUNE 14
 
 #define CE_STABLE "stable" // Inaprovaline
 #define CE_ANTIBIOTIC "antibiotic" // Antibiotics

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -438,6 +438,7 @@
 #define SPECIES_PROTEAN			"Protean"
 #define SPECIES_RAPALA			"Rapala"
 #define SPECIES_SERGAL			"Sergal"
+#define SPECIES_SHADEKIN_CREW   "Black-Eyed Shadekin"
 #define SPECIES_VASILISSAN		"Vasilissan"
 #define SPECIES_VULPKANIN		"Vulpkanin"
 #define SPECIES_XENOCHIMERA		"Xenochimera"
@@ -446,11 +447,11 @@
 #define SPECIES_ZORREN_HIGH		"Highlander Zorren"
 #define SPECIES_CUSTOM			"Custom Species"
 #define SPECIES_PLASMAMAN		"Phoronoid"
-
+//monkey species
 #define SPECIES_MONKEY_AKULA		"Sobaka"
 #define SPECIES_MONKEY_NEVREAN		"Sparra"
 #define SPECIES_MONKEY_SERGAL		"Saru"
 #define SPECIES_MONKEY_VULPKANIN	"Wolpin"
-
+//event species
 #define SPECIES_WEREBEAST			"Werebeast"
 #define SPECIES_SHADEKIN			"Shadekin"

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -48,10 +48,14 @@
 	flags =  NO_SCAN | NO_MINOR_CUT | NO_INFECT
 	spawn_flags = SPECIES_IS_WHITELISTED | SPECIES_CAN_JOIN | SPECIES_WHITELIST_SELECTABLE
 
+	reagent_tag = IS_SHADEKIN // for shadekin-unique chem interactions
+
 	flesh_color = "#FFC896"
 	blood_color = "#A10808"
 	base_color = "#f0f0f0"
 	color_mult = 1
+
+	inherent_verbs = list(/mob/living/proc/shred_limb)
 
 	has_glowing_eyes = TRUE
 
@@ -62,8 +66,7 @@
 
 	speech_bubble_appearance = "ghost"
 
-	genders = list(PLURAL, NEUTER)		//no sexual dymorphism
-	ambiguous_genders = TRUE	//but just in case
+	genders = list(MALE, FEMALE, PLURAL, NEUTER, HERM)	//fuck it. shadekins with titties
 
 	virus_immune = 1
 

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -1021,3 +1021,109 @@
 		"Your overheated skin itches."
 		)
 
+/datum/species/crew_shadekin
+	name = SPECIES_SHADEKIN_CREW
+	name_plural = "Black-Eyed Shadekin"
+	icobase = 'icons/mob/human_races/r_shadekin_vr.dmi'
+	deform = 'icons/mob/human_races/r_shadekin_vr.dmi'
+	tail = "tail"
+	blurb = "Very little is known about these creatures. They appear to be largely mammalian in appearance. \
+	Seemingly very rare to encounter, there have been widespread myths of these creatures the galaxy over, \
+	but next to no verifiable evidence to their existence. However, they have recently been more verifiably \
+	documented in the Virgo system, following a mining bombardment of Virgo 3. The crew of NSB Adephagia have \
+	taken to calling these creatures 'Shadekin', and the name has generally stuck and spread. "		//TODO: Something more fitting for black-eyes	//CIT ADDENDUM: since we're not really on the tether anymore we'll need a bullshit reason as to why we have shadekin on a ship
+	wikilink = "https://wiki.vore-station.net/Shadekin"
+
+	language = LANGUAGE_SHADEKIN
+	name_language = LANGUAGE_SHADEKIN
+	species_language = LANGUAGE_SHADEKIN
+	secondary_langs = list(LANGUAGE_SHADEKIN)
+	num_alternate_languages = 3
+	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
+	rarity_value = 5	//INTERDIMENSIONAL FLUFFERS
+
+	siemens_coefficient = 0	//completely shockproof (this is no longer the case on virgo, feel free to change if it needs rebalancing)
+	darksight = 10	//best darksight around
+
+	slowdown = 0.5	//as slow as unathi
+	item_slowdown_mod = 1.5	//they're not as fit as them, though, slowed down more by heavy gear
+
+	total_health = 75	//fragile
+	brute_mod = 1.25 // Frail
+	burn_mod = 1.25	// Furry
+	blood_volume = 500	//slightly less blood than human baseline
+	hunger_factor = 0.2	//gets hungrier faster than human baseline
+
+	warning_low_pressure = 50
+	hazard_low_pressure = -1
+
+	warning_high_pressure = 300
+	hazard_high_pressure = INFINITY
+
+	cold_level_1 = -1	//Immune to cold
+	cold_level_2 = -1
+	cold_level_3 = -1
+
+	heat_level_1 = 850	//Resistant to heat
+	heat_level_2 = 1000
+	heat_level_3 = 1150
+
+	flags =  NO_SCAN	//shadekin biology is still unknown to the universe (unless some bullshit lore says otherwise)
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED | SPECIES_WHITELIST_SELECTABLE
+
+	reagent_tag = IS_SHADEKIN // for shadekin-unique chem interactions
+
+	flesh_color = "#FFC896"
+	blood_color = "#A10808"
+	base_color = "#f0f0f0"
+	color_mult = 1
+
+	inherent_verbs = list(/mob/living/proc/shred_limb)
+
+	has_glowing_eyes = TRUE	//TODO: port the ability to give neutral traits to all species from vorestation
+
+	male_cough_sounds = null
+	female_cough_sounds = null
+	male_sneeze_sound = null
+	female_sneeze_sound = null
+
+	speech_bubble_appearance = "ghost"
+
+	genders = list(MALE, FEMALE, PLURAL, NEUTER, HERM)	//fuck it. shadekins with titties
+
+	breath_type = null	//they don't breathe
+	poison_type = null
+
+	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_SKIN_COLOR | HAS_UNDERWEAR
+
+	has_organ = list(
+		O_HEART =		/obj/item/organ/internal/heart,
+		O_VOICE = 		/obj/item/organ/internal/voicebox,
+		O_LIVER =		/obj/item/organ/internal/liver,
+		O_KIDNEYS =		/obj/item/organ/internal/kidneys,
+		O_BRAIN =		/obj/item/organ/internal/brain,
+		O_EYES =		/obj/item/organ/internal/eyes,
+		O_STOMACH =		/obj/item/organ/internal/stomach,
+		O_INTESTINE =	/obj/item/organ/internal/intestine
+		)
+	
+	has_limbs = list(
+		BP_TORSO =  list("path" = /obj/item/organ/external/chest/crewkin),
+		BP_GROIN =  list("path" = /obj/item/organ/external/groin/crewkin),
+		BP_HEAD =   list("path" = /obj/item/organ/external/head/vr/crewkin),
+		BP_L_ARM =  list("path" = /obj/item/organ/external/arm/crewkin),
+		BP_R_ARM =  list("path" = /obj/item/organ/external/arm/right/crewkin),
+		BP_L_LEG =  list("path" = /obj/item/organ/external/leg/crewkin),
+		BP_R_LEG =  list("path" = /obj/item/organ/external/leg/right/crewkin),
+		BP_L_HAND = list("path" = /obj/item/organ/external/hand/crewkin),
+		BP_R_HAND = list("path" = /obj/item/organ/external/hand/right/crewkin),
+		BP_L_FOOT = list("path" = /obj/item/organ/external/foot/crewkin),
+		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right/crewkin)
+		)
+
+/datum/species/shadekin/get_bodytype()
+	return SPECIES_SHADEKIN
+
+/datum/species/shadekin/can_breathe_water()
+	return TRUE	//they dont quite breathe 
+

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -47,7 +47,7 @@
 	var/icon_add = 'icons/mob/human_face.dmi'
 	//Enhanced colours and hair for all
 	var/color_blend_mode = ICON_MULTIPLY
-	species_allowed = list(SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_UNATHI, SPECIES_TAJ, SPECIES_NEVREAN, SPECIES_AKULA, SPECIES_SERGAL, SPECIES_ZORREN_FLAT, SPECIES_ZORREN_HIGH, SPECIES_VULPKANIN, SPECIES_XENOCHIMERA, SPECIES_XENOHYBRID, SPECIES_VASILISSAN, SPECIES_RAPALA, SPECIES_PROTEAN, SPECIES_ALRAUNE, SPECIES_WEREBEAST, SPECIES_SHADEKIN) //This lets all races use the default hairstyles.
+	species_allowed = list(SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_UNATHI, SPECIES_TAJ, SPECIES_NEVREAN, SPECIES_AKULA, SPECIES_SERGAL, SPECIES_ZORREN_FLAT, SPECIES_ZORREN_HIGH, SPECIES_VULPKANIN, SPECIES_XENOCHIMERA, SPECIES_XENOHYBRID, SPECIES_VASILISSAN, SPECIES_RAPALA, SPECIES_PROTEAN, SPECIES_ALRAUNE, SPECIES_WEREBEAST, SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW) //This lets all races use the default hairstyles.
 	var/flags
 
 	eighties
@@ -1805,7 +1805,7 @@
 		icon = 'icons/mob/human_face_vr.dmi'
 		icon_add = 'icons/mob/human_face_vr_add.dmi'
 		icon_state = "shadekin_short"
-		species_allowed = list(SPECIES_SHADEKIN)
+		species_allowed = list(SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW)
 		gender = NEUTER
 
 	shadekin_hair_poofy
@@ -1813,7 +1813,7 @@
 		icon = 'icons/mob/human_face_vr.dmi'
 		icon_add = 'icons/mob/human_face_vr_add.dmi'
 		icon_state = "shadekin_poofy"
-		species_allowed = list(SPECIES_SHADEKIN)
+		species_allowed = list(SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW)
 		gender = NEUTER
 
 	shadekin_hair_long
@@ -1821,7 +1821,7 @@
 		icon = 'icons/mob/human_face_vr.dmi'
 		icon_add = 'icons/mob/human_face_vr_add.dmi'
 		icon_state = "shadekin_long"
-		species_allowed = list(SPECIES_SHADEKIN)
+		species_allowed = list(SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW)
 		gender = NEUTER
 
 	shadekin_hair_rivyr
@@ -1830,7 +1830,7 @@
 		icon_add = 'icons/mob/human_face_vr_add.dmi'
 		icon_state = "shadekin_rivyr"
 		ckeys_allowed = list("verysoft")
-		species_allowed = list(SPECIES_SHADEKIN)
+		species_allowed = list(SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW)
 		gender = NEUTER
 
 /datum/sprite_accessory/facial_hair
@@ -2806,7 +2806,7 @@
 		icon_state = "shadekin-snoot"
 		color_blend_mode = ICON_MULTIPLY
 		body_parts = list(BP_HEAD)
-		species_allowed = list(SPECIES_SHADEKIN)
+		species_allowed = list(SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW)
 
 	taj_nose_alt
 		name = "Nose Color, alt. (Taj)"

--- a/code/modules/organs/subtypes/shadekin.dm
+++ b/code/modules/organs/subtypes/shadekin.dm
@@ -39,4 +39,4 @@
 	min_broken_damage = 7
 
 /obj/item/organ/external/hand/right/crewkin
-	min_broken_damage = 7 
+	min_broken_damage = 7

--- a/code/modules/organs/subtypes/shadekin.dm
+++ b/code/modules/organs/subtypes/shadekin.dm
@@ -4,3 +4,39 @@
 	var/dark_energy = 100
 	var/max_dark_energy = 100
 	var/dark_energy_infinite = FALSE
+
+/obj/item/organ/external/chest/crewkin
+	min_broken_damage = 20
+
+/obj/item/organ/external/groin/crewkin
+	min_broken_damage = 20
+
+/obj/item/organ/external/head/vr/crewkin
+	min_broken_damage = 15
+
+	eye_icons_vr = 'icons/mob/human_face_vr.dmi'
+	eye_icon_vr = "eyes_shadekin_station"
+
+/obj/item/organ/external/arm/crewkin
+	min_broken_damage = 15
+
+/obj/item/organ/external/arm/right/crewkin
+	min_broken_damage = 15
+
+/obj/item/organ/external/leg/crewkin
+	min_broken_damage = 15
+
+/obj/item/organ/external/leg/right/crewkin
+	min_broken_damage = 15
+
+/obj/item/organ/external/foot/crewkin
+	min_broken_damage = 7
+
+/obj/item/organ/external/foot/right/crewkin
+	min_broken_damage = 7
+
+/obj/item/organ/external/hand/crewkin
+	min_broken_damage = 7
+
+/obj/item/organ/external/hand/right/crewkin
+	min_broken_damage = 7 

--- a/code/modules/vore/appearance/sprite_accessories_taur_vr.dm
+++ b/code/modules/vore/appearance/sprite_accessories_taur_vr.dm
@@ -175,7 +175,7 @@
 	clip_mask_icon = null
 	clip_mask_state = null
 	apply_restrictions = TRUE
-	species_allowed = list(SPECIES_SHADEKIN)
+	species_allowed = list(SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW)
 
 /datum/sprite_accessory/tail/taur/shadekin_tail/shadekin_tail_2c
 	name = "Shadekin Tail dual-color (Shadekin)"

--- a/code/modules/vore/appearance/sprite_accessories_vr.dm
+++ b/code/modules/vore/appearance/sprite_accessories_vr.dm
@@ -39,7 +39,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	apply_restrictions = TRUE
-	species_allowed = list(SPECIES_SHADEKIN)
+	species_allowed = list(SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW)
 
 // Ears avaliable to anyone
 


### PR DESCRIPTION
## About The Pull Request

this is a port of virgo PRs https://github.com/VOREStation/VOREStation/pull/6241 and partially https://github.com/VOREStation/VOREStation/pull/9578, allowing the selection of nerfed shadekins (if headmins decide to allow using them that is)

at the moment, black-eyed shadekins:
-lose all shadekin powers (phase shift, corpsemending, flashdark)
-have less health than their non-powerless counterparts, with a higher brute modifier
-are completely immune to shocks (subject to change)
-have the best darksight modifier around (equal to normal shadekin)
-are slower than humans on baseline as well as get weighed down more by heavy objects
-are immune to vaccuum (they do not breathe and are immune to cold and low pressure)
-are immune to high pressures
-are resistant to high temperatures
-cannot be resleeved/cloned/whatever we call it these days, thus needing to use a bioadaptive NIF

## Why It's Good For The Game

funny species that vores things

## Changelog
:cl:
add: Black-eyed shadekin.
/:cl: