### PR TITLE
Fixes a few issues with mirrors

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -665,7 +665,7 @@
 		new_character.dna.SetSEState(GLASSESBLOCK,1,0)
 		new_character.disabilities |= NEARSIGHTED
 	if(client.prefs.mirror == TRUE)
-		if((client.prefs.organ_data[O_BRAIN] == "mechanical") || (client.prefs.organ_data[O_BRAIN] == "digital") || (client.prefs.organ_data[O_BRAIN] == "assisted"))
+		if((client.prefs.organ_data[O_BRAIN] != null))
 			var/obj/item/implant/mirror/positronic/F = new /obj/item/implant/mirror/positronic(new_character)
 			F.handle_implant(new_character)
 			F.post_implant(new_character)

--- a/code/modules/resleeving/mirror.dm
+++ b/code/modules/resleeving/mirror.dm
@@ -31,8 +31,9 @@
 
 /obj/item/implant/mirror/post_implant(var/mob/living/carbon/human/H)
 	spawn(20)
-	if((H.client.prefs.organ_data[O_BRAIN] == "mechanical") || (H.client.prefs.organ_data[O_BRAIN] == "digital") || (H.client.prefs.organ_data[O_BRAIN] == "assisted"))
+	if((H.client.prefs.organ_data[O_BRAIN] != null))
 		to_chat(usr, "<span class='warning'>WARNING: WRONG MIRROR TYPE DETECTED, PLEASE RECTIFY IMMEDIATELY TO AVOID REAL DEATH.</span>")
+		H.mirror = src
 		return
 	else
 		stored_mind = SStranscore.m_backupE(H.mind, one_time = TRUE)
@@ -67,11 +68,13 @@
 
 /obj/item/implant/mirror/positronic/post_implant(var/mob/living/carbon/human/H)
 	spawn(20)
-	if((H.client.prefs.organ_data[O_BRAIN] == "mechanical") || (H.client.prefs.organ_data[O_BRAIN] == "digital") || (H.client.prefs.organ_data[O_BRAIN] == "assisted"))
+	if((H.client.prefs.organ_data[O_BRAIN] != null))
 		stored_mind = SStranscore.m_backupE(H.mind, one_time = TRUE)
 		icon_state = "mirror_implant"
+		H.mirror = src
 	else
 		to_chat(usr, "<span class='warning'>WARNING: WRONG MIRROR TYPE DETECTED, PLEASE RECTIFY IMMEDIATELY TO AVOID REAL DEATH.</span>")
+		H.mirror = src
 		return
 
 /obj/item/mirrorscanner
@@ -122,6 +125,9 @@
 
 	else if (target_zone == BP_TORSO && imp != null)
 		if (imp)
+			if(!M.client)
+				to_chat(usr, "Manual mirror transplant into mindless body not supported, please use the resleeving console.")
+				return
 			if(M.mirror)
 				to_chat(usr, "This person already has a mirror!")
 				return

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -223,6 +223,9 @@
 					var/obj/item/implant/imp = obj
 					imp.imp_in = null
 					imp.implanted = 0
+					if(istype(obj, /obj/item/implant/mirror))
+						target.mirror = null
+
 				else if(istype(tool,/obj/item/nif)){var/obj/item/nif/N = tool;N.unimplant(target)} //VOREStation Add - NIF support
 		else
 			user.visible_message("<font color=#4F49AF>[user] removes \the [tool] from [target]'s [affected.name].</font>", \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I never expected people to actually try to remove mirrors with surgery instead of the convenient tool, so I never made mirrors null out when removed through surgery which basically bricked them and made it impossible to implant a new one without var editing. Now it's fixed for when people do it wrong/accidentally do it wrong because they tried to remove shrapnel.
(Because I also forgot how dogshit surgery is for shrapnel removal)

ALSO.
Synthetics don't spawn with mirrors. This is now fixed.
You also are now incapable of installing mirrors into mobs that have no client attached. Use the resleeving console. An error message has been added to facilitate this.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

obvious tbh

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: synthetics now spawn with mirrors as intended
tweak: Mirrors can now properly be removed through surgery without bricking the mobs respawning
tweak: it is now impossible to install a mirror into a body with no attached client. Use the resleeving console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
