### PR TITLE
makes it so mediborgs actually have burn kits (god i'm really dumb)

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station/medical.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/medical.dm
@@ -72,6 +72,7 @@
 	B.uses_charge = 1
 	B.charge_costs = list(1000)
 	B.synths = list(medicine)
+	src.modules += O
 	src.modules += N
 	src.modules += B
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Yeah, I forgot to add the line of code that makes adding the ointment module actually happen.  I quickly realized this when trying to do surgery on a burn victim
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I'm dumb and forgot to do this before
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
adds burn kit to medical cyborg module
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
