### PR TITLE
Talon Changes and Additions

### DIFF
--- a/_maps/map_levels/140x140/talon/talon1.dmm
+++ b/_maps/map_levels/140x140/talon/talon1.dmm
@@ -222,11 +222,7 @@
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/talon/deckone/medical)
 "ax" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/tank/oxygen,
-/obj/item/tank/oxygen,
-/obj/item/tank/oxygen,
-/obj/item/tank/oxygen,
+/obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/eris/dark/danger,
 /area/talon/deckone/secure_storage)
 "ay" = (
@@ -285,12 +281,18 @@
 /turf/simulated/wall/rshull,
 /area/talon/maintenance/deckone_port)
 "aD" = (
-/obj/structure/table/rack/steel,
 /obj/machinery/camera/network/talon,
-/obj/item/suit_cooling_unit,
-/obj/item/suit_cooling_unit,
-/obj/item/suit_cooling_unit,
-/obj/item/suit_cooling_unit,
+/obj/item/storage/briefcase/inflatable{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/storage/briefcase/inflatable{
+	pixel_x = -3
+	},
+/obj/structure/table/steel,
 /turf/simulated/floor/tiled/eris/dark/danger,
 /area/talon/deckone/secure_storage)
 "aE" = (
@@ -345,10 +347,10 @@
 /area/talon/maintenance/deckone_port_fore_wing)
 "aJ" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/void/mining,
+/obj/item/clothing/suit/space/void/mining,
+/obj/item/clothing/head/helmet/space/void/mining,
+/obj/item/clothing/head/helmet/space/void/mining,
 /turf/simulated/floor/tiled/eris/dark/danger,
 /area/talon/deckone/secure_storage)
 "aK" = (
@@ -375,23 +377,15 @@
 /area/talon/maintenance/deckone_port)
 "aN" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/carbondioxide,
+/obj/item/clothing/suit/space/void/refurb/talon,
+/obj/item/clothing/suit/space/void/refurb/talon,
+/obj/item/clothing/head/helmet/space/void/refurb/talon,
+/obj/item/clothing/head/helmet/space/void/refurb/talon,
 /turf/simulated/floor/tiled/eris/dark/danger,
 /area/talon/deckone/secure_storage)
 "aO" = (
 /turf/simulated/wall,
 /area/talon/maintenance/deckone_starboard)
-"aP" = (
-/obj/structure/table/rack/steel,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/syndicate/black,
-/obj/item/clothing/head/helmet/space/syndicate/black,
-/turf/simulated/floor/tiled/eris/white/danger,
-/area/talon/deckone/armory)
 "aQ" = (
 /obj/machinery/computer/ship/engines{
 	dir = 8;
@@ -435,11 +429,16 @@
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/deckone_port)
 "aW" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
 /obj/machinery/alarm/talon{
 	dir = 1;
 	pixel_y = -25
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled/eris/dark/danger,
 /area/talon/deckone/secure_storage)
 "aX" = (
@@ -483,6 +482,7 @@
 "be" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table/standard,
+/obj/random/soap,
 /obj/item/clothing/gloves/sterile/nitrile,
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/suit/surgicalapron,
@@ -741,6 +741,9 @@
 /area/talon/deckone/bridge)
 "bE" = (
 /obj/machinery/vending/engineering{
+	icon = 'icons/obj/vending_vr.dmi';
+	icon_deny = null;
+	icon_state = "sovietsoda";
 	products = list(/obj/item/clothing/under/rank/chief_engineer = 4, /obj/item/clothing/under/rank/engineer = 4, /obj/item/clothing/shoes/orange = 4, /obj/item/clothing/head/hardhat = 4, /obj/item/storage/belt/utility = 4, /obj/item/clothing/glasses/meson = 4, /obj/item/clothing/gloves/yellow = 4, /obj/item/tool/screwdriver = 12, /obj/item/tool/crowbar = 12, /obj/item/tool/wirecutters = 12, /obj/item/multitool = 12, /obj/item/tool/wrench = 12, /obj/item/t_scanner = 12, /obj/item/stack/cable_coil/heavyduty = 8, /obj/item/cell = 8, /obj/item/weldingtool = 8, /obj/item/clothing/head/welding = 8, /obj/item/light/tube = 10, /obj/item/clothing/head/hardhat/red = 4, /obj/item/clothing/suit/fire = 4, /obj/item/stock_parts/scanning_module = 5, /obj/item/stock_parts/micro_laser = 5, /obj/item/stock_parts/matter_bin = 5, /obj/item/stock_parts/manipulator = 5, /obj/item/stock_parts/console_screen = 5);
 	req_access = list(301);
 	req_log_access = 301;
@@ -756,6 +759,7 @@
 /obj/machinery/alarm/talon{
 	pixel_y = 28
 	},
+/obj/item/inducer/syndicate,
 /turf/simulated/floor/tiled/eris/dark/brown_platform,
 /area/talon/deckone/port_eng_store)
 "bG" = (
@@ -1228,7 +1232,7 @@
 /obj/machinery/camera/network/talon{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/eris/white/gray_platform,
+/turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/talon/deckone/bridge_hallway)
 "cz" = (
 /obj/structure/catwalk,
@@ -1308,13 +1312,17 @@
 /area/talon/maintenance/deckone_port)
 "cI" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/gun/energy/gun/burst,
+/obj/item/clothing/accessory/holster/waist,
 /obj/item/cell/device/weapon{
 	pixel_x = -5;
 	pixel_y = 2
 	},
+/obj/item/cell/device/weapon{
+	pixel_x = 5;
+	pixel_y = 2
+	},
 /obj/item/cell/device/weapon,
-/obj/item/clothing/accessory/holster/waist,
+/obj/item/gun/energy/gun/burst,
 /turf/simulated/floor/tiled/eris/white/danger,
 /area/talon/deckone/armory)
 "cJ" = (
@@ -1337,7 +1345,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/eris/white/gray_platform,
+/turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/talon/deckone/bridge_hallway)
 "cL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1410,6 +1418,8 @@
 /area/talon/deckone/port_eng)
 "cQ" = (
 /obj/structure/table/rack/shelf/steel,
+/obj/item/gun/energy/frontier,
+/obj/item/gun/energy/frontier,
 /obj/item/gun/energy/frontier,
 /turf/simulated/floor/tiled/eris/white/danger,
 /area/talon/deckone/armory)
@@ -1552,8 +1562,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/vending/medical_talon{
-	dir = 4
+/obj/machinery/vending/medical{
+	req_access = list(301);
+	req_log_access = list(301)
 	},
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/talon/deckone/medical)
@@ -1674,7 +1685,11 @@
 /area/talon/deckone/medical)
 "en" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/suit/space/void/refurb/talon,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
 /turf/simulated/floor/tiled/eris/dark/danger,
 /area/talon/deckone/secure_storage)
 "eo" = (
@@ -1784,6 +1799,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled/eris/dark/orangecorner,
 /area/talon/deckone/secure_storage)
 "fJ" = (
@@ -2037,7 +2053,7 @@
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/deckone/central_hallway)
 "iP" = (
-/turf/simulated/floor/tiled/eris/white/gray_platform,
+/turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/talon/deckone/bridge_hallway)
 "iR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -2082,6 +2098,12 @@
 /obj/machinery/suit_cycler/vintage/tguard,
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/deckone/brig)
+"jn" = (
+/obj/structure/table/rack/steel,
+/obj/item/inducer/syndicate,
+/obj/item/inducer/syndicate,
+/turf/simulated/floor/tiled/eris/white/danger,
+/area/talon/deckone/armory)
 "jp" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/eris/white,
@@ -2368,6 +2390,7 @@
 	dir = 9
 	},
 /obj/structure/table/standard,
+/obj/item/storage/box/flare,
 /turf/simulated/floor/tiled/eris/white/gray_platform,
 /area/shuttle/talonboat)
 "mf" = (
@@ -2467,7 +2490,8 @@
 "mS" = (
 /obj/structure/table/standard,
 /obj/fiftyspawner/steel,
-/obj/structure/outcrop/lead,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
 /turf/simulated/floor/tiled/eris/steel/gray_perforated,
 /area/talon/deckone/workroom)
 "mT" = (
@@ -2538,13 +2562,8 @@
 /area/talon/deckone/central_hallway)
 "oc" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/gun/energy/netgun,
-/obj/item/cell/device/weapon{
-	pixel_x = -5;
-	pixel_y = 2
-	},
 /obj/item/cell/device/weapon,
-/obj/item/clothing/accessory/holster/waist,
+/obj/item/gun/energy/ionrifle,
 /turf/simulated/floor/tiled/eris/white/danger,
 /area/talon/deckone/armory)
 "oh" = (
@@ -2579,7 +2598,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/junction,
-/turf/simulated/floor/tiled/eris/white/gray_platform,
+/turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/talon/deckone/bridge_hallway)
 "oS" = (
 /obj/structure/bed/chair/bay/comfy/yellow{
@@ -2728,6 +2747,9 @@
 	name = "north bump";
 	pixel_y = 28
 	},
+/obj/machinery/suit_cycler/mining{
+	req_access = list(301)
+	},
 /turf/simulated/floor/tiled/eris/dark/orangecorner,
 /area/talon/deckone/secure_storage)
 "qo" = (
@@ -2789,6 +2811,10 @@
 	},
 /turf/simulated/floor/hull/airless,
 /area/talon/maintenance/deckone_starboard_fore_wing)
+"qG" = (
+/obj/structure/vehiclecage/quadbike,
+/turf/simulated/floor/tiled/eris/steel,
+/area/talon/deckone/central_hallway)
 "qL" = (
 /obj/machinery/light/small,
 /obj/machinery/power/port_gen/pacman{
@@ -2923,9 +2949,13 @@
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/deckone_starboard)
 "sK" = (
-/obj/machinery/suit_cycler/vintage/tcrew,
-/turf/simulated/floor/tiled/eris/dark/danger,
-/area/talon/deckone/secure_storage)
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/accessory/holster/machete,
+/obj/item/clothing/accessory/holster/machete,
+/obj/item/material/knife/machete,
+/obj/item/material/knife/machete,
+/turf/simulated/floor/tiled/eris/white/danger,
+/area/talon/deckone/armory)
 "sL" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -2937,9 +2967,16 @@
 /area/talon/maintenance/deckone_starboard)
 "sS" = (
 /obj/structure/table/rack/shelf/steel,
+/obj/item/cell/device/weapon{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/cell/device/weapon,
 /obj/item/gun/energy/gun,
-/obj/item/clothing/accessory/holster/machete,
-/obj/item/material/knife/machete,
 /turf/simulated/floor/tiled/eris/white/danger,
 /area/talon/deckone/armory)
 "sY" = (
@@ -3219,9 +3256,7 @@
 /turf/simulated/floor/tiled/eris/steel/cargo,
 /area/talon/deckone/workroom)
 "wj" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/suit/space/void/refurb/talon,
-/obj/item/clothing/head/helmet/space/void/refurb/talon,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/eris/dark/danger,
 /area/talon/deckone/secure_storage)
 "wk" = (
@@ -3962,7 +3997,7 @@
 	pixel_y = 31
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/eris/white/gray_platform,
+/turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/talon/deckone/bridge_hallway)
 "ES" = (
 /obj/structure/grille,
@@ -4005,9 +4040,6 @@
 	},
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/deckone_starboard)
-"Fl" = (
-/turf/simulated/floor/tiled/eris/white/danger,
-/area/talon/deckone/armory)
 "Fs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4178,6 +4210,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/machinery/suit_cycler/vintage/tcrew,
 /turf/simulated/floor/tiled/eris/dark/orangecorner,
 /area/talon/deckone/secure_storage)
 "Hl" = (
@@ -4212,6 +4245,9 @@
 "Hy" = (
 /turf/simulated/floor/tiled/eris/dark/orangecorner,
 /area/talon/deckone/brig)
+"HC" = (
+/turf/simulated/floor/tiled/eris/white/orangecorner,
+/area/talon/deckone/armory)
 "HQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -4221,7 +4257,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/eris/white/gray_platform,
+/turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/talon/deckone/bridge_hallway)
 "HW" = (
 /obj/machinery/computer/ship/sensors,
@@ -4267,7 +4303,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated,
-/turf/simulated/floor/plating/eris/under,
+/turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/talon/deckone/bridge_hallway)
 "Ij" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -4578,7 +4614,7 @@
 "KP" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/eris/white/gray_platform,
+/turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/talon/deckone/bridge_hallway)
 "La" = (
 /obj/structure/grille,
@@ -4658,7 +4694,11 @@
 /area/talon/deckone/brig)
 "LO" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/head/helmet/space/void/refurb/talon,
+/obj/item/suit_cooling_unit,
+/obj/item/suit_cooling_unit,
+/obj/item/suit_cooling_unit,
+/obj/item/suit_cooling_unit,
+/obj/item/suit_cooling_unit,
 /turf/simulated/floor/tiled/eris/dark/danger,
 /area/talon/deckone/secure_storage)
 "LU" = (
@@ -4944,7 +4984,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/eris/white/gray_platform,
+/turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/talon/deckone/bridge_hallway)
 "OS" = (
 /obj/machinery/atmospherics/unary/engine/bigger{
@@ -5227,6 +5267,17 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/table/standard,
 /obj/machinery/cell_charger,
+/obj/item/cell/super{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/cell/super{
+	pixel_y = 10
+	},
+/obj/item/cell/super{
+	pixel_x = 5;
+	pixel_y = 5
+	},
 /turf/simulated/floor/tiled/eris/steel/cargo,
 /area/talon/deckone/workroom)
 "Te" = (
@@ -5319,9 +5370,18 @@
 /area/talon/maintenance/deckone_port)
 "TX" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/gun/energy/netgun,
+/obj/item/clothing/accessory/holster/waist,
+/obj/item/clothing/accessory/holster/waist,
 /obj/item/cell/device/weapon{
 	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 5;
 	pixel_y = 2
 	},
 /obj/item/cell/device/weapon{
@@ -5329,7 +5389,9 @@
 	pixel_y = 2
 	},
 /obj/item/cell/device/weapon,
-/obj/item/clothing/accessory/holster/waist,
+/obj/item/cell/device/weapon,
+/obj/item/gun/energy/netgun,
+/obj/item/gun/energy/netgun,
 /turf/simulated/floor/tiled/eris/white/danger,
 /area/talon/deckone/armory)
 "Uq" = (
@@ -5347,7 +5409,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/eris/white/gray_platform,
+/turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/talon/deckone/bridge_hallway)
 "Ut" = (
 /obj/structure/table/standard,
@@ -5456,7 +5518,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/eris/white/gray_platform,
+/turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/talon/deckone/bridge_hallway)
 "UY" = (
 /obj/structure/grille,
@@ -5491,7 +5553,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/eris/white/gray_platform,
+/turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/talon/deckone/bridge_hallway)
 "VB" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -5590,6 +5652,9 @@
 "Wt" = (
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/atm{
+	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/eris/dark/monofloor,
 /area/talon/deckone/central_hallway)
@@ -5832,7 +5897,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/eris/white/gray_platform,
+/turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/talon/deckone/bridge_hallway)
 "Zj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
@@ -5866,7 +5931,7 @@
 /turf/simulated/floor/plating/eris/under,
 /area/talon/deckone/central_hallway)
 "Zt" = (
-/turf/simulated/floor/tiled/eris/white/orangecorner,
+/turf/simulated/floor/tiled/eris/white/danger,
 /area/talon/deckone/armory)
 "Zz" = (
 /obj/machinery/alarm/talon{
@@ -15069,7 +15134,7 @@ ab
 ac
 aD
 kN
-sK
+xV
 kN
 aW
 aR
@@ -15107,7 +15172,7 @@ zE
 dL
 wk
 cr
-Bj
+qG
 Bj
 bS
 ki
@@ -16348,7 +16413,7 @@ ac
 zx
 Gd
 uM
-Zt
+HC
 kV
 bQ
 bQ
@@ -16488,9 +16553,9 @@ ab
 ab
 ac
 aE
-Fl
-aP
-Fl
+Zt
+jn
+Zt
 bG
 aY
 aO
@@ -16630,9 +16695,9 @@ aa
 ab
 ac
 TX
-Fl
+Zt
 oc
-Fl
+Zt
 cI
 aY
 aO
@@ -16773,7 +16838,7 @@ ab
 ac
 cQ
 le
-cQ
+sK
 bK
 sS
 aY

--- a/_maps/map_levels/140x140/talon/talon2.dmm
+++ b/_maps/map_levels/140x140/talon/talon2.dmm
@@ -291,6 +291,7 @@
 	pixel_y = 26
 	},
 /obj/structure/closet/secure_closet/talon_captain,
+/obj/item/binoculars/spyglass,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/talon/decktwo/cap_room)
 "aQ" = (
@@ -336,10 +337,6 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -25
 	},
 /turf/simulated/floor/reinforced,
 /area/talon/decktwo/vault)
@@ -717,6 +714,10 @@
 /obj/machinery/camera/network/talon{
 	dir = 9
 	},
+/obj/item/firing_pin,
+/obj/item/firing_pin,
+/obj/item/firing_pin,
+/obj/item/firing_pin,
 /turf/simulated/floor/reinforced,
 /area/talon/decktwo/vault)
 "bF" = (
@@ -856,15 +857,10 @@
 /area/talon/maintenance/decktwo_starboard)
 "bR" = (
 /obj/structure/table/steel,
-/obj/random/ammo_all,
-/obj/random/ammo_all,
-/obj/random/ammo_all,
-/obj/random/ammo_all,
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo,
+/obj/item/melee/energy/hfmachete,
+/obj/item/melee/energy/sword/imperial,
+/obj/item/nullrod,
+/obj/item/nullrod,
 /turf/simulated/floor/reinforced,
 /area/talon/decktwo/vault)
 "bS" = (

--- a/_maps/map_levels/140x140/talon/talon2.dmm
+++ b/_maps/map_levels/140x140/talon/talon2.dmm
@@ -158,17 +158,16 @@
 /area/talon/decktwo/bridge_upper)
 "az" = (
 /obj/structure/bed/double/padded,
-/obj/item/bedsheet/bluedouble,
-/turf/simulated/floor/carpet/blucarpet,
+/obj/item/bedsheet/hopdouble,
+/turf/simulated/floor/carpet/sblucarpet,
 /area/talon/decktwo/cap_room)
 "aA" = (
-/obj/structure/table/woodentable,
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
+/obj/machinery/vending/boozeomat{
+	req_access = list(301);
+	req_log_access = 301
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon/decktwo/cap_room)
+/turf/simulated/wall,
+/area/talon/decktwo/bar)
 "aB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -237,16 +236,18 @@
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/decktwo_aft)
 "aK" = (
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon/decktwo/cap_room)
+/obj/structure/table/steel,
+/obj/random/rigsuit,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/random/multiple/voidsuit,
+/obj/random/multiple/voidsuit,
+/turf/simulated/floor/reinforced,
+/area/talon/decktwo/vault)
 "aL" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/talon_captain,
-/obj/item/radio/off{
-	channels = list("Talon" = 1)
-	},
+/obj/machinery/suit_cycler/vintage/tcaptain,
 /turf/simulated/floor/wood,
 /area/talon/decktwo/cap_room)
 "aM" = (
@@ -285,13 +286,13 @@
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/decktwo_aft)
 "aP" = (
-/obj/machinery/alarm/talon{
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
 	},
-/obj/structure/table/standard,
-/turf/simulated/floor/wood,
-/area/talon/decktwo/bar)
+/obj/structure/closet/secure_closet/talon_captain,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/talon/decktwo/cap_room)
 "aQ" = (
 /turf/simulated/floor/wood,
 /area/talon/decktwo/bar)
@@ -308,9 +309,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/vending/food{
-	dir = 1
-	},
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/eris/steel/gray_perforated,
 /area/talon/decktwo/bar)
 "aT" = (
@@ -332,12 +331,18 @@
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/decktwo/central_hallway)
 "aW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon/decktwo/cap_room)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor/reinforced,
+/area/talon/decktwo/vault)
 "aX" = (
 /obj/structure/bed/chair/bay/chair{
 	dir = 1
@@ -381,24 +386,30 @@
 /turf/simulated/floor/wood,
 /area/talon/decktwo/eng_room)
 "bb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/cap_room)
 "bc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/talon/decktwo/cap_room)
 "bd" = (
@@ -407,9 +418,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -431,9 +440,6 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/talon_engineer,
-/obj/item/radio/off{
-	channels = list("Talon" = 1)
-	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/eng_room)
 "bg" = (
@@ -441,9 +447,6 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/talon_pilot,
-/obj/item/radio/off{
-	channels = list("Talon" = 1)
-	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/pilot_room)
 "bh" = (
@@ -512,21 +515,39 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/talon/decktwo/tech)
 "bm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/cap_room)
 "bn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/button/remote/airlock{
+	dir = 1;
+	id = "talon_vault";
+	name = "Vault Access";
+	pixel_x = 1;
+	pixel_y = -24;
+	req_access = list(301);
+	req_one_access = list(301);
+	specialfunctions = 4
+	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/cap_room)
 "bo" = (
-/obj/structure/cable/green{
-	dir = 1;
-	icon_state = "1-2"
+/obj/structure/cable/green,
+/obj/machinery/power/apc/talon{
+	name = "south bump";
+	pixel_y = -28;
+	req_access = list()
 	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/cap_room)
@@ -584,29 +605,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/med_room)
-"bu" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/talon/decktwo/cap_room)
 "bv" = (
-/obj/structure/cable/green,
-/obj/machinery/power/apc/talon{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/wood,
-/area/talon/decktwo/cap_room)
+/turf/simulated/wall/r_wall,
+/area/talon/decktwo/vault)
 "bw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/talon_doctor,
-/obj/item/radio/off{
-	channels = list("Talon" = 1)
-	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/med_room)
 "bx" = (
@@ -628,9 +634,6 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/talon_guard,
-/obj/item/radio/off{
-	channels = list("Talon" = 1)
-	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/sec_room)
 "bz" = (
@@ -661,26 +664,61 @@
 /turf/simulated/floor/tiled/eris/dark/violetcorener,
 /area/talon/decktwo/tech)
 "bB" = (
-/obj/machinery/alarm/talon{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/wood,
-/area/talon/decktwo/cap_room)
+/obj/structure/table/rack/shelf/steel,
+/obj/item/moneybag/vault,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c500,
+/obj/random/multiple/treasure,
+/obj/random/multiple/treasure,
+/obj/random/multiple/treasure,
+/obj/random/multiple/treasure,
+/obj/item/stolenpackageplus,
+/obj/item/stolenpackageplus,
+/obj/item/stolenpackageplus,
+/obj/item/stolenpackageplus,
+/obj/item/stolenpackageplus,
+/turf/simulated/floor/reinforced,
+/area/talon/decktwo/vault)
 "bC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/bed/chair/wood,
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon/decktwo/cap_room)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/talon/decktwo/vault)
 "bD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/bed/chair/wood,
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon/decktwo/cap_room)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/button/remote/airlock{
+	id = "talon_vault";
+	name = "Vault Access";
+	pixel_y = 24;
+	req_access = list(301);
+	req_one_access = list(301);
+	specialfunctions = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/talon/decktwo/vault)
 "bE" = (
-/obj/structure/bed/chair/wood,
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon/decktwo/cap_room)
+/obj/structure/closet/secure_closet/guncabinet{
+	req_access = list(301);
+	req_one_access = list(301)
+	},
+/obj/machinery/camera/network/talon{
+	dir = 9
+	},
+/turf/simulated/floor/reinforced,
+/area/talon/decktwo/vault)
 "bF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -711,16 +749,19 @@
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/decktwo_port)
 "bH" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/bed/chair/bay/chair,
+/obj/machinery/alarm/talon{
+	dir = 4;
+	pixel_x = -22
 	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/bar)
 "bI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/bar)
 "bJ" = (
@@ -732,15 +773,16 @@
 /turf/simulated/floor/wood,
 /area/talon/decktwo/bar)
 "bK" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/structure/table/woodentable,
-/obj/item/modular_computer/tablet/preset/custom_loadout/advanced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon/decktwo/cap_room)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/reinforced,
+/area/talon/decktwo/vault)
 "bL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -755,9 +797,28 @@
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/decktwo_starboard)
 "bM" = (
-/obj/item/modular_computer/console/preset/talon,
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon/decktwo/cap_room)
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/talon{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/random/projectile,
+/obj/random/weapon/guarenteed,
+/obj/random/weapon/guarenteed,
+/obj/random/weapon/guarenteed,
+/obj/random/multiple/gun/projectile/rifle,
+/obj/random/multiple/gun/projectile/shotgun,
+/obj/random/multiple/gun/projectile/smg,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/talon/decktwo/vault)
 "bN" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -794,11 +855,18 @@
 /turf/simulated/wall/rshull,
 /area/talon/maintenance/decktwo_starboard)
 "bR" = (
-/obj/structure/bed/chair/office/light{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon/decktwo/cap_room)
+/obj/structure/table/steel,
+/obj/random/ammo_all,
+/obj/random/ammo_all,
+/obj/random/ammo_all,
+/obj/random/ammo_all,
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/ammo,
+/turf/simulated/floor/reinforced,
+/area/talon/decktwo/vault)
 "bS" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -1051,6 +1119,9 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating/eris/under,
 /area/talon/decktwo/central_hallway)
+"cO" = (
+/turf/simulated/floor/carpet/sblucarpet,
+/area/talon/decktwo/cap_room)
 "cP" = (
 /obj/machinery/alarm/talon{
 	dir = 4;
@@ -1294,9 +1365,21 @@
 /turf/simulated/floor/wood,
 /area/talon/decktwo/eng_room)
 "er" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon/decktwo/cap_room)
+/obj/machinery/alarm/talon{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/cell/device/weapon/empty,
+/obj/item/cell/device/weapon/empty,
+/obj/item/cell/device/weapon/empty,
+/obj/item/cell/device/weapon/empty,
+/obj/item/cell/device/weapon/empty,
+/obj/random/energy,
+/obj/random/energy,
+/obj/random/energy,
+/turf/simulated/floor/reinforced,
+/area/talon/decktwo/vault)
 "ev" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -1587,6 +1670,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/sec_room)
+"fX" = (
+/obj/structure/table/marble,
+/obj/machinery/microwave,
+/turf/simulated/floor/tiled/eris/cafe,
+/area/talon/decktwo/bar)
 "gn" = (
 /turf/simulated/open,
 /area/talon/maintenance/decktwo_aft)
@@ -1672,6 +1760,12 @@
 "gZ" = (
 /turf/simulated/wall,
 /area/talon/maintenance/decktwo_port)
+"hm" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/talon/decktwo/cap_room)
 "hn" = (
 /obj/structure/railing{
 	dir = 1
@@ -1754,6 +1848,12 @@
 	},
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/decktwo_port)
+"hN" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/talon/decktwo/bridge_upper)
 "hO" = (
 /obj/effect/overmap/visitable/ship/talon,
 /turf/space,
@@ -1763,7 +1863,12 @@
 /turf/space,
 /area/space)
 "hQ" = (
-/obj/structure/table/bench/wooden,
+/obj/machinery/alarm/talon{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/structure/table/woodentable,
+/obj/item/flashlight/lamp,
 /turf/simulated/floor/wood,
 /area/talon/decktwo/cap_room)
 "hX" = (
@@ -1887,7 +1992,7 @@
 /obj/machinery/power/apc/talon{
 	name = "south bump";
 	pixel_y = -28;
-	req_access = list(67)
+	req_access = list()
 	},
 /turf/simulated/floor/tiled/eris/dark/cyancorner,
 /area/talon/decktwo/bridge_upper)
@@ -1923,6 +2028,11 @@
 	},
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/decktwo/central_hallway)
+"jR" = (
+/obj/structure/table/marble,
+/obj/machinery/reagentgrinder,
+/turf/simulated/floor/tiled/eris/cafe,
+/area/talon/decktwo/bar)
 "jV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -1937,10 +2047,11 @@
 /area/talon/decktwo/central_hallway)
 "kh" = (
 /obj/structure/cable/green{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
+/obj/structure/bed/chair/office/light,
 /turf/simulated/floor/wood,
-/area/talon/decktwo/bar)
+/area/talon/decktwo/cap_room)
 "kn" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2179,9 +2290,11 @@
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/decktwo/central_hallway)
 "nu" = (
-/obj/structure/table/bench/wooden,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/item/modular_computer/console/preset/talon{
+	dir = 1
+	},
+/obj/machinery/camera/network/talon{
+	dir = 10
 	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/cap_room)
@@ -2210,25 +2323,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/decktwo/central_hallway)
-"nR" = (
-/obj/machinery/suit_cycler/vintage/tcaptain,
-/turf/simulated/floor/wood,
-/area/talon/decktwo/cap_room)
 "ol" = (
 /obj/structure/sign/poster{
 	dir = 1;
 	icon_state = ""
 	},
 /turf/simulated/wall,
-/area/talon/decktwo/bar)
-"om" = (
-/obj/machinery/vending/boozeomat{
-	density = 0;
-	pixel_y = 32;
-	req_access = list(301);
-	req_log_access = 301
-	},
-/turf/simulated/floor/tiled/eris/cafe,
 /area/talon/decktwo/bar)
 "oX" = (
 /obj/structure/cable/heavyduty{
@@ -2413,7 +2513,7 @@
 /area/talon/decktwo/lifeboat)
 "rU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/stool,
+/obj/item/stool/padded,
 /turf/simulated/floor/tiled/eris/cafe,
 /area/talon/decktwo/bar)
 "rW" = (
@@ -2478,8 +2578,15 @@
 	id = "talon_capdoor";
 	name = "Door Bolts";
 	pixel_x = 28;
+	pixel_y = 6;
 	specialfunctions = 4
 	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 28;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood,
 /area/talon/decktwo/cap_room)
 "sy" = (
@@ -2517,6 +2624,9 @@
 	},
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/decktwo/central_hallway)
+"tJ" = (
+/turf/simulated/wall/rshull,
+/area/talon/decktwo/vault)
 "tM" = (
 /obj/structure/loot_pile/maint/trash,
 /turf/simulated/floor/plating/eris/under,
@@ -2611,10 +2721,10 @@
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/decktwo/central_hallway)
 "uM" = (
-/obj/item/stool,
 /obj/machinery/camera/network/talon{
 	dir = 6
 	},
+/obj/item/stool/padded,
 /turf/simulated/floor/tiled/eris/cafe,
 /area/talon/decktwo/bar)
 "uQ" = (
@@ -2962,7 +3072,13 @@
 /area/talon/decktwo/central_hallway)
 "AC" = (
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	dir = 1;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/bar)
@@ -3176,7 +3292,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/item/stool,
+/obj/item/stool/padded,
 /turf/simulated/floor/tiled/eris/cafe,
 /area/talon/decktwo/bar)
 "Dr" = (
@@ -3458,6 +3574,10 @@
 	},
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/decktwo_starboard)
+"If" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/wood,
+/area/talon/decktwo/cap_room)
 "Iw" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
@@ -3648,6 +3768,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/decktwo_port)
+"Lq" = (
+/obj/structure/table/steel,
+/obj/item/storage/toolbox/syndicate/powertools,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/talon/decktwo/vault)
 "LH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3660,6 +3788,14 @@
 	},
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/decktwo_starboard)
+"LX" = (
+/obj/structure/table/steel,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/turf/simulated/floor/reinforced,
+/area/talon/decktwo/vault)
 "Mk" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small,
@@ -3760,7 +3896,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/item/storage/dicecup/loaded,
 /turf/simulated/floor/tiled/eris/cafe,
 /area/talon/decktwo/bar)
 "NE" = (
@@ -3836,11 +3971,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/item/stool,
 /obj/structure/cable/green{
-	dir = 1;
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
+/obj/item/stool/padded,
 /turf/simulated/floor/tiled/eris/cafe,
 /area/talon/decktwo/bar)
 "OO" = (
@@ -4044,6 +4178,24 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/violetcorener,
 /area/talon/decktwo/tech)
+"RI" = (
+/obj/machinery/door/airlock/vault/bolted{
+	id_tag = talon_vault;
+	name = "Talon Trading Goods";
+	req_one_access = list(301)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/glass/talon,
+/turf/simulated/floor/reinforced,
+/area/talon/decktwo/vault)
 "RQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4078,7 +4230,7 @@
 /obj/effect/landmark/start{
 	name = "Talon Captain"
 	},
-/turf/simulated/floor/carpet/blucarpet,
+/turf/simulated/floor/carpet/sblucarpet,
 /area/talon/decktwo/cap_room)
 "Tg" = (
 /obj/structure/cable/green{
@@ -4330,6 +4482,11 @@
 "VZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/eris/cafe,
 /area/talon/decktwo/bar)
 "Wa" = (
@@ -4367,13 +4524,22 @@
 "WS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/stool,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/stool/padded,
 /turf/simulated/floor/tiled/eris/cafe,
 /area/talon/decktwo/bar)
 "WZ" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/structure/table/woodentable,
+/obj/item/pen,
+/obj/item/paper_bin,
+/obj/item/modular_computer/tablet,
 /turf/simulated/floor/wood,
 /area/talon/decktwo/cap_room)
 "Xa" = (
@@ -4444,6 +4610,29 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/eris/techmaint_panels,
 /area/talon/decktwo/central_hallway)
+"XX" = (
+/obj/structure/table/standard,
+/obj/item/deck/unus{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/deck/cards{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/deck/cah{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/deck/cah/black{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/storage/dicecup/loaded{
+	pixel_y = 6
+	},
+/turf/simulated/floor/wood,
+/area/talon/decktwo/bar)
 "XY" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -13297,10 +13486,10 @@ ap
 ap
 Vu
 dw
-ap
-ap
-ap
-ap
+tJ
+tJ
+tJ
+tJ
 cb
 cj
 cc
@@ -13437,13 +13626,13 @@ aC
 aC
 aC
 aC
-nu
+WZ
 hQ
-aC
-aC
-aC
-aC
-aC
+bv
+bv
+bv
+bv
+bv
 cc
 cc
 lR
@@ -13578,14 +13767,14 @@ ap
 aC
 az
 SU
-nR
-WZ
-aM
-bu
+hm
+kh
+nu
+bv
 bB
-aM
-aM
-aC
+Lq
+LX
+bv
 ck
 cy
 NT
@@ -13718,16 +13907,16 @@ ab
 ab
 ab
 aC
-aA
-aK
+aP
+cO
 aM
 bb
 bm
-bm
+RI
 bC
 bK
 aK
-aC
+bv
 cl
 cz
 kn
@@ -13862,14 +14051,14 @@ ac
 ac
 aC
 aL
-aM
+If
 bc
 bn
-bn
+bv
 bD
 aW
 bR
-aC
+bv
 cl
 cz
 NT
@@ -13996,7 +14185,7 @@ aa
 ab
 ac
 ae
-ae
+hN
 ae
 ae
 aj
@@ -14011,7 +14200,7 @@ bv
 bE
 bM
 er
-aC
+bv
 cm
 cz
 Fc
@@ -14149,11 +14338,11 @@ aC
 aC
 bi
 aC
-aC
-aC
-aC
-aC
-aC
+bv
+bv
+bv
+bv
+bv
 cl
 cA
 NT
@@ -14712,8 +14901,8 @@ ae
 ai
 jz
 aw
-aF
-aP
+bH
+XX
 aX
 aF
 bq
@@ -14848,7 +15037,7 @@ aa
 ab
 ac
 ae
-ae
+an
 ae
 ae
 an
@@ -14857,9 +15046,9 @@ aw
 aG
 aQ
 aQ
-kh
-bH
-bH
+aQ
+aQ
+aQ
 AC
 vB
 bW
@@ -15279,9 +15468,9 @@ aa
 aa
 aa
 ax
-aw
-om
+aA
 ZF
+UY
 UY
 vW
 UY
@@ -15423,8 +15612,8 @@ aa
 ax
 aw
 aw
-aw
-aw
+fX
+jR
 KR
 uQ
 aw

--- a/code/modules/maps/talon/talon.dm
+++ b/code/modules/maps/talon/talon.dm
@@ -261,9 +261,11 @@ Once in open space, consider disabling nonessential power-consuming electronics 
 		/obj/item/clothing/suit/storage/vest,
 		/obj/item/melee/telebaton,
 		/obj/item/flash,
+		/obj/item/radio,
 		/obj/item/radio/headset/talon,
 		/obj/item/clothing/head/helmet/space/void/refurb/officer/talon,
 		/obj/item/clothing/suit/space/void/refurb/officer/talon,
+		/obj/item/clothing/shoes/magboots,
 		/obj/item/tank/oxygen,
 		/obj/item/suit_cooling_unit,
 		/obj/item/gps/command/taloncap
@@ -286,10 +288,12 @@ Once in open space, consider disabling nonessential power-consuming electronics 
 		/obj/item/flashlight/maglight,
 		/obj/item/clothing/glasses/sunglasses,
 		/obj/item/storage/belt/security,
+		/obj/item/radio,
 		/obj/item/radio/headset/talon,
 		/obj/item/clothing/accessory/solgov/department/security,
 		/obj/item/clothing/head/helmet/space/void/refurb/marine/talon,
 		/obj/item/clothing/suit/space/void/refurb/marine/talon,
+		/obj/item/clothing/shoes/magboots,
 		/obj/item/tank/oxygen,
 		/obj/item/suit_cooling_unit,
 		/obj/item/gps/security/talonguard,
@@ -308,9 +312,11 @@ Once in open space, consider disabling nonessential power-consuming electronics 
 		/obj/item/clothing/suit/storage/toggle/labcoat,
 		/obj/item/clothing/suit/storage/toggle/fr_jacket,
 		/obj/item/clothing/shoes/white,
+		/obj/item/radio,
 		/obj/item/radio/headset/talon,
 		/obj/item/clothing/head/helmet/space/void/refurb/medical/alt/talon,
 		/obj/item/clothing/suit/space/void/refurb/medical/talon,
+		/obj/item/clothing/shoes/magboots,
 		/obj/item/tank/oxygen,
 		/obj/item/suit_cooling_unit,
 		/obj/item/gps/medical/talonmed
@@ -325,6 +331,7 @@ Once in open space, consider disabling nonessential power-consuming electronics 
 		/obj/item/clothing/accessory/storage/brown_vest,
 		/obj/item/flashlight,
 		/obj/item/extinguisher,
+		/obj/item/radio,
 		/obj/item/radio/headset/talon,
 		/obj/item/clothing/suit/storage/hazardvest,
 		/obj/item/clothing/mask/gas,
@@ -332,6 +339,7 @@ Once in open space, consider disabling nonessential power-consuming electronics 
 		/obj/item/tank/emergency/oxygen/engi,
 		/obj/item/clothing/head/helmet/space/void/refurb/engineering/talon,
 		/obj/item/clothing/suit/space/void/refurb/engineering/talon,
+		/obj/item/clothing/shoes/magboots,
 		/obj/item/tank/oxygen,
 		/obj/item/suit_cooling_unit,
 		/obj/item/gps/engineering/taloneng
@@ -359,28 +367,11 @@ Once in open space, consider disabling nonessential power-consuming electronics 
 		/obj/item/flashlight/color/orange,
 		/obj/item/clothing/head/helmet/space/void/refurb/pilot/talon,
 		/obj/item/clothing/suit/space/void/refurb/pilot/talon,
+		/obj/item/clothing/shoes/magboots,
 		/obj/item/tank/oxygen,
 		/obj/item/suit_cooling_unit,
 		/obj/item/gps/explorer/talonpilot
 	)
-
-/obj/machinery/vending/medical_talon //Not a subtype for *reasons*
-	name = "NanoMed Plus"
-	desc = "Medical drug dispenser."
-	icon_state = "med"
-	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;Natural chemicals!;This stuff saves lives.;Don't you want some?;Ping!"
-	req_access = list(access_talon)
-	products = list(/obj/item/reagent_containers/glass/bottle/antitoxin = 4,/obj/item/reagent_containers/glass/bottle/inaprovaline = 4,
-					/obj/item/reagent_containers/glass/bottle/stoxin = 4,/obj/item/reagent_containers/glass/bottle/toxin = 4,
-					/obj/item/reagent_containers/syringe/antiviral = 4,/obj/item/reagent_containers/syringe = 12,
-					/obj/item/healthanalyzer = 5,/obj/item/reagent_containers/glass/beaker = 4, /obj/item/reagent_containers/dropper = 2,
-					/obj/item/stack/medical/advanced/bruise_pack = 6, /obj/item/stack/medical/advanced/ointment = 6, /obj/item/stack/medical/splint = 4,
-					/obj/item/storage/pill_bottle/carbon = 2, /obj/item/clothing/glasses/omnihud/med = 4,
-					/obj/item/glasses_kit = 1,  /obj/item/storage/quickdraw/syringe_case = 4)
-	contraband = list(/obj/item/reagent_containers/pill/tox = 3,/obj/item/reagent_containers/pill/stox = 4,/obj/item/reagent_containers/pill/antitox = 6)
-	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
-	req_log_access = access_talon
-	has_logs = 1
 
 ///////////////////////////
 //// Computers

--- a/code/modules/maps/talon/talon_areas.dm
+++ b/code/modules/maps/talon/talon_areas.dm
@@ -18,7 +18,7 @@
 	icon_state = "gray-s"
 /area/talon/maintenance/deckone_port_fore_wing
 	name = "\improper Deck One - Fore Port Wing"
-	icon_state = "gray-p"	
+	icon_state = "gray-p"
 /area/talon/maintenance/deckone_starboard_fore_wing
 	name = "\improper Deck One - Fore Starboard Wing"
 	icon_state = "gray-s"
@@ -107,3 +107,6 @@
 /area/talon/decktwo/bridge_upper
 	name = "\improper Deck Two - Upper Bridge"
 	icon_state = "blue"
+/area/talon/decktwo/vault
+	name = "\improper Deck Two - Vault"
+	icon_state = "red"


### PR DESCRIPTION
## About The Pull Request
I probably should have split this up since it contains fixes to oversights *and* my own additions, but PRing twice for map changes on the same DMM is painful in my experience and I already had it all finished before thinking about it.

-I fixed up the weapon and suit storage rooms. Added two mining voidsuits and a suit cycler with the appropriate access so that abnormal crew (teshari and such) have temperature resistant suits that they can wear.
-Added a vault that has a bit of mostly random loot that can be traded with the colony and its crew for things the Talon needs/wants. The vault shouldn't be looted without the captain's permission. I'd make special access for the captain only, but I'm hoping that it would be unnecessary.

## Why It's Good For The Game
-Everyone in the Talon should have access to voidsuits.
-Having things to trade without looting planets from underneath exploration's nose is nice.
-Most New weapons are a single frontier phaser and ion rifle. 6-9 new cells were added for the existing weapons because the Talon can't print replacements.

## Changelog
:cl:
add: Added a vault to store loot, and use randomly generated loot for trading. 
add: Added inducers to engineering and weapon storage, a few super power cells and materials to the workroom, some more weapons and power cells to weapon storage, and a spyglass to the captain's quarters.
tweak: Shuffled stuff around in the Talon's bar and captain's quarters.
fix: Fixed oversights with Talon's vendor access, Talon's vendors being invisible, and missing magboots/shortrange radios from Talon crew's lockers.
/:cl: