### PR TITLE
this should fix issue #3213

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -1176,8 +1176,9 @@ I said no!
 	fruit = list("cabbage" = 1)
 	reagents = list("rice" = 20)
 	items = list(
+		/obj/item/reagent_containers/food/snacks/carpmeat,
 		/obj/item/reagent_containers/food/snacks/carpmeat/fish,
-		/obj/item/reagent_containers/food/snacks/carpmeat/fish
+		/obj/item/reagent_containers/food/snacks/carpmeat/sif
 	)
 	result = /obj/item/reagent_containers/food/snacks/sliceable/sushi
 


### PR DESCRIPTION
it _should_, anyway.


closes #3213 on fullmerge automatically if it does

also there was a /obj/item/reagent_containers/food/snacks/carpmeat/fish in a list() twice, don't know what that was about. if this breaks something, reply and i'll amend further

:cl:
fix: fixes sushi being ruined when using sif meat
/:cl: