### PR TITLE
IP Reputation port from Vorestation & Return to menu >> Respawn

### DIFF
--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -12,7 +12,7 @@
 	closeToolTip(usr)
 
 /obj/screen/ghost/returntomenu
-	name = "Return to menu"
+	name = "Respawn"
 	desc = "Return to the title screen menu."
 	icon_state = "returntomenu"
 

--- a/code/controllers/configuration_old/configuration.dm
+++ b/code/controllers/configuration_old/configuration.dm
@@ -117,6 +117,14 @@
 	var/panic_bunker_message = "Sorry, this server is not accepting connections from never seen before players."
 	var/paranoia_logging = 0
 
+	var/ip_reputation = FALSE		//Should we query IPs to get scores? Generates HTTP traffic to an API service.
+	var/ipr_email					//Left null because you MUST specify one otherwise you're making the internet worse.
+	var/ipr_block_bad_ips = FALSE	//Should we block anyone who meets the minimum score below? Otherwise we just log it (If paranoia logging is on, visibly in chat).
+	var/ipr_bad_score = 1			//The API returns a value between 0 and 1 (inclusive), with 1 being 'definitely VPN/Tor/Proxy'. Values equal/above this var are considered bad.
+	var/ipr_allow_existing = FALSE 	//Should we allow known players to use VPNs/Proxies? If the player is already banned then obviously they still can't connect.
+	var/ipr_minimum_age = 5
+	var/ipqualityscore_apikey //API key for ipqualityscore.com
+
 	var/serverurl
 	var/server
 	var/banappeals
@@ -816,6 +824,24 @@
 
 				if ("paranoia_logging")
 					config_legacy.paranoia_logging = 1
+
+				if("ip_reputation")
+					config_legacy.ip_reputation = 1
+
+				if("ipr_email")
+					config_legacy.ipr_email = value
+
+				if("ipr_block_bad_ips")
+					config_legacy.ipr_block_bad_ips = 1
+
+				if("ipr_bad_score")
+					config_legacy.ipr_bad_score = text2num(value)
+
+				if("ipr_allow_existing")
+					config_legacy.ipr_allow_existing = 1
+
+				if("ipr_minimum_age")
+					config_legacy.ipr_minimum_age = text2num(value)
 
 				if("minute_click_limit")
 					config_legacy.minute_click_limit = text2num(value)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -189,6 +189,7 @@ var/list/admin_verbs_server = list(
 	/client/proc/modify_server_news,
 	/client/proc/recipe_dump,
 	/client/proc/panicbunker,
+	/client/proc/ip_reputation,
 	/client/proc/paranoia_logging
 	)
 

--- a/code/modules/admin/verbs/panicbunker.dm
+++ b/code/modules/admin/verbs/panicbunker.dm
@@ -60,3 +60,17 @@ GLOBAL_LIST_EMPTY(bunker_passthrough)
 	if (config_legacy.paranoia_logging && (!dbcon || !dbcon.IsConnected()))
 		message_admins("The Database is not connected! Paranoia logging will not be able to give 'player age' (time since first connection) warnings, only Byond account warnings.")
 	feedback_add_details("admin_verb","PARLOG") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/client/proc/ip_reputation()
+	set category = "Server"
+	set name = "Toggle IP Rep Checks"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	config_legacy.ip_reputation = (!config_legacy.ip_reputation)
+
+	log_and_message_admins("[key_name(usr)] has toggled IP reputation checks, it is now [(config_legacy.ip_reputation?"on":"off")].")
+	if (config_legacy.ip_reputation && (!dbcon || !dbcon.IsConnected()))
+		message_admins("The database is not connected! IP reputation logging will not be able to allow existing players to bypass the reputation checks (if that is enabled).")
+	feedback_add_details("admin_verb","IPREP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/client/client procs_vr.dm
+++ b/code/modules/client/client procs_vr.dm
@@ -1,0 +1,100 @@
+//Uses a couple different services
+/client/update_ip_reputation()
+	var/scores[] = list("GII" = ipr_getipintel(), "IPQS" = ipr_ipqualityscore())
+
+	var/log_output = "IP Reputation [key] from [address]"
+	var/worst = 0
+
+	for(var/service in scores)
+		var/score = scores[service]
+		if(score > worst)
+			worst = score
+		log_output += " - [service] ([num2text(score)])"
+
+	log_admin(log_output)
+	ip_reputation = worst
+	return TRUE
+
+//Service returns a single float in html body
+/client/proc/ipr_getipintel()
+	if(!config_legacy.ipr_email)
+		return -1
+
+	var/request = "http://check.getipintel.net/check.php?ip=[address]&contact=[(config_legacy.ipr_email)]"
+	var/http[] = world.Export(request)
+
+	if(!http || !islist(http)) //If we couldn't check, the service might be down, fail-safe.
+		log_admin("Couldn't connect to getipintel.net to check [address] for [key]")
+		return -1
+
+	//429 is rate limit exceeded
+	if(text2num(http["STATUS"]) == 429)
+		log_and_message_admins("getipintel.net reports HTTP status 429. IP reputation checking is now disabled. If you see this, let a developer know.")
+		config_legacy.ip_reputation = FALSE
+		return -1
+
+	var/content = file2text(http["CONTENT"]) //world.Export actually returns a file object in CONTENT
+	var/score = text2num(content)
+	if(isnull(score))
+		return -1
+
+	//Error handling
+	if(score < 0)
+		var/fatal = TRUE
+		var/ipr_error = "getipintel.net IP reputation check error while checking [address] for [key]: "
+		switch(score)
+			if(-1)
+				ipr_error += "No input provided"
+			if(-2)
+				fatal = FALSE
+				ipr_error += "Invalid IP provided"
+			if(-3)
+				fatal = FALSE
+				ipr_error += "Unroutable/private IP (spoofing?)"
+			if(-4)
+				fatal = FALSE
+				ipr_error += "Unable to reach database"
+			if(-5)
+				ipr_error += "Our IP is banned or otherwise forbidden"
+			if(-6)
+				ipr_error += "Missing contact info"
+
+		log_and_message_admins(ipr_error)
+		if(fatal)
+			config_legacy.ip_reputation = FALSE
+			log_and_message_admins("With this error, IP reputation checking is disabled for this shift. Let a developer know.")
+		return -1
+
+	//Went fine
+	else
+		return score
+
+//Service returns JSON in html body
+/client/proc/ipr_ipqualityscore()
+	if(!config_legacy.ipqualityscore_apikey)
+		return -1
+
+	var/request = "http://www.ipqualityscore.com/api/json/ip/[(config_legacy.ipqualityscore_apikey)]/[address]?strictness=1&fast=true&byond_key=[key]"
+	var/http[] = world.Export(request)
+
+	if(!http || !islist(http)) //If we couldn't check, the service might be down, fail-safe.
+		log_admin("Couldn't connect to ipqualityscore.com to check [address] for [key]")
+		return -1
+
+	var/content = file2text(http["CONTENT"]) //world.Export actually returns a file object in CONTENT
+	var/response = json_decode(content)
+	if(isnull(response))
+		return -1
+
+	//Error handling
+	if(!response["success"])
+		log_admin("IPQualityscore.com returned an error while processing [key] from [address]: " + response["message"])
+		return -1
+
+	var/score = 0
+	if(response["proxy"])
+		score = 100
+	else
+		score = response["fraud_score"]
+
+	return score/100 //To normalize with the 0.0 to 1.0 scores.

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -37,11 +37,12 @@
 		//SECURITY//
 		////////////
 	// comment out the line below when debugging locally to enable the options & messages menu
-	//control_freak = CONTROL_FREAK_ALL
+	//control_freak = 1
 
 	var/received_irc_pm = -99999
 	var/irc_admin			//IRC admin that spoke with them last.
 	var/mute_irc = 0
+	var/ip_reputation = 0 //Do we think they're using a proxy/vpn? Only if IP Reputation checking is enabled in config.
 
 
 		////////////////////////////////////
@@ -52,7 +53,8 @@
 	var/related_accounts_cid = "(Requires database)"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this computer id
 	var/account_join_date = "(Requires database)"
 	var/account_age = "(Requires database)"
-	var/list/department_hours	// VOREStation Edit - Track hours of leave accured for each department.
+	var/list/department_hours = list()	// VOREStation Edit - Track hours of leave accured for each department.
+	var/list/play_hours	= list() // VOREStation Edit - Tracks total playtime hours for each departments.
 
 	preload_rsc = PRELOAD_RSC
 
@@ -60,9 +62,6 @@
 
 	var/lastping = 0
 	var/avgping = 0
-	var/connection_time //world.time they connected
-	var/connection_realtime //world.realtime they connected
-	var/connection_timeofday //world.timeofday they connected
 
 	var/list/topiclimiter
 	var/list/clicklimiter
@@ -76,3 +75,10 @@
 	/// Last asset send job id.
 	var/last_asset_job = 0
 	var/last_completed_asset_job = 0
+
+ 	///world.time they connected
+	var/connection_time
+ 	///world.realtime they connected
+	var/connection_realtime
+ 	///world.timeofday they connected
+	var/connection_timeofday

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -515,6 +515,27 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(player_age == -1)
 		player_age = 0		//math requires this to not be -1.
 
+	if(config_legacy.ip_reputation)
+		if(config_legacy.ipr_allow_existing && player_age >= config_legacy.ipr_minimum_age)
+			log_admin("Skipping IP reputation check on [key] with [address] because of player age")
+		else if(update_ip_reputation()) //It is set now
+			if(ip_reputation >= config_legacy.ipr_bad_score) //It's bad
+				//Log it
+				if(config_legacy.paranoia_logging) //We don't block, but we want paranoia log messages
+					log_and_message_admins("[key] at [address] has bad IP reputation: [ip_reputation]. Will be kicked if enabled in config.")
+				else //We just log it
+					log_admin("[key] at [address] has bad IP reputation: [ip_reputation]. Will be kicked if enabled in config.")
+
+				//Take action if required
+				if(config_legacy.ipr_block_bad_ips && config_legacy.ipr_allow_existing) //We allow players of an age, but you don't meet it
+					disconnect_with_message("Sorry, we only allow VPN/Proxy/Tor usage for players who have spent at least [config_legacy.ipr_minimum_age] days on the server. If you are unable to use the internet without your VPN/Proxy/Tor, please contact an admin out-of-game to let them know so we can accommodate this.")
+					return 0
+				else if(config_legacy.ipr_block_bad_ips) //We don't allow players of any particular age
+					disconnect_with_message("Sorry, we do not accept connections from users via VPN/Proxy/Tor connections. If you believe this is in error, contact an admin out-of-game.")
+					return 0
+		else
+			log_admin("Couldn't perform IP check on [key] with [address]")
+
 	// VOREStation Edit Start - Department Hours
 	if(config_legacy.time_off)
 		var/DBQuery/query_hours = dbcon.NewQuery("SELECT department, hours FROM vr_player_hours WHERE ckey = '[sql_ckey]'")
@@ -712,3 +733,69 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 /client/proc/AnnouncePR(announcement)
 	//if(prefs && prefs.chat_toggles & CHAT_PULLR)
 	to_chat(src, announcement)
+
+//This is for getipintel.net.
+//You're welcome to replace this proc with your own that does your own cool stuff.
+//Just set the client's ip_reputation var and make sure it makes sense with your config settings (higher numbers are worse results)
+/client/proc/update_ip_reputation()
+	var/request = "http://check.getipintel.net/check.php?ip=[address]&contact=[config_legacy.ipr_email]"
+	var/http[] = world.Export(request)
+
+	/* Debug
+	to_world_log("Requested this: [request]")
+	for(var/entry in http)
+		to_world_log("[entry] : [http[entry]]")
+	*/
+
+	if(!http || !islist(http)) //If we couldn't check, the service might be down, fail-safe.
+		log_admin("Couldn't connect to getipintel.net to check [address] for [key]")
+		return FALSE
+
+	//429 is rate limit exceeded
+	if(text2num(http["STATUS"]) == 429)
+		log_and_message_admins("getipintel.net reports HTTP status 429. IP reputation checking is now disabled. If you see this, let a developer know.")
+		config_legacy.ip_reputation = FALSE
+		return FALSE
+
+	var/content = file2text(http["CONTENT"]) //world.Export actually returns a file object in CONTENT
+	var/score = text2num(content)
+	if(isnull(score))
+		return FALSE
+
+	//Error handling
+	if(score < 0)
+		var/fatal = TRUE
+		var/ipr_error = "getipintel.net IP reputation check error while checking [address] for [key]: "
+		switch(score)
+			if(-1)
+				ipr_error += "No input provided"
+			if(-2)
+				fatal = FALSE
+				ipr_error += "Invalid IP provided"
+			if(-3)
+				fatal = FALSE
+				ipr_error += "Unroutable/private IP (spoofing?)"
+			if(-4)
+				fatal = FALSE
+				ipr_error += "Unable to reach database"
+			if(-5)
+				ipr_error += "Our IP is banned or otherwise forbidden"
+			if(-6)
+				ipr_error += "Missing contact info"
+
+		log_and_message_admins(ipr_error)
+		if(fatal)
+			config_legacy.ip_reputation = FALSE
+			log_and_message_admins("With this error, IP reputation checking is disabled for this shift. Let a developer know.")
+		return FALSE
+
+	//Went fine
+	else
+		ip_reputation = score
+		return TRUE
+
+/client/proc/disconnect_with_message(var/message = "You have been intentionally disconnected by the server.<br>This may be for security or administrative reasons.")
+	message = "<head><title>You Have Been Disconnected</title></head><body><hr><center><b>[message]</b></center><hr><br>If you feel this is in error, you can contact an administrator out-of-game (for example, on Discord).</body>"
+	window_flash(src)
+	src << browse(message,"window=dropmessage;size=480x360;can_close=1")
+	qdel(src)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -399,7 +399,7 @@
 		return 	// Don't set it, no need
 
 /mob/verb/abandon_mob()
-	set name = "Return to Menu"
+	set name = "Respawn (Return to Menu)"
 	set category = "OOC"
 
 	if(stat != DEAD || !SSticker)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1594,6 +1594,7 @@
 #include "code\modules\catalogue\cataloguer.dm"
 #include "code\modules\catalogue\cataloguer_visuals.dm"
 #include "code\modules\catalogue\cataloguer_vr.dm"
+#include "code\modules\client\client procs_vr.dm"
 #include "code\modules\client\client_defines.dm"
 #include "code\modules\client\client_procs.dm"
 #include "code\modules\client\movement.dm"


### PR DESCRIPTION


## About The Pull Request
Ports IP reputation from Vorestation

## Why It's Good For The Game

making it harder to grief

## Changelog
:cl:
add: IP reputation checking
tweak: return to menu is now respawn. 
config: new things to config: IP rep
admin: IP rep admin verb

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
