### PR TITLE
adds _contents() wrapper for SELECT SDQL2 statements

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -244,3 +244,9 @@
 /proc/__nan()
 	var/list/L = json_decode("{\"value\":NaN}")
 	return L["value"]
+
+/**
+ * Wrapper to return a copy of contents, as SDQL2 can't tell an internal list from a normal list.
+ */
+/atom/proc/_contents()
+	return contents.Copy()


### PR DESCRIPTION
sdql2 can't access contents natively and still print while retaining assoclist printing functionality due to byond being byond.