### PR TITLE
Makes '*chuckle' to 'chuckles.' instead of laugh

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -227,15 +227,15 @@
 
 		if ("chuckle")
 			if(miming)
-                message = "appears to chuckle."
-                m_type = 1
-            else
-                if (!muzzled)
-                    message = "chuckles."
-                    m_type = 2
-                else
-                    message = "makes a noise."
-                    m_type = 2
+				message = "appears to chuckle."
+				m_type = 1
+			else
+				if (!muzzled)
+					message = "chuckles."
+					m_type = 2
+				else
+					message = "makes a noise."
+					m_type = 2
 
 		if ("twitch")
 			message = "twitches."

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -226,7 +226,8 @@
 			m_type = 1
 
 		if ("chuckle")
-			emote("laugh")
+			message = "chuckles."
+			m_type = 1
 
 		if ("twitch")
 			message = "twitches."

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -226,8 +226,16 @@
 			m_type = 1
 
 		if ("chuckle")
-			message = "chuckles."
-			m_type = 1
+			if(miming)
+                message = "appears to chuckle."
+                m_type = 1
+            else
+                if (!muzzled)
+                    message = "chuckles."
+                    m_type = 2
+                else
+                    message = "makes a noise."
+                    m_type = 2
 
 		if ("twitch")
 			message = "twitches."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Multiple people have been raging about this.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Multiple people have been raging about this.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: *chuckle no longer plays the laugh emote
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
