### PR TITLE
cyborg rechargers now charge 20 nutrition per tick instead of 10

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -119,10 +119,9 @@
 
 			// Also recharge their internal battery.
 			if(H.isSynthetic() && H.nutrition < 450)
-				var/needed = clamp(450 - H.nutrition, 0, 10)
+				var/needed = clamp(450 - H.nutrition, 0, 20)
 				var/drained = cell.use(needed * SYNTHETIC_NUTRITION_CHARGE_RATE)
 				H.nutrition += drained / SYNTHETIC_NUTRITION_CHARGE_RATE
-				// cell.use(7000/450*10)		YOU CAN JUST SAY 155.333, JACKASS
 
 			// And clear up radiation
 			if(H.radiation > 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

staring at a 1x1 room to recharge is pretty unfun
plus this makes it marginally worth it to use these instead of hyper expensive APC connectors goddamn
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: cyborg chargers charge synths/FBPs 2x fast (cyborgs unchanged)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
