### PR TITLE
fixes issue #3227

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -373,10 +373,14 @@ HALOGEN COUNTER	- Radcount on mobs
 
 /obj/item/analyzer/afterattack(var/obj/O, var/mob/user, var/proximity)
 	if(proximity)
+		if(istype(O, /obj/item/tank)) // don't double post what atmosanalyzer_scan returns
+			return
 		analyze_gases(O, user)
 	return
 
 /obj/item/analyzer/longrange/afterattack(var/obj/O, var/mob/user, var/proximity)
+	if(istype(O, /obj/item/tank)) // don't double post what atmosanalyzer_scan returns
+		return
 	analyze_gases(O, user)
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes issue #3227 
the gas analyzer can analyze a great many things including turfs and containers, and as such, needed this check a long time ago. see: ancient vorecode where this bug remains likely to this day

by adding the check, we eliminate the duplicate output without refactoring analyzer code. there is a separate proc that handles checking a tank's contents, so this stops the first proc from being called at the same time as the second.

## Why It's Good For The Game

closes #3227 

## Changelog
:cl:
fix: fixes gas analyzers duplicating output
/:cl:
![tank](https://user-images.githubusercontent.com/42501819/125170656-edb29f00-e17d-11eb-99b6-0bae0b86012b.png)
