### PR TITLE
Various alt titles removed after being erroneously re-added or making…

### DIFF
--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -17,7 +17,7 @@
 	minimal_access = list()	//See /datum/job/assistant/get_access()
 
 	outfit_type = /decl/hierarchy/outfit/job/assistant
-	alt_titles = list("Visitor" = /datum/alt_title/visitor, "Server" = /datum/alt_title/server, "Entertainer" = /datum/alt_title/entertainer, "Morale Officer" = /datum/alt_title/morale_officer)
+	alt_titles = list("Visitor" = /datum/alt_title/visitor, "Server" = /datum/alt_title/server, "Morale Officer" = /datum/alt_title/morale_officer)
 
 /datum/job/assistant/get_access()
 	if(config_legacy.assistant_maint)
@@ -46,9 +46,6 @@
 /datum/alt_title/server
 	title = "Server"
 	title_outfit = /decl/hierarchy/outfit/job/service/server
-
-/datum/alt_title/entertainer
-	title = "Entertainer"
 
 /datum/alt_title/morale_officer
 	title = "Morale Officer"

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -29,9 +29,6 @@
 /datum/alt_title/chaplain/scholar
 	title = "Paracausal Scholar"
 
-/datum/alt_title/chaplain/exorcist
-	title = "Exorcist"
-
 /datum/job/chaplain/equip(var/mob/living/carbon/human/H, var/alt_title, var/ask_questions = TRUE)
 	. = ..()
 	if(!.)

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -31,7 +31,7 @@
 			            access_heads, access_construction, access_sec_doors,
 			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
 	minimal_player_age = 7
-	alt_titles = list("Head Engineer" = /datum/alt_title/head_engineer, "Foreman" = /datum/alt_title/foreman, "Maintenance Manager" = /datum/alt_title/maintenance_manager, "Engineering Director" = /datum/alt_title/engineering_director)
+	alt_titles = list("Head Engineer" = /datum/alt_title/head_engineer, "Maintenance Manager" = /datum/alt_title/maintenance_manager, "Engineering Director" = /datum/alt_title/engineering_director)
 
 	outfit_type = /decl/hierarchy/outfit/job/engineering/chief_engineer
 	job_description = "The Chief Engineer manages the Engineering Department, ensuring that the Engineers work on what needs to be done, handling distribution \
@@ -44,9 +44,6 @@
 
 /datum/alt_title/head_engineer
 	title = "Head Engineer"
-
-/datum/alt_title/foreman
-	title = "Foreman"
 
 /datum/alt_title/maintenance_manager
 	title = "Maintenance Manager"
@@ -70,7 +67,7 @@
 	minimal_access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction)
 	alt_titles = list("Maintenance Technician" = /datum/alt_title/maint_tech,
 						"Engine Technician" = /datum/alt_title/engine_tech, "Electrician" = /datum/alt_title/electrician,
-						"Shipwright" = /datum/alt_title/shipwright, "Apprentice Engineer" = /datum/alt_title/apprentice_engineer)
+						"Apprentice Engineer" = /datum/alt_title/apprentice_engineer)
 
 	minimal_player_age = 3
 
@@ -94,9 +91,6 @@
 	title = "Electrician"
 	title_blurb = "An Electrician's primary duty is making sure power is properly distributed thoughout the station, utilizing solars, substations, and other \
 					methods to ensure every department has power in an emergency."
-
-/datum/alt_title/shipwright
-	title = "Shipwright"
 
 /datum/alt_title/apprentice_engineer
 	title = "Apprentice Engineer"

--- a/code/game/jobs/job/exploration.dm
+++ b/code/game/jobs/job/exploration.dm
@@ -95,8 +95,7 @@
 	minimal_access = list(access_pilot, access_external_airlocks)
 	outfit_type = /decl/hierarchy/outfit/job/pilot
 	job_description = "A Pilot flies the various shuttles in the Virgo-Erigone System."
-	alt_titles = list("Co-Pilot" = /datum/alt_title/co_pilot, "Navigator" = /datum/alt_title/navigator,
-		"Aviator" = /datum/alt_title/pilot/aviator)
+	alt_titles = list("Co-Pilot" = /datum/alt_title/co_pilot, "Navigator" = /datum/alt_title/navigator)
 
 /datum/alt_title/co_pilot
 	title = "Co-Pilot"
@@ -105,8 +104,6 @@
 /datum/alt_title/navigator
 	title = "Navigator"
 
-/datum/alt_title/pilot/aviator
-	title = "Aviator"
 
 /datum/job/explorer
 	title = "Explorer"

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -73,11 +73,6 @@
 						prisoners that have been processed and brigged, and are responsible for their well being. The Warden is also in charge of distributing \
 						Armoury gear in a crisis, and retrieving it when the crisis has passed. In an emergency, the Warden may be called upon to direct the \
 						Security Department as a whole."
-	alt_titles = list("Senior Constable" = /datum/alt_title/senior_constable)
-
-
-/datum/alt_title/senior_constable
-	title = "Senior Constable"
 
 //////////////////////////////////
 //			Detective
@@ -137,7 +132,7 @@
 						apprehending criminals. A Security Officer is responsible for the health, safety, and processing of any prisoner they arrest. \
 						No one is above the Law, not Security or Command."
 	alt_titles = list("Junior Officer" = /datum/alt_title/security_officer/junior, "Security Cadet" = /datum/alt_title/security_officer/cadet,
-		"Security Guard" = /datum/alt_title/security_officer/guard, "Constable" = /datum/alt_title/security_officer/constable)
+		"Security Guard" = /datum/alt_title/security_officer/guard)
 
 // Security Officer Alt Titles
 /datum/alt_title/security_officer/junior
@@ -151,6 +146,3 @@
 
 /datum/alt_title/security_officer/guard
 	title = "Security Guard"
-
-/datum/alt_title/security_officer/constable
-	title = "Constable"


### PR DESCRIPTION
… no sense at all.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
-Entertainer: This is an alt title for Visitor but also it's own job. So that alt title is gone.
-Exorcist: Why did it even exist to begin with.
-Foreman: A chief engineer and a foreman aren't even close to the same thing
-Shipwright: We're not on a ship anymore
-Aviator: Aviators fly planes.
-Constable/Senior Constable: These words are outdated even in the one country that still uses them.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Pain

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

del: A few wrong/inappropriate alt titles

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
