### PR TITLE
mobs are no longer HARDDEL_NOW for performance reasons because the occasional bugged player is a small price to pay for server speedups.

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -15,7 +15,7 @@
 	ghostize()
 	QDEL_NULL(plane_holder)
 	..()
-	return QDEL_HINT_HARDDEL_NOW
+	return QDEL_HINT_HARDDEL
 
 /mob/proc/remove_screen_obj_references()
 	hands = null


### PR DESCRIPTION
>bandaiding shit code practices with setting things to harddel_now

lmfao no.