### PR TITLE
nerfs kinetic daggers 

### DIFF
--- a/code/__DEFINES/dcs/flags.dm
+++ b/code/__DEFINES/dcs/flags.dm
@@ -39,3 +39,6 @@
 //Ouch my toes!
 #define CALTROP_BYPASS_SHOES 1
 #define CALTROP_IGNORE_WALKERS 2
+
+// Conflict element IDs
+#define CONFLICT_ELEMENT_CRUSHER			"crusher"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -375,6 +375,6 @@ obj/item signals
 
 // conflict checking elements
 /// (id) - returns flags - Registered on something by conflict checking elements.
-#define COMSIG_CONFLICT_ELEMENT_CHECK
+#define COMSIG_CONFLICT_ELEMENT_CHECK "conflict_element_check"
 	/// A conflict was found
-	#define ELEMENT_CONFLICT_FOUND
+	#define ELEMENT_CONFLICT_FOUND	(1<<0)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -372,3 +372,9 @@ obj/item signals
 #define COMSIG_XENO_TURF_CLICK_CTRL "xeno_turf_click_alt"					//from turf AltClickOn(): (/mob)
 #define COMSIG_XENO_MONKEY_CLICK_CTRL "xeno_monkey_click_ctrl"				//from monkey CtrlClickOn(): (/mob)
 */
+
+// conflict checking elements
+/// (id) - returns flags - Registered on something by conflict checking elements.
+#define COMSIG_CONFLICT_ELEMENT_CHECK
+	/// A conflict was found
+	#define ELEMENT_CONFLICT_FOUND

--- a/code/datums/elements/conflict_checking.dm
+++ b/code/datums/elements/conflict_checking.dm
@@ -1,0 +1,35 @@
+/**
+ * Simple conflict checking for getting number of conflicting things on someone with the same ID.
+ */
+/datum/element/conflict_checking
+	element_flags = ELEMENT_BESPOKE
+	/// we don't need to KNOW who has us, only our ID.
+	var/id
+
+/datum/element/conflict_checking/Attach(datum/target, id)
+	. = ..()
+	if(. & ELEMENT_INCOMPATIBLE)
+		return
+	if(!isatom(target))
+		return ELEMENT_INCOMPATIBLE
+	if(!length(id))
+		. = ELEMENT_INCOMPATIBLE
+		CRASH("Invalid ID in conflict checking element.")
+	if(isnull(src.id))
+		src.id = id
+	RegisterSignal(target, COMSIG_CONFLICT_ELEMENT_CHECK, .proc/check)
+
+/datum/element/conflict_checking/proc/check(datum/source, id_to_check)
+	if(id == id_to_check)
+		return ELEMENT_CONFLICT_FOUND
+
+/**
+ * Counts number of conflicts on something that have a conflict checking element.
+ */
+/atom/movable/proc/ConflictElementCount(id)
+	. = 0
+	for(var/i in GetAllContents(src))
+		var/atom/movable/AM = i
+		if(SEND_SIGNAL(AM, COMSIG_CONFLICT_ELEMENT_CHECK, id) & ELEMENT_CONFLICT_FOUND)
+			++.
+

--- a/code/datums/elements/conflict_checking.dm
+++ b/code/datums/elements/conflict_checking.dm
@@ -28,7 +28,7 @@
  */
 /atom/movable/proc/ConflictElementCount(id)
 	. = 0
-	for(var/i in GetAllContents(src))
+	for(var/i in GetAllContents())
 		var/atom/movable/AM = i
 		if(SEND_SIGNAL(AM, COMSIG_CONFLICT_ELEMENT_CHECK, id) & ELEMENT_CONFLICT_FOUND)
 			++.

--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -70,7 +70,7 @@
 	timerid = null
 
 /datum/looping_sound/proc/sound_loop(starttime)
-	if(max_loops && world.time >= starttime + mid_length * max_loops)
+	if(max_loops && (world.time >= (starttime + mid_length * max_loops)))
 		stop()
 		return
 	if(!chance || prob(chance))

--- a/code/modules/mining/kinetic_crusher.dm
+++ b/code/modules/mining/kinetic_crusher.dm
@@ -164,7 +164,7 @@
 		D.fire()
 		charged = FALSE
 		update_icon()
-		addtimer(CALLBACK(src, .proc/Recharge), charge_time * ConflictElementCount(CONFLICT_ELEMENT_CRUSHER))
+		addtimer(CALLBACK(src, .proc/Recharge), charge_time * (user?.ConflictElementCount(CONFLICT_ELEMENT_CRUSHER) || 1))
 		return
 	if(proximity_flag && isliving(target))
 		detonate(target, user)

--- a/code/modules/mining/kinetic_crusher.dm
+++ b/code/modules/mining/kinetic_crusher.dm
@@ -53,6 +53,10 @@
 	detonation_damage = 60
 	wielded = 1
 
+/obj/item/kinetic_crusher/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/conflict_checking, CONFLICT_ELEMENT_CRUSHER)
+
 /*
 /obj/item/kinetic_crusher/Initialize()
 	. = ..()
@@ -160,7 +164,7 @@
 		D.fire()
 		charged = FALSE
 		update_icon()
-		addtimer(CALLBACK(src, .proc/Recharge), charge_time)
+		addtimer(CALLBACK(src, .proc/Recharge), charge_time * ConflictElementCount(CONFLICT_ELEMENT_CRUSHER))
 		return
 	if(proximity_flag && isliving(target))
 		detonate(target, user)
@@ -302,8 +306,8 @@
 	requires_wield = FALSE
 	charge_overlay = FALSE
 	// yeah yeah buff but rp mobs are tough as fuck.
-	backstab_bonus = 25
-	detonation_damage = 35
+	backstab_bonus = 30
+	detonation_damage = 30
 	// woohoo
 	thrown_bonus = 35
 	update_item_state = FALSE

--- a/code/modules/mining/kinetic_crusher.dm
+++ b/code/modules/mining/kinetic_crusher.dm
@@ -306,8 +306,8 @@
 	requires_wield = FALSE
 	charge_overlay = FALSE
 	// yeah yeah buff but rp mobs are tough as fuck.
-	backstab_bonus = 30
-	detonation_damage = 30
+	backstab_bonus = 35
+	detonation_damage = 25
 	// woohoo
 	thrown_bonus = 35
 	update_item_state = FALSE

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -326,6 +326,7 @@
 #include "code\datums\components\anti_magic.dm"
 #include "code\datums\components\orbiter.dm"
 #include "code\datums\elements\_element.dm"
+#include "code\datums\elements\conflict_checking.dm"
 #include "code\datums\elements\persistence.dm"
 #include "code\datums\helper_datums\construction_datum.dm"
 #include "code\datums\helper_datums\events.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

stacking them on someone will now cause recharge conflicts.
slightly nerfs damage, you now need to backstab to do the full 75 damage. otherwise damage on detonation is now 40 instead of 50.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

haha funny backup weapon
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Kinetic daggers have been slightly nerfed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
