### PR TITLE
fixes singularities ignoring containment fields. singularities are now damaged by explosions. bags of holding now detonate upon being eaten by a singularity.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1311,8 +1311,6 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		if(1e12 to 1e15-1)
 			return "[round(number / 1e12, 0.1)] T[symbol]" // tera
 
-
-
 //ultra range (no limitations on distance, faster than range for distances > 8); including areas drastically decreases performance
 /proc/urange(dist=0, atom/center=usr, orange=0, areas=0)
 	if(!dist)
@@ -1331,6 +1329,118 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		. += T.contents
 		if(areas)
 			. |= T.loc
+
+//similar function to range(), but with no limitations on the distance; will search spiralling outwards from the center
+/proc/spiral_range(dist=0, center=usr, orange=0)
+	if(!dist)
+		if(!orange)
+			return list(center)
+		else
+			return list()
+
+	var/turf/t_center = get_turf(center)
+	if(!t_center)
+		return list()
+
+	var/list/L = list()
+	var/turf/T
+	var/y
+	var/x
+	var/c_dist = 1
+
+	if(!orange)
+		L += t_center
+		L += t_center.contents
+
+	while( c_dist <= dist )
+		y = t_center.y + c_dist
+		x = t_center.x - c_dist + 1
+		for(x in x to t_center.x+c_dist)
+			T = locate(x,y,t_center.z)
+			if(T)
+				L += T
+				L += T.contents
+
+		y = t_center.y + c_dist - 1
+		x = t_center.x + c_dist
+		for(y in t_center.y-c_dist to y)
+			T = locate(x,y,t_center.z)
+			if(T)
+				L += T
+				L += T.contents
+
+		y = t_center.y - c_dist
+		x = t_center.x + c_dist - 1
+		for(x in t_center.x-c_dist to x)
+			T = locate(x,y,t_center.z)
+			if(T)
+				L += T
+				L += T.contents
+
+		y = t_center.y - c_dist + 1
+		x = t_center.x - c_dist
+		for(y in y to t_center.y+c_dist)
+			T = locate(x,y,t_center.z)
+			if(T)
+				L += T
+				L += T.contents
+		c_dist++
+
+	return L
+
+//similar function to RANGE_TURFS(), but will search spiralling outwards from the center (like the above, but only turfs)
+/proc/spiral_range_turfs(dist=0, center=usr, orange=0, list/outlist = list(), tick_checked)
+	outlist.Cut()
+	if(!dist)
+		outlist += center
+		return outlist
+
+	var/turf/t_center = get_turf(center)
+	if(!t_center)
+		return outlist
+
+	var/list/L = outlist
+	var/turf/T
+	var/y
+	var/x
+	var/c_dist = 1
+
+	if(!orange)
+		L += t_center
+
+	while( c_dist <= dist )
+		y = t_center.y + c_dist
+		x = t_center.x - c_dist + 1
+		for(x in x to t_center.x+c_dist)
+			T = locate(x,y,t_center.z)
+			if(T)
+				L += T
+
+		y = t_center.y + c_dist - 1
+		x = t_center.x + c_dist
+		for(y in t_center.y-c_dist to y)
+			T = locate(x,y,t_center.z)
+			if(T)
+				L += T
+
+		y = t_center.y - c_dist
+		x = t_center.x + c_dist - 1
+		for(x in t_center.x-c_dist to x)
+			T = locate(x,y,t_center.z)
+			if(T)
+				L += T
+
+		y = t_center.y - c_dist + 1
+		x = t_center.x - c_dist
+		for(y in y to t_center.y+c_dist)
+			T = locate(x,y,t_center.z)
+			if(T)
+				L += T
+		c_dist++
+		if(tick_checked)
+			CHECK_TICK
+
+	return L
 
 #define NOT_FLAG(flag) (!(flag & use_flags))
 #define HAS_FLAG(flag) (flag & use_flags)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -61,6 +61,14 @@
 		return
 	. = ..()
 
+/obj/item/storage/backpack/holding/singularity_act(obj/singularity/S, current_size)
+	var/turf/lastLoc = get_turf(src)
+	. = ..()
+	if(lastLoc)
+		var/dist = max((current_size - 2),1)
+		log_game("Bag of holding detonated at [COORD(lastLoc)]")
+		explosion(lastLoc, (dist), (dist*2), (dist*4))
+
 //Please don't clutter the parent storage item with stupid hacks.
 /*/obj/item/storage/backpack/holding/can_be_inserted(obj/item/W as obj, stop_messages = 0)
 	if(istype(W, /obj/item/storage/backpack/holding))

--- a/code/modules/power/singularity/act.dm
+++ b/code/modules/power/singularity/act.dm
@@ -1,9 +1,9 @@
 #define I_SINGULO "singulo"
 
-/atom/proc/singularity_act()
+/atom/proc/singularity_act(obj/singularity/S, current_size)
 	return
 
-/atom/proc/singularity_pull(S, current_size)
+/atom/proc/singularity_pull(obj/singularity/S, current_size)
 	return
 
 /mob/living/singularity_act()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -50,20 +50,19 @@ GLOBAL_LIST_BOILERPLATE(all_singularities, /obj/singularity)
 	consume(user)
 	return 1
 
-/obj/singularity/ex_act(severity)
-	if(current_size == STAGE_SUPER)//IT'S UNSTOPPABLE
-		return
+/obj/singularity/ex_act(severity, target)
 	switch(severity)
-		if(1.0)
-			if(prob(25))
-				investigate_log("has been destroyed by an explosion.", I_SINGULO)
+		if(1)
+			if(current_size <= STAGE_TWO)
+				investigate_log("has been destroyed by a heavy explosion.", INVESTIGATE_SINGULO)
 				qdel(src)
 				return
 			else
-				energy += 50
-		if(2.0 to 3.0)
-			energy += round((rand(20,60)/2),1)
-			return
+				energy -= round(((energy+1)/2),1)
+		if(2)
+			energy -= round(((energy+1)/3),1)
+		if(3)
+			energy -= round(((energy+1)/4),1)
 
 /obj/singularity/bullet_act(obj/item/projectile/P)
 	return 0 //Will there be an impact? Who knows. Will we see it? No.

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -310,11 +310,11 @@ GLOBAL_LIST_BOILERPLATE(all_singularities, /obj/singularity)
 	step(src, movement_dir)
 
 /obj/singularity/proc/check_cardinals_range(steps, retry_with_move = FALSE)
-	. = length(GLOB.cardinals)			//Should be 4.
-	for(var/i in GLOB.cardinals)
+	. = length(GLOB.cardinal)			//Should be 4.
+	for(var/i in GLOB.cardinal)
 		. -= check_turfs_in(i, steps)	//-1 for each working direction
 	if(. && retry_with_move)			//If there's still a positive value it means it didn't pass. Retry with move if applicable
-		for(var/i in GLOB.cardinals)
+		for(var/i in GLOB.cardinal)
 			if(step(src, i))			//Move in each direction.
 				if(check_cardinals_range(steps, FALSE))		//New location passes, return true.
 					return TRUE
@@ -376,10 +376,10 @@ GLOBAL_LIST_BOILERPLATE(all_singularities, /obj/singularity)
 /obj/singularity/proc/can_move(turf/T)
 	if(!T)
 		return 0
-	if((locate(/obj/machinery/field/containment) in T)||(locate(/obj/machinery/shieldwall) in T))
+	if((locate(/obj/machinery/containment_field) in T)||(locate(/obj/machinery/shieldwall) in T))
 		return 0
-	else if(locate(/obj/machinery/field/generator) in T)
-		var/obj/machinery/field/generator/G = locate(/obj/machinery/field/generator) in T
+	else if(locate(/obj/machinery/field_generator) in T)
+		var/obj/machinery/field_generator/G = locate(/obj/machinery/field_generator) in T
 		if(G && G.active)
 			return 0
 	else if(locate(/obj/machinery/shieldwallgen) in T)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -54,7 +54,7 @@ GLOBAL_LIST_BOILERPLATE(all_singularities, /obj/singularity)
 	switch(severity)
 		if(1)
 			if(current_size <= STAGE_TWO)
-				investigate_log("has been destroyed by a heavy explosion.", INVESTIGATE_SINGULO)
+				investigate_log("has been destroyed by a heavy explosion.", I_SINGULO)
 				qdel(src)
 				return
 			else

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -135,28 +135,29 @@ GLOBAL_LIST_BOILERPLATE(all_singularities, /obj/singularity)
 			if(chained)
 				overlays = "chain_s1"
 			visible_message("<span class='notice'>The singularity has shrunk to a rather pitiful size.</span>")
-		if (STAGE_TWO) //1 to 3 does not check for the turfs if you put the gens right next to a 1x1 then its going to eat them.
-			name = "gravitational singularity"
-			desc = "A gravitational singularity."
-			current_size = STAGE_TWO
-			icon = 'icons/effects/96x96.dmi'
-			icon_state = "singularity_s3"
-			pixel_x = -32
-			pixel_y = -32
-			grav_pull = 6
-			consume_range = 1
-			dissipate_delay = 10
-			dissipate_track = 0
-			dissipate_strength = 5
-			overlays = 0
-			if(chained)
-				overlays = "chain_s3"
-			if(growing)
-				visible_message("<span class='notice'>The singularity noticeably grows in size.</span>")
-			else
-				visible_message("<span class='notice'>The singularity has shrunk to a less powerful size.</span>")
+		if (STAGE_TWO)
+			if(check_cardinals_range(1, TRUE))
+				name = "gravitational singularity"
+				desc = "A gravitational singularity."
+				current_size = STAGE_TWO
+				icon = 'icons/effects/96x96.dmi'
+				icon_state = "singularity_s3"
+				pixel_x = -32
+				pixel_y = -32
+				grav_pull = 6
+				consume_range = 1
+				dissipate_delay = 10
+				dissipate_track = 0
+				dissipate_strength = 5
+				overlays = 0
+				if(chained)
+					overlays = "chain_s3"
+				if(growing)
+					visible_message("<span class='notice'>The singularity noticeably grows in size.</span>")
+				else
+					visible_message("<span class='notice'>The singularity has shrunk to a less powerful size.</span>")
 		if (STAGE_THREE)
-			if ((check_turfs_in(1, 2)) && (check_turfs_in(2, 2)) && (check_turfs_in(4, 2)) && (check_turfs_in(8, 2)))
+			if(check_cardinals_range(2, TRUE))
 				name = "gravitational singularity"
 				desc = "A gravitational singularity."
 				current_size = STAGE_THREE
@@ -177,7 +178,7 @@ GLOBAL_LIST_BOILERPLATE(all_singularities, /obj/singularity)
 				else
 					visible_message("<span class='notice'>The singularity has returned to a safe size.</span>")
 		if(STAGE_FOUR)
-			if ((check_turfs_in(1, 3)) && (check_turfs_in(2, 3)) && (check_turfs_in(4, 3)) && (check_turfs_in(8, 3)))
+			if(check_cardinals_range(3, TRUE))
 				name = "gravitational singularity"
 				desc = "A gravitational singularity."
 				current_size = STAGE_FOUR
@@ -264,16 +265,23 @@ GLOBAL_LIST_BOILERPLATE(all_singularities, /obj/singularity)
 	return 1
 
 /obj/singularity/proc/eat()
-	for(var/T in orange(grav_pull, src))
-		var/atom/X = T
-		if(!X.simulated)
+	set waitfor = FALSE
+	for(var/tile in spiral_range_turfs(grav_pull, src))
+		var/turf/T = tile
+		if(!T || !isturf(loc))
 			continue
-		var/dist = get_dist(X, src)
-		if(dist > consume_range)
-			X.singularity_pull(src, current_size)
+		if(get_dist(T, src) > consume_range)
+			T.singularity_pull(src, current_size)
 		else
-			consume(X)
-	return
+			consume(T)
+		for(var/thing in T)
+			if(isturf(loc) && thing != src)
+				var/atom/movable/X = thing
+				if(get_dist(X, src) > consume_range)
+					X.singularity_pull(src, current_size)
+				else
+					consume(X)
+			CHECK_TICK
 
 /obj/singularity/proc/consume(const/atom/A)
 	src.energy += A.singularity_act(src, current_size)
@@ -301,7 +309,18 @@ GLOBAL_LIST_BOILERPLATE(all_singularities, /obj/singularity)
 
 	step(src, movement_dir)
 
-/obj/singularity/proc/check_turfs_in(var/direction = 0, var/step = 0)
+/obj/singularity/proc/check_cardinals_range(steps, retry_with_move = FALSE)
+	. = length(GLOB.cardinals)			//Should be 4.
+	for(var/i in GLOB.cardinals)
+		. -= check_turfs_in(i, steps)	//-1 for each working direction
+	if(. && retry_with_move)			//If there's still a positive value it means it didn't pass. Retry with move if applicable
+		for(var/i in GLOB.cardinals)
+			if(step(src, i))			//Move in each direction.
+				if(check_cardinals_range(steps, FALSE))		//New location passes, return true.
+					return TRUE
+	. = !.
+
+/obj/singularity/proc/check_turfs_in(direction = 0, step = 0)
 	if(!direction)
 		return 0
 	var/steps = 0
@@ -317,8 +336,6 @@ GLOBAL_LIST_BOILERPLATE(all_singularities, /obj/singularity)
 				steps = 4
 			if(STAGE_FIVE)
 				steps = 5
-			if(STAGE_SUPER)
-				steps = 6
 	else
 		steps = step
 	var/list/turfs = list()
@@ -338,12 +355,12 @@ GLOBAL_LIST_BOILERPLATE(all_singularities, /obj/singularity)
 			dir2 = 1
 			dir3 = 2
 	var/turf/T2 = T
-	for(var/j = 1 to steps)
+	for(var/j = 1 to steps-1)
 		T2 = get_step(T2,dir2)
 		if(!isturf(T2))
 			return 0
 		turfs.Add(T2)
-	for(var/k = 1 to steps)
+	for(var/k = 1 to steps-1)
 		T = get_step(T,dir3)
 		if(!isturf(T))
 			return 0
@@ -355,26 +372,19 @@ GLOBAL_LIST_BOILERPLATE(all_singularities, /obj/singularity)
 			return 0
 	return 1
 
-/obj/singularity/proc/can_move(const/turf/T)
-	if (!isturf(T))
-		return 0
 
-	// VOREStation Edit Start
-	if(istype(get_area(T), /area/crew_quarters/sleep)) //No going to dorms
+/obj/singularity/proc/can_move(turf/T)
+	if(!T)
 		return 0
-	// VOREStation Edit End
-
-	if ((locate(/obj/machinery/containment_field) in T) || (locate(/obj/machinery/shieldwall) in T))
+	if((locate(/obj/machinery/field/containment) in T)||(locate(/obj/machinery/shieldwall) in T))
 		return 0
-	else if (locate(/obj/machinery/field_generator) in T)
-		var/obj/machinery/field_generator/G = locate(/obj/machinery/field_generator) in T
-
-		if (G && G.active)
+	else if(locate(/obj/machinery/field/generator) in T)
+		var/obj/machinery/field/generator/G = locate(/obj/machinery/field/generator) in T
+		if(G && G.active)
 			return 0
-	else if (locate(/obj/machinery/shieldwallgen) in T)
+	else if(locate(/obj/machinery/shieldwallgen) in T)
 		var/obj/machinery/shieldwallgen/S = locate(/obj/machinery/shieldwallgen) in T
-
-		if (S && S.active)
+		if(S && S.active)
 			return 0
 	return 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bags of holding now detonate when thrown into a singularity.
Explosions can now damage the singularity
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I can't possibly see anything bad with enabling suicide missions to destroy the singularity.
(Remember this isn't main. You can't outrun explosions.)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Singularity shouldn't break containment anymore
add: BoHs now detonate on being thrown into a singularity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
