### PR TITLE
[RFM]Off-duty command

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -4,7 +4,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	title = "Facility Director"
 	flag = CAPTAIN
 	department = "Command"
-	disallow_jobhop = TRUE
+	allow_jobhop = FALSE
 	head_position = 1
 	department_flag = ENGSEC
 	faction = "Station"
@@ -40,7 +40,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	department = "Command"
 	head_position = 1
 	department_flag = CIVILIAN
-	disallow_jobhop = TRUE
+	allow_jobhop = FALSE
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
@@ -76,7 +76,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	department = "Command"
 	head_position = 1
 	department_flag = CIVILIAN
-	disallow_jobhop = FALSE
+	allow_jobhop = TRUE
 	faction = "Station"
 	total_positions = 3
 	spawn_positions = 2

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -76,7 +76,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	department = "Command"
 	head_position = 1
 	department_flag = CIVILIAN
-	disallow_jobhop = TRUE
+	disallow_jobhop = FALSE
 	faction = "Station"
 	total_positions = 3
 	spawn_positions = 2

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -4,7 +4,7 @@
 	head_position = 1
 	department = "Engineering"
 	department_flag = ENGSEC
-	disallow_jobhop = TRUE
+	allow_jobhop = FALSE
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -38,7 +38,7 @@
 	var/timeoff_factor = 3
 
 	//Disallow joining as this job midround from off-duty position via going on-duty
-	var/disallow_jobhop = FALSE
+	var/allow_jobhop = TRUE
 
 // Check client-specific availability rules.
 /datum/job/proc/player_has_enough_pto(client/C)

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -4,7 +4,7 @@
 	head_position = 1
 	department = "Medical"
 	department_flag = MEDSCI
-	disallow_jobhop = TRUE
+	allow_jobhop = FALSE
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1

--- a/code/game/jobs/job/offduty.dm
+++ b/code/game/jobs/job/offduty.dm
@@ -2,7 +2,7 @@
 // "Off-duty" jobs are for people who want to do nothing and have earned it.
 //
 /datum/job/offduty_command
-	title = "Off-duty Officer"
+	title = "Off-duty Command"
 	latejoin_only = TRUE
 	timeoff_factor = -1
 	total_positions = -1
@@ -79,7 +79,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/assistant/scientist
 
 /datum/job/offduty_security
-	title = "Off-duty Guard"
+	title = "Off-duty Officer"
 	latejoin_only = TRUE
 	timeoff_factor = -1
 	total_positions = -1

--- a/code/game/jobs/job/offduty.dm
+++ b/code/game/jobs/job/offduty.dm
@@ -1,7 +1,18 @@
 //
 // "Off-duty" jobs are for people who want to do nothing and have earned it.
 //
-
+/datum/job/offduty_commander
+	title = "Off-duty Commander"
+	latejoin_only = TRUE
+	timeoff_factor = -1
+	total_positions = -1
+	faction = "Station"
+	department = "Command"
+	supervisors = "nobody! Enjoy your time off"
+	selection_color = "#9b633e"
+	access = list(access_maint_tunnels)
+	minimal_access = list(access_maint_tunnels)
+	outfit_type = /decl/hierarchy/outfit/job/secretary
 /datum/job/offduty_civilian
 	title = "Off-duty Worker"
 	latejoin_only = TRUE

--- a/code/game/jobs/job/offduty.dm
+++ b/code/game/jobs/job/offduty.dm
@@ -1,8 +1,8 @@
 //
 // "Off-duty" jobs are for people who want to do nothing and have earned it.
 //
-/datum/job/offduty_commander
-	title = "Off-duty Commander"
+/datum/job/offduty_command
+	title = "Off-duty Officer"
 	latejoin_only = TRUE
 	timeoff_factor = -1
 	total_positions = -1
@@ -79,7 +79,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/assistant/scientist
 
 /datum/job/offduty_security
-	title = "Off-duty Officer"
+	title = "Off-duty Guard"
 	latejoin_only = TRUE
 	timeoff_factor = -1
 	total_positions = -1

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -4,7 +4,7 @@
 	head_position = 1
 	department = "Science"
 	department_flag = MEDSCI
-	disallow_jobhop = TRUE
+	allow_jobhop = FALSE
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -4,7 +4,7 @@
 	head_position = 1
 	department = "Security"
 	department_flag = ENGSEC
-	disallow_jobhop = TRUE
+	allow_jobhop = FALSE
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -138,11 +138,15 @@
 		return 1
 	return 1 // Return 1 to update UI
 
+
 /obj/machinery/computer/timeclock/proc/getOpenOnDutyJobs(var/mob/user, var/department)
 	var/list/available_jobs = list()
 	for(var/datum/job/job in SSjobs.occupations)
 		if(job && job.is_position_available() && !job.whitelist_only && !jobban_isbanned(user,job.title) && job.player_old_enough(user.client))
 			if(job.department == department && !job.disallow_jobhop && job.timeoff_factor > 0)
+				if(department == "Command")
+					if(job.title != "Command Secretary")
+						continue
 				available_jobs += job.title
 				if(job.alt_titles)
 					for(var/alt_job in job.alt_titles)
@@ -185,8 +189,6 @@
 	if(!foundjob)
 		return
 	var/real_dept = foundjob.department
-	if(real_dept && real_dept == "Command")
-		real_dept = "Civilian"
 	var/datum/job/ptojob = null
 	for(var/datum/job/job in SSjobs.occupations)
 		if(job.department == real_dept && job.timeoff_factor < 0)

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -143,10 +143,7 @@
 	var/list/available_jobs = list()
 	for(var/datum/job/job in SSjobs.occupations)
 		if(job && job.is_position_available() && !job.whitelist_only && !jobban_isbanned(user,job.title) && job.player_old_enough(user.client))
-			if(job.department == department && !job.disallow_jobhop && job.timeoff_factor > 0)
-				if(department == "Command")
-					if(job.title != "Command Secretary")
-						continue
+			if(job.department == department && job.allow_jobhop && job.timeoff_factor > 0)
 				available_jobs += job.title
 				if(job.alt_titles)
 					for(var/alt_job in job.alt_titles)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the off-duty commander role, to allow people to reduce their command PTO, they can only join again as command secretary.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Off-duty command
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Off-Duty Command
code: Allow_jobhup is no longer double negated
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
