### PR TITLE
stupid fix for get_map_levels() 

### DIFF
--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -165,13 +165,13 @@ var/list/all_maps = list()
 			return list(srcz)
 
 		// Just the sector we're in
-		if(om_range == -1)
+		if(!long_range || (om_range < 0))
 			return O.map_z.Copy()
 
 		// Otherwise every sector we're on top of
 		var/list/connections = list()
 		var/turf/T = get_turf(O)
-		for(var/obj/effect/overmap/visitable/V in range(long_range ? om_range : -1, T))
+		for(var/obj/effect/overmap/visitable/V in range(om_range, T))
 			connections += V.map_z	// Adding list to list adds contents
 		return connections
 


### PR DESCRIPTION
oh so this two line fix was why triumph had a snowflake get map zlevels proc are you kidding me how did we not have this fix if you're good enough to port overmaps you should be good enough to not snowflake this