### PR TITLE
fixes synth bodyparts persisting between charslots (again)

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -145,6 +145,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	character.synth_markings 	= pref.synth_markings
 
 	// Destroy/cyborgize organs and limbs.
+	character.synthetic = null
 	for(var/name in list(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM, BP_L_FOOT, BP_R_FOOT, BP_L_LEG, BP_R_LEG, BP_GROIN, BP_TORSO))
 		var/status = pref.organ_data[name]
 		var/obj/item/organ/external/O = character.organs_by_name[name]


### PR DESCRIPTION
## About The Pull Request

see title

## Why It's Good For The Game

i don't want to have to switch to a different species before hitting the reset slot button every time i want to look at a different bodypart

## Changelog
:cl:Kraseo
fix: Synthetics no longer carry over every single character save.
/:cl:
