### PR TITLE
Tether ReMap Part 3 of X: Surface Tether

### DIFF
--- a/_maps/map_files/tether/tether-01-surface1.dmm
+++ b/_maps/map_files/tether/tether-01-surface1.dmm
@@ -559,16 +559,10 @@
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/medical/mentalhealth)
 "aaW" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
+/obj/machinery/floodlight,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/vacant_site)
+/area/tether/surfacebase/emergency_storage/atrium)
 "aaX" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -984,6 +978,8 @@
 "abJ" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -1007,12 +1003,14 @@
 /obj/structure/catwalk,
 /obj/random/junk,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
+/obj/structure/cable{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
@@ -1022,10 +1020,12 @@
 "abO" = (
 /obj/structure/catwalk,
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "abP" = (
@@ -1041,31 +1041,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/medical/mentalhealth)
-"abQ" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/vacant_site)
-"abR" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/vacant_site)
 "abS" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
 	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/vacant_site)
@@ -1264,8 +1250,12 @@
 	icon_state = "map_vent_out";
 	use_power = 1
 	},
+/obj/structure/sign/signnew/biohazard{
+	pixel_y = -32
+	},
+/obj/machinery/light/small/emergency,
 /turf/simulated/floor/virgo3b,
-/area/tether/surfacebase/lowernortheva/external)
+/area/medical/virology)
 "acl" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1344,12 +1334,13 @@
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/medical/first_aid_west)
 "act" = (
-/obj/machinery/door/airlock/maintenance/common{
-	name = "Tram Maintenance Access"
+/obj/structure/window/reinforced/full,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/visitor_dining)
+/turf/simulated/floor/virgo3b,
+/area/tether/surfacebase/tram)
 "acu" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
@@ -1551,9 +1542,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/medical/paramed)
 "acM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
-/turf/simulated/floor/virgo3b,
-/area/tether/surfacebase/lowernortheva/external)
+/obj/machinery/door/blast/regular{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/tunnel)
 "acN" = (
 /obj/structure/cable/ender{
 	icon_state = "1-2";
@@ -2707,14 +2700,13 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "aex" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	desc = "Looks like it's set to history channel, the show is talking about modern aliens.  I wonder what else is on?";
 	icon_state = "frame";
 	pixel_y = -32
 	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "aey" = (
@@ -2749,9 +2741,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/disposalpipe/junction/yjunction,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/north_stairs_one)
 "aeA" = (
@@ -3294,13 +3284,17 @@
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 6
 	},
-/obj/structure/disposalpipe/junction,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "afq" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 5
 	},
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/virgo3b,
 /area/tether/surfacebase/outside/outside1)
 "afr" = (
@@ -3469,8 +3463,14 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/lowernorthhall)
 "afG" = (
-/obj/structure/bed/chair,
 /obj/machinery/camera/network/civilian,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/bed/chair,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "afH" = (
@@ -3672,6 +3672,8 @@
 /area/rnd/hardstorage)
 "afY" = (
 /obj/machinery/camera/network/civilian,
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/food/condiment/small/sugar,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "afZ" = (
@@ -4032,18 +4034,7 @@
 "agQ" = (
 /obj/structure/catwalk,
 /obj/random/cigarettes,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/mob/living/simple_mob/vore/aggressive/rat{
-	ai_holder_type = /datum/ai_holder/simple_mob/retaliate
-	},
+/mob/living/simple_mob/vore/aggressive/rat/maurice,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "agR" = (
@@ -4317,9 +4308,6 @@
 /obj/random/junk,
 /obj/random/maintenance/clean,
 /obj/random/tool,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "ahq" = (
@@ -4427,9 +4415,6 @@
 /area/maintenance/lower/mining_eva)
 "ahC" = (
 /obj/structure/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -23
@@ -4814,10 +4799,19 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "aig" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/vending/snack,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 9
 	},
-/obj/machinery/smartfridge/secure/virology,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "aih" = (
@@ -4963,6 +4957,9 @@
 "ait" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/emergency_storage/atrium)
 "aiu" = (
@@ -5223,7 +5220,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/testingroom)
@@ -5332,17 +5330,12 @@
 	},
 /area/tether/surfacebase/surface_one_hall)
 "ajb" = (
-/obj/machinery/computer/arcade{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 9
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 9
-	},
+/obj/machinery/smartfridge/secure/virology,
 /turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/area/medical/virology)
 "ajc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -5373,14 +5366,14 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
@@ -5402,9 +5395,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -5475,9 +5465,6 @@
 "ajm" = (
 /obj/machinery/vending/tool{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/testingroom)
@@ -6082,9 +6069,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/rnd/testingroom)
 "akq" = (
@@ -6268,9 +6252,6 @@
 /obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
 /obj/random/junk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "akJ" = (
@@ -6967,10 +6948,6 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled,
 /area/rnd/testingroom)
 "alJ" = (
@@ -7106,6 +7083,7 @@
 	name = "Testing Room";
 	req_access = list(47)
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/testingroom)
 "alU" = (
@@ -7114,7 +7092,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/rnd/testingroom)
 "alV" = (
@@ -7207,17 +7184,9 @@
 /turf/simulated/floor/tiled,
 /area/rnd/tankstorage)
 "amc" = (
-/obj/structure/sink{
-	pixel_y = 26
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/lowernortheva/external)
 "amd" = (
 /obj/structure/sign/warning/nosmoking_2,
 /turf/simulated/wall/r_wall,
@@ -7593,23 +7562,10 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/rnd/tankstorage)
 "amP" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "amQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -7822,9 +7778,6 @@
 /obj/random/junk,
 /obj/random/junk,
 /obj/random/maintenance/cargo,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = -12;
@@ -7981,20 +7934,12 @@
 	desc = "This trash looks like it's had one too many.";
 	name = "Wasted waste"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "anr" = (
 /obj/structure/catwalk,
 /obj/random/cigarettes,
 /obj/random/junk,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -8248,13 +8193,6 @@
 	can_open = 1
 	},
 /area/maintenance/lower/atmos)
-"anL" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
 "anM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
@@ -8465,14 +8403,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/emergency_storage/atrium)
-"aod" = (
-/obj/machinery/floodlight,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/emergency_storage/atrium)
 "aoe" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
 	frequency = 1379;
@@ -8570,16 +8500,17 @@
 "aon" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/emergency_storage/atrium)
 "aoo" = (
-/obj/structure/table/standard,
-/obj/item/t_scanner,
-/obj/item/storage/briefcase/inflatable,
-/obj/random/maintenance/cargo,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/emergency_storage/atrium)
 "aop" = (
@@ -8588,7 +8519,18 @@
 /obj/random/junk,
 /obj/random/maintenance/clean,
 /obj/structure/cable{
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
@@ -8834,6 +8776,7 @@
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/north_stairs_one)
 "aoM" = (
@@ -8877,7 +8820,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 8
 	},
@@ -8929,16 +8871,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
-"aoU" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/emergency_storage/atrium)
 "aoV" = (
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/storage/surface_eva/external)
@@ -9279,6 +9211,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
 "apw" = (
@@ -9297,26 +9230,12 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/north_stairs_one)
 "apz" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_one_hall)
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/xenoflora)
 "apA" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/grass,
@@ -9367,13 +9286,8 @@
 /turf/simulated/wall,
 /area/maintenance/lower/vacant_site)
 "apG" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/vacant_site)
+/area/tether/surfacebase/emergency_storage/atrium)
 "apH" = (
 /obj/machinery/access_button/airlock_exterior{
 	master_tag = "civ_airlock";
@@ -9616,24 +9530,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/north_stairs_one)
-"aqd" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_one_hall)
 "aqe" = (
 /obj/structure/railing{
 	dir = 8
@@ -9665,14 +9561,21 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "aqi" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/vacant_site)
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
+	},
+/obj/structure/sink{
+	pixel_y = 22
+	},
+/obj/structure/mirror{
+	dir = 4;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
 "aqj" = (
 /obj/structure/ladder/up,
 /obj/structure/catwalk,
@@ -10005,27 +9908,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_one_hall)
-"aqJ" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_one_hall)
 "aqK" = (
 /mob/living/simple_mob/animal/passive/fish/koi/poisonous,
 /turf/simulated/floor/water/pool,
@@ -10053,21 +9935,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_one_hall)
 "aqN" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/door/firedoor/glass,
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/vacant_site)
 "aqO" = (
 /obj/structure/catwalk,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/vacant_site)
 "aqP" = (
 /obj/structure/catwalk,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -10076,16 +9955,16 @@
 /area/maintenance/lower/vacant_site)
 "aqQ" = (
 /obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/random/junk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/vacant_site)
@@ -10227,7 +10106,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 8
 	},
@@ -10262,16 +10140,13 @@
 /turf/simulated/floor,
 /area/maintenance/lower/xenoflora)
 "arj" = (
-/obj/structure/railing{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -28
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/vacant_site)
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
 "ark" = (
 /turf/simulated/floor/plating,
 /area/maintenance/lower/vacant_site)
@@ -10402,29 +10277,9 @@
 	pixel_x = -22
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
-"arx" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/tether{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_one_hall)
 "ary" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
@@ -10441,14 +10296,22 @@
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/surface_one_hall)
 "arB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/area/medical/virology)
 "arC" = (
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/floor_decal/rust,
-/obj/random/junk,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -28
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/vacant_site)
 "arD" = (
@@ -10605,7 +10468,6 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 8
 	},
@@ -10719,24 +10581,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/disposalpipe/up{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/xenoflora)
-"arY" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/xenoflora)
-"arZ" = (
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
@@ -10868,7 +10713,6 @@
 "asq" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
@@ -10878,7 +10722,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 8
 	},
@@ -11147,49 +10990,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
-"asK" = (
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/xenoflora)
-"asL" = (
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/xenoflora)
 "asM" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/surface_one_hall)
-"asN" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "asO" = (
 /obj/machinery/light/small,
@@ -11806,19 +11610,29 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker)
 "atW" = (
-/obj/structure/flora/pottedplant/stoutbush,
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "atX" = (
-/obj/structure/bed/chair,
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/bed/chair,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "atY" = (
-/obj/structure/bed/chair,
 /obj/machinery/status_display{
 	pixel_y = 30
 	},
@@ -12137,12 +11951,18 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker)
 "auA" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
 /obj/machinery/computer/guestpass{
 	dir = 4;
 	pixel_x = -28
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/structure/bed/chair{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
@@ -12230,22 +12050,8 @@
 /turf/simulated/wall,
 /area/maintenance/lower/solars)
 "auL" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/virusdish/random,
-/obj/item/virusdish/random,
-/obj/item/virusdish/random,
-/obj/item/virusdish/random,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
@@ -12316,16 +12122,24 @@
 /turf/simulated/wall,
 /area/security/checkpoint)
 "auS" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/structure/bed/chair{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "auT" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "auU" = (
@@ -12333,7 +12147,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "auV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "auW" = (
@@ -12806,7 +12620,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/checkpoint)
-"avy" = (
+"avz" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -12814,43 +12628,36 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/security/checkpoint)
-"avz" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 5
-	},
-/obj/structure/bookcase,
-/obj/item/book/manual/standard_operating_procedure,
-/obj/item/book/manual/security_space_law,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint)
 "avA" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 10
+	},
 /obj/structure/bed/chair{
 	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = -30
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "avB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/door/window/eastleft{
+	name = "Tram Station Holding Cell"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "avC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
@@ -12860,9 +12667,7 @@
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "avE" = (
@@ -13049,10 +12854,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "avS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "avT" = (
@@ -13115,19 +12920,15 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "avY" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/green,
-/obj/machinery/camera/network/medbay{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/area/medical/virology)
 "avZ" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -13189,23 +12990,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/checkpoint)
-"awg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/security/checkpoint)
-"awh" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/security/checkpoint)
 "awi" = (
-/obj/structure/bed/chair{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "awj" = (
@@ -13367,23 +13157,32 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/solars)
 "awu" = (
-/obj/item/stool/padded,
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/structure/closet/crate/freezer,
+/obj/item/virusdish/random,
+/obj/item/virusdish/random,
+/obj/item/virusdish/random,
+/obj/item/virusdish/random,
+/obj/machinery/camera/network/medbay{
 	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/lime/border{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/area/medical/virology)
 "awv" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/area/medical/virology)
 "aww" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -13669,29 +13468,7 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint)
-"awP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Security Officer"
-	},
-/turf/simulated/floor/tiled,
-/area/security/checkpoint)
 "awQ" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/table/glass,
-/obj/item/folder/red,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint)
 "awR" = (
@@ -14097,14 +13874,13 @@
 /obj/effect/landmark/start{
 	name = "Medical Doctor"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
@@ -14254,22 +14030,15 @@
 "axw" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/table/glass,
-/obj/item/storage/box/donut,
+/obj/structure/bookcase,
+/obj/item/book/manual/security_space_law,
+/obj/item/book/manual/standard_operating_procedure,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint)
 "axx" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 6
-	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
 /obj/structure/table/glass,
-/obj/machinery/recharger,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint)
 "axy" = (
@@ -14373,32 +14142,47 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/disease2/isolator,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "axG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "axH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "axI" = (
@@ -14411,19 +14195,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/solars)
 "axJ" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/green,
-/obj/machinery/status_display{
-	pixel_x = 32
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Virology Isolation Room Two";
+	req_one_access = list(39)
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 4
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/area/medical/virology)
 "axK" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14522,6 +14308,9 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 6
+	},
+/obj/structure/sign/department/virology{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
@@ -14778,18 +14567,12 @@
 	pixel_x = 2;
 	pixel_y = 2
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "ayl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 5
-	},
 /obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/disease2/isolator,
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -14883,45 +14666,23 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "ayt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/disposalpipe/junction{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/wall/r_wall,
 /area/medical/virology)
 "ayu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
@@ -14932,110 +14693,85 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "ayw" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "Virology Laboratory";
-	req_access = list(39)
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "ayx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Virology Isolation Room Three";
+	req_one_access = list(39)
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"ayy" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/structure/bed/padded,
+/obj/item/bedsheet/green,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"ayz" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"ayy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/area/medical/virology)
+"ayA" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"ayz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"ayA" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/green,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/turf/simulated/floor/plating,
+/area/maintenance/lowmedbaymaint)
 "ayB" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -15114,16 +14850,30 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "ayL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lowmedbaymaint)
 "ayM" = (
+/obj/item/storage/belt/utility{
+	desc = "It's full of holes and tears.";
+	name = "raggedy tool-belt"
+	},
+/obj/structure/closet/crate/trashcart,
+/obj/random/junk,
+/obj/random/maintenance/cargo,
+/turf/simulated/floor/plating,
+/area/maintenance/lowmedbaymaint)
+"ayN" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes,
 /obj/machinery/light{
@@ -15135,45 +14885,23 @@
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/lime/bordercorner2{
-	dir = 6
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"ayN" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lime/bordercorner2{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
 "ayO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/obj/structure/table/rack,
+/obj/effect/floor_decal/rust,
+/obj/item/soap/syndie,
+/obj/item/bananapeel,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/funny/hideyhole)
 "ayP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/turf/simulated/floor/plating,
+/area/maintenance/lowmedbaymaint)
 "ayQ" = (
 /obj/machinery/status_display{
 	pixel_y = 30
@@ -15270,23 +14998,30 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker/laundry_arrival)
 "ayX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/effect/floor_decal/rust,
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -25
 	},
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 24
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 4
+/obj/structure/table/rack,
+/obj/item/card/id/gold{
+	access = list(746);
+	desc = "Did someone spraypaint this card?";
+	name = "captians id card"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/obj/item/clothing/gloves/fyellow{
+	desc = "These are what qualifies as a quality product these days?";
+	name = "insulted gloves"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/funny/hideyhole)
 "ayY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -15621,20 +15356,12 @@
 /obj/effect/floor_decal/corner/lime/border,
 /obj/effect/floor_decal/borderfloorwhite/corner2,
 /obj/effect/floor_decal/corner/lime/bordercorner2,
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"azw" = (
-/obj/structure/table/glass,
-/obj/item/storage/lockbox/vials,
-/obj/item/reagent_containers/dropper,
 /obj/item/storage/secure/safe{
 	pixel_y = -28
 	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/lime/border,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"azx" = (
+"azw" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers,
 /obj/item/storage/box/syringes{
@@ -15651,6 +15378,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"azx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
 "azy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
@@ -15659,61 +15391,62 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "azz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/lime/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/lime/bordercorner2,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "azA" = (
-/obj/machinery/vending/snack{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
+/obj/item/storage/box/masks,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"azB" = (
-/obj/structure/table/standard,
-/obj/item/soap/nanotrasen,
-/obj/item/storage/box/cups,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/lime/bordercorner2,
 /turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/area/medical/virology)
+"azB" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/rust,
+/obj/item/toy/bouquet,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/funny/hideyhole)
 "azC" = (
-/obj/structure/reagent_dispensers/water_cooler/full{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/obj/structure/table/rack,
+/obj/item/toy/tennis/yellow,
+/obj/item/toy/tennis/green,
+/obj/item/toy/tennis/blue,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/funny/hideyhole)
 "azD" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/warning/full,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/closet{
+	desc = "Dents and old flaky paint blanket this old storage unit.";
+	name = "old locker"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/obj/item/storage/toolbox/lunchbox/filled,
+/obj/random/plushielarge,
+/turf/simulated/floor/plating,
+/area/maintenance/lowmedbaymaint)
 "azE" = (
 /obj/structure/railing,
 /obj/machinery/camera/network/medbay{
@@ -15770,21 +15503,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "azJ" = (
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Virology Isolation Room Two";
-	req_one_access = list(39)
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/lime{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
+/turf/simulated/floor/plating,
+/area/maintenance/lowmedbaymaint)
 "azK" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor,
@@ -15922,10 +15645,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
 "azV" = (
-/turf/simulated/wall,
-/area/medical/virology)
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/lowmedbaymaint)
 "azW" = (
-/obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -15938,26 +15669,28 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "azX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "azY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
@@ -15965,6 +15698,8 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
+/obj/structure/bed/padded,
+/obj/item/bedsheet/green,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "azZ" = (
@@ -16080,7 +15815,6 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralstairwell)
 "aAe" = (
-/obj/structure/bed/padded,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -16091,6 +15825,7 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
+/obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "aAf" = (
@@ -16110,16 +15845,16 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aAh" = (
-/obj/structure/table/standard,
+/obj/structure/bed/padded,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = -32
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"aAh" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
@@ -16127,6 +15862,8 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
+/obj/structure/bed/padded,
+/obj/item/bedsheet/green,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "aAi" = (
@@ -16332,20 +16069,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
-"aAA" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
 "aAB" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -16366,20 +16089,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/lowernortheva)
 "aAC" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/green,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 5
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/obj/random/maintenance/cargo,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
 "aAD" = (
 /turf/simulated/wall,
 /area/maintenance/lowmedbaymaint)
@@ -16427,11 +16145,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "aAH" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -16571,23 +16284,14 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
 /obj/structure/cable/green{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/maintenance/lowmedbaymaint)
 "aAX" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/zpipe/up/supply{
 	dir = 1
 	},
@@ -16603,6 +16307,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "aAY" = (
@@ -16703,8 +16408,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "aBi" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/door/firedoor/glass,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "aBj" = (
@@ -16772,15 +16479,9 @@
 "aBo" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "aBp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -16788,13 +16489,8 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/area/maintenance/lowmedbaymaint)
 "aBq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -16802,7 +16498,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/area/maintenance/lowmedbaymaint)
 "aBr" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -18271,12 +17967,29 @@
 	dir = 4;
 	pixel_x = -30
 	},
-/obj/structure/flora/pottedplant/stoutbush,
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/mauve/bordercorner2{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "aEc" = (
 /obj/machinery/status_display{
 	pixel_y = 30
+	},
+/obj/structure/bed/chair/wood{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
@@ -18605,7 +18318,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/bed/chair/wood,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "aEO" = (
@@ -18615,7 +18327,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/bed/chair/wood,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "aEP" = (
@@ -19100,23 +18811,20 @@
 /area/crew_quarters/visitor_dining)
 "aFC" = (
 /obj/structure/table/marble,
-/obj/item/reagent_containers/food/drinks/glass2/square{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/drinks/glass2/square{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/drinks/glass2/square{
-	pixel_x = 8;
-	pixel_y = 8
-	},
 /obj/machinery/floor_light/prebuilt{
 	on = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/item/storage/box/glasses/meta{
+	pixel_x = 8
+	},
+/obj/item/storage/box/glasses/meta{
+	pixel_x = -8
+	},
+/obj/item/storage/box/glasses/meta{
+	pixel_y = 8
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_dining)
@@ -19130,17 +18838,44 @@
 	layer = 3.1;
 	name = "Cafe Shutters"
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/visitor_dining)
 "aFE" = (
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/mauve/bordercorner2{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "aFF" = (
-/obj/structure/bed/chair/wood{
-	dir = 4
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
@@ -19148,7 +18883,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/table/woodentable,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "aFH" = (
@@ -19156,9 +18890,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/bed/chair/wood{
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
@@ -19373,17 +19104,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/Dorm_2)
-"aFW" = (
-/obj/structure/bed/chair/wood{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/tram)
 "aFX" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/bed/chair/wood{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
@@ -19757,9 +19485,8 @@
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
 "aGA" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -25
+/obj/structure/bed/chair/wood{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
@@ -19769,10 +19496,16 @@
 	pixel_y = -28
 	},
 /obj/machinery/light,
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/mauve/border,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "aGC" = (
 /obj/machinery/light,
+/obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/surfacebase/tram)
 "aGD" = (
@@ -20441,11 +20174,10 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/visitor_dining)
 "aHH" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/visitor_dining)
+/obj/random/junk,
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/tunnel)
 "aHI" = (
 /obj/machinery/light{
 	dir = 1
@@ -20874,6 +20606,9 @@
 	dir = 8
 	},
 /obj/structure/table/woodentable,
+/obj/structure/flora/pottedplant/small{
+	pixel_y = 12
+	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/visitor_dining)
 "aIA" = (
@@ -21325,6 +21060,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/item/reagent_containers/food/drinks/cup,
 /turf/simulated/floor/lino,
 /area/crew_quarters/visitor_dining)
 "aJo" = (
@@ -21345,6 +21081,9 @@
 	docking_controller = null;
 	landmark_tag = "escape_station";
 	name = "Tether Surface Base"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/tram)
@@ -22736,6 +22475,19 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
+	},
+/obj/structure/flora/pottedplant/minitree,
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/mauve/bordercorner2{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
@@ -29689,10 +29441,20 @@
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
 	},
+/obj/machinery/button/windowtint{
+	id = "cdorm2";
+	pixel_x = -3;
+	pixel_y = -22
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/maintDorm3)
 "baM" = (
 /obj/item/stack/material/steel,
+/obj/machinery/button/windowtint{
+	id = "cdorm2";
+	pixel_x = -3;
+	pixel_y = -22
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/maintDorm2)
 "baO" = (
@@ -29709,27 +29471,44 @@
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
 	},
+/obj/machinery/button/windowtint{
+	id = "cdorm1";
+	pixel_x = -3;
+	pixel_y = -22
+	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm1)
 "baR" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
+/obj/structure/window/reinforced/polarized/full{
+	id = "cdorm2"
+	},
+/obj/structure/window/reinforced/polarized{
+	id = "cdorm3"
+	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm3)
 "baS" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
+/obj/structure/window/reinforced/polarized/full{
+	id = "cdorm2"
+	},
+/obj/structure/window/reinforced/polarized{
+	id = "cdorm2"
+	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm2)
 "baT" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
+/obj/structure/window/reinforced/polarized/full{
+	id = "cdorm1"
+	},
+/obj/structure/window/reinforced/polarized{
+	id = "cdorm1"
+	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm1)
 "baU" = (
@@ -30473,31 +30252,14 @@
 /turf/simulated/mineral,
 /area/maintenance/lower/xenoflora)
 "bcf" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/gloves{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/lime/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
 	},
-/obj/item/storage/box/masks,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/effect/floor_decal/corner/lime/bordercorner2{
+	dir = 9
 	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/corner/lime/bordercorner2,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "bch" = (
@@ -30709,6 +30471,12 @@
 /obj/effect/floor_decal/corner/grey/border{
 	dir = 5
 	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner2{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "bcI" = (
@@ -30729,10 +30497,23 @@
 /area/crew_quarters/visitor_laundry)
 "bcJ" = (
 /obj/effect/floor_decal/borderfloor{
-	dir = 4
+	dir = 9
 	},
 /obj/effect/floor_decal/corner/grey/border{
-	dir = 4
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner2{
+	dir = 10
+	},
+/obj/structure/table/bench/wooden,
+/obj/machinery/button/remote/airlock{
+	id = "dressing2";
+	name = "Dressing Room 2 Lock";
+	pixel_x = -32;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
@@ -30744,19 +30525,30 @@
 /obj/effect/floor_decal/corner/grey/border{
 	dir = 10
 	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner2{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "bcL" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/grey/border,
-/obj/structure/table/bench/standard,
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 5
+	},
+/obj/structure/table/bench/wooden,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "bcM" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/grey/border,
 /obj/machinery/light/small,
-/obj/structure/table/bench/standard,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/grey/bordercorner2,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "bcN" = (
@@ -30767,6 +30559,12 @@
 	dir = 6
 	},
 /obj/structure/closet/firecloset,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner2{
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "bcP" = (
@@ -31283,15 +31081,55 @@
 /obj/structure/barricade/cutout/mime,
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/funny/mimeoffice)
+"bog" = (
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/mauve/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/mauve/bordercorner2,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
+"bpe" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/structure/closet/crate/engineering,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/glass,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "bqI" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/security/brig/storage)
+"bvJ" = (
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	id = "old-tram-west";
+	name = "Cargo Tram Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/old_tram)
 "bwr" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
+"bws" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "byn" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -31387,6 +31225,12 @@
 	},
 /turf/simulated/floor,
 /area/tether/surfacebase/security/gasstorage)
+"bLW" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "bMs" = (
 /obj/machinery/door/airlock/glass_external/public,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -31480,12 +31324,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "bTt" = (
-/obj/structure/table/rack,
-/obj/item/weldingtool/mini{
-	desc = "It says 'keychain welder' on the side, but there's no bail to hook it on.";
-	name = "keychain welder";
-	toolspeed = 5
-	},
+/obj/structure/closet/crate,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "bTE" = (
@@ -31495,11 +31334,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "bWg" = (
-/obj/machinery/vending/loadout/costume{
-	dir = 4
-	},
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/tether/surfacebase/funny/hideyhole)
+/area/maintenance/lowmedbaymaint)
 "bZC" = (
 /turf/simulated/floor/looking_glass,
 /area/looking_glass/lg_1)
@@ -31545,6 +31383,34 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"ciq" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 4
+	},
+/turf/simulated/floor/virgo3b,
+/area/tether/surfacebase/outside/outside1)
+"ciu" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/vacant_site)
+"cnr" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/obj/random/tool,
+/obj/random/tool,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "cpp" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/disposalpipe/segment{
@@ -31603,6 +31469,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"crZ" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Construction Tram Airlock";
+	req_access = newlist()
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "csb" = (
 /obj/structure/railing{
 	dir = 4
@@ -31626,6 +31499,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
+"czD" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/storage/box/donut,
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/security/checkpoint)
 "cAR" = (
 /turf/simulated/floor/looking_glass/center,
 /area/looking_glass/lg_1)
@@ -31701,11 +31585,11 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "cNL" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/railing{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
+/area/maintenance/lower/trash_pit)
 "cOq" = (
 /obj/random/cutout,
 /turf/simulated/floor/plating,
@@ -31748,15 +31632,14 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/lowernorthhall)
 "cUh" = (
-/obj/item/storage/belt/utility{
-	desc = "It's full of holes and tears.";
-	name = "raggedy tool-belt"
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/structure/closet/crate/trashcart,
-/obj/random/junk,
-/obj/random/maintenance/cargo,
 /turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
+/area/maintenance/lower/trash_pit)
 "cUB" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
@@ -31793,14 +31676,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/vacant_site)
-"cZL" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/random/junk,
-/obj/fiftyspawner/glass,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
 "ddU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -31887,9 +31762,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "dtz" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
 "dxY" = (
@@ -31940,6 +31813,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/weaponsrange)
+"dDU" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"dEV" = (
+/obj/structure/fence,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "dFD" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -31981,6 +31870,28 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhall)
+"dKG" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"dLt" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/security/checkpoint)
 "dMu" = (
 /obj/machinery/light{
 	dir = 4
@@ -32022,6 +31933,12 @@
 /obj/item/mop,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
+"dPM" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "dQn" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -32039,14 +31956,27 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civ_west)
 "dSg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
+"dTs" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 6
+	},
+/obj/random/junk,
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "old-tram-east";
+	name = "Tram Shutters Control";
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "dYd" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -32089,6 +32019,25 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig)
+"ebN" = (
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/item/reagent_containers/food/condiment/small/sugar,
+/turf/simulated/floor/lino,
+/area/crew_quarters/visitor_dining)
+"ecj" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/clean,
+/obj/random/junk,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "eeo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/green{
 	dir = 8
@@ -32113,6 +32062,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker/laundry_arrival)
+"egP" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/stairs/spawner/north,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
+"eiO" = (
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
+"eiT" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/red/bordercorner2,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
 "eku" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/target_stake,
@@ -32135,6 +32103,12 @@
 /mob/living/simple_mob/animal/passive/mimepet,
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/funny/mimeoffice)
+"enB" = (
+/obj/random/junk,
+/turf/simulated/mineral/floor/virgo3b{
+	ignore_mapgen = 1
+	},
+/area/tether/surfacebase/cave)
 "eow" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -32220,7 +32194,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/tether/surfacebase/security/brig/bathroom)
 "eAt" = (
-/turf/simulated/mineral,
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "eBd" = (
 /obj/machinery/cryopod,
@@ -32303,6 +32279,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/security/brig)
+"eMD" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "eQz" = (
 /turf/simulated/floor,
 /area/maintenance/lower/mining_eva)
@@ -32315,6 +32297,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker/laundry_arrival)
+"eSn" = (
+/obj/item/flame/lighter/zippo/bullet,
+/turf/simulated/mineral/floor/virgo3b{
+	ignore_mapgen = 1
+	},
+/area/tether/surfacebase/cave)
 "eUS" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -32333,7 +32321,14 @@
 /area/tether/surfacebase/surface_one_hall)
 "eWR" = (
 /obj/structure/table/rack,
-/obj/random/maintenance/clean,
+/obj/item/tool/prybar/red{
+	desc = "Haven't I seen this before?";
+	name = "old red crowbar";
+	toolspeed = 3
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "fcT" = (
@@ -32397,20 +32392,17 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker/laundry_arrival)
 "fAv" = (
-/obj/machinery/door/airlock/silver{
-	name = "Tomfoolery Closet";
-	req_one_access = list(137)
-	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
 "fAW" = (
@@ -32467,12 +32459,14 @@
 /turf/simulated/floor,
 /area/tether/surfacebase/security/gasstorage)
 "fDO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
 /obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "fFb" = (
@@ -32504,6 +32498,9 @@
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
+"fLc" = (
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/tunnel)
 "fLB" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 5
@@ -32550,6 +32547,17 @@
 "fWT" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/funny/hideyhole)
+"gcH" = (
+/obj/random/junk,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
+"gcX" = (
+/obj/structure/fence/door{
+	dir = 4
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "geO" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -32616,6 +32624,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"ghB" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "gjD" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -32647,6 +32662,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"glt" = (
+/turf/simulated/mineral/floor/virgo3b{
+	ignore_mapgen = 1
+	},
+/area/tether/surfacebase/cave)
 "glH" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
@@ -32667,16 +32687,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/weaponsrange)
-"gnH" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
 "gnW" = (
 /obj/machinery/door/airlock/glass_security{
 	id_tag = "briginner";
@@ -32715,6 +32725,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"gqk" = (
+/obj/structure/fence/corner,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "gud" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -32741,7 +32756,7 @@
 /obj/random/drinkbottle,
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/vacant_site)
+/area/tether/surfacebase/emergency_storage/atrium)
 "gxa" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -32831,8 +32846,8 @@
 /turf/simulated/floor/carpet/gaycarpet,
 /area/tether/surfacebase/funny/clownoffice)
 "gIt" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/vending/loadout/costume{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
@@ -32852,6 +32867,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/lowernorthhall)
+"gMg" = (
+/turf/simulated/mineral,
+/area/maintenance/lower/atmos)
+"gPD" = (
+/obj/random/outcrop,
+/turf/simulated/mineral/floor/virgo3b{
+	ignore_mapgen = 1
+	},
+/area/tether/surfacebase/cave)
+"gSj" = (
+/obj/structure/table/bench/sifwooden,
+/obj/random/contraband,
+/turf/simulated/mineral/floor/virgo3b{
+	ignore_mapgen = 1
+	},
+/area/tether/surfacebase/cave)
 "gVe" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -32873,40 +32904,51 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "gVF" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
+"gWO" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
-"gWO" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/rust,
-/obj/item/toy/crossbow,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/funny/hideyhole)
 "gYx" = (
+/obj/machinery/door/airlock/silver{
+	name = "Tomfoolery Closet";
+	req_one_access = list(137)
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
+/area/tether/surfacebase/funny/hideyhole)
 "gZN" = (
 /turf/simulated/floor/looking_glass{
 	dir = 9
 	},
 /area/looking_glass/lg_1)
 "haw" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/structure/railing{
 	dir = 4
+	},
+/obj/random/junk,
+/obj/fiftyspawner/glass,
+/obj/structure/railing{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
@@ -32935,6 +32977,21 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/lowerhall)
+"hju" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside1)
+"hjA" = (
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/tunnel)
 "hmx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -33002,6 +33059,10 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/surfacebase/lowernortheva)
+"hsB" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/maglev/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "huE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33190,6 +33251,10 @@
 /obj/effect/floor_decal/corner/lightorange,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
+"hQz" = (
+/obj/random/junk,
+/turf/simulated/floor/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "hQP" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -33207,6 +33272,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
+"hRz" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/outside/outside1)
+"hSA" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "hTw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -33285,9 +33365,6 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/surfacebase/lowernortheva)
 "iaI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -33295,7 +33372,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/area/maintenance/lowmedbaymaint)
 "icB" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -33420,6 +33497,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhall)
+"izt" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/security/checkpoint)
+"iAU" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "iEk" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 8;
@@ -33451,12 +33546,28 @@
 "iKy" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/lower/mining_eva)
+"iKH" = (
+/obj/structure/mirror/long/left{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/visitor_laundry)
 "iPZ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/cargostore/warehouse)
+"iSH" = (
+/turf/simulated/mineral/floor/virgo3b{
+	ignore_mapgen = 1
+	},
+/area/tether/surfacebase/outside/outside1)
+"iTM" = (
+/obj/structure/stairs/spawner/north,
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "iUF" = (
 /obj/structure/table/steel,
 /obj/machinery/alarm{
@@ -33484,6 +33595,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/lowerhall)
+"iWC" = (
+/obj/structure/fence/door/locked,
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside1)
+"iZr" = (
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/tunnel)
 "jbU" = (
 /obj/effect/landmark{
 	name = "maint_pred"
@@ -33502,6 +33626,34 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
+"jgj" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 1
+	},
+/obj/random/trash,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"jgW" = (
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
 "jio" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -33577,17 +33729,8 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "jvS" = (
-/obj/effect/floor_decal/rust,
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
@@ -33649,6 +33792,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
+"jEb" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"jGq" = (
+/obj/structure/stairs/spawner/north,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "jGM" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable{
@@ -33686,6 +33848,57 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhall)
+"jKZ" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/clean,
+/obj/random/junk,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"jNb" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"jOe" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/table/glass,
+/obj/item/folder/red,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/outside/outside1)
 "jOI" = (
 /turf/simulated/wall{
 	can_open = 1
@@ -33745,6 +33958,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhall)
+"jUm" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "jXR" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -33902,6 +34121,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/mimeoffice)
 "kwN" = (
@@ -33940,6 +34160,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhall)
+"kxZ" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/tunnel)
 "kyE" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -34115,6 +34341,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker)
+"kPi" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/obj/structure/mirror/long/left{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/visitor_laundry)
 "kPT" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -34136,6 +34378,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"kSv" = (
+/obj/random/mre,
+/turf/simulated/mineral/floor/virgo3b{
+	ignore_mapgen = 1
+	},
+/area/tether/surfacebase/cave)
+"kUl" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/tunnel)
 "kUN" = (
 /obj/machinery/camera/network/security{
 	dir = 5
@@ -34148,6 +34399,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig)
+"kUQ" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"kWs" = (
+/obj/random/trash_pile,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/tunnel)
 "laI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -34169,6 +34433,12 @@
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
+"lbn" = (
+/obj/machinery/light/small/flicker{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/tunnel)
 "lbu" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -34187,6 +34457,17 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner2,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
+"lbC" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/structure/ladder/up,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "ldI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34260,7 +34541,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/table/woodentable,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "lwL" = (
@@ -34322,16 +34602,8 @@
 /turf/simulated/wall,
 /area/hallway/lower/first_west)
 "lBO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
@@ -34413,21 +34685,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"lMj" = (
+/obj/structure/fence,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "lMK" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/lime/border{
-	dir = 8
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/lime/bordercorner2{
-	dir = 10
-	},
+/obj/structure/table/glass,
 /turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/area/medical/virology)
 "lNp" = (
 /turf/simulated/floor/looking_glass/optional{
 	dir = 4
@@ -34453,6 +34725,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"lPs" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 8
+	},
+/obj/random/tool,
+/obj/random/tool,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "lPQ" = (
 /obj/item/stack/cable_coil/random_belt,
 /turf/simulated/floor/plating,
@@ -34471,6 +34761,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"lRZ" = (
+/obj/structure/stairs/spawner/south,
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "lSW" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/blanks{
@@ -34526,6 +34820,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhall)
+"lUf" = (
+/obj/machinery/door/blast/regular{
+	dir = 4
+	},
+/turf/simulated/floor/maglev,
+/area/tether/surfacebase/tunnel)
 "lUk" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -34568,15 +34868,34 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_one)
-"lXE" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+"maL" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
 	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/funny/hideyhole)
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 10
+	},
+/obj/random/trash,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "meS" = (
 /turf/simulated/floor/carpet/gaycarpet,
 /area/tether/surfacebase/funny/clownoffice)
+"mgu" = (
+/turf/simulated/floor/maglev/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "mhu" = (
 /obj/structure/closet/secure_closet/brig,
 /turf/simulated/floor/tiled/dark,
@@ -34585,6 +34904,16 @@
 /obj/item/bananapeel,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/clownoffice)
+"mmZ" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/machinery/light/small,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/structure/mirror/long/right{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/visitor_laundry)
 "mnN" = (
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
@@ -34604,8 +34933,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"mpK" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "mrj" = (
-/obj/machinery/gear_painter,
+/obj/random/cutout,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "mrO" = (
@@ -34623,6 +34961,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig)
+"mrQ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 10
+	},
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/visitor_laundry)
 "mrR" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -34657,6 +35005,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/tram)
+"mur" = (
+/obj/structure/closet/crate/miningcar,
+/turf/simulated/mineral/floor/virgo3b{
+	ignore_mapgen = 1
+	},
+/area/tether/surfacebase/outside/outside1)
 "mvM" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -34688,6 +35042,16 @@
 /obj/random/drinkbottle,
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/funny/mimeoffice)
+"mzX" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/structure/table/woodentable,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/mauve/border,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
 "mAR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -34726,6 +35090,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"mEg" = (
+/turf/simulated/mineral,
+/area/maintenance/lower/vacant_site)
+"mFL" = (
+/obj/structure/bed/chair/wood,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
 "mGH" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -34779,6 +35156,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/weaponsrange)
+"mNB" = (
+/turf/simulated/mineral,
+/area/holodeck_control)
+"mOe" = (
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"mOn" = (
+/obj/machinery/door/airlock{
+	id_tag = "dressing1";
+	name = "Dressing Room 1"
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/visitor_laundry)
 "mOz" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -34800,6 +35190,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
+"mPE" = (
+/obj/structure/stairs/spawner/west,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "mRF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -34807,11 +35201,14 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/tram)
 "mRY" = (
-/obj/structure/catwalk,
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/door/firedoor/glass,
+/obj/structure/closet{
+	desc = "Dents and old flaky paint blanket this old storage unit.";
+	name = "old locker"
+	},
+/obj/item/storage/toolbox/lunchbox/syndicate,
+/obj/item/clothing/head/cakehat,
 /turf/simulated/floor/plating,
-/area/maintenance/lower/vacant_site)
+/area/maintenance/lowmedbaymaint)
 "mSz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
@@ -34906,13 +35303,25 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "naC" = (
-/turf/simulated/wall/r_wall,
-/area/medical/virologyisolation)
+/obj/structure/catwalk,
+/obj/random/junk,
+/obj/random/junk,
+/obj/random/maintenance/clean,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
 "naO" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/rust,
-/obj/item/soap/syndie,
-/obj/item/bananapeel,
+/obj/item/toy/bouquet/fake,
+/obj/item/reagent_containers/spray/waterflower,
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
 "nbj" = (
@@ -34950,6 +35359,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhall)
+"nfT" = (
+/turf/unsimulated/mineral/virgo3b,
+/area/tether/surfacebase/outside/outside1)
+"nig" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "nis" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
@@ -34982,6 +35403,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker/laundry_arrival)
+"njD" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "njE" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -35017,8 +35444,12 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/clownoffice)
 "nlT" = (
-/turf/simulated/wall/r_wall,
-/area/tether/surfacebase/funny/hideyhole)
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
 "nmb" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/carpet/bcarpet,
@@ -35091,6 +35522,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/weaponsrange)
+"nqX" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/tunnel)
 "nsp" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -35105,6 +35542,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"nsv" = (
+/obj/structure/table/standard,
+/obj/random/toolbox,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "ntZ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -35174,6 +35616,28 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhall)
+"nCS" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner2{
+	dir = 1
+	},
+/obj/structure/table/bench/wooden,
+/obj/machinery/button/remote/airlock{
+	id = "dressing1";
+	name = "Dressing Room 1 Lock";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/visitor_laundry)
 "nDD" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
@@ -35190,6 +35654,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
+"nED" = (
+/obj/random/junk,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/tunnel)
+"nER" = (
+/obj/effect/floor_decal/industrial/warning/dust,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"nGS" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
 "nID" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -35209,8 +35691,8 @@
 	desc = "Dents and old flaky paint blanket this old storage unit.";
 	name = "old locker"
 	},
-/obj/item/storage/toolbox/lunchbox/filled,
-/obj/random/plushielarge,
+/obj/item/storage/toolbox/lunchbox/heart,
+/obj/random/plushie,
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "nOB" = (
@@ -35255,15 +35737,7 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "nUG" = (
-/obj/structure/table/rack,
-/obj/item/tool/prybar/red{
-	desc = "Haven't I seen this before?";
-	name = "old red crowbar";
-	toolspeed = 3
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/gear_painter,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "nZj" = (
@@ -35285,7 +35759,8 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/surfacebase/tram)
 "oeB" = (
-/obj/structure/closet/crate,
+/obj/structure/table/rack,
+/obj/fiftyspawner/wood,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "ofS" = (
@@ -35344,6 +35819,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"oiW" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "ojM" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/table/standard{
@@ -35370,6 +35851,21 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
+"okQ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "oli" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
@@ -35391,6 +35887,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/vacant_site)
+"onE" = (
+/obj/random/trash_pile,
+/turf/simulated/mineral/floor/virgo3b{
+	ignore_mapgen = 1
+	},
+/area/tether/surfacebase/outside/outside1)
 "oox" = (
 /obj/item/radio/intercom{
 	pixel_y = -24
@@ -35526,15 +36028,22 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/tether/surfacebase/security/brig/bathroom)
-"oId" = (
-/obj/structure/closet{
-	desc = "Dents and old flaky paint blanket this old storage unit.";
-	name = "old locker"
+"oBP" = (
+/obj/random/junk,
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/item/storage/toolbox/lunchbox/heart,
-/obj/random/plushie,
-/turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
+"oId" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/emergency_storage/atrium)
 "oJY" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -35602,6 +36111,9 @@
 	dir = 4
 	},
 /area/looking_glass/lg_1)
+"oSL" = (
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "oTK" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -35645,12 +36157,12 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhall)
 "pdo" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
+/obj/structure/table/standard,
+/obj/item/t_scanner,
+/obj/item/storage/briefcase/inflatable,
+/obj/random/maintenance/cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/emergency_storage/atrium)
 "pea" = (
 /obj/machinery/door/window/northright,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -35658,6 +36170,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/weaponsrange)
+"pgc" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "pjs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
 /obj/machinery/alarm{
@@ -35685,6 +36204,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
+"poq" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/obj/structure/table/glass,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/outside/outside1)
 "ptv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
@@ -35725,15 +36255,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "pIG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/area/maintenance/lowmedbaymaint)
 "pKE" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -35759,13 +36284,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
+"pNR" = (
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/tunnel)
 "pUI" = (
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/random/junk,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
+"pVi" = (
+/turf/simulated/mineral,
+/area/maintenance/lower/mining_eva)
 "pVp" = (
 /obj/machinery/alarm{
 	alarm_id = "pen_nine";
@@ -35780,19 +36311,45 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
+"pXc" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/old_tram)
 "pZb" = (
 /obj/structure/closet/wardrobe/orange,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig/storage)
-"qaa" = (
-/obj/structure/closet{
-	desc = "Dents and old flaky paint blanket this old storage unit.";
-	name = "old locker"
+"pZk" = (
+/obj/structure/table/bench/sifwooden,
+/obj/random/junk,
+/turf/simulated/mineral/floor/virgo3b{
+	ignore_mapgen = 1
 	},
-/obj/item/storage/toolbox/lunchbox/syndicate,
-/obj/item/clothing/head/cakehat,
+/area/tether/surfacebase/cave)
+"qaa" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/random/junk,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
+/area/maintenance/lower/trash_pit)
+"qau" = (
+/obj/structure/simple_door/iron,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/tunnel)
+"qbe" = (
+/obj/random/trash,
+/turf/simulated/mineral/floor/virgo3b{
+	ignore_mapgen = 1
+	},
+/area/tether/surfacebase/outside/outside1)
 "qbw" = (
 /obj/structure/bed/chair/bar_stool,
 /obj/machinery/alarm{
@@ -35800,6 +36357,22 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/funny/mimeoffice)
+"qct" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/mauve/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
+"qdt" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/vacant_site)
 "qfJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -35849,11 +36422,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "qhs" = (
-/obj/structure/table/rack,
-/obj/item/toy/crossbow,
-/obj/item/coin/silver,
+/obj/machinery/door/airlock/silver{
+	name = "Mime's Office";
+	req_one_access = list(138)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
-/area/tether/surfacebase/funny/hideyhole)
+/area/tether/surfacebase/funny/mimeoffice)
 "qjE" = (
 /obj/effect/floor_decal/borderfloor/shifted{
 	dir = 1
@@ -35871,16 +36450,43 @@
 /obj/item/bedsheet,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig)
+"qkO" = (
+/obj/structure/fence/door,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
+"qlj" = (
+/obj/structure/table/woodentable,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
 "qmc" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
+"qnh" = (
+/obj/machinery/door/airlock/glass_security{
+	id_tag = null;
+	layer = 2.8;
+	name = "Security Checkpoint";
+	req_access = list(1)
+	},
+/turf/simulated/floor/tiled,
+/area/security/checkpoint)
+"qnD" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/tram)
 "qnZ" = (
 /obj/structure/table/rack,
-/obj/item/toy/tennis/yellow,
-/obj/item/toy/tennis/green,
-/obj/item/toy/tennis/blue,
+/obj/item/toy/stickhorse,
+/obj/item/toy/katana,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
 "qor" = (
@@ -35900,6 +36506,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
+"qpp" = (
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Construction Tram Airlock";
+	req_access = newlist()
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "qsl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -35915,6 +36528,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/lowerhall)
+"qwj" = (
+/obj/machinery/door/airlock/maintenance/common{
+	name = "Tram Maintenance Access"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
 "qwm" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -35931,6 +36551,20 @@
 "qwV" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/security/brig)
+"qxr" = (
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/virgo3b,
+/area/tether/surfacebase/outside/outside1)
+"qBf" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/lino,
+/area/crew_quarters/visitor_dining)
 "qDR" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -35947,10 +36581,14 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/clownoffice)
 "qJl" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/door/firedoor/glass,
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/area/maintenance/lower/vacant_site)
 "qJT" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/gglasses{
@@ -36024,6 +36662,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
+"qPH" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 5
+	},
+/obj/item/paper{
+	desc = "How long has that been lying there?";
+	info = "I am being laid off tomorrow, nine months on this tram line to no-where and after all that its only half done. Colony is out of money they say. BULLSHIT! I have been staring at that forsaken space elevator for the better part of a year, watching them embezzel all their cash into it, Ten Thousand Thalers for a Couch? More like ten thousand for the Colony Director's Martian Hedge Fund. Bullshit! This entire colony is one big scam. If anyone finds this note, tell those bigwigs up in colony command that Thomas the Engineer, gives them a middle finger.";
+	name = "dusty note"
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "qPR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/green{
 	dir = 1
@@ -36085,8 +36750,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
@@ -36152,6 +36817,9 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/tether/surfacebase/security/gasstorage)
+"raJ" = (
+/turf/simulated/mineral,
+/area/tether/surfacebase/public_garden_one)
 "raS" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -36169,6 +36837,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
+"rey" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "rhc" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -36177,24 +36852,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/vacant_site)
+"rju" = (
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "rse" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/mimedouble,
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/funny/mimeoffice)
 "ruj" = (
-/obj/machinery/door/airlock/silver{
-	name = "Mime's Office";
-	req_one_access = list(138)
-	},
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/catwalk,
+/obj/random/junk,
 /turf/simulated/floor/plating,
-/area/tether/surfacebase/funny/mimeoffice)
+/area/maintenance/lower/vacant_site)
 "rxq" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -36234,12 +36907,8 @@
 /area/tether/surfacebase/security/weaponsrange)
 "rzF" = (
 /obj/structure/table/rack,
-/obj/effect/floor_decal/rust,
-/obj/item/toy/bouquet/fake,
-/obj/item/reagent_containers/spray/waterflower,
-/obj/machinery/alarm{
-	pixel_y = 25
-	},
+/obj/item/toy/crossbow,
+/obj/item/coin/silver,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
 "rzZ" = (
@@ -36262,11 +36931,29 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
+"rBp" = (
+/turf/simulated/mineral,
+/area/storage/surface_eva)
 "rBG" = (
 /obj/structure/closet,
 /obj/item/material/minihoe,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig/storage)
+"rDe" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/junk,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"rDs" = (
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "rDJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36292,6 +36979,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/weaponsrange)
+"rGF" = (
+/obj/structure/stairs/spawner/east,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "rHb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -36304,13 +36998,32 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/funny/mimeoffice)
+"rJi" = (
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "rJv" = (
 /turf/simulated/floor/plating,
 /area/maintenance/lower/solars)
+"rLy" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "rNu" = (
-/obj/random/cutout,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/area/tether/surfacebase/outside/outside1)
 "rOh" = (
 /obj/machinery/disposal,
 /turf/simulated/floor/tiled/dark,
@@ -36366,6 +37079,11 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/tether/surfacebase/security/brig/bathroom)
+"rTn" = (
+/obj/structure/table/woodentable,
+/obj/structure/flora/pottedplant/small,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
 "rVb" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -36466,6 +37184,9 @@
 /mob/living/simple_mob/animal/passive/honkpet,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/clownoffice)
+"saT" = (
+/turf/simulated/mineral,
+/area/maintenance/lower/research)
 "sbD" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 9
@@ -36489,6 +37210,19 @@
 /obj/effect/floor_decal/corner/lightorange,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
+"ski" = (
+/turf/simulated/mineral,
+/area/crew_quarters/locker)
+"smL" = (
+/obj/item/pickaxe,
+/turf/simulated/mineral/floor/virgo3b{
+	ignore_mapgen = 1
+	},
+/area/tether/surfacebase/outside/outside1)
+"sst" = (
+/obj/machinery/light/spot,
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "svZ" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -36530,6 +37264,10 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/visitor_dining)
+"syb" = (
+/obj/structure/sign/signnew/biohazard,
+/turf/simulated/wall/r_wall,
+/area/tether/surfacebase/outside/outside1)
 "szT" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -36588,11 +37326,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"sFC" = (
+/obj/structure/railing,
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "sHK" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/funny/mimeoffice)
@@ -36607,6 +37353,12 @@
 	dir = 6
 	},
 /area/looking_glass/lg_1)
+"sJj" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/tether/surfacebase/tram)
 "sJP" = (
 /obj/structure/cable/orange{
 	d1 = 16;
@@ -36648,6 +37400,10 @@
 	},
 /turf/simulated/wall,
 /area/maintenance/substation/SurfMedsubstation)
+"sQf" = (
+/obj/random/junk,
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "sQB" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass,
@@ -36676,6 +37432,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig/storage)
+"sYo" = (
+/obj/random/contraband,
+/turf/simulated/mineral/floor/virgo3b{
+	ignore_mapgen = 1
+	},
+/area/tether/surfacebase/cave)
 "tak" = (
 /obj/structure/table/steel,
 /obj/structure/cable/green{
@@ -36698,6 +37460,10 @@
 "tdh" = (
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
+"thi" = (
+/obj/random/trash_pile,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "tiJ" = (
 /obj/effect/floor_decal/corner/lightorange{
 	dir = 5
@@ -36727,6 +37493,21 @@
 "trV" = (
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/security/brig/storage)
+"tsb" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "tvk" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -36754,6 +37535,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"tvG" = (
+/obj/random/junk,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "txZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36777,6 +37563,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhall)
+"tzm" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/vacant_site)
+"tAb" = (
+/turf/simulated/mineral,
+/area/hallway/lower/first_west)
+"tAf" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/junk,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "tCV" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -36817,6 +37623,12 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/funny/mimeoffice)
+"tIm" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "tLx" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -36878,6 +37690,13 @@
 "tOe" = (
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/clownoffice)
+"tOU" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/vacant_site)
 "tQH" = (
 /obj/machinery/camera/network/security{
 	dir = 10
@@ -36966,8 +37785,8 @@
 /area/tether/surfacebase/surface_one_hall)
 "tXi" = (
 /obj/structure/table/rack,
-/obj/item/toy/stickhorse,
-/obj/item/toy/katana,
+/obj/effect/floor_decal/rust,
+/obj/item/toy/crossbow,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
 "uaa" = (
@@ -37011,6 +37830,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/lowerhall)
+"ucB" = (
+/turf/simulated/mineral/virgo3b,
+/area/tether/surfacebase/cave)
+"ufn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/security/checkpoint)
 "uge" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -37029,6 +37855,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhall)
+"uhx" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 10
+	},
+/obj/random/junk,
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "old-tram-west";
+	name = "Tram Shutters Control";
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "uiK" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/security/weaponsrange)
@@ -37061,15 +37900,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker)
+"uww" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "uwD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/railing{
+	dir = 4
 	},
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
+/area/maintenance/lower/vacant_site)
 "uxF" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass{
@@ -37087,6 +37933,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
+"uzK" = (
+/turf/simulated/wall/rshull,
+/area/tether/surfacebase/old_tram)
 "uAA" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/mauve/bordercorner,
@@ -37098,6 +37947,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"uAX" = (
+/obj/machinery/computer{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"uDy" = (
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "uDQ" = (
 /obj/machinery/button/remote/airlock{
 	id = "brigouter";
@@ -37210,6 +38077,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
+"uIQ" = (
+/obj/effect/floor_decal/industrial/warning/dust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "uKS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -37260,6 +38131,22 @@
 "uVK" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/funny/clownoffice)
+"vdH" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 6
+	},
+/obj/random/trash,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "vfy" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -37278,6 +38165,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"vfV" = (
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
+"vhH" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/junk,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "vhI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -37300,10 +38199,11 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
 "vkL" = (
-/obj/machinery/power/apc{
-	pixel_y = -25
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green,
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/funny/mimeoffice)
 "vlJ" = (
@@ -37334,6 +38234,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"vsz" = (
+/obj/structure/fence,
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside1)
+"vuz" = (
+/obj/structure/fence/door,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "vuO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37346,12 +38255,35 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
+"vvC" = (
+/obj/machinery/door/airlock{
+	id_tag = "dressing2";
+	name = "Dressing Room 2"
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/visitor_laundry)
+"vxA" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "vBy" = (
 /obj/machinery/vending/cigarette{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/funny/mimeoffice)
+"vBZ" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/random/junk,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "vCb" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
@@ -37402,6 +38334,22 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet/gaycarpet,
 /area/tether/surfacebase/funny/clownoffice)
+"vEJ" = (
+/obj/structure/bonfire/sifwood,
+/turf/simulated/mineral/floor/virgo3b{
+	ignore_mapgen = 1
+	},
+/area/tether/surfacebase/cave)
+"vGn" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/random/tool,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "vHE" = (
 /obj/structure/closet{
 	desc = "Dents and old flaky paint blanket this old storage unit.";
@@ -37438,9 +38386,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
+"vKa" = (
+/obj/machinery/computer{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"vNb" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "vRL" = (
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhall)
+"vSj" = (
+/obj/structure/table/bench/sifwooden,
+/turf/simulated/mineral/floor/virgo3b{
+	ignore_mapgen = 1
+	},
+/area/tether/surfacebase/cave)
 "vSS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
@@ -37475,6 +38439,13 @@
 	},
 /turf/simulated/floor,
 /area/tether/surfacebase/security/gasstorage)
+"vUo" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "vVr" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/tiled,
@@ -37482,6 +38453,9 @@
 "waR" = (
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/weaponsrange)
+"web" = (
+/turf/simulated/mineral,
+/area/tether/surfacebase/surface_one_hall)
 "whV" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -37499,6 +38473,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
+"wnS" = (
+/obj/machinery/computer{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "wpZ" = (
 /obj/machinery/door/airlock/glass_security{
 	id_tag = "brigouter";
@@ -37550,17 +38536,27 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
 "wvv" = (
-/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
+"wvR" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/yellow/bordercorner2,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "wvV" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "wwm" = (
@@ -37651,6 +38647,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
+"wJv" = (
+/obj/machinery/door/blast/shutters{
+	dir = 4;
+	id = "old-tram-east";
+	name = "Cargo Tram Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/old_tram)
+"wKu" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/old_tram)
 "wOK" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small{
@@ -37672,6 +38682,9 @@
 /obj/random/mre,
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/funny/mimeoffice)
+"wTo" = (
+/turf/simulated/floor/maglev/virgo3b,
+/area/tether/surfacebase/tunnel)
 "wUW" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -37727,7 +38740,11 @@
 /area/tether/surfacebase/security/brig)
 "wWK" = (
 /obj/structure/table/rack,
-/obj/fiftyspawner/wood,
+/obj/item/weldingtool/mini{
+	desc = "It says 'keychain welder' on the side, but there's no bail to hook it on.";
+	name = "keychain welder";
+	toolspeed = 5
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "wXW" = (
@@ -37739,6 +38756,13 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/surfacebase/tram)
+"xcQ" = (
+/obj/structure/mirror/long/right{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/visitor_laundry)
 "xdV" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -37753,6 +38777,13 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/tether/surfacebase/security/brig/bathroom)
+"xek" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/vacant_site)
 "xgQ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -37790,6 +38821,18 @@
 /obj/structure/sign/biohazard,
 /turf/simulated/wall,
 /area/maintenance/lower/trash_pit)
+"xjn" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside1)
+"xlW" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "xnn" = (
 /obj/machinery/holoposter,
 /turf/simulated/wall,
@@ -37814,23 +38857,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civ_west)
 "xpP" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/lime/bordercorner2{
-	dir = 5
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"xqO" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "xqZ" = (
 /obj/structure/catwalk,
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -37887,7 +38929,6 @@
 "xyI" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/grey/border,
-/obj/structure/table/bench/standard,
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -37923,6 +38964,17 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig/storage)
+"xLJ" = (
+/obj/random/trash_pile,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
+"xNr" = (
+/obj/structure/fence/door{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "xOH" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -37954,12 +39006,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/clownoffice)
-"xSF" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/rust,
-/obj/item/toy/bouquet,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/funny/hideyhole)
 "xTI" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -37967,10 +39013,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
@@ -37980,6 +39026,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhall)
+"xWh" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "xYx" = (
 /obj/structure/table/steel,
 /obj/machinery/microwave,
@@ -37998,18 +39048,36 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
 "xZq" = (
-/obj/structure/table/rack,
-/obj/item/clothing/gloves/fyellow{
-	desc = "These are what qualifies as a quality product these days?";
-	name = "insulted gloves"
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/item/card/id/gold{
-	access = list(746);
-	desc = "Did someone spraypaint this card?";
-	name = "captians id card"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
+"xZy" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 5
+	},
+/obj/structure/closet/wardrobe/engineering_yellow,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"xZZ" = (
+/turf/simulated/mineral/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "yaU" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -38039,6 +39107,21 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
+"ybQ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/structure/closet/crate/engineering,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "yey" = (
 /obj/structure/sink{
 	dir = 8;
@@ -38078,87 +39161,97 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"yls" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
+/turf/simulated/floor/tiled,
+/area/security/checkpoint)
 "ylH" = (
 /obj/machinery/fitness/punching_bag/clown,
 /turf/simulated/floor/carpet/gaycarpet,
 /area/tether/surfacebase/funny/clownoffice)
 
 (1,1,1) = {"
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
 aaa
 aaa
 aaa
@@ -38174,134 +39267,134 @@ asQ
 asR
 asQ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
 "}
 (2,1,1) = {"
+nfT
+xZZ
+xZZ
+ucB
+ucB
+ucB
+ucB
+ucB
+ucB
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
 aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
 aGD
 aaa
 aHL
@@ -38316,134 +39409,134 @@ aHL
 aHL
 aHL
 aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+ucB
+ucB
+ucB
+ucB
+ucB
+ucB
+ucB
+ucB
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (3,1,1) = {"
+nfT
+xZZ
+ucB
+ucB
+gPD
+ucB
+ucB
+ucB
+ucB
+ucB
+ucB
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+mPE
 aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
 aGE
 aaa
 aHL
@@ -38458,134 +39551,134 @@ aHL
 aHL
 aHL
 aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+ucB
+ucB
+kSv
+pZk
+vSj
+glt
+enB
+ucB
+ucB
+ucB
+ucB
+ucB
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (4,1,1) = {"
+nfT
+ucB
+ucB
+glt
+glt
+glt
+ucB
+ucB
+ucB
+ucB
+ucB
+ucB
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+aad
+aad
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+aad
+aad
+aad
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+aad
+aad
+aad
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+aoq
 aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
 aGE
 aHo
 aad
@@ -38600,59 +39693,89 @@ aHL
 aad
 aad
 aHo
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+ucB
+gSj
+glt
+glt
+sYo
+glt
+glt
+glt
+glt
+ucB
+ucB
+ucB
+ucB
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (5,1,1) = {"
-aaa
+nfT
+ucB
+gPD
+glt
+glt
+glt
+glt
+glt
+glt
+glt
+ucB
+ucB
+ucB
+ucB
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+aad
+aad
+aad
+aad
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -38662,6 +39785,12 @@ aad
 aad
 aad
 aad
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -38671,48 +39800,12 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -38732,6 +39825,10 @@ aGE
 aad
 aad
 aad
+aHL
+aad
+aHL
+aHL
 aad
 aad
 aad
@@ -38739,62 +39836,78 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+ucB
+pZk
+glt
+vEJ
+glt
+glt
+glt
+glt
+glt
+glt
+ucB
+ucB
+ucB
+ucB
+xZZ
+xZZ
+nfT
 "}
 (6,1,1) = {"
-aaa
+nfT
+ucB
+glt
+glt
+glt
+glt
+ucB
+ucB
+glt
+glt
+glt
+glt
+ucB
+ucB
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -38848,27 +39961,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aoq
 aad
 aGF
 aad
@@ -38878,7 +39971,7 @@ aad
 aad
 aad
 aad
-aad
+aHL
 aad
 aHL
 aad
@@ -38886,57 +39979,74 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+ucB
+glt
+sYo
+glt
+eSn
+glt
+glt
+ucB
+ucB
+glt
+glt
+glt
+ucB
+ucB
+xZZ
+xZZ
+nfT
 "}
 (7,1,1) = {"
-aaa
+nfT
+ucB
+glt
+glt
+gPD
+glt
+ucB
+ucB
+ucB
+ucB
+glt
+glt
+glt
+ucB
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -38993,28 +40103,12 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aGG
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -39029,56 +40123,68 @@ aad
 aad
 aad
 aad
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+ucB
+kSv
+enB
+gSj
+vSj
+enB
+kSv
+ucB
+ucB
+ucB
+ucB
+glt
+ucB
+ucB
+xZZ
+xZZ
+nfT
 "}
 (8,1,1) = {"
-aaa
+nfT
+ucB
+glt
+glt
+glt
+glt
+ucB
+ucB
+ucB
+ucB
+ucB
+ucB
+glt
+glt
 aad
 aad
 aad
@@ -39133,32 +40239,19 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
+aoq
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aGG
 aad
+aHL
 aad
-aad
-aad
+aoq
 aad
 aad
 aad
@@ -39181,46 +40274,57 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+ucB
+ucB
+ucB
+ucB
+ucB
+ucB
+ucB
+ucB
+ucB
+ucB
+glt
+glt
+ucB
+ucB
+xZZ
+nfT
 "}
 (9,1,1) = {"
-aaa
+nfT
+ucB
+gPD
+glt
+glt
+gPD
+ucB
+ucB
+ucB
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -39275,25 +40379,14 @@ aad
 aad
 aad
 aad
+aoq
 aad
 aad
 aad
+aHL
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aGG
@@ -39301,6 +40394,11 @@ aad
 aad
 aad
 aad
+aHL
+aad
+aad
+aHL
+aHL
 aad
 aad
 aad
@@ -39319,59 +40417,54 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+ucB
+ucB
+ucB
+ucB
+xZZ
+ucB
+ucB
+ucB
+ucB
+glt
+glt
+ucB
+ucB
+xZZ
+nfT
 "}
 (10,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+nfT
+ucB
+ucB
+glt
+glt
+ucB
+ucB
+ucB
+xZZ
+xZZ
 aad
 aad
 aad
@@ -39429,16 +40522,301 @@ aad
 aad
 aad
 aad
+aHL
+aHL
+aad
+aad
+aad
+aHL
+aHL
+aad
+aad
+aGG
+aad
+aHL
 aad
 aad
 aad
 aad
 aad
+aad
+aad
+aad
+aHL
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+aad
+aad
+aad
+aad
+aad
+aad
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+ucB
+ucB
+ucB
+ucB
+glt
+glt
+ucB
+ucB
+xZZ
+nfT
+"}
+(11,1,1) = {"
+nfT
+xZZ
+ucB
+glt
+gPD
+ucB
+ucB
+xZZ
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aHL
+aHL
+aad
+aad
+aad
+aad
+aad
+aad
+aHL
+aad
+aad
+aad
+aHL
+aGG
+aad
+amP
+aHL
+aHL
+aad
+aad
+aHL
+aHL
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+ucB
+ucB
+ucB
+glt
+glt
+glt
+ucB
+ucB
+xZZ
+nfT
+"}
+(12,1,1) = {"
+nfT
+xZZ
+ucB
+ucB
+ucB
+ucB
+xZZ
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aHL
+aHL
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aHL
+aHL
+aHL
+aHL
 aad
 aad
 aad
 aad
 aGG
+aad
 aad
 aad
 aad
@@ -39488,307 +40866,27 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(11,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aGG
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(12,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aGG
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+ucB
+ucB
+glt
+glt
+ucB
+ucB
+ucB
+xZZ
+xZZ
+nfT
 "}
 (13,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+ucB
+ucB
+xZZ
 aad
 aad
 aad
@@ -39841,25 +40939,20 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
+aoq
 aad
+aHL
 aad
+aHL
 aad
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -39874,6 +40967,11 @@ aad
 aad
 aad
 aad
+aHL
+aad
+aad
+aad
+aHL
 aad
 aad
 aad
@@ -39912,25 +41010,110 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+ucB
+glt
+glt
+ucB
+ucB
+ucB
+ucB
+xZZ
+xZZ
+nfT
 "}
 (14,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aHL
+aHL
+aHL
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aGE
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aHL
+aad
+aad
+aad
+aHL
+aad
+aad
 aad
 aad
 aad
@@ -39971,108 +41154,23 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aGE
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+glt
+ucB
+ucB
+ucB
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (15,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -40122,17 +41220,12 @@ aad
 aad
 aad
 aad
+amP
+aHL
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -40158,6 +41251,13 @@ aad
 aad
 aad
 aad
+aHL
+aHL
+aad
+aad
+aad
+aad
+aHL
 aad
 aad
 aad
@@ -40198,23 +41298,21 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+ucB
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (16,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -40229,12 +41327,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -40267,12 +41360,12 @@ aad
 aad
 aad
 aad
+aHL
+aad
+aHL
 aad
 aad
-aad
-aad
-aad
-aad
+aoq
 aad
 aad
 aad
@@ -40304,6 +41397,7 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -40347,16 +41441,19 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (17,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -40370,6 +41467,27 @@ aad
 aad
 aad
 aad
+aHL
+aad
+aad
+aad
+aHL
+aHL
+amP
+aad
+aoq
+aad
+aad
+aHL
+aad
+aHL
+aad
+aad
+aad
+aHL
+aHL
+aad
+aHL
 aad
 aad
 aad
@@ -40378,36 +41496,11 @@ aad
 aad
 aad
 aad
+aHL
+aHL
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
+aHL
 aad
 aad
 aad
@@ -40444,6 +41537,7 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -40489,16 +41583,19 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (18,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -40511,6 +41608,23 @@ aad
 aad
 aad
 aad
+aHL
+aad
+aad
+aad
+aoq
+aad
+aHL
+aHL
+aad
+aad
+aHL
+aad
+aad
+aoq
+aad
+aHL
+aHL
 aad
 aad
 aad
@@ -40518,41 +41632,20 @@ aad
 aad
 aad
 aad
+aHL
+aHL
+aHL
+aHL
 aad
 aad
+aHL
+aHL
+aHL
+aad
+aHL
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -40586,6 +41679,11 @@ aad
 aad
 aad
 aad
+aHL
+aad
+aoq
+aad
+aHL
 aad
 aad
 aad
@@ -40626,25 +41724,20 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (19,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -40660,35 +41753,35 @@ aad
 aad
 ajK
 aad
+aHL
 aad
 aad
 aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
 aad
+aHL
+aad
+aHL
+aHL
+aHL
+aad
+aad
+aHL
+aHL
 aad
 aad
 aad
 aad
+aHL
+aHL
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -40772,44 +41865,35 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (20,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
 aad
 aad
 aad
+bcV
 aad
 aad
 aad
+aHL
+aHL
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-akH
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 akH
@@ -40821,6 +41905,14 @@ aad
 aad
 aad
 aad
+akH
+aad
+aad
+aHL
+aad
+aad
+aad
+aHL
 aad
 aad
 aad
@@ -40833,6 +41925,7 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -40872,9 +41965,9 @@ aad
 aad
 aad
 aad
+aHL
 aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -40914,17 +42007,21 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (21,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -40934,15 +42031,11 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 ajO
 ajO
@@ -40958,9 +42051,9 @@ ajO
 ajO
 aad
 aad
+aHL
 aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -40971,8 +42064,8 @@ aad
 aah
 aad
 aad
-aad
-aad
+aHL
+aHL
 aad
 aad
 aad
@@ -41055,18 +42148,22 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (22,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -41076,15 +42173,11 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
+aHL
 aad
 ajO
 akL
@@ -41101,9 +42194,9 @@ ajO
 adK
 aeo
 aeo
-aeo
-aeo
-aeo
+uww
+pgc
+aep
 adK
 aah
 aah
@@ -41113,9 +42206,9 @@ aah
 aah
 aad
 aad
+aHL
 aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -41159,6 +42252,7 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -41196,19 +42290,22 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (23,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -41220,11 +42317,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -41254,7 +42347,7 @@ aah
 aah
 aah
 aad
-aad
+aoq
 aad
 aad
 aad
@@ -41298,6 +42391,10 @@ aad
 aad
 aad
 aad
+aHL
+aHL
+aad
+aHL
 aad
 aad
 aad
@@ -41335,22 +42432,22 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (24,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -41359,14 +42456,10 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
+aHL
+aHL
+aHL
 aad
 aad
 aad
@@ -41385,8 +42478,8 @@ ajO
 adK
 aep
 aep
-aeo
-aeo
+xqO
+xqO
 aeo
 adK
 aah
@@ -41482,17 +42575,21 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (25,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -41502,11 +42599,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -41587,6 +42680,7 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -41623,18 +42717,21 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (26,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -41642,13 +42739,9 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+amP
+aHL
+aHL
 aad
 aad
 aad
@@ -41725,6 +42818,9 @@ aah
 aah
 aad
 aad
+aoq
+aad
+aHL
 aad
 aad
 aad
@@ -41763,20 +42859,21 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (27,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -41784,11 +42881,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -41869,6 +42962,7 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -41908,17 +43002,20 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (28,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -41926,11 +43023,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -42052,28 +43145,28 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (29,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
 aad
 aad
+aHL
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
+aoq
 aad
 aad
 aad
@@ -42152,9 +43245,9 @@ aah
 aah
 aad
 aad
+aHL
 aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -42194,25 +43287,25 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (30,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -42294,7 +43387,7 @@ aah
 aah
 aad
 aad
-aad
+aHL
 aad
 aad
 aad
@@ -42336,15 +43429,18 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (31,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -42352,10 +43448,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -42384,7 +43477,7 @@ lNp
 cAR
 bZC
 ajS
-aah
+rBp
 agU
 agU
 agU
@@ -42478,27 +43571,27 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (32,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
+aHL
+aHL
 aad
 aad
 aad
@@ -42526,7 +43619,7 @@ tRJ
 oRz
 sIO
 ajS
-aah
+rBp
 agU
 ahi
 alE
@@ -42577,10 +43670,10 @@ aah
 aah
 aah
 aad
+aHL
 aad
 aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -42621,17 +43714,17 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (33,1,1) = {"
-aaa
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -42668,7 +43761,7 @@ atd
 ajS
 ajS
 ajS
-aah
+rBp
 agU
 ahj
 ahD
@@ -42721,6 +43814,7 @@ aah
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -42763,25 +43857,24 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (34,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
 aad
+aoq
 aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
+aHL
 aad
 aad
 aad
@@ -42808,9 +43901,9 @@ sbD
 abK
 orF
 ajS
-aah
-aah
-aah
+raJ
+raJ
+rBp
 agU
 akm
 ahE
@@ -42863,6 +43956,7 @@ aah
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -42905,21 +43999,20 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (35,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -42950,9 +44043,9 @@ alw
 ajS
 ajS
 ajS
-aah
-aah
-aah
+raJ
+raJ
+rBp
 agU
 agU
 anw
@@ -43003,6 +44096,7 @@ aah
 aah
 aah
 aad
+aHL
 aad
 aad
 aad
@@ -43047,23 +44141,22 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (36,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -43078,10 +44171,10 @@ aah
 ajL
 bdc
 ajL
-aah
-aah
-aah
-aah
+mNB
+mNB
+mNB
+mNB
 ajS
 ajS
 akD
@@ -43092,10 +44185,10 @@ alx
 alM
 ajS
 ajS
-aah
-aah
-aah
-aah
+raJ
+raJ
+rBp
+rBp
 agU
 agU
 agU
@@ -43145,6 +44238,8 @@ aah
 aah
 aah
 aad
+aHL
+aHL
 aad
 aad
 aad
@@ -43189,22 +44284,20 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+nfT
 "}
 (37,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -43235,12 +44328,12 @@ alN
 ame
 ajS
 ajS
-aah
-aah
-aah
-aah
-aah
-aah
+raJ
+tAb
+tAb
+tAb
+tAb
+tAb
 agU
 aoz
 ape
@@ -43287,6 +44380,7 @@ aah
 aah
 aah
 aad
+aHL
 aad
 aad
 aad
@@ -43332,16 +44426,15 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+nfT
 "}
 (38,1,1) = {"
-aaa
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -43377,12 +44470,12 @@ alN
 amf
 amA
 ajS
-aah
-aah
-aah
-aah
-aah
-aah
+raJ
+tAb
+tAb
+tAb
+tAb
+tAb
 agU
 aoA
 apf
@@ -43436,6 +44529,9 @@ aad
 aad
 aad
 aad
+sFC
+aad
+xjn
 aad
 aad
 aad
@@ -43471,23 +44567,20 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (39,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -43519,9 +44612,9 @@ alN
 amg
 amB
 ajS
-aah
-aah
-aah
+raJ
+tAb
+tAb
 ahl
 ahl
 ahl
@@ -43572,8 +44665,14 @@ aah
 aad
 aad
 aad
+aHL
 aad
+ano
+ano
+ano
 aad
+sFC
+auf
 ano
 ano
 ano
@@ -43598,9 +44697,6 @@ ano
 aad
 aad
 aad
-ano
-ano
-ano
 aad
 aad
 aad
@@ -43613,24 +44709,21 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (40,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
 aad
 aad
 aad
 aad
 aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -43661,9 +44754,9 @@ alN
 amh
 ajS
 ajS
-aah
-aah
-aah
+raJ
+tAb
+tAb
 ahl
 ahG
 aiD
@@ -43711,7 +44804,7 @@ aKL
 aNv
 aoq
 aad
-aad
+aHL
 aad
 aad
 aad
@@ -43721,13 +44814,7 @@ ano
 ano
 aad
 aad
-aad
 ano
-ano
-ano
-aad
-aad
-aad
 ano
 ano
 ano
@@ -43746,6 +44833,9 @@ ano
 aad
 aad
 aad
+ano
+ano
+ano
 aad
 aad
 aad
@@ -43760,19 +44850,22 @@ aad
 aad
 aad
 aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (41,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
 aad
 aad
 aad
 aad
 aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -43787,11 +44880,11 @@ aah
 ajL
 aLm
 ajQ
-aah
-aah
-aah
-aah
-aah
+akn
+akn
+akn
+akn
+akn
 ajS
 ajS
 akF
@@ -43802,10 +44895,10 @@ alz
 alO
 ajS
 ajS
-aah
-aah
-aah
-aah
+raJ
+raJ
+tAb
+tAb
 ahl
 afz
 aiE
@@ -43854,16 +44947,16 @@ aNw
 aoq
 aad
 aad
-aad
-aad
+aHL
+aHL
 aad
 aad
 ano
 ano
 ano
 aad
-aad
-aad
+sFC
+auI
 ano
 ano
 ano
@@ -43899,21 +44992,21 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (42,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
 aad
 aad
 aad
 aad
-aad
-aad
-aad
+aoq
 aad
 aad
 aad
@@ -43934,7 +45027,7 @@ aki
 aki
 aki
 akl
-aah
+akn
 ajS
 ajS
 akQ
@@ -43943,11 +45036,11 @@ all
 alA
 ajS
 ajS
-aah
-aah
-aah
-aah
-aah
+raJ
+raJ
+raJ
+tAb
+tAb
 ahl
 ahI
 anN
@@ -43994,6 +45087,19 @@ aMb
 aMK
 aNw
 aoq
+aHL
+aad
+aad
+aHL
+aad
+aad
+aad
+aad
+aad
+aad
+sFC
+aad
+xjn
 aad
 aad
 aad
@@ -44028,30 +45134,17 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (43,1,1) = {"
-aaa
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -44076,16 +45169,16 @@ bdn
 bdn
 bds
 ajQ
-aah
-aah
+akn
+akn
 ajS
 ajS
 lWT
 alm
 ajS
 ajS
-aah
-aah
+raJ
+raJ
 atH
 atH
 atH
@@ -44138,6 +45231,7 @@ aNx
 aoq
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -44182,22 +45276,21 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (44,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -44225,9 +45318,9 @@ ajS
 alc
 aln
 ajS
-aah
-aah
-aah
+raJ
+raJ
+raJ
 atH
 xoT
 sBl
@@ -44283,6 +45376,8 @@ aad
 aad
 aad
 aad
+aHL
+aHL
 aad
 aad
 aad
@@ -44323,23 +45418,21 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (45,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -44424,6 +45517,7 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -44465,24 +45559,23 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (46,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+aHL
+aHL
 aad
 aad
 aah
@@ -44566,6 +45659,11 @@ aad
 aad
 aad
 aad
+aHL
+aad
+aHL
+aHL
+aHL
 aad
 aad
 aad
@@ -44603,27 +45701,22 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (47,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -44710,6 +45803,17 @@ aad
 aad
 aad
 aad
+aHL
+aad
+aad
+aad
+aHL
+aHL
+aad
+aHL
+aHL
+aad
+aHL
 aad
 aad
 aad
@@ -44739,29 +45843,18 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (48,1,1) = {"
-aaa
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -44784,7 +45877,7 @@ eFp
 kjX
 dfJ
 uiK
-aah
+akn
 akn
 abE
 jbU
@@ -44859,7 +45952,7 @@ aad
 aad
 aad
 aad
-aad
+aHL
 aad
 aad
 aad
@@ -44893,21 +45986,21 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (49,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -44926,7 +46019,7 @@ klO
 geO
 rDJ
 uiK
-aah
+akn
 abC
 abF
 abG
@@ -44998,18 +46091,18 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
 aad
 aad
+aHL
+aad
+aoq
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+aoq
 aad
 aad
 aad
@@ -45035,22 +46128,22 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (50,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+aHL
+aHL
 aad
 aad
 aah
@@ -45081,9 +46174,9 @@ ahl
 ahl
 ahl
 ahl
-aah
-aah
-aah
+tAb
+tAb
+tAb
 ahl
 anA
 anP
@@ -45148,8 +46241,8 @@ aad
 aad
 aad
 aad
-aad
-aad
+aoq
+aoq
 aad
 aad
 aad
@@ -45177,21 +46270,21 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (51,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -45219,13 +46312,13 @@ fCk
 exW
 bJz
 lTn
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+tAb
+tAb
+tAb
+tAb
+tAb
+tAb
+tAb
 ahl
 ahL
 acV
@@ -45293,9 +46386,9 @@ aad
 aad
 aad
 aad
+aoq
 aad
-aad
-aad
+aoq
 aad
 aad
 aad
@@ -45320,21 +46413,21 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (52,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+aHL
+aHL
 aad
 aad
 aad
@@ -45361,13 +46454,13 @@ fpU
 rVW
 bJz
 lTn
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+tAb
+tAb
+tAb
+tAb
+tAb
+tAb
+tAb
 ahl
 ahN
 anP
@@ -45437,6 +46530,8 @@ aad
 aad
 aad
 aad
+aoq
+aoq
 aad
 aad
 aad
@@ -45460,24 +46555,22 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (53,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
 aad
 aad
 aad
 aad
 aad
 aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -45503,13 +46596,13 @@ qPR
 hco
 ubK
 lTn
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+tAb
+tAb
+tAb
+tAb
+tAb
+tAb
+tAb
 ahl
 ahL
 anP
@@ -45581,6 +46674,9 @@ aad
 aad
 aad
 aad
+aHL
+aad
+aoq
 aad
 aad
 aad
@@ -45601,24 +46697,21 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (54,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aoq
 aad
 aad
 aad
@@ -45647,11 +46740,11 @@ lTn
 lTn
 odn
 odn
-aah
-aah
-aah
-aah
-aah
+tAb
+tAb
+tAb
+tAb
+tAb
 ahl
 ahL
 anP
@@ -45723,6 +46816,7 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -45745,21 +46839,20 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (55,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -45789,11 +46882,11 @@ iqO
 xVX
 adH
 odn
-aah
-aah
-aah
-aah
-aah
+tAb
+tAb
+tAb
+tAb
+tAb
 ahl
 anB
 anP
@@ -45830,17 +46923,17 @@ aDg
 aGo
 aGY
 awn
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+saT
+saT
+saT
+saT
+saT
+saT
+saT
+saT
+saT
+saT
+saT
 aOR
 aOR
 aOR
@@ -45865,6 +46958,9 @@ aad
 aad
 aad
 aad
+aHL
+aad
+aHL
 aad
 aad
 aad
@@ -45885,23 +46981,20 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (56,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 bcV
@@ -45931,11 +47024,11 @@ dMu
 jIc
 aeV
 odn
-aah
-aah
-aah
-aah
-aah
+tAb
+tAb
+tAb
+tAb
+tAb
 ahl
 ahR
 anP
@@ -45975,14 +47068,14 @@ awn
 aBO
 aBO
 aBO
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+saT
+saT
+saT
+saT
+saT
+saT
+saT
+saT
 aOR
 aPl
 aPl
@@ -46010,6 +47103,7 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -46029,21 +47123,20 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (57,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -46117,14 +47210,14 @@ aHt
 aBN
 aIa
 aBO
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+saT
+saT
+saT
+saT
+saT
+saT
+saT
+saT
 aOR
 aPl
 aPL
@@ -46153,6 +47246,7 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -46171,22 +47265,21 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (58,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -46295,6 +47388,10 @@ aad
 aad
 aad
 aad
+aHL
+aad
+aad
+aHL
 aad
 aad
 aad
@@ -46310,26 +47407,22 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (59,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -46438,6 +47531,7 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -46455,23 +47549,22 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (60,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -46537,8 +47630,8 @@ aDO
 aEr
 aFh
 aDi
-aah
-aah
+saT
+saT
 aBO
 aBP
 aIG
@@ -46581,6 +47674,10 @@ aad
 aad
 aad
 aad
+aHL
+aad
+aad
+aHL
 aad
 aad
 aad
@@ -46594,27 +47691,23 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (61,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
+aHL
 aad
 aad
 aad
@@ -46679,8 +47772,8 @@ aDP
 aEs
 aFi
 aDi
-aah
-aah
+saT
+saT
 aBO
 aCh
 aIG
@@ -46724,6 +47817,7 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -46737,27 +47831,26 @@ aad
 aad
 aad
 aad
+aHL
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+aHL
+xZZ
+xZZ
+nfT
 "}
 (62,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
+aHL
+aHL
 aad
 aad
 aad
@@ -46821,8 +47914,8 @@ aDQ
 aEt
 aFj
 aDi
-aah
-aah
+saT
+saT
 aBO
 aIa
 aIG
@@ -46870,6 +47963,7 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -46878,28 +47972,27 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+xjn
 aaa
+xZZ
+nfT
 "}
 (63,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
+aHL
 aad
 aad
 aad
@@ -46963,8 +48056,8 @@ aDi
 aDi
 aDi
 aDi
-aah
-aah
+saT
+saT
 aBO
 aIa
 aIG
@@ -47009,6 +48102,10 @@ aad
 aad
 aad
 aad
+aHL
+aHL
+aad
+aHL
 aad
 aad
 aad
@@ -47020,17 +48117,16 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-baV
+rGF
 aaa
+xZZ
+nfT
 "}
 (64,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -47039,10 +48135,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -47101,12 +48194,12 @@ agb
 aBJ
 aAE
 aBO
-aah
-aah
-aah
-aah
-aah
-aah
+saT
+saT
+saT
+saT
+saT
+saT
 aBO
 aIa
 aIG
@@ -47156,23 +48249,26 @@ aad
 aad
 aad
 aad
+aHL
+aad
+aad
+aHL
+aad
+aHL
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-baV
+aaa
+aaa
+aaa
 aaa
 "}
 (65,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -47180,10 +48276,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -47243,12 +48336,12 @@ agb
 aBJ
 aAE
 aBO
-aah
-aah
-aah
-aah
-aah
-aah
+saT
+saT
+saT
+saT
+saT
+saT
 aBO
 aCi
 aHc
@@ -47295,14 +48388,14 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
 aad
 aad
 aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -47314,20 +48407,20 @@ aaa
 aaa
 "}
 (66,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -47385,12 +48478,12 @@ agb
 aBJ
 aAE
 aBO
-aah
-aah
-aah
-aah
-aah
-aah
+saT
+saT
+saT
+saT
+saT
+saT
 aBO
 aIb
 aHc
@@ -47439,10 +48532,10 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aHL
+aHL
+aHL
+aHL
 aad
 aad
 aad
@@ -47456,19 +48549,19 @@ aoq
 asG
 "}
 (67,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+dPM
+dPM
 aad
 aad
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
+aHL
 aad
 aad
 aad
@@ -47527,10 +48620,10 @@ agb
 aBJ
 aAE
 aBO
-aah
-aah
-aah
-aah
+saT
+saT
+saT
+saT
 aBO
 aBO
 aBO
@@ -47555,10 +48648,10 @@ aRW
 aSD
 aTk
 aIh
-aah
-aah
-aah
-aah
+gMg
+gMg
+gMg
+gMg
 aVn
 aTZ
 aWs
@@ -47589,29 +48682,29 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
-aad
-baV
+aHL
 aoq
 aoq
 asS
 "}
 (68,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+iTM
+aad
+aad
+aHL
+aHL
+aad
+aHL
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -47669,10 +48762,10 @@ agb
 aBJ
 aAE
 aBO
-aah
-aah
-aah
-aah
+saT
+saT
+saT
+saT
 aBO
 aHb
 aBt
@@ -47697,10 +48790,10 @@ aRX
 aSE
 aSE
 aIh
-aah
-aah
-aah
-aah
+gMg
+gMg
+gMg
+gMg
 aVn
 aTZ
 aWt
@@ -47726,9 +48819,9 @@ aad
 aad
 aad
 aad
+aHL
 aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -47740,7 +48833,10 @@ aoq
 asS
 "}
 (69,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+iTM
 aad
 aad
 aad
@@ -47748,12 +48844,9 @@ aad
 aad
 aad
 aad
+aHL
 aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -47775,11 +48868,11 @@ auJ
 auX
 fqa
 anp
-adK
-aah
-aah
-aah
-aah
+abT
+pVi
+pVi
+pVi
+pVi
 abT
 abT
 abT
@@ -47811,10 +48904,10 @@ agb
 avU
 aAE
 aBO
-aah
-aah
-aah
-aah
+saT
+saT
+saT
+saT
 aBO
 aHc
 aHv
@@ -47839,10 +48932,10 @@ aSn
 aSF
 aTl
 aIh
-aah
-aah
-aah
-aah
+gMg
+gMg
+gMg
+gMg
 aVn
 aTZ
 aEC
@@ -47874,8 +48967,8 @@ aad
 aad
 aad
 aad
-aad
-baV
+aHL
+aHL
 baV
 aoq
 aoq
@@ -47883,18 +48976,18 @@ asS
 "}
 (70,1,1) = {"
 aaa
+aaa
+aaa
+aaa
+aaa
+aad
+aad
+aHL
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -47930,11 +49023,11 @@ bbR
 aez
 aoL
 apv
-aqb
-aqb
-aqb
+alb
+alb
+alb
 arw
-ate
+apz
 arX
 apu
 aqb
@@ -47953,10 +49046,10 @@ aAN
 agM
 aAF
 aBO
-aah
-aah
-aah
-aah
+saT
+saT
+saT
+saT
 aBO
 aHc
 aHv
@@ -47983,8 +49076,8 @@ aTm
 aIh
 aIh
 aIh
-aah
-aah
+gMg
+gMg
 aVn
 aTZ
 aWv
@@ -48014,9 +49107,9 @@ aad
 aad
 aad
 aad
+aHL
 aad
-aad
-aad
+aHL
 baV
 baV
 aoq
@@ -48077,7 +49170,7 @@ apu
 apu
 aqb
 arM
-arY
+csb
 apu
 aqb
 atg
@@ -48095,10 +49188,10 @@ aAO
 agM
 aAw
 aBO
-aah
-aah
-aah
-aah
+saT
+saT
+saT
+saT
 aBO
 aBl
 aeb
@@ -48125,8 +49218,8 @@ aTn
 aTN
 aTN
 aIh
-aah
-aah
+gMg
+gMg
 aVn
 aTZ
 aED
@@ -48159,13 +49252,17 @@ aad
 aad
 aad
 aad
-baV
+aHL
 baV
 aoq
 aoq
 asS
 "}
 (72,1,1) = {"
+aaa
+aaa
+aaa
+aaa
 aaa
 aad
 aad
@@ -48175,11 +49272,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+aHL
 aad
 aad
 aad
@@ -48219,9 +49312,9 @@ aqF
 ari
 aqb
 aqb
-arZ
+aqb
 asq
-asK
+aqb
 apu
 apu
 apu
@@ -48237,10 +49330,10 @@ agM
 agM
 aAw
 aBO
-aah
-aah
-aah
-aah
+saT
+saT
+saT
+saT
 aBO
 aHf
 aHv
@@ -48267,8 +49360,8 @@ aRM
 aPG
 aTY
 aIh
-aah
-aah
+gMg
+gMg
 aVn
 aTZ
 aWx
@@ -48300,7 +49393,7 @@ aad
 aad
 aad
 aad
-aad
+aHL
 baV
 baV
 aoq
@@ -48309,6 +49402,10 @@ asS
 "}
 (73,1,1) = {"
 aaa
+aaa
+aaa
+aaa
+aaa
 aad
 aad
 aad
@@ -48316,6 +49413,7 @@ aad
 aad
 aad
 aad
+aHL
 aad
 aad
 aad
@@ -48323,19 +49421,14 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-adK
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+abT
+pVi
+pVi
+pVi
+pVi
+pVi
+pVi
+pVi
 abT
 vCb
 acS
@@ -48363,7 +49456,7 @@ apu
 apu
 apu
 apu
-asL
+aqb
 ath
 axS
 apu
@@ -48379,10 +49472,10 @@ agM
 aAo
 aAE
 aBO
-aah
-aah
-aah
-aah
+saT
+saT
+saT
+saT
 aBO
 aHf
 aHv
@@ -48444,7 +49537,7 @@ aad
 aad
 aad
 aad
-baV
+aHL
 aoq
 aoq
 asS
@@ -48464,7 +49557,7 @@ ajK
 aad
 aad
 aad
-aad
+aHL
 adK
 adK
 aad
@@ -48474,10 +49567,10 @@ aaq
 aaq
 aaq
 aaq
-aah
-aah
-aah
-aah
+pVi
+pVi
+pVi
+pVi
 abT
 abH
 acX
@@ -48501,11 +49594,11 @@ ahX
 ahX
 ahX
 ahX
-aah
-aah
-aah
+bcd
+bcd
+bcd
 apu
-asL
+aqb
 apu
 axS
 apu
@@ -48521,10 +49614,10 @@ agM
 aAp
 aAK
 aBO
-aah
-aah
-aah
-aah
+saT
+saT
+saT
+saT
 aBO
 aHf
 aHv
@@ -48604,8 +49697,8 @@ aae
 aae
 aae
 aae
-aae
-aae
+amc
+amc
 aae
 akK
 akK
@@ -48643,11 +49736,11 @@ aoO
 apy
 aqG
 ahX
-aah
-aah
-aah
+bcd
+bcd
+bcd
 apu
-asL
+aqb
 apu
 axS
 apu
@@ -48663,10 +49756,10 @@ agM
 aAq
 aAE
 aBO
-aah
-aah
-aah
-aah
+saT
+saT
+saT
+saT
 aBO
 aHf
 aHw
@@ -48746,7 +49839,7 @@ aae
 aae
 aae
 aae
-aae
+amc
 aae
 aae
 aae
@@ -48785,11 +49878,11 @@ apx
 aqc
 aqH
 ahX
-aah
-aah
-aah
+bcd
+bcd
+bcd
 apu
-asL
+aqb
 ati
 apu
 apu
@@ -48805,10 +49898,10 @@ agM
 aAr
 aAE
 aBO
-aah
-aah
-aah
-aah
+saT
+saT
+saT
+saT
 aBO
 aHf
 aBH
@@ -48871,9 +49964,9 @@ aad
 aad
 aad
 aad
-aad
-baV
-aaa
+xZZ
+xZZ
+nfT
 "}
 (77,1,1) = {"
 aqR
@@ -48887,9 +49980,9 @@ aae
 aae
 aae
 aae
+amc
 aae
-aae
-aae
+amc
 aae
 aae
 aae
@@ -48927,11 +50020,11 @@ ahX
 ahX
 ahX
 ahX
-aah
-aah
-aah
+bcd
+bcd
+bcd
 apu
-asL
+aqb
 atj
 atL
 atL
@@ -49012,10 +50105,10 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (78,1,1) = {"
 aqR
@@ -49032,7 +50125,7 @@ aaf
 aae
 aae
 aae
-aae
+amc
 aae
 aae
 aae
@@ -49065,15 +50158,15 @@ ahX
 aiY
 afa
 ahX
-aah
+web
 agM
 agM
 agM
-aah
-aah
-aah
+bcd
+bcd
+bcd
 apu
-asL
+aqb
 apu
 agM
 agM
@@ -49154,10 +50247,10 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (79,1,1) = {"
 aqR
@@ -49207,15 +50300,15 @@ ahX
 aiZ
 afc
 ahX
-aah
+web
 agM
 ahc
 agM
-aah
-aah
-aah
+bcd
+bcd
+bcd
 apu
-asL
+aqb
 apu
 ahc
 agM
@@ -49296,10 +50389,10 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (80,1,1) = {"
 aqR
@@ -49437,11 +50530,11 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (81,1,1) = {"
 aqR
@@ -49491,15 +50584,15 @@ anD
 anU
 afp
 aoP
-apz
-aqd
-aqJ
+auN
+atk
+atM
 arf
-arx
+avm
 arN
-aqd
+atk
 asr
-asN
+atk
 atk
 atM
 aus
@@ -49512,14 +50605,14 @@ abh
 abk
 osh
 agM
-aah
-aah
-aah
+saT
+saT
+saT
 aBO
 aEw
 aFl
 aBO
-aah
+saT
 aBO
 aHC
 aIh
@@ -49579,11 +50672,11 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (82,1,1) = {"
 aqR
@@ -49654,14 +50747,14 @@ tvk
 abl
 ghr
 agM
-aah
-aah
-aah
+saT
+saT
+saT
 aBO
 aAV
 aFl
 aBO
-aah
+saT
 aBO
 aHC
 aIh
@@ -49721,11 +50814,11 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (83,1,1) = {"
 aqR
@@ -49796,14 +50889,14 @@ gVe
 lNt
 mon
 agM
-aah
-aah
-aah
+saT
+saT
+saT
 aBO
 aAY
 aFl
 aBO
-aah
+saT
 aBO
 aHC
 aIh
@@ -49863,11 +50956,11 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (84,1,1) = {"
 aqR
@@ -49939,13 +51032,13 @@ aqM
 agM
 agM
 agM
-aah
-aah
+saT
+saT
 aBO
 aEz
 aFl
 aBO
-aah
+saT
 aBO
 aHD
 aIh
@@ -50005,11 +51098,11 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (85,1,1) = {"
 aaa
@@ -50081,13 +51174,13 @@ ahc
 agM
 aAS
 agM
-aah
-aah
+saT
+saT
 aBO
 aEz
 aFn
 aBO
-aah
+saT
 aBO
 aBL
 aBb
@@ -50147,17 +51240,17 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (86,1,1) = {"
-aaa
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -50229,7 +51322,7 @@ ayh
 aAZ
 aFl
 aBO
-aah
+saT
 aBO
 aBQ
 aCp
@@ -50290,16 +51383,16 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (87,1,1) = {"
-aaa
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -50371,7 +51464,7 @@ ayh
 aBa
 aFl
 aBO
-aah
+saT
 aBO
 aBO
 aEz
@@ -50422,6 +51515,7 @@ aad
 aad
 aad
 aad
+ajK
 aad
 aad
 aad
@@ -50431,17 +51525,16 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (88,1,1) = {"
-aaa
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -50513,8 +51606,8 @@ aDS
 aBb
 aBg
 aBO
-aah
-aah
+saT
+saT
 aBO
 aEz
 aHC
@@ -50574,17 +51667,17 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (89,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -50655,8 +51748,8 @@ ayh
 aBc
 aFl
 aBO
-aah
-aah
+saT
+saT
 aBO
 aCu
 aHC
@@ -50716,17 +51809,17 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (90,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -50797,8 +51890,8 @@ ayh
 aBd
 aFl
 aBO
-aah
-aah
+saT
+saT
 aBO
 aIk
 aHC
@@ -50858,17 +51951,17 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (91,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -50939,8 +52032,8 @@ ayh
 aBe
 aFl
 aBO
-aah
-aah
+saT
+saT
 aBO
 aBO
 aJb
@@ -51000,20 +52093,20 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (92,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+bcV
 aad
 aad
 aad
@@ -51142,17 +52235,17 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (93,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -51284,16 +52377,16 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (94,1,1) = {"
-aaa
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -51425,17 +52518,17 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (95,1,1) = {"
-aaa
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -51567,17 +52660,17 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (96,1,1) = {"
-aaa
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -51708,17 +52801,17 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (97,1,1) = {"
-aaa
-aad
-aad
+nfT
+xZZ
+xZZ
 aad
 aad
 aad
@@ -51850,17 +52943,17 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (98,1,1) = {"
-aaa
-aad
-aad
+nfT
+xZZ
+xZZ
 aad
 aad
 aad
@@ -51898,8 +52991,8 @@ aGw
 aHi
 aef
 eAt
-eAt
-eAt
+mnN
+bTt
 agM
 agM
 aoa
@@ -51992,17 +53085,17 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (99,1,1) = {"
-aaa
-aad
-aad
+nfT
+xZZ
+xZZ
 aad
 aad
 aad
@@ -52046,7 +53139,7 @@ ahx
 anI
 aob
 aom
-ahx
+aom
 guV
 apF
 ahc
@@ -52134,18 +53227,18 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (100,1,1) = {"
-aaa
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -52188,11 +53281,11 @@ ahx
 ait
 aoc
 aon
-aoU
+apG
 apG
 apF
 aqN
-apF
+aqN
 aqN
 apF
 ash
@@ -52276,18 +53369,18 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (101,1,1) = {"
-aaa
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -52328,15 +53421,15 @@ mnN
 bTt
 ahx
 anJ
-aod
+apG
 aoo
-ahx
+pdo
 aaW
-aqi
+apF
 aqO
-mRY
-aql
-aql
+apF
+apF
+apF
 ash
 asu
 asU
@@ -52418,18 +53511,18 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (102,1,1) = {"
-aaa
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -52465,20 +53558,20 @@ ylH
 oMC
 guO
 aaU
-rNu
-mnN
-oeB
+aaU
+aBo
+aaU
 ahx
 ahx
 ahx
+oId
 ahx
 ahx
 apF
-apF
-aqP
-apF
-apF
-apF
+aql
+arO
+ark
+arO
 ash
 asv
 asU
@@ -52560,18 +53653,18 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (103,1,1) = {"
-aaa
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -52607,17 +53700,17 @@ meS
 meS
 meS
 aaU
-aaU
-qJl
-aaU
+aAC
+mnN
+cNL
 aaU
 bwr
-bwr
-cZL
+nlT
+xqZ
 haw
 pKR
 apF
-aqP
+aql
 apF
 arL
 arO
@@ -52702,18 +53795,18 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (104,1,1) = {"
-aaa
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -52762,7 +53855,7 @@ omy
 aqQ
 tnF
 rhc
-apF
+ark
 ash
 asx
 asU
@@ -52845,21 +53938,21 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (105,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+ajK
 aad
 aad
 aad
@@ -52987,17 +54080,17 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (106,1,1) = {"
-aaa
-aad
-aad
-aad
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -53041,12 +54134,12 @@ anf
 aaU
 xqZ
 pUI
-mnN
+aaU
 apF
-abQ
-arj
+aqP
+arl
 apF
-aah
+mEg
 ash
 ast
 asU
@@ -53129,16 +54222,16 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (107,1,1) = {"
-aaa
-aad
-aad
+nfT
+xZZ
+xZZ
 aad
 aad
 aad
@@ -53181,14 +54274,14 @@ ajP
 akY
 anq
 xik
-gnH
+xqZ
+qaa
+cNL
 aaU
-aaU
-aaU
-abR
+aqP
 ark
 apF
-aah
+mEg
 ash
 ast
 asU
@@ -53196,9 +54289,9 @@ atv
 asU
 ast
 auR
-avy
-awg
-awP
+avz
+awQ
+awQ
 axw
 auR
 azj
@@ -53248,14 +54341,14 @@ bcD
 bcI
 bcK
 aUm
+nCS
+mrQ
+aUm
 aah
 aah
 aah
 aah
 aah
-aah
-aah
-aah
 aad
 aad
 aad
@@ -53271,14 +54364,16 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (108,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
 aad
 aad
 aad
@@ -53286,9 +54381,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
+bcV
 aad
 aad
 aad
@@ -53330,7 +54423,7 @@ abO
 abS
 arC
 apF
-aah
+mEg
 ash
 asy
 asV
@@ -53339,7 +54432,7 @@ atV
 auz
 auR
 avz
-awh
+awQ
 awQ
 axx
 auR
@@ -53388,16 +54481,16 @@ aWY
 aUm
 bcE
 aUP
-bcL
+aUP
+mOn
+iKH
+mmZ
 aUm
 aah
 aah
 aah
 aah
 aah
-aah
-aah
-aah
 aad
 aad
 aad
@@ -53412,15 +54505,17 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (109,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
 aad
 aad
 aad
@@ -53437,9 +54532,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
+aah
 aeE
 afm
 afm
@@ -53448,9 +54541,9 @@ afm
 afm
 aeE
 aeE
-azV
-azV
-azV
+aeE
+aeE
+aeE
 aAb
 aAD
 uVK
@@ -53463,16 +54556,16 @@ ahg
 ahz
 ajZ
 alD
-anL
+xqZ
 fgm
-ruj
 lry
 lry
 lry
-aql
+lry
+aqP
 arl
 apF
-aah
+mEg
 ash
 ash
 ash
@@ -53480,10 +54573,10 @@ ash
 ash
 ash
 auR
-auR
-auR
-auR
-auR
+izt
+ufn
+yls
+czD
 ayn
 azd
 ayG
@@ -53534,11 +54627,11 @@ bcM
 aUm
 aUm
 aUm
+aUm
 aah
 aah
 aah
 aah
-aah
 aad
 aad
 aad
@@ -53554,15 +54647,17 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (110,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
 aad
 aad
 aad
@@ -53579,9 +54674,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
+aah
 aeE
 afn
 avk
@@ -53603,29 +54696,29 @@ bbV
 bbj
 ahk
 ahA
-ahk
-ahA
+cUh
+naC
 aop
 lry
 sHK
 yey
 nmb
 lry
-aql
+aqP
 arl
 apF
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+mEg
+mEg
+mEg
+mEg
+ski
+ski
+ski
+auR
+dLt
+awQ
+jOe
+poq
 agM
 azl
 iti
@@ -53643,7 +54736,7 @@ aDu
 aIv
 aDu
 aCP
-aDu
+qBf
 aLj
 aLj
 ave
@@ -53696,15 +54789,17 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (111,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
 aad
 aad
 aad
@@ -53721,9 +54816,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
+aah
 aeE
 afx
 avl
@@ -53735,7 +54828,7 @@ azI
 azX
 aAg
 aeE
-aAz
+ayA
 aAD
 uVK
 bbj
@@ -53745,27 +54838,27 @@ bbW
 bbj
 aaU
 aaU
-aaU
+gVF
 xik
-aBo
+aaU
 lry
 tHb
 emK
 vkL
-lry
-aql
+qhs
+qJl
 arl
 apF
-aah
-aah
-aah
-aah
+mEg
+mEg
+mEg
+mEg
 atx
 atx
 atx
-atx
-atx
-atx
+auR
+auR
+qnh
 atx
 atx
 atx
@@ -53813,7 +54906,7 @@ aUP
 aXb
 aUm
 bcH
-bcJ
+aUP
 bcN
 aUm
 aUm
@@ -53838,15 +54931,18 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (112,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -53862,10 +54958,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
+aah
 aeE
 afB
 avQ
@@ -53873,22 +54966,22 @@ axj
 ayk
 ayK
 azv
-azH
-azY
-aAh
 aeE
-aAz
-aAD
+aeE
+aeE
+aeE
+ayL
+ayP
 aAW
 bbr
 bbz
 bbL
 bbY
 nbj
-mnN
-mnN
-mnN
-mnN
+aAI
+aAI
+gWO
+aAI
 aBp
 nmA
 fvL
@@ -53898,16 +54991,16 @@ lry
 aql
 nlo
 apF
-aah
-aah
-aah
-aah
+mEg
+mEg
+mEg
+mEg
 atx
 atW
 auA
 auS
 avA
-atW
+eiT
 atx
 axy
 ayo
@@ -53920,7 +55013,7 @@ atx
 aEb
 auB
 aFE
-auB
+aFF
 aLK
 act
 aDu
@@ -53955,15 +55048,16 @@ aWN
 aXc
 aUm
 aUm
+vvC
 aUm
 aUm
-aUm
 aah
 aah
 aah
 aah
 aah
 aah
+aah
 aad
 aad
 aad
@@ -53974,21 +55068,23 @@ aad
 aad
 aad
 aad
+bcV
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (113,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -53999,15 +55095,12 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+syb
+vsz
+vsz
+vsz
+vsz
+ano
 aeE
 afD
 avl
@@ -54015,22 +55108,22 @@ axF
 ayl
 avl
 azw
+azH
+azW
+aAe
 aeE
-aeE
-aeE
-aeE
-aAA
+dSg
 aAH
 aAX
 sQc
 bbA
 bbj
 bbj
-aaU
-aaU
-aaU
-aaU
-aaU
+aAD
+aAI
+aAI
+gWO
+aAI
 iaI
 lry
 qbw
@@ -54040,10 +55133,10 @@ lry
 aql
 aql
 apF
-aah
-aah
-aah
-aah
+mEg
+mEg
+mEg
+mEg
 atx
 afG
 auB
@@ -54061,11 +55154,11 @@ axy
 atx
 afY
 auB
-aFF
 auB
 auB
-aCO
-aHH
+auB
+qnD
+aDu
 aIu
 aDu
 aDu
@@ -54096,6 +55189,9 @@ aUm
 aUm
 aUm
 aUm
+bcJ
+xcQ
+aUm
 aah
 aah
 aah
@@ -54105,7 +55201,6 @@ aah
 aah
 aah
 aah
-aah
 aad
 aad
 aad
@@ -54119,18 +55214,20 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (114,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -54140,11 +55237,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+bLW
 aad
 aad
 aad
@@ -54155,13 +55248,13 @@ afL
 avR
 axG
 ayt
-avl
+arB
 azx
-azH
-azW
-aAe
+axJ
+azX
+aAg
 aeE
-aAI
+ayM
 dSg
 wvV
 fVG
@@ -54182,13 +55275,13 @@ lry
 aqj
 cZF
 apF
-aah
-aah
-aah
-aah
+mEg
+mEg
+mEg
+mEg
 atx
 atX
-auB
+auT
 auT
 avB
 awi
@@ -54204,9 +55297,9 @@ atx
 aEc
 aEN
 aFG
-aFW
 aGA
-aCO
+bog
+act
 aHI
 aIy
 aJW
@@ -54237,6 +55330,10 @@ aVj
 aUm
 aah
 aah
+aUm
+bcL
+kPi
+aUm
 aah
 aah
 aah
@@ -54246,7 +55343,6 @@ aah
 aah
 aah
 aah
-aah
 aad
 aad
 aad
@@ -54259,20 +55355,21 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (115,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -54282,11 +55379,7 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
+bLW
 aad
 aad
 aad
@@ -54297,22 +55390,22 @@ agq
 avS
 axH
 ayu
-ayL
+avl
 azz
-azJ
-azX
-aAg
 aeE
-cUh
-uwD
+aeE
+aeE
+aeE
+fWT
+fWT
 gYx
-pdo
-gVF
-aAD
-aBi
-aAD
+fWT
+fWT
+fWT
 aAD
 aAD
+aAD
+bWg
 aAD
 lry
 lry
@@ -54324,10 +55417,10 @@ lry
 aql
 sJX
 apF
-aah
-aah
-aah
-aah
+mEg
+mEg
+mEg
+mEg
 atx
 atY
 auB
@@ -54346,8 +55439,8 @@ aDw
 auB
 aEO
 lsh
-aFW
-auB
+rTn
+mzX
 aCO
 jCv
 aIz
@@ -54355,7 +55448,7 @@ aJV
 aDu
 aDu
 aLl
-aJn
+ebN
 aCO
 aah
 aah
@@ -54371,23 +55464,27 @@ aah
 aah
 aah
 aah
-aad
-aad
-aad
-aad
-aad
-aad
+xLJ
+qxr
+tvG
+aoq
+aoq
+eiO
+aah
+aah
+aUm
+aUm
+aUm
+aUm
+aah
+aah
+aah
+aHL
+adK
 aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aad
-aah
 aad
 aad
 aad
@@ -54399,63 +55496,59 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (116,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
+adK
+dPM
+dPM
 aad
 aad
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+iWC
 aad
 aad
 ack
-acM
-acM
+aen
+aen
 aen
 aig
 auL
 xpP
 ayv
-ayM
+avl
 bcf
 azH
 azY
 aAh
 aeE
-fWT
-fWT
+ayO
+ayX
 fAv
+azB
+azC
 fWT
-fWT
-fWT
+azD
+azJ
+aBi
 aAI
-aAI
-aAI
-cNL
-aAI
+mRY
 lry
 uaa
 lry
@@ -54463,13 +55556,13 @@ wRb
 fkx
 vCn
 lry
+aqO
 apF
 apF
 apF
-aah
-aah
-aah
-aah
+apF
+apF
+apF
 atx
 atZ
 auC
@@ -54508,18 +55601,18 @@ aah
 aah
 aah
 aah
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+tvG
+aHL
+aHL
+tvG
+aep
+aHL
+aHL
+aeo
+aoq
+aeo
+aep
+tvG
 aah
 aah
 aah
@@ -54528,6 +55621,12 @@ aah
 aah
 aah
 aah
+aep
+vUo
+aad
+aah
+aah
+aah
 aad
 aad
 aad
@@ -54538,25 +55637,25 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (117,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
+adK
+iTM
 aad
 aad
 aad
@@ -54564,29 +55663,23 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
+bLW
 aad
 aad
 aad
 aad
 aah
-aah
 aeE
-aeE
-aeE
-azH
+aqi
+avl
+arj
 ayw
+avY
+awv
+ayx
+azX
+ayz
 aeE
-aeE
-aeE
-aeE
-aeE
-nlT
 naO
 jvS
 lBO
@@ -54594,9 +55687,9 @@ dtz
 qnZ
 fWT
 nMH
-oId
+aAI
 fRJ
-qaa
+aAI
 vHE
 lry
 lry
@@ -54605,15 +55698,15 @@ iWa
 fkx
 rse
 lry
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+aql
+uwD
+xek
+ciu
+tzm
+tOU
+qdt
 atx
-auB
+vfV
 auB
 auU
 auB
@@ -54631,25 +55724,47 @@ auB
 auB
 auU
 auB
-auB
-auB
-auB
-auB
-atW
+qct
+nGS
+mFL
+qlj
+jgW
 atx
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+oBP
+rLy
+aep
+eiO
+aHL
+aoq
+aoq
+aep
+tvG
+thi
 aah
 aah
 aah
+aHL
+aHL
+aep
+aHL
+aHL
+aeo
+gcH
+aoq
+aoq
+aoq
+aeo
+aHL
+aHL
+aHL
+aHL
+tvG
+aHL
+aHL
+aoq
+aoq
+aHL
+vUo
 aad
 aad
 aad
@@ -54658,47 +55773,31 @@ aad
 aad
 aad
 aad
+ajK
 aad
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (118,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
+adK
+iTM
 aad
 aad
 aad
@@ -54706,55 +55805,49 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
+bLW
 aad
 aad
 aad
 aad
 aah
-aah
-naC
+aeE
 ajb
 awu
 lMK
-ayx
+aeE
 ayN
 azA
-naC
-aah
-aah
-fWT
+azH
+ayy
+ayy
+aeE
 rzF
-lXE
+wvv
 gIt
 wvv
 tXi
 fWT
 aAD
+azV
+aAD
+azV
 aAD
 aAD
-aAD
-aAD
-aAD
-aah
+aoq
 lry
 kuT
 kuT
 lry
 lry
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-atx
+ruj
+aql
+aql
+aql
+aql
+aql
+aql
+qwj
 auB
 auB
 auB
@@ -54779,6 +55872,41 @@ auB
 auB
 auB
 atx
+jGq
+aoq
+aoq
+aep
+aoq
+aeo
+aHL
+aoq
+aHL
+aoq
+aoq
+aoq
+aoq
+aeo
+aHL
+aHL
+gcH
+aoq
+aHL
+aHL
+aeo
+aep
+aHL
+tvG
+aeo
+aHL
+aep
+aoq
+aeo
+aoq
+aeo
+aeo
+aeo
+aeo
+qkO
 aad
 aad
 aad
@@ -54793,104 +55921,69 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (119,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aah
-aah
-naC
-amc
-arB
-arB
-ayy
-ayO
-azB
-naC
-aah
-aah
+nfT
+kUl
+kUl
+kUl
+kUl
+kUl
+kUl
+dEV
+dEV
+xNr
+dEV
+dEV
+dEV
+dEV
+syb
+dEV
+dEV
+dEV
+dEV
+ano
+aeE
+aeE
+aeE
+aeE
+aeE
+aeE
+aeE
+aeE
+aeE
+aeE
+aeE
 fWT
-qhs
 xZq
-bWg
-xSF
-gWO
 fWT
-aah
-aah
-aad
-aad
-aad
-aad
-aad
-aah
-aad
-aad
-aah
-aah
-aah
-aah
+xZq
+fWT
+fWT
+aoq
+aoq
+aoq
+aoq
+aoq
+aoq
+aoq
+aoq
+aoq
+aoq
+aoq
+adK
+rNu
+rNu
 aty
 atx
 atx
@@ -54921,6 +56014,41 @@ oeA
 oeA
 aGC
 aty
+egP
+aep
+aoq
+aoq
+aoq
+tvG
+aHL
+aoq
+aeo
+aoq
+aHL
+aep
+aHL
+gcH
+aoq
+aoq
+aHL
+aep
+aHL
+aep
+aHL
+aHL
+aHL
+aHL
+aoq
+aoq
+aoq
+aHL
+aHL
+aep
+tvG
+aHL
+aeo
+aoq
+vxA
 aad
 aad
 aad
@@ -54935,104 +56063,69 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+adK
+adK
+adK
+adK
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (120,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aah
-aah
-naC
-amP
-awv
-awv
-ayz
-ayP
-azC
-naC
-aah
-aah
-fWT
-fWT
-fWT
-fWT
-fWT
-fWT
-fWT
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aah
-aah
-aah
-aah
+nfT
+acM
+kxZ
+kxZ
+hjA
+kxZ
+kxZ
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
+oiW
 auD
 atz
 atz
@@ -55063,6 +56156,44 @@ auc
 auc
 auc
 auD
+hRz
+oiW
+oiW
+hRz
+hRz
+hRz
+hRz
+oiW
+oSL
+hRz
+hRz
+oSL
+hRz
+hRz
+rey
+hRz
+hRz
+oiW
+hRz
+oiW
+aep
+oSL
+aep
+hRz
+rey
+oiW
+rey
+vNb
+aep
+aep
+aeo
+hRz
+aeo
+aep
+vxA
+oSL
+aad
+aeo
 aad
 aad
 aad
@@ -55074,57 +56205,2209 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+iSH
+iSH
+iSH
+qbe
+iSH
+iSH
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (121,1,1) = {"
-aaa
+nfT
+acM
+fLc
+fLc
+fLc
+fLc
+fLc
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+auD
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+sJj
+sJj
+sJj
+sJj
+sJj
+sJj
+aJq
+sJj
+sJj
+sJj
+sJj
+sJj
+sJj
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+auD
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+vNb
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+vNb
+oSL
+oSL
+oSL
+oSL
+oSL
+aeo
+oSL
+aep
+vNb
+aep
+vNb
+aeo
+rju
+aeo
+vxA
+aad
+aad
+aad
+aad
+aad
+aad
+aeo
+aad
+oSL
+aad
+aad
+aad
+oSL
+aad
+iSH
+aeo
+iSH
+iSH
+iSH
+iSH
+onE
+xZZ
+xZZ
+nfT
+"}
+(122,1,1) = {"
+nfT
+acM
+fLc
+fLc
+fLc
+fLc
+fLc
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+auD
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+auD
+oSL
+vNb
+oSL
+oSL
+uzK
+uzK
+bvJ
+bvJ
+bvJ
+uzK
+uzK
+uzK
+qpp
+uzK
+uzK
+uzK
+uzK
+uzK
+uzK
+uzK
+uzK
+ghB
+oSL
+sQf
+oSL
+oSL
+oSL
+oSL
+aep
+vNb
+aeo
+oSL
+adK
+aHL
+vxA
+aad
+aad
+aad
+oSL
+aad
+oSL
+aeo
+aad
+aad
+aad
+aad
+aad
+aeo
+aad
+iSH
+iSH
+oSL
+iSH
+oSL
+iSH
+iSH
+xZZ
+xZZ
+nfT
+"}
+(123,1,1) = {"
+nfT
+lUf
+wTo
+wTo
+wTo
+wTo
+wTo
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+auD
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+auD
+mgu
+mgu
+hsB
+mgu
+uzK
+hSA
+tIm
+tIm
+tIm
+uhx
+uzK
+maL
+mOe
+jNb
+uzK
+jgj
+vGn
+dDU
+nig
+wnS
+wKu
+mgu
+mgu
+mgu
+hsB
+mgu
+hsB
+mgu
+mgu
+mgu
+mgu
+hsB
+adK
+aHL
+vxA
+aad
+oSL
+aad
+aad
+aeo
+oSL
+aad
+oSL
+aad
+oSL
+oSL
+aad
+aad
+aad
+iSH
+iSH
+aeo
+iSH
+iSH
+aeo
+iSH
+xZZ
+xZZ
+nfT
+"}
+(124,1,1) = {"
+nfT
+acM
+fLc
+fLc
+fLc
+fLc
+fLc
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+auD
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+auD
+oSL
+oSL
+oSL
+sst
+uzK
+vBZ
+jKZ
+mOe
+xWh
+uIQ
+crZ
+mOe
+mOe
+mOe
+qpp
+mOe
+mOe
+mOe
+rJi
+vKa
+wKu
+aep
+oSL
+oSL
+oSL
+oSL
+aeo
+aep
+oSL
+aeo
+vNb
+oSL
+adK
+aoq
+vxA
+aad
+aad
+aeo
+oSL
+aeo
+aad
+oSL
+aad
+aeo
+aad
+aad
+aad
+aeo
+aad
+aeo
+oSL
+iSH
+iSH
+iSH
+qbe
+xZZ
+xZZ
+xZZ
+nfT
+"}
+(125,1,1) = {"
+nfT
+acM
+fLc
+fLc
+fLc
+fLc
+fLc
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+auD
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+auD
+oSL
+oSL
+oSL
+vNb
+uzK
+xlW
+dKG
+mOe
+ecj
+uIQ
+uzK
+tsb
+mOe
+wvR
+uzK
+qPH
+mOe
+jEb
+mpK
+uAX
+wKu
+oSL
+oSL
+oSL
+aep
+sQf
+oSL
+oSL
+oSL
+aeo
+aeo
+vNb
+qxr
+aeo
+vUo
+aeo
+aad
+aad
+oSL
+aad
+aad
+aad
+aad
+oSL
+aad
+aad
+aad
+aad
+aad
+iSH
+iSH
+aeo
+iSH
+iSH
+iSH
+iSH
+xZZ
+xZZ
+nfT
+"}
+(126,1,1) = {"
+nfT
+acM
+fLc
+fLc
+fLc
+fLc
+fLc
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+auD
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+auD
+oSL
+oSL
+oSL
+oSL
+uzK
+xlW
+vhH
+mOe
+xWh
+uIQ
+uzK
+bpe
+mOe
+iAU
+uzK
+uzK
+qpp
+uzK
+uzK
+uzK
+uzK
+uDy
+aep
+oSL
+aep
+oSL
+aeo
+oSL
+aep
+oSL
+oSL
+aeo
+sQf
+aoq
+vUo
+aad
+aeo
+aad
+aad
+aad
+aad
+oSL
+aad
+aad
+aad
+aad
+oSL
+aeo
+aad
+qbe
+iSH
+iSH
+iSH
+smL
+iSH
+oSL
+iSH
+xZZ
+nfT
+"}
+(127,1,1) = {"
+nfT
+acM
+fLc
+fLc
+fLc
+fLc
+fLc
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+auD
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+auD
+oSL
+vNb
+oSL
+oSL
+uzK
+xlW
+xWh
+mOe
+rDe
+uIQ
+uzK
+ybQ
+mOe
+kUQ
+dDU
+okQ
+mOe
+lPs
+wKu
+aep
+oSL
+oSL
+oSL
+oSL
+oSL
+aep
+oSL
+aep
+oSL
+aeo
+aep
+vNb
+rju
+aeo
+vUo
+aad
+aad
+oSL
+aad
+oSL
+aeo
+aad
+oSL
+aad
+aeo
+aad
+aad
+aad
+aad
+oSL
+iSH
+aeo
+iSH
+iSH
+iSH
+iSH
+iSH
+xZZ
+nfT
+"}
+(128,1,1) = {"
+nfT
+acM
+fLc
+fLc
+fLc
+fLc
+fLc
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+auD
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+auD
+oSL
+oSL
+oSL
+sst
+uzK
+xlW
+tAf
+mOe
+bws
+nER
+uzK
+lbC
+mOe
+mOe
+mOe
+mOe
+mOe
+nsv
+wKu
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+aeo
+oSL
+oSL
+oSL
+vNb
+aeo
+adK
+aoq
+vUo
+aad
+oSL
+aad
+aad
+oSL
+aad
+aad
+oSL
+aad
+aad
+oSL
+aad
+aad
+aad
+iSH
+iSH
+iSH
+aeo
+iSH
+oSL
+iSH
+xZZ
+xZZ
+nfT
+"}
+(129,1,1) = {"
+nfT
+lUf
+wTo
+wTo
+wTo
+wTo
+wTo
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+auD
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+afH
+auD
+mgu
+hsB
+mgu
+mgu
+uzK
+jUm
+eMD
+eMD
+eMD
+dTs
+uzK
+xZy
+mOe
+vdH
+mpK
+mpK
+mpK
+cnr
+wKu
+mgu
+mgu
+mgu
+mgu
+hsB
+hsB
+mgu
+mgu
+hsB
+mgu
+hsB
+mgu
+mgu
+adK
+aHL
+vUo
+aad
+aad
+aeo
+aad
+aad
+aad
+aeo
+aad
+aad
+aeo
+aad
+aeo
+aeo
+aad
+aeo
+iSH
+iSH
+iSH
+iSH
+iSH
+qbe
+xZZ
+xZZ
+nfT
+"}
+(130,1,1) = {"
+nfT
+acM
+fLc
+fLc
+fLc
+fLc
+fLc
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+auD
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+auD
+oSL
+oSL
+oSL
+oSL
+uzK
+uzK
+wJv
+wJv
+wJv
+uzK
+uzK
+uzK
+qpp
+uzK
+pXc
+pXc
+pXc
+uzK
+uzK
+uDy
+aep
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+aep
+vNb
+aeo
+oSL
+adK
+aep
+vUo
+aad
+oSL
+aad
+oSL
+oSL
+aad
+aad
+aeo
+aad
+aad
+oSL
+aad
+aad
+aad
+iSH
+iSH
+oSL
+iSH
+iSH
+iSH
+xZZ
+xZZ
+xZZ
+nfT
+"}
+(131,1,1) = {"
+nfT
+acM
+fLc
+fLc
+fLc
+fLc
+fLc
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+auD
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+aud
+auD
+oSL
+oSL
+vNb
+oSL
+oSL
+oSL
+oSL
+oSL
+vNb
+oSL
+oSL
+oSL
+oSL
+oSL
+oSL
+vNb
+oSL
+oSL
+aep
+oSL
+oSL
+sQf
+aep
+oSL
+aeo
+oSL
+aep
+vNb
+vNb
+oSL
+hQz
+aeo
+rDs
+aep
+vuz
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aeo
+aad
+aad
+aeo
+aad
+aad
+aeo
+iSH
+oSL
+iSH
+iSH
+mur
+iSH
+xZZ
+xZZ
+xZZ
+nfT
+"}
+(132,1,1) = {"
+nfT
+acM
+nqX
+nqX
+iZr
+nqX
+nqX
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+auD
+atC
+atC
+atC
+atC
+aua
+atC
+atC
+atC
+atC
+aue
+aua
+atC
+atC
+atC
+aua
+atC
+atC
+atC
+aua
+aue
+atC
+atC
+atC
+aua
+atC
+atC
+atC
+atC
+auD
+njD
+njD
+njD
+njD
+vNb
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+vNb
+njD
+njD
+njD
+njD
+njD
+njD
+njD
+oSL
+aep
+njD
+aep
+njD
+njD
+ciq
+njD
+aep
+njD
+ciq
+vNb
+aep
+aHL
+vUo
+aad
+aad
+aad
+aad
+aad
+oSL
+aad
+aad
+aad
+aeo
+aad
+oSL
+aad
+aad
+iSH
+iSH
+qbe
+iSH
+iSH
+onE
+xZZ
+xZZ
+xZZ
+nfT
+"}
+(133,1,1) = {"
+nfT
+kUl
+kUl
+qau
+kUl
+kUl
+kUl
+dEV
+dEV
+xNr
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+xNr
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+xNr
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+dEV
+aty
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+atx
+aty
+lMj
+lMj
+lMj
+lMj
+lMj
+lMj
+gcX
+lMj
+lMj
+lMj
+lMj
+lMj
+lMj
+lMj
+lMj
+lMj
+lMj
+lMj
+lMj
+lMj
+lMj
+lMj
+gcX
+lMj
+lMj
+lMj
+lMj
+dEV
+dEV
+dEV
+lMj
+lMj
+lMj
+lMj
+gqk
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+adK
+adK
+adK
+adK
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
+"}
+(134,1,1) = {"
+nfT
+kUl
+nED
+pNR
+kUl
+adK
+iTM
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+lRZ
+adK
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
+"}
+(135,1,1) = {"
+nfT
+kUl
+pNR
+pNR
+kUl
+adK
+iTM
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+lRZ
+adK
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
+"}
+(136,1,1) = {"
+nfT
+kUl
+lbn
+nED
+kUl
+adK
+hju
+hju
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
 aad
 aad
 aad
@@ -55143,20 +58426,6 @@ ajK
 aad
 aad
 aad
-aah
-naC
-aAC
-avY
-axJ
-ayA
-ayX
-azD
-naC
-aah
-aah
-aah
-aah
-aah
 aad
 aad
 aad
@@ -55173,38 +58442,6 @@ aad
 aad
 aad
 aad
-aah
-aah
-auD
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aJq
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-auD
 aad
 aad
 aad
@@ -55239,2164 +58476,27 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(122,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-naC
-naC
-naC
-naC
-naC
-naC
-naC
-naC
-aah
-aah
-aah
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-auD
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-auD
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(123,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aah
-aah
-aah
-aah
-aah
-aah
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-auD
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-auD
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(124,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-auD
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-auD
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(125,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-auD
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-auD
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(126,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-auD
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-auD
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(127,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-auD
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-auD
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-bcV
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(128,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-auD
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-auD
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(129,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-auD
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-afH
-auD
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(130,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-bcV
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-bcV
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-auD
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-auD
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(131,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-auD
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-aud
-auD
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-bcV
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(132,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-auD
-atC
-atC
-atC
-atC
-aua
-atC
-atC
-atC
-atC
-aue
-aua
-atC
-atC
-atC
-aua
-atC
-atC
-atC
-aua
-aue
-atC
-atC
-atC
-aua
-atC
-atC
-atC
-atC
-auD
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(133,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aty
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-atx
-aty
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(134,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(135,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-"}
-(136,1,1) = {"
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+adK
+adK
+adK
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (137,1,1) = {"
-aaa
+nfT
+kUl
+kWs
+aHH
+kUl
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -57418,6 +58518,7 @@ aad
 aad
 aad
 aad
+ajK
 aad
 aad
 aad
@@ -57517,28 +58618,28 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (138,1,1) = {"
-aaa
+nfT
+kUl
+kUl
+kUl
+kUl
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -57642,6 +58743,7 @@ aad
 aad
 aad
 aad
+ajK
 aad
 aad
 aad
@@ -57657,30 +58759,30 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (139,1,1) = {"
-aaa
+nfT
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
 aad
 aad
 aad
@@ -57799,29 +58901,31 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+xZZ
+nfT
 "}
 (140,1,1) = {"
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
 aaa
 aaa
 aaa
@@ -57938,28 +59042,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
+nfT
 "}

--- a/_maps/map_files/tether/tether-02-surface2.dmm
+++ b/_maps/map_files/tether/tether-02-surface2.dmm
@@ -394,15 +394,8 @@
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/medical/centralhall)
 "aaI" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -441,36 +434,19 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/medical/morgue)
 "aaL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralhall)
 "aaM" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -486,9 +462,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -501,11 +474,6 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralhall)
 "aaO" = (
@@ -515,19 +483,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralhall)
@@ -556,20 +516,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -594,7 +540,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
-	icon_state = "0-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralhall)
@@ -2007,10 +1954,6 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralstairwell)
 "ada" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
@@ -2824,6 +2767,10 @@
 "aes" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralhall)
 "aet" = (
@@ -3474,18 +3421,14 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/patient_b)
 "afo" = (
-/obj/structure/bed/chair/wheelchair{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/pink/border{
 	dir = 8
+	},
+/obj/machinery/computer/transhuman/designer{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/examroom)
@@ -3506,15 +3449,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
 "afs" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/obj/structure/catwalk,
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/north)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/examroom)
 "aft" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -3911,9 +3850,6 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/medical/patient_c)
 "afY" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = -24
@@ -3923,6 +3859,9 @@
 	},
 /obj/effect/floor_decal/corner/pink/border{
 	dir = 8
+	},
+/obj/structure/bed/chair/wheelchair{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/examroom)
@@ -3975,10 +3914,6 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralhall)
 "agd" = (
@@ -4434,18 +4369,19 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralstairwell)
 "agT" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralhall)
@@ -4523,6 +4459,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralhall)
 "ahb" = (
@@ -4530,6 +4477,14 @@
 /obj/effect/floor_decal/corner/paleblue/border,
 /obj/effect/floor_decal/borderfloorwhite/corner2,
 /obj/effect/floor_decal/corner/paleblue/bordercorner2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralhall)
 "ahc" = (
@@ -4853,6 +4808,14 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralhall)
 "ahE" = (
@@ -4902,24 +4865,36 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralhall)
 "ahH" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	name = "CMO Office";
-	sortType = "CMO Office"
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/surface_two_hall)
+/obj/effect/floor_decal/corner/pink/border{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/examroom)
 "ahI" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	name = "Medical Breakroom";
-	sortType = "Medical Breakroom"
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/surface_two_hall)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/centralhall)
 "ahJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4944,9 +4919,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
@@ -4967,18 +4942,25 @@
 "ahO" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/green/border,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 4;
+	name = "CMO Office";
+	sortType = "CMO Office"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
 "ahP" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/green/border,
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/sortjunction/flipped{
+	name = "Trash";
+	sortType = "Trash"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
@@ -4989,14 +4971,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable/green{
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralhall)
@@ -5273,13 +5256,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "aiq" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/light/small{
+	dir = 4;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor,
 /area/maintenance/substation/medsec)
 "air" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -5422,6 +5408,9 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralhall)
 "aiz" = (
@@ -8130,7 +8119,7 @@
 /area/tether/surfacebase/security/armory)
 "amD" = (
 /turf/simulated/wall/r_wall,
-/area/maintenance/lower/north)
+/area/maintenance/substation/medsec)
 "amE" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Surfsec Substation Bypass"
@@ -8161,14 +8150,20 @@
 /turf/simulated/floor,
 /area/maintenance/substation/medsec)
 "amH" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Security Substation";
-	secured_wires = 1
-	},
-/obj/machinery/door/firedoor/glass,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/closet/toolcloset,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
 /turf/simulated/floor,
 /area/maintenance/substation/medsec)
 "amI" = (
@@ -8867,9 +8862,15 @@
 /turf/simulated/floor,
 /area/maintenance/lower/north)
 "anW" = (
-/obj/effect/floor_decal/rust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/area/maintenance/lower/rnd)
 "anX" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 9
@@ -9370,7 +9371,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/closet/crate/trashcart,
+/obj/random/junk,
+/obj/random/junk,
+/obj/random/junk,
+/turf/simulated/floor,
 /area/maintenance/substation/medsec)
 "aoJ" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -9514,14 +9519,13 @@
 /area/tether/surfacebase/medical/recoveryward)
 "aoX" = (
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/bar)
@@ -9535,6 +9539,7 @@
 /obj/machinery/door/airlock/multi_tile/metal/mait{
 	name = "Maintenance Access"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/bar)
 "aoZ" = (
@@ -9542,7 +9547,6 @@
 /area/chapel/main)
 "apa" = (
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/bar)
 "apb" = (
@@ -9605,7 +9609,9 @@
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/disposalpipe/up,
+/obj/structure/disposalpipe/up{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
 "apg" = (
@@ -9619,21 +9625,18 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/railing{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
 "api" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/rnd)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/east_stairs_two)
 "apj" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -9645,19 +9648,26 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
 "apl" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
 "apm" = (
 /obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
 "apn" = (
@@ -10109,12 +10119,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
 "apU" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/rnd)
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/east_stairs_two)
 "apV" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -10168,15 +10179,6 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
 "aqb" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /turf/simulated/floor,
 /area/maintenance/substation/medsec)
 "aqc" = (
@@ -10226,12 +10228,8 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/bathroom)
 "aqg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/rnd)
+/turf/simulated/mineral,
+/area/tether/surfacebase/reading_room)
 "aqh" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/machinery/light/small{
@@ -11300,14 +11298,14 @@
 /area/maintenance/substation/medsec)
 "ase" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/medsec)
@@ -11400,12 +11398,12 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/tether/surfacebase/outside/outside2)
+/area/maintenance/lower/south)
 "asn" = (
 /obj/item/clothing/under/batter,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/tether/surfacebase/outside/outside2)
+/area/maintenance/lower/south)
 "aso" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -11500,7 +11498,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/tether/surfacebase/outside/outside2)
+/area/maintenance/lower/south)
 "asy" = (
 /obj/structure/table/rack/holorack,
 /obj/random/maintenance/clean,
@@ -11720,10 +11718,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
 "asN" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/engineering{
-	name = "Security Substation";
-	secured_wires = 1
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/medsec)
@@ -11733,7 +11734,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/tether/surfacebase/outside/outside2)
+/area/maintenance/lower/south)
 "asP" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -11786,7 +11787,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/tether/surfacebase/outside/outside2)
+/area/maintenance/lower/south)
 "asV" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -13030,16 +13031,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
-"auX" = (
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
 "auY" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -13844,9 +13835,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/bar)
-"aww" = (
-/turf/simulated/mineral,
-/area/maintenance/lower/public_garden_maintenence/upper)
 "awx" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -14517,16 +14505,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
-"axH" = (
-/turf/simulated/mineral,
-/area/maintenance/lower/mining)
 "axI" = (
 /obj/structure/closet/crate,
 /obj/random/cash,
 /obj/random/contraband,
 /obj/random/drinkbottle,
 /turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/area/maintenance/lower/bar)
 "axJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14695,18 +14680,13 @@
 /obj/random/trash_pile,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
-"ayh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/surface_two_hall)
 "ayi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
@@ -14724,10 +14704,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
@@ -14964,9 +14940,10 @@
 "ayM" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/green/border,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 4;
+	name = "Medical Breakroom";
+	sortType = "Medical Breakroom"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
@@ -14979,7 +14956,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
 "ayO" = (
@@ -15418,21 +15398,14 @@
 /obj/effect/floor_decal/corner/green/border{
 	dir = 8
 	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	name = "Trash";
-	sortType = "Trash"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
 "azR" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4
@@ -15660,7 +15633,6 @@
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
 "aAu" = (
@@ -15817,8 +15789,7 @@
 /area/teleporter)
 "aAQ" = (
 /obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
@@ -16094,6 +16065,10 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/bar)
@@ -17354,9 +17329,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/chapel/main)
-"aDO" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -17686,6 +17658,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aEs" = (
@@ -18011,6 +17984,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aEX" = (
@@ -18141,10 +18115,8 @@
 /area/maintenance/lower/rnd)
 "aFj" = (
 /obj/structure/lattice,
-/obj/structure/disposalpipe/down{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/down,
 /turf/simulated/open,
 /area/maintenance/lower/rnd)
 "aFk" = (
@@ -18159,13 +18131,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/rnd)
-"aFm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
 "aFn" = (
@@ -18364,23 +18329,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/chapel/main)
-"aFF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aFG" = (
@@ -18855,19 +18810,19 @@
 "aGG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/turcarpet,
 /area/bridge/meeting_room)
 "aGH" = (
 /obj/structure/bed/chair/comfy/black,
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/turcarpet,
 /area/bridge/meeting_room)
 "aGI" = (
 /obj/structure/bed/chair/comfy/black,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/turcarpet,
 /area/bridge/meeting_room)
 "aGJ" = (
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/turcarpet,
 /area/bridge/meeting_room)
 "aGK" = (
 /obj/machinery/firealarm{
@@ -18929,7 +18884,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aGR" = (
 /turf/simulated/floor/tiled/dark,
@@ -18938,20 +18893,22 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aGT" = (
-/turf/simulated/floor/carpet,
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
+/obj/effect/floor_decal/chapel{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aGU" = (
-/obj/structure/table/bench/padded,
 /obj/machinery/light_switch{
 	name = "light switch ";
 	on = 0;
 	pixel_y = 36
-	},
-/obj/effect/landmark/start{
-	name = "Chaplain"
 	},
 /obj/machinery/button/windowtint{
 	dir = 1;
@@ -18961,7 +18918,7 @@
 	pixel_y = 30;
 	range = 8
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aGV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18981,6 +18938,7 @@
 	pixel_y = 29;
 	req_access = list(27)
 	},
+/obj/structure/flora/pottedplant/orientaltree,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aGX" = (
@@ -19010,9 +18968,6 @@
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "aHa" = (
-/obj/structure/bed/chair/comfy/blue{
-	dir = 4
-	},
 /obj/effect/landmark/start{
 	name = "Command Secretary"
 	},
@@ -19020,27 +18975,30 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/turcarpet,
 /area/bridge/meeting_room)
 "aHb" = (
 /obj/item/book/manual/security_space_law,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/table/fancyblack,
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/carpet/turcarpet,
 /area/bridge/meeting_room)
 "aHc" = (
 /obj/item/folder/red,
 /obj/structure/disposalpipe/segment,
-/obj/structure/table/fancyblack,
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/carpet/turcarpet,
 /area/bridge/meeting_room)
 "aHd" = (
-/obj/structure/bed/chair/comfy/blue{
+/obj/structure/bed/chair/comfy/black{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/turcarpet,
 /area/bridge/meeting_room)
 "aHe" = (
 /obj/machinery/power/apc{
@@ -19092,18 +19050,14 @@
 /turf/simulated/floor/grass,
 /area/chapel/main)
 "aHj" = (
-/obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/carpet,
-/area/chapel/main)
-"aHk" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aHl" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/carpet,
+/obj/effect/floor_decal/chapel{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aHm" = (
 /turf/simulated/mineral,
@@ -19147,13 +19101,13 @@
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "aHr" = (
-/obj/structure/bed/chair/comfy/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/turcarpet,
 /area/bridge/meeting_room)
 "aHs" = (
 /obj/item/paper_bin{
@@ -19164,23 +19118,23 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/table/fancyblack,
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/carpet/turcarpet,
 /area/bridge/meeting_room)
 "aHt" = (
 /obj/item/folder/blue,
 /obj/structure/disposalpipe/segment,
-/obj/structure/table/fancyblack,
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/carpet/turcarpet,
 /area/bridge/meeting_room)
 "aHu" = (
-/obj/structure/bed/chair/comfy/blue{
-	dir = 8
-	},
 /obj/effect/landmark/start{
 	name = "Command Secretary"
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/turcarpet,
 /area/bridge/meeting_room)
 "aHv" = (
 /obj/item/radio/intercom{
@@ -19239,21 +19193,23 @@
 /obj/machinery/camera/network/civilian{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aHA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
+/obj/effect/floor_decal/chapel,
+/turf/simulated/wall,
 /area/chapel/main)
 "aHB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet,
+/obj/effect/floor_decal/chapel{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aHC" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aHD" = (
 /obj/machinery/camera/network/outside{
@@ -19315,20 +19271,20 @@
 /area/tether/surfacebase/surface_two_hall)
 "aHL" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/turcarpet,
 /area/bridge/meeting_room)
 "aHM" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/turcarpet,
 /area/bridge/meeting_room)
 "aHN" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/turcarpet,
 /area/bridge/meeting_room)
 "aHO" = (
 /obj/effect/floor_decal/borderfloor{
@@ -19454,37 +19410,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aHW" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Chapeal";
+	sortType = "Chapel"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aHX" = (
-/obj/structure/table/bench/padded,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/chapel/main)
-"aHY" = (
-/obj/structure/table/bench/padded,
-/obj/effect/floor_decal/chapel{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/chapel/main)
-"aHZ" = (
-/obj/structure/table/bench/padded,
-/obj/effect/floor_decal/chapel{
-	dir = 4
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aIa" = (
@@ -19496,13 +19435,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aIc" = (
-/obj/structure/table/bench/padded,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aId" = (
 /obj/structure/closet,
@@ -19688,6 +19627,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/flora/pottedplant/smalltree,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aIy" = (
@@ -19699,7 +19639,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aIz" = (
 /obj/structure/disposalpipe/segment,
@@ -19719,7 +19659,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aIA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -19733,7 +19673,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aIB" = (
 /obj/structure/cable{
@@ -19741,25 +19681,17 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	name = "Chapel";
-	sortType = "Chapel"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aIC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19769,30 +19701,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aID" = (
-/obj/effect/floor_decal/chapel{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aIE" = (
-/obj/effect/floor_decal/chapel,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -19801,7 +19715,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aIF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -19813,7 +19728,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aIG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -19830,15 +19745,10 @@
 /turf/simulated/floor/carpet,
 /area/chapel/main)
 "aIH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/bed/chair/wood{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/floor_decal/chapel,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aII" = (
@@ -19851,7 +19761,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aIJ" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -19982,18 +19893,23 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aJb" = (
-/obj/structure/table/bench/padded,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aJc" = (
-/obj/structure/table/bench/padded,
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aJd" = (
-/obj/structure/table/bench/padded,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aJe" = (
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -20179,7 +20095,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aJz" = (
 /obj/structure/railing{
@@ -20398,14 +20314,12 @@
 /turf/simulated/floor/lino,
 /area/chapel/office)
 "aJV" = (
-/obj/structure/table/bench/padded,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aJW" = (
-/obj/structure/table/bench/padded,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -20770,19 +20684,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aKH" = (
-/obj/effect/floor_decal/chapel{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aKI" = (
-/obj/effect/floor_decal/chapel,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "aKJ" = (
 /obj/machinery/camera/network/civilian{
 	dir = 1
 	},
+/obj/structure/flora/pottedplant/overgrown,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aKK" = (
@@ -23902,9 +23817,6 @@
 /obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"aQy" = (
-/turf/simulated/wall,
-/area/rnd/workshop)
 "aQz" = (
 /obj/structure/railing{
 	dir = 8
@@ -25774,18 +25686,6 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering/pumpstation)
-"aUa" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/east_stairs_two)
 "aUb" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -25796,10 +25696,7 @@
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/east_stairs_two)
 "aUc" = (
@@ -26070,7 +25967,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/east_stairs_two)
 "aUL" = (
@@ -26346,7 +26242,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/multi_tile/glass,
 /turf/simulated/floor/tiled/techmaint,
@@ -27027,7 +26922,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/east_stairs_two)
 "aWo" = (
@@ -27494,6 +27388,7 @@
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/east_stairs_two)
 "aXi" = (
@@ -27647,12 +27542,10 @@
 /turf/simulated/open,
 /area/engineering/atmos)
 "aXK" = (
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/machinery/camera/network/engineering{
 	dir = 8
 	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/engineering/atmos)
 "aXL" = (
@@ -27691,10 +27584,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/east_stairs_two)
 "aXN" = (
@@ -27705,7 +27594,8 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/east_stairs_two)
@@ -29023,10 +28913,10 @@
 /turf/simulated/open,
 /area/engineering/atmos)
 "bbB" = (
-/obj/structure/railing,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/engineering/atmos)
 "bbE" = (
@@ -30181,7 +30071,10 @@
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "beO" = (
 /obj/machinery/mecha_part_fabricator/pros{
-	name = "Legitimate Prosthetics Fabricator";
+	component_coeff = 1;
+	desc = "A machine used for construction of legit prosthetics. You weren't sure if cardboard was considered an engineering material before now.";
+	dir = 4;
+	name = "Legitmate Prosthetics Fabricator";
 	req_access = list();
 	res_max_amount = 150000
 	},
@@ -33830,7 +33723,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor,
 /area/maintenance/substation/medsec)
 "boD" = (
 /obj/structure/sign/department/chapel,
@@ -34109,7 +34002,6 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/obj/structure/catwalk,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
 "bpH" = (
@@ -34183,6 +34075,16 @@
 /obj/random/trash_pile,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
+"bpR" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "bpV" = (
 /obj/structure/window/reinforced/polarized/full{
 	id = "ward_tint"
@@ -34219,12 +34121,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"brF" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"buW" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "bCs" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
 /turf/simulated/floor/outdoors/beach/sand/desert,
 /area/tether/surfacebase/fish_farm)
+"bNt" = (
+/obj/structure/sign/mining/survival,
+/obj/effect/floor_decal/rust,
+/turf/simulated/shuttle/wall/voidcraft,
+/area/tether/surfacebase/old_shelter)
 "bOW" = (
 /obj/structure/railing{
 	dir = 1
@@ -34232,6 +34152,31 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/fish_farm)
+"bSn" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/glass/bucket/wood,
+/turf/simulated/mineral/floor/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"bSE" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"ccf" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"chh" = (
+/obj/structure/sign/warning/bomb_range{
+	name = "\improper MINING AREA - WATCH FOR BLASTING"
+	},
+/turf/unsimulated/wall/planetary/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "ckv" = (
 /obj/structure/railing{
 	dir = 4
@@ -34242,12 +34187,24 @@
 /obj/random/trash_pile,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/lower/bar)
+"cFL" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "cJE" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"cQJ" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "djo" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/camera/network/civilian,
@@ -34259,6 +34216,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"dpF" = (
+/turf/simulated/mineral/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "dAB" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -34267,6 +34227,9 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/reading_room)
+"dNl" = (
+/turf/simulated/mineral,
+/area/tether/surfacebase/east_stairs_two)
 "dSO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -34295,6 +34258,14 @@
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"edh" = (
+/obj/item/material/minihoe,
+/turf/simulated/mineral/floor/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"ehI" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "ekH" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -34311,6 +34282,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/reading_room)
+"elS" = (
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/old_tram)
 "etU" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access = list(746)
@@ -34324,6 +34298,16 @@
 "eKn" = (
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
+"eNv" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/lattice,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "eOL" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
@@ -34351,12 +34335,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
+"fvp" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/rust,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "fxr" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
+"fyr" = (
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"fBe" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "fIS" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
@@ -34368,6 +34373,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/fish_farm)
+"gdk" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "glx" = (
 /obj/structure/cable/orange{
 	d1 = 16;
@@ -34403,11 +34414,93 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/fish_farm)
+"gLR" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"gUK" = (
+/turf/unsimulated/mineral/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"hnm" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"hRU" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"idu" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"ikR" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"iyz" = (
+/obj/item/reagent_containers/glass/bottle/left4zed,
+/turf/simulated/mineral/floor/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"iFX" = (
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"iMt" = (
+/obj/structure/catwalk,
+/obj/structure/stairs/spawner/south,
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"iNK" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"iQT" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/voidcraft/survival_pod,
+/obj/effect/floor_decal/rust,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/tether/surfacebase/old_shelter)
 "jCz" = (
 /turf/simulated/wall{
 	can_open = 1
 	},
 /area/tether/surfacebase/public_garden_two)
+"jLj" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "jNC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -34426,6 +34519,25 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/reading_room)
+"jZK" = (
+/obj/structure/stairs/spawner/south,
+/obj/structure/catwalk,
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"kjM" = (
+/obj/random/junk,
+/turf/simulated/mineral/floor/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"kDE" = (
+/obj/structure/sign/mining/survival{
+	dir = 8
+	},
+/turf/simulated/shuttle/wall/voidcraft,
+/area/tether/surfacebase/old_shelter)
+"kOp" = (
+/obj/structure/sign/warning/lethal_turrets,
+/turf/simulated/wall/r_wall,
+/area/tcommsat/chamber)
 "kPb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34454,10 +34566,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
-"laD" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/techfloor,
+"kZw" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/open/virgo3b,
 /area/tether/surfacebase/outside/outside2)
+"laD" = (
+/turf/simulated/mineral,
+/area/maintenance/lower/south)
 "llG" = (
 /obj/machinery/space_heater,
 /obj/structure/window/reinforced{
@@ -34477,6 +34594,18 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
 /area/chapel/main)
+"lTc" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"lWO" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/floodlight,
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/old_tram)
 "mnt" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -34497,6 +34626,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"mpW" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/old_tram)
+"mrH" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "mCl" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -34535,6 +34675,18 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
+"nlA" = (
+/obj/structure/railing,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"nwI" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"nzq" = (
+/obj/random/junk,
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "nFT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34549,6 +34701,10 @@
 /obj/item/deck/cah,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"nSc" = (
+/obj/machinery/floodlight,
+/turf/simulated/mineral/floor/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "olc" = (
 /obj/item/grenade/chem_grenade/cleaner{
 	pixel_x = -10
@@ -34556,6 +34712,21 @@
 /obj/item/grenade/anti_photon,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
+"oMx" = (
+/obj/machinery/sleeper/survival_pod,
+/obj/effect/floor_decal/rust,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/tether/surfacebase/old_shelter)
+"oPK" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"oZh" = (
+/turf/simulated/mineral/floor/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "pah" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock{
@@ -34564,10 +34735,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"pcN" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/shuttle/wall/voidcraft,
+/area/tether/surfacebase/old_shelter)
+"pdh" = (
+/obj/item/reagent_containers/spray/plantbgone,
+/turf/simulated/mineral/floor/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "pqb" = (
 /obj/structure/sink/puddle,
 /turf/simulated/floor/outdoors/beach/sand/desert,
 /area/tether/surfacebase/fish_farm)
+"pKw" = (
+/obj/structure/railing,
+/obj/structure/lattice,
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "pLH" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 10
@@ -34577,6 +34761,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
+"pTt" = (
+/obj/item/reagent_containers/glass/bottle/eznutrient,
+/turf/simulated/mineral/floor/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"pWo" = (
+/obj/item/analyzer/plant_analyzer,
+/turf/simulated/mineral/floor/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "qpA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -34602,6 +34794,66 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/bar)
+"qLQ" = (
+/obj/item/reagent_containers/glass/bottle/diethylamine,
+/turf/simulated/mineral/floor/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"rfi" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"rhH" = (
+/obj/machinery/smartfridge/survival_pod,
+/obj/item/fbp_backup_cell,
+/obj/item/fbp_backup_cell,
+/obj/item/storage/mre/random,
+/obj/effect/floor_decal/rust,
+/obj/random/junk,
+/obj/random/junk,
+/obj/random/junk,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/tether/surfacebase/old_shelter)
+"rqH" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"rrr" = (
+/obj/structure/railing,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"rsG" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"rzz" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"rEz" = (
+/obj/structure/ladder{
+	pixel_y = 6
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/effect/floor_decal/industrial/warning/full,
+/turf/simulated/floor/tiled/techfloor/grid/virgo3b,
+/area/tether/surfacebase/old_tram)
 "rJc" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/landmark/start{
@@ -34635,6 +34887,20 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/lower/bar)
+"snt" = (
+/obj/structure/sign/warning/caution{
+	desc = "No unarmed personnel beyond this point.";
+	name = "\improper DANGER - WILDERNESS"
+	},
+/turf/unsimulated/wall/planetary/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"sue" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "swg" = (
 /obj/structure/railing,
 /obj/structure/catwalk,
@@ -34643,6 +34909,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/fish_farm)
+"sKe" = (
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "sLx" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -34655,6 +34928,16 @@
 	},
 /turf/simulated/floor/water/indoors,
 /area/tether/surfacebase/fish_farm)
+"sSc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Security Substation";
+	secured_wires = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/substation/medsec)
 "sVf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34673,6 +34956,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"sXo" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/tether/surfacebase/old_shelter)
 "sZp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34710,6 +34997,18 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining)
+"tNw" = (
+/obj/structure/tubes,
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/button/remote/airlock/survival_pod{
+	dir = 10;
+	pixel_y = -24
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/tether/surfacebase/old_shelter)
 "tPB" = (
 /turf/simulated/floor/grass,
 /area/chapel/main)
@@ -34720,6 +35019,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
+"ueA" = (
+/turf/simulated/shuttle/wall/voidcraft,
+/area/tether/surfacebase/old_shelter)
+"uiV" = (
+/obj/structure/loot_pile/surface/bones,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/gloves/fyellow,
+/obj/item/clothing/under/color/grey,
+/obj/item/clothing/shoes/black,
+/obj/item/clothing/head/hardhat/red,
+/obj/item/tank/emergency/oxygen,
+/turf/simulated/mineral/floor/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"ujr" = (
+/obj/structure/fans,
+/obj/effect/floor_decal/rust,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/tether/surfacebase/old_shelter)
 "unM" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -34727,6 +35045,14 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"uzX" = (
+/obj/structure/railing,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"uAB" = (
+/obj/structure/frame/computer,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/tether/surfacebase/old_shelter)
 "uFL" = (
 /obj/structure/railing{
 	dir = 1
@@ -34737,6 +35063,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/fish_farm)
+"uGs" = (
+/obj/structure/stairs/spawner/north,
+/obj/structure/catwalk,
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "uHy" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -34761,6 +35092,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"uOJ" = (
+/obj/structure/bed/pod,
+/obj/random/junk,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/tether/surfacebase/old_shelter)
+"uYv" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "viY" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -34774,6 +35116,22 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
+"vGp" = (
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"vIP" = (
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/mineral/floor/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"vOC" = (
+/obj/structure/railing,
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "vTb" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -34788,6 +35146,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
+"vXH" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
+"whG" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/railing,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/old_tram)
 "wqU" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -34798,6 +35168,29 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
+"wuA" = (
+/obj/structure/table/survival_pod,
+/obj/effect/floor_decal/rust,
+/obj/random/junk,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/tether/surfacebase/old_shelter)
+"wuG" = (
+/obj/structure/railing,
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"wJy" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"wYX" = (
+/obj/structure/sign/mining/survival{
+	dir = 4
+	},
+/turf/simulated/shuttle/wall/voidcraft,
+/area/tether/surfacebase/old_shelter)
 "xbt" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/sign/poster{
@@ -34811,6 +35204,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"xma" = (
+/obj/structure/sign/mining,
+/obj/effect/floor_decal/rust,
+/turf/simulated/shuttle/wall/voidcraft,
+/area/tether/surfacebase/old_shelter)
+"xmA" = (
+/obj/structure/sign/warning/high_voltage{
+	name = "\improper SOLAR FARM"
+	},
+/turf/unsimulated/wall/planetary/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "xpO" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -34821,12 +35225,33 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"xwZ" = (
+/obj/structure/sign/mining/survival{
+	dir = 1
+	},
+/turf/simulated/shuttle/wall/voidcraft,
+/area/tether/surfacebase/old_shelter)
+"xCK" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"xQs" = (
+/obj/structure/simple_door/iron,
+/turf/simulated/floor/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "xSO" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
+"yiF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "ylZ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -34835,579 +35260,605 @@
 /area/maintenance/lower/north)
 
 (1,1,1) = {"
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+aaa
+aaa
+aaa
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+aaa
+aaa
+aaa
+aaa
+aaa
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+aaa
+aaa
+aaa
+aaa
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
 "}
 (2,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+gUK
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+abn
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+abn
+wuG
+ehI
+ehI
+ehI
+ehI
+ehI
+aeG
+ehI
+ehI
+aeG
+aeG
+ehI
+ehI
+ehI
+ehI
+aeG
+aeG
+ehI
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (3,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+gUK
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+abn
+abn
+wuG
+ehI
+aab
+ehI
+ehI
+ehI
+ehI
+ehI
+ehI
+ehI
+ehI
+ehI
+aeG
+ehI
+ehI
+ehI
+ehI
+ehI
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (4,1,1) = {"
+gUK
+ueA
+ueA
+kDE
+ueA
+pcN
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+aab
+aab
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+aab
+aab
+aab
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+aab
+aab
+aab
+abn
+abn
+abn
+abn
+abn
+abn
+wuG
+wJy
+arj
 aaa
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+cFL
+xmA
+cFL
+cFL
+cFL
+wJy
+wJy
+cFL
+cFL
+cFL
+wJy
+cFL
+cFL
+xmA
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (5,1,1) = {"
-aaa
+gUK
+pcN
+ujr
+oMx
+wuA
+bNt
+abn
+abn
+nzq
+abn
+abn
+dpF
+dpF
+dpF
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
 aab
 aab
 aab
 aab
+abn
+abn
+abn
+abn
 aab
 aab
 aab
@@ -35417,6 +35868,12 @@ aab
 aab
 aab
 aab
+abn
+abn
+abn
+abn
+abn
+abn
 aab
 aab
 aab
@@ -35426,6 +35883,12 @@ aab
 aab
 aab
 aab
+abn
+abn
+abn
+abn
+abn
+abn
 aab
 aab
 aab
@@ -35456,96 +35919,78 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (6,1,1) = {"
-aaa
+gUK
+xwZ
+rhH
+sXo
+sXo
+iQT
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
 aab
 aab
 aab
@@ -35617,77 +36062,74 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (7,1,1) = {"
-aaa
+gUK
+pcN
+uAB
+uOJ
+tNw
+xma
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
 aab
 aab
 aab
@@ -35764,72 +36206,68 @@ aab
 aab
 aab
 aab
+abn
+abn
+abn
+abn
+abn
+abn
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (8,1,1) = {"
-aaa
+gUK
+ueA
+pcN
+wYX
+ueA
+pcN
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
 aab
 aab
 aab
@@ -35919,59 +36357,57 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (9,1,1) = {"
-aaa
+gUK
+dpF
+dpF
+dpF
+dpF
+dpF
+abn
+nzq
+abn
+abn
+abn
+abn
 aab
 aab
 aab
@@ -36064,56 +36500,54 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (10,1,1) = {"
-aaa
+gUK
+dpF
+dpF
+dpF
+dpF
+abn
+abn
+abn
+abn
+abn
 aab
 aab
 aab
@@ -36210,52 +36644,50 @@ aab
 aab
 aab
 aab
+abn
+abn
+abn
+abn
+abn
 aab
 aab
 aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (11,1,1) = {"
-aaa
+gUK
+dpF
+dpF
+dpF
+abn
+abn
+abn
+abn
 aab
 aab
 aab
@@ -36367,37 +36799,36 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (12,1,1) = {"
-aaa
+gUK
+dpF
+dpF
+dpF
+abn
+abn
+abn
 aab
 aab
 aab
@@ -36518,28 +36949,27 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (13,1,1) = {"
-aaa
+gUK
+dpF
+dpF
+abn
+abn
+abn
 aab
 aab
 aab
@@ -36663,25 +37093,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (14,1,1) = {"
-aaa
+gUK
+dpF
+dpF
+abn
+abn
+abn
 aab
 aab
 aab
@@ -36807,23 +37237,23 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (15,1,1) = {"
-aaa
+gUK
+dpF
+dpF
+abn
+abn
+abn
 aab
 aab
 aab
@@ -36951,21 +37381,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (16,1,1) = {"
-aaa
+gUK
+dpF
+dpF
+abn
+abn
+abn
 aab
 aab
 aab
@@ -37094,20 +37524,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (17,1,1) = {"
-aaa
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -37237,19 +37666,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (18,1,1) = {"
-aaa
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -37378,20 +37807,20 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (19,1,1) = {"
-aaa
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -37519,25 +37948,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (20,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -37665,21 +38090,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (21,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -37806,22 +38231,22 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (22,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -37948,22 +38373,22 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (23,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -38090,22 +38515,22 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (24,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -38233,21 +38658,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (25,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -38375,21 +38800,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (26,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -38517,17 +38942,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (27,1,1) = {"
-aaa
+gUK
+dpF
+abn
+abn
+abn
 aab
 aab
 aab
@@ -38543,10 +38972,6 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
 adt
 adt
 adt
@@ -38616,12 +39041,6 @@ adt
 adt
 adt
 adt
-aab
-aab
-aab
-aab
-aab
-aab
 aab
 aab
 aab
@@ -38666,10 +39085,20 @@ aab
 aab
 aab
 aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (28,1,1) = {"
-aaa
+gUK
+dpF
+abn
+abn
+abn
 aab
 aab
 aab
@@ -38685,10 +39114,6 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
 adt
 adt
 adt
@@ -38758,11 +39183,6 @@ adt
 adt
 adt
 adt
-aab
-aab
-aab
-aab
-aab
 aab
 aab
 aab
@@ -38808,10 +39228,19 @@ aab
 aab
 aab
 aab
-aaa
+abn
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (29,1,1) = {"
-aaa
+gUK
+dpF
+abn
+abn
+abn
 aab
 aab
 aab
@@ -38827,10 +39256,6 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
 adt
 adt
 adt
@@ -38901,11 +39326,6 @@ adt
 adt
 adt
 adt
-aab
-aab
-aab
-aab
-aab
 aab
 aab
 aab
@@ -38950,10 +39370,18 @@ aab
 aab
 aab
 aab
-aaa
+abn
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (30,1,1) = {"
-aaa
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -38970,9 +39398,6 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
 adt
 adt
 adt
@@ -39043,11 +39468,6 @@ adt
 adt
 adt
 adt
-aab
-aab
-aab
-aab
-aab
 aab
 aab
 aab
@@ -39092,13 +39512,18 @@ aab
 aab
 aab
 aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (31,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -39229,18 +39654,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+dpF
+gUK
 "}
 (32,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -39372,17 +39797,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+gUK
 "}
 (33,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -39515,16 +39940,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+abn
+abn
+abn
 aaa
 "}
 (34,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
 aab
 aab
 aab
@@ -39657,16 +40082,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+abn
+abn
+abn
 aaa
 "}
 (35,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
 aab
 aab
 aab
@@ -39799,16 +40224,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+abn
+abn
+abn
 aaa
 "}
 (36,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
 aab
 aab
 aab
@@ -39896,11 +40321,11 @@ adt
 adt
 adt
 aab
-aab
-aab
-aab
-aab
-aab
+arj
+arj
+arj
+arj
+arj
 aab
 aab
 aab
@@ -39942,15 +40367,15 @@ aab
 aab
 aab
 aab
-aab
-aab
+abn
+abn
 aaa
 "}
 (37,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -40036,17 +40461,17 @@ adt
 adt
 adt
 adt
-adt
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+pKw
+uGs
+ark
+ark
+ark
+jZK
+fBe
+lTc
+acp
+acp
 bdS
 bel
 beH
@@ -40084,15 +40509,15 @@ aab
 aab
 aab
 aab
-aab
-aab
+abn
+abn
 aaa
 "}
 (38,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -40180,14 +40605,14 @@ adt
 adt
 adt
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+kZw
+brF
+ark
+ark
+ark
+ark
+ark
+cQJ
 aab
 bdS
 bem
@@ -40225,16 +40650,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+abn
+abn
+abn
 aaa
 "}
 (39,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -40323,13 +40748,13 @@ adt
 aab
 aab
 aab
-aab
-aab
+vOC
+ark
 ael
 ael
 ael
-aab
-aab
+ark
+hnm
 aab
 bdS
 ben
@@ -40367,15 +40792,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+gUK
 "}
 (40,1,1) = {"
-aaa
-aab
-aab
+gUK
+abn
+abn
 aab
 aab
 aab
@@ -40460,19 +40885,19 @@ aHE
 adt
 adt
 adt
-adt
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+acp
+acp
+acp
+acp
+pKw
+ark
 ael
 ael
 ael
-aab
-aab
-aab
+ark
+ark
+ark
 bdS
 beo
 beJ
@@ -40508,16 +40933,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+gUK
 "}
 (41,1,1) = {"
-aaa
-aab
-aab
+gUK
+abn
+abn
 aab
 aab
 aab
@@ -40607,13 +41032,13 @@ aab
 aab
 aab
 aab
-aab
-aab
+vOC
+ark
 ael
 ael
 ael
-aab
-aab
+ark
+rzz
 aab
 bdS
 bep
@@ -40650,16 +41075,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (42,1,1) = {"
-aaa
-aab
-aab
+gUK
+abn
+abn
 aab
 aab
 aab
@@ -40748,14 +41173,14 @@ adt
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+arj
+sKe
+ark
+ark
+ark
+ark
+ark
+cQJ
 aab
 bdS
 beq
@@ -40792,17 +41217,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (43,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -40886,19 +41311,19 @@ aHE
 adt
 adt
 adt
-adt
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+acp
+acp
+pKw
+uGs
+ark
+ark
+ark
+iMt
+eNv
+xCK
+acp
+acp
 bdS
 ber
 beK
@@ -40934,17 +41359,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (44,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -41032,11 +41457,11 @@ adt
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
+kZw
+kZw
+kZw
+kZw
+kZw
 aab
 aab
 aab
@@ -41076,17 +41501,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (45,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -41217,18 +41642,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (46,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -41359,18 +41784,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (47,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
 aab
 aab
 aab
@@ -41501,18 +41926,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (48,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
 aab
 aab
 aab
@@ -41644,17 +42069,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (49,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
 aab
 aab
 aab
@@ -41690,7 +42115,7 @@ atL
 aiQ
 aqF
 aqF
-ajV
+azs
 awY
 axR
 ayw
@@ -41786,17 +42211,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (50,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
 aab
 aab
 aab
@@ -41832,7 +42257,7 @@ atM
 auo
 avk
 aqF
-aww
+awY
 awY
 awY
 awY
@@ -41865,9 +42290,9 @@ aIP
 aOf
 aKb
 aKb
-aQy
-aQy
-aQy
+aHE
+aHE
+aHE
 aSu
 aQv
 aHE
@@ -41928,17 +42353,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (51,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -41974,7 +42399,7 @@ atN
 aqF
 aqF
 aqF
-aww
+awY
 awY
 awY
 awY
@@ -42071,16 +42496,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+dpF
+dpF
+gUK
 "}
 (52,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -42213,15 +42638,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (53,1,1) = {"
-aaa
-aab
-aab
+gUK
+dpF
+abn
 aab
 aab
 aab
@@ -42355,16 +42780,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (54,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -42497,16 +42922,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (55,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -42639,17 +43064,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (56,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
+abn
 aab
 aab
 aab
@@ -42781,17 +43206,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (57,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -42923,17 +43348,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (58,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+dpF
+abn
 aab
 aab
 aab
@@ -43065,17 +43490,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (59,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+dpF
+abn
 aab
 aab
 aab
@@ -43207,17 +43632,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (60,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+dpF
+abn
 aab
 aab
 aab
@@ -43349,17 +43774,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+gUK
 "}
 (61,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -43492,16 +43917,16 @@ aab
 aab
 aab
 aab
-aab
-aab
+rfi
+rqH
 aaa
 "}
 (62,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -43634,16 +44059,16 @@ aab
 aab
 aab
 aab
-aab
-aab
+oPK
+ehI
 aaa
 "}
 (63,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -43776,15 +44201,15 @@ aab
 aab
 aab
 aab
-aab
-aab
+uYv
+ehI
 aaa
 "}
 (64,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -43917,16 +44342,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+uYv
+ehI
+ehI
 aaa
 "}
 (65,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -44059,16 +44484,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+snt
+ehI
+ehI
 aaa
 "}
 (66,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+abn
+abn
+abn
 aab
 aab
 aab
@@ -44201,15 +44626,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+uYv
+aeG
+ehI
 aaa
 "}
 (67,1,1) = {"
 aaa
-aab
-aab
+ikR
+ikR
 aab
 aab
 aab
@@ -44343,15 +44768,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+idu
+ehI
+ehI
 aaa
 "}
 (68,1,1) = {"
 aaa
-aab
-aab
+aeG
+ehI
 aab
 aab
 aab
@@ -44485,15 +44910,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+oPK
+ehI
+aeG
 aaa
 "}
 (69,1,1) = {"
 aaa
-aab
-aab
+ehI
+ehI
 aab
 aab
 aab
@@ -44627,17 +45052,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+uYv
+aeG
+ehI
 aaa
 "}
 (70,1,1) = {"
 aaa
-aab
-aab
-aab
-aab
+ehI
+aeG
+rsG
+aaa
 aab
 aab
 aab
@@ -44769,17 +45194,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+uYv
+ehI
+ehI
 aaa
 "}
 (71,1,1) = {"
 aaa
-aab
-aab
-aab
-aab
+ehI
+ehI
+ehI
+rrr
 aab
 aab
 aab
@@ -44911,17 +45336,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+uYv
+ehI
+aeG
 aaa
 "}
 (72,1,1) = {"
 aaa
-aab
-aab
-aab
-aab
+aeG
+aeG
+ehI
+nlA
 aab
 aab
 aab
@@ -44970,8 +45395,8 @@ aCz
 ayW
 apb
 ape
-aFl
 aEc
+aFl
 aGz
 aGy
 aGy
@@ -45053,17 +45478,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+uYv
+ehI
+ehI
 aaa
 "}
 (73,1,1) = {"
 aaa
-aab
-aab
-aab
-aab
+ehI
+ehI
+ehI
+rrr
 aab
 aab
 aab
@@ -45112,8 +45537,8 @@ aCA
 ayW
 aEc
 aFh
-aFm
-aEc
+aIm
+aFl
 aGA
 aGw
 aGw
@@ -45195,17 +45620,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+idu
+aeG
+ehI
 aaa
 "}
 (74,1,1) = {"
 aaa
-aab
-aab
-aab
-aab
+ehI
+ehI
+aeG
+chh
 aab
 aab
 aab
@@ -45253,10 +45678,10 @@ aBO
 aCB
 ayW
 aGz
-aFh
-api
+anW
+apj
 apm
-aqg
+apj
 apj
 aqj
 apj
@@ -45337,17 +45762,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+uYv
+ehI
+ehI
 aaa
 "}
 (75,1,1) = {"
 aaa
-aab
-aab
-aab
-aab
+aeG
+ehI
+ehI
+cQJ
 aab
 aab
 aab
@@ -45396,9 +45821,9 @@ aCC
 ayW
 aEc
 apf
-apj
-apU
-aLH
+aEc
+aFl
+aEc
 aGw
 aGw
 avD
@@ -45479,17 +45904,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+snt
+ehI
+aeG
 aaa
 "}
 (76,1,1) = {"
 aaa
-aab
-aab
-aab
-aab
+aeG
+ehI
+ehI
+cQJ
 aab
 aab
 aab
@@ -45622,16 +46047,16 @@ aab
 aab
 aab
 aab
-aab
-aab
+abn
+abn
 aaa
 "}
 (77,1,1) = {"
 aaa
-aab
-aab
-aab
-aab
+ehI
+ehI
+aeG
+cQJ
 aab
 aab
 aab
@@ -45763,17 +46188,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+gUK
 "}
 (78,1,1) = {"
 aaa
-aab
-aab
-aab
-aab
+ehI
+ehI
+aeG
+cQJ
 aab
 aab
 aab
@@ -45905,17 +46330,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (79,1,1) = {"
 aaa
-aab
-aab
-aab
-aab
+aeG
+ehI
+ehI
+cQJ
 aab
 aab
 aab
@@ -46047,17 +46472,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (80,1,1) = {"
 aaa
-aab
-aab
-aab
-aab
+aeG
+ehI
+ehI
+cQJ
 aab
 aab
 aab
@@ -46188,18 +46613,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+gUK
 "}
 (81,1,1) = {"
 aaa
-aab
-aab
-aab
-aab
+ehI
+ehI
+aeG
+cQJ
 aab
 aab
 aab
@@ -46330,18 +46755,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (82,1,1) = {"
 aaa
-aab
-aab
-aab
-aab
+ehI
+aeG
+aeG
+cQJ
 aab
 aab
 aab
@@ -46372,10 +46797,10 @@ alD
 boR
 tpu
 bpG
-afs
-laD
-aac
-adt
+afr
+tpu
+ajE
+awD
 avD
 axp
 ayd
@@ -46472,18 +46897,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (83,1,1) = {"
 aaa
-aab
-aab
-aab
-aab
+ehI
+ehI
+ehI
+cQJ
 aab
 aab
 aab
@@ -46515,9 +46940,9 @@ boQ
 bpe
 bpH
 afr
-laD
-aac
-adt
+tpu
+ajE
+awD
 avD
 axq
 ayd
@@ -46614,18 +47039,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (84,1,1) = {"
 aaa
-aab
-aab
-aab
-aab
+ehI
+ehI
+aeG
+cQJ
 aab
 aab
 aab
@@ -46650,14 +47075,14 @@ ajP
 alN
 akM
 amH
-alD
+aqb
 asN
 alD
 anC
 anC
 boS
 nFT
-aac
+ajE
 avD
 avD
 avD
@@ -46756,18 +47181,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (85,1,1) = {"
 aaa
-aab
-aab
-aab
-aab
+aeG
+ehI
+ehI
+chh
 aab
 aab
 aab
@@ -46794,7 +47219,7 @@ akM
 aoI
 aiq
 boC
-boC
+sSc
 boI
 boI
 kRb
@@ -46872,6 +47297,10 @@ bgz
 bhk
 aLY
 adt
+bSn
+pdh
+vIP
+vIP
 adt
 adt
 adt
@@ -46880,10 +47309,6 @@ adt
 adt
 adt
 adt
-adt
-adt
-adt
-adt
 aab
 aab
 aab
@@ -46898,17 +47323,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+gUK
 "}
 (86,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+abn
+abn
+abn
 aab
 aab
 aab
@@ -46986,17 +47411,17 @@ awe
 aSd
 aWg
 aXb
-aXB
-aXB
-aXB
-aXB
-aXB
-aXB
-aXB
-aXB
-aXB
-aXB
-bbA
+aXC
+aXC
+aXC
+aXC
+aXC
+aXC
+aXC
+aXC
+aXC
+aXC
+bbL
 bbJ
 bbJ
 aVP
@@ -47014,18 +47439,18 @@ bgA
 bhl
 bfw
 adt
+vIP
+pTt
+oZh
+oZh
+edh
+nSc
 adt
 adt
 adt
 adt
 adt
 adt
-adt
-adt
-adt
-adt
-adt
-adt
 aab
 aab
 aab
@@ -47041,16 +47466,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (87,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -47129,43 +47554,43 @@ aSd
 aWh
 aXc
 aXK
-aXB
-aXB
-aXB
-aXB
-aXB
-aXB
-aXB
-aXB
-aXB
+bbJ
+bbJ
+bbJ
+bbJ
+bbJ
+bbJ
+bbJ
+bbJ
+bbJ
 bbB
 bbJ
 bbJ
 aVP
-adt
-adt
+laD
+laD
 aLY
 bdr
 aLX
 aLY
-adt
-adt
+laD
+laD
 bfw
 bfU
 bgB
 bhm
 bfw
 adt
+vIP
+qLQ
+oZh
+iyz
+oZh
+oZh
+oZh
 adt
 adt
 adt
-adt
-adt
-adt
-adt
-adt
-adt
-adt
 aab
 aab
 aab
@@ -47183,16 +47608,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (88,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -47284,14 +47709,14 @@ aVP
 aVP
 aVP
 aVP
-adt
-adt
+laD
+laD
 aLY
 bdr
 aLX
 aLY
-adt
-adt
+laD
+laD
 bfw
 bfV
 aKX
@@ -47299,15 +47724,15 @@ bhn
 bfw
 adt
 adt
+pWo
+vIP
+vIP
+adt
+adt
+oZh
 adt
 adt
 adt
-adt
-adt
-adt
-adt
-adt
-adt
 aab
 aab
 aab
@@ -47325,17 +47750,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (89,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -47368,8 +47793,8 @@ ajE
 amS
 amU
 ajE
-aac
-aac
+ajE
+ajE
 avD
 mnt
 aye
@@ -47426,14 +47851,14 @@ aFX
 bbM
 bcg
 aLY
-adt
-adt
+laD
+laD
 aLY
 bds
 aLX
 aLY
-adt
-adt
+laD
+laD
 bfw
 bfW
 bgD
@@ -47446,10 +47871,10 @@ adt
 adt
 adt
 adt
+oZh
 adt
 adt
 adt
-adt
 aab
 aab
 aab
@@ -47467,17 +47892,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (90,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -47510,8 +47935,8 @@ tpu
 kPb
 tpu
 awH
-aac
-adt
+ajE
+awD
 avD
 axw
 ayd
@@ -47568,8 +47993,8 @@ bbM
 aZr
 aZr
 aLY
-adt
-adt
+laD
+laD
 aLY
 bdt
 aLX
@@ -47588,11 +48013,11 @@ biv
 biv
 biv
 adt
+oZh
+oZh
 adt
 adt
 adt
-adt
-adt
 aab
 aab
 aab
@@ -47609,17 +48034,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (91,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -47685,9 +48110,9 @@ aME
 aNl
 awd
 avD
-adt
-adt
-adt
+dNl
+dNl
+dNl
 aRy
 aTZ
 atB
@@ -47710,8 +48135,8 @@ aZr
 aGx
 aHF
 aLY
-adt
-adt
+laD
+laD
 aLY
 bdu
 bdP
@@ -47731,9 +48156,9 @@ bkc
 biv
 adt
 adt
+oZh
 adt
 adt
-adt
 aab
 aab
 aab
@@ -47751,17 +48176,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (92,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -47798,8 +48223,8 @@ anD
 anO
 avD
 axy
-ayf
-ayM
+ayd
+ayI
 aze
 azL
 aAn
@@ -47827,9 +48252,9 @@ aMF
 avD
 avD
 avD
-adt
-adt
-adt
+dNl
+dNl
+dNl
 aRy
 aRy
 aRy
@@ -47852,8 +48277,8 @@ aZr
 aLY
 aLY
 aLY
-adt
-adt
+laD
+laD
 aLY
 bdv
 aLX
@@ -47873,9 +48298,9 @@ bkd
 biv
 adt
 adt
+oZh
 adt
 adt
-adt
 aab
 aab
 aab
@@ -47893,17 +48318,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (93,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
+abn
 aab
 aab
 aab
@@ -47922,7 +48347,7 @@ aeo
 afc
 abz
 aaR
-aam
+ahI
 aiy
 ajF
 aky
@@ -47940,8 +48365,8 @@ anD
 anD
 avD
 axz
-ahH
-ahO
+ayd
+ayI
 aze
 azM
 aAo
@@ -47969,14 +48394,14 @@ aMt
 avD
 aNS
 aNo
-adt
-adt
-adt
-adt
-adt
-adt
-adt
-adt
+dNl
+dNl
+dNl
+dNl
+dNl
+dNl
+dNl
+dNl
 aNo
 aWm
 aWm
@@ -47994,8 +48419,8 @@ aZr
 aGB
 bci
 aLY
-adt
-adt
+laD
+laD
 aLY
 bdw
 aLX
@@ -48015,11 +48440,11 @@ bke
 biv
 adt
 adt
+oZh
+oZh
 adt
 adt
 adt
-adt
-adt
 aab
 aab
 aab
@@ -48035,16 +48460,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+gUK
 "}
 (94,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -48082,8 +48507,8 @@ anL
 anD
 avD
 axA
-ahI
-ahP
+ayd
+ayI
 aze
 azN
 aAp
@@ -48136,8 +48561,8 @@ aZr
 aZr
 aZr
 aLY
-adt
-adt
+laD
+laD
 aLY
 bdx
 aLX
@@ -48158,10 +48583,10 @@ biv
 adt
 adt
 adt
+oZh
+oZh
 adt
 adt
-adt
-adt
 aab
 aab
 aab
@@ -48176,17 +48601,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+gUK
 "}
 (95,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -48224,7 +48649,7 @@ avF
 anP
 avD
 axB
-ayh
+ayd
 ayI
 aze
 azO
@@ -48259,7 +48684,7 @@ aQX
 aRz
 aSl
 aTa
-aUa
+aUK
 aUK
 aVt
 aWn
@@ -48278,8 +48703,8 @@ bbM
 aGC
 aZr
 aLY
-adt
-adt
+laD
+laD
 aLY
 bdy
 aLY
@@ -48301,9 +48726,9 @@ bgT
 bgT
 bgT
 bgT
+oZh
 adt
 adt
-adt
 aab
 aab
 aab
@@ -48318,17 +48743,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (96,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+abn
+abn
+abn
 aab
 aab
 aab
@@ -48367,7 +48792,7 @@ anS
 avD
 axC
 ayi
-ayI
+ahO
 aze
 azP
 aAr
@@ -48402,9 +48827,9 @@ aRA
 aSm
 aTb
 aUb
-aNV
-aNn
-aNV
+api
+apU
+api
 aXh
 aXN
 aYy
@@ -48425,8 +48850,8 @@ aLY
 aLY
 bdy
 aLY
-adt
-adt
+laD
+laD
 bfc
 bfz
 bgc
@@ -48443,10 +48868,10 @@ bkN
 biy
 biD
 bgT
+oZh
 adt
 adt
 adt
-adt
 aab
 aab
 aab
@@ -48459,17 +48884,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (97,1,1) = {"
-aaa
-aab
-aab
+gUK
+abn
+abn
 aab
 aab
 aab
@@ -48567,8 +48992,8 @@ bcK
 bda
 bdz
 aLY
-adt
-adt
+laD
+laD
 bfc
 bfA
 bgc
@@ -48584,9 +49009,9 @@ bkz
 biH
 bkY
 blB
-bgT
+kOp
+oZh
 adt
-adt
 aab
 aab
 aab
@@ -48601,17 +49026,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (98,1,1) = {"
-aaa
-aab
-aab
+gUK
+abn
+abn
 aab
 aab
 aab
@@ -48655,7 +49080,7 @@ ayN
 azf
 azQ
 aAs
-aAs
+ahP
 aBu
 aBY
 aBY
@@ -48677,12 +49102,12 @@ aLk
 aLR
 aMt
 avD
-adt
-adt
-adt
-adt
-adt
-adt
+laD
+laD
+laD
+laD
+laD
+laD
 aLY
 aTd
 aUc
@@ -48709,8 +49134,8 @@ aIl
 bdb
 bdA
 aLY
-adt
-adt
+laD
+laD
 bfc
 aJY
 bgd
@@ -48727,8 +49152,8 @@ biH
 bkZ
 biy
 bgT
+oZh
 adt
-adt
 aab
 aab
 aab
@@ -48743,17 +49168,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (99,1,1) = {"
-aaa
-aab
-aab
+gUK
+dpF
+abn
 aab
 aab
 aab
@@ -48795,9 +49220,9 @@ axF
 ayc
 ayd
 azg
-ayh
 ayd
 ayd
+aAQ
 ayd
 ayd
 ayd
@@ -48821,10 +49246,10 @@ aMG
 avD
 asm
 asx
-adt
-adt
-adt
-adt
+laD
+laD
+laD
+laD
 aLY
 aTe
 aUc
@@ -48851,7 +49276,7 @@ bcM
 bdb
 aIo
 aLY
-adt
+laD
 beF
 beF
 beF
@@ -48869,8 +49294,8 @@ biH
 bla
 blC
 bgT
+oZh
 adt
-adt
 aab
 aab
 aab
@@ -48885,18 +49310,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (100,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -48964,9 +49389,9 @@ avD
 asn
 asO
 asU
-adt
-adt
-adt
+laD
+laD
+laD
 aLY
 aTf
 aUc
@@ -48977,7 +49402,7 @@ aXj
 aXR
 aYB
 aUc
-adt
+laD
 aLY
 bak
 aLX
@@ -48993,7 +49418,7 @@ bcM
 bdb
 aIo
 aLY
-adt
+laD
 beF
 bfd
 bfC
@@ -49011,10 +49436,10 @@ bjc
 blb
 biy
 bgT
+oZh
 adt
 adt
 adt
-adt
 aab
 aab
 aab
@@ -49027,18 +49452,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (101,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -49108,7 +49533,7 @@ aLY
 aLY
 aLY
 aLY
-adt
+laD
 aLY
 aTg
 aUc
@@ -49119,23 +49544,23 @@ aXk
 aXS
 aYC
 aUc
-adt
+laD
 aLY
 bal
 aLX
 aEh
 aLY
-adt
-adt
-adt
-adt
+laD
+laD
+laD
+laD
 aLY
 aLX
 bcM
 bdb
 aIq
 aLY
-adt
+laD
 beF
 bfe
 bfD
@@ -49153,10 +49578,10 @@ biH
 biH
 biy
 bgT
+oZh
+oZh
 adt
 adt
-adt
-adt
 aab
 aab
 aab
@@ -49169,18 +49594,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (102,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
 aab
 aab
 aab
@@ -49213,11 +49638,11 @@ bpd
 bpD
 bpJ
 akq
-auX
-asV
-atY
-anW
-axH
+auY
+avJ
+ard
+aoc
+aym
 aym
 aym
 avD
@@ -49261,23 +49686,23 @@ aUc
 aUc
 aUc
 aUc
-adt
+laD
 aLY
 bam
 aLX
 baK
 aLY
-adt
-adt
-adt
-adt
+laD
+laD
+laD
+laD
 aLY
 aLX
 bcN
 bdd
 bdD
 aLY
-adt
+laD
 beF
 bff
 bfE
@@ -49295,9 +49720,9 @@ biy
 blc
 blD
 bgT
+oZh
+ael
 adt
-adt
-adt
 aab
 aab
 aab
@@ -49311,18 +49736,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (103,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
 aab
 aab
 aab
@@ -49355,10 +49780,10 @@ aiK
 aiK
 aiK
 aiK
-auX
-asV
-atY
-anW
+auY
+avJ
+ard
+aoc
 axI
 aym
 aym
@@ -49400,10 +49825,10 @@ aUQ
 aVy
 aWt
 aUc
-adt
-adt
-adt
-adt
+laD
+laD
+laD
+laD
 aLY
 ban
 aLX
@@ -49411,7 +49836,7 @@ baK
 aLY
 aLY
 aLY
-adt
+laD
 aLY
 aLY
 aLY
@@ -49419,7 +49844,7 @@ aLY
 aZr
 bdy
 aLY
-adt
+laD
 beF
 bfg
 bfF
@@ -49437,9 +49862,9 @@ biH
 biH
 biy
 bgT
+oZh
 adt
 adt
-adt
 aab
 aab
 aab
@@ -49453,18 +49878,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (104,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+dpF
+abn
 aab
 aab
 aab
@@ -49497,11 +49922,11 @@ akV
 alM
 alU
 aiK
-auX
-asV
-atY
-anW
-anW
+auY
+avJ
+ard
+aoc
+aoc
 aoc
 aym
 aym
@@ -49561,7 +49986,7 @@ baY
 aZr
 bdy
 aLY
-adt
+laD
 beF
 bfh
 bfG
@@ -49579,8 +50004,8 @@ bjc
 bld
 biy
 bgT
+oZh
 adt
-adt
 aab
 aab
 aab
@@ -49596,17 +50021,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+gUK
 "}
 (105,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -49703,7 +50128,7 @@ aLY
 aZr
 bdy
 aLY
-adt
+laD
 beF
 bfi
 bfH
@@ -49721,8 +50146,8 @@ biH
 ble
 blE
 bgT
+oZh
 adt
-adt
 aab
 aab
 aab
@@ -49738,17 +50163,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+gUK
 "}
 (106,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+dpF
+abn
+abn
 aab
 aab
 aab
@@ -49799,7 +50224,7 @@ aDL
 aEq
 ard
 aFC
-aDP
+aHA
 aqh
 lOO
 aDP
@@ -49845,7 +50270,7 @@ aSo
 bde
 bdE
 aLY
-adt
+laD
 beF
 beF
 beF
@@ -49863,8 +50288,8 @@ biH
 blf
 biy
 bgT
+oZh
 adt
-adt
 aab
 aab
 aab
@@ -49880,16 +50305,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+gUK
 "}
 (107,1,1) = {"
-aaa
-aab
-aab
+gUK
+abn
+abn
 aab
 aab
 aab
@@ -49987,11 +50412,11 @@ aLY
 bdf
 aLY
 aLY
-adt
-adt
-adt
-adt
-adt
+bdQ
+bdQ
+bdQ
+bdQ
+bdQ
 bgT
 bhC
 big
@@ -50004,9 +50429,9 @@ bkD
 biH
 blg
 blB
-bgT
-adt
-adt
+kOp
+oZh
+abn
 aab
 aab
 aab
@@ -50022,16 +50447,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+gUK
 "}
 (108,1,1) = {"
-aaa
-aab
-aab
+gUK
+abn
+abn
 aab
 aab
 aab
@@ -50124,7 +50549,7 @@ baO
 bax
 bax
 bax
-adt
+bdQ
 bax
 bdg
 baO
@@ -50147,8 +50572,8 @@ biy
 biy
 biD
 bgT
-adt
-adt
+oZh
+abn
 aab
 aab
 aab
@@ -50163,17 +50588,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (109,1,1) = {"
 aaa
-aab
-aab
+abn
+abn
 aab
 aab
 aab
@@ -50220,18 +50645,18 @@ avL
 avL
 aoX
 apa
-aDO
-aDO
-aDO
-aDO
-aFF
+aGR
+aGR
+aGR
+aGR
+aGR
 aGr
 aGR
 aGR
 aGR
-aHX
+aGR
 aIC
-aJb
+aIb
 aIb
 aJV
 aKG
@@ -50276,8 +50701,8 @@ beg
 beg
 bdQ
 bdQ
-adt
-adt
+bdQ
+bdQ
 bgT
 bgT
 bgT
@@ -50305,17 +50730,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (110,1,1) = {"
 aaa
-aab
-aab
+abn
+abn
 aab
 aab
 aab
@@ -50369,14 +50794,14 @@ ard
 boD
 aDP
 aGR
+aHl
+aHB
 aGR
+aIG
 aGR
-aHY
-aID
-aJc
+aHl
+aHB
 aGR
-aHY
-aKH
 aDP
 aLY
 aLY
@@ -50418,12 +50843,12 @@ beg
 beg
 beg
 bdQ
-adt
-adt
-adt
-adt
-adt
-adt
+bdQ
+bdQ
+aqg
+aqg
+aqg
+aqg
 bgU
 mDn
 ekH
@@ -50447,17 +50872,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (111,1,1) = {"
 aaa
-aab
-aab
+abn
+abn
 aab
 aab
 aab
@@ -50512,20 +50937,20 @@ aFH
 aDP
 aGS
 aGT
-aGT
-aHZ
-aIE
+aIH
 aJc
+aIG
+aJc
+aGT
+aIH
 aGR
-aHZ
-aKI
 aLq
 aLZ
 aDP
-adt
-adt
-adt
-adt
+laD
+laD
+laD
+laD
 aLY
 aRd
 aRd
@@ -50589,18 +51014,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (112,1,1) = {"
 aaa
-aab
-aab
-aab
+abn
+abn
+abn
 aab
 aab
 aab
@@ -50617,7 +51042,7 @@ aab
 ado
 aav
 aeD
-afp
+afs
 afp
 afp
 aaP
@@ -50652,9 +51077,9 @@ ard
 aEY
 mUP
 aDP
-aGT
+aGR
 aHj
-aHA
+aIa
 aIa
 aIF
 aGR
@@ -50664,7 +51089,7 @@ aGR
 aDP
 aMa
 aDP
-adt
+laD
 aLY
 aLY
 aLY
@@ -50716,6 +51141,7 @@ bli
 blG
 blG
 bmb
+abn
 aab
 aab
 aab
@@ -50730,19 +51156,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (113,1,1) = {"
-aaa
-aab
-aab
-aab
+gUK
+abn
+abn
+abn
 aab
 aab
 aab
@@ -50795,18 +51220,18 @@ aEZ
 llG
 aDP
 aGU
-aHk
-aGT
-aGT
+aJc
+aJc
+aJc
 aIG
-aGT
-aGT
-aGT
+aJc
+aJc
+aJc
 aGR
 aLr
 aMb
 aDP
-adt
+laD
 aLY
 aOP
 aPz
@@ -50858,6 +51283,7 @@ blj
 blH
 blS
 bmb
+abn
 aab
 aab
 aab
@@ -50871,21 +51297,20 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+dpF
+dpF
+gUK
 "}
 (114,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+adt
+abn
+abn
+abn
 aab
 aab
 aab
@@ -50901,7 +51326,7 @@ aab
 ado
 aak
 aaA
-aaA
+ahH
 aaD
 ahK
 ait
@@ -50936,19 +51361,19 @@ aEs
 aFa
 aFI
 aDP
-aGT
+aGR
 aHl
 aHB
-aIb
-aIH
 aGR
+aIG
 aGR
-aGR
+aHl
+aHB
 aGR
 aDP
 aDP
 aDP
-adt
+laD
 aLY
 aOP
 aPC
@@ -51000,6 +51425,7 @@ blk
 blG
 blT
 bmb
+abn
 aab
 aab
 aab
@@ -51012,22 +51438,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+gUK
 "}
 (115,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+abn
+abn
 aab
 aab
 aab
@@ -51080,13 +51505,13 @@ ard
 aDP
 aGS
 aGT
-aGT
-aHY
-aID
+aIH
 aJc
+aIG
+aJc
+aGT
+aIH
 aGR
-aHY
-aKH
 aDP
 adt
 adt
@@ -51116,14 +51541,14 @@ adt
 adt
 adt
 adt
-adt
-adt
-adt
 abn
 abn
 abn
-adt
-adt
+abn
+abn
+abn
+abn
+abn
 abn
 aab
 abn
@@ -51142,6 +51567,7 @@ blh
 blI
 blh
 blh
+abn
 aab
 aab
 aab
@@ -51153,24 +51579,23 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (116,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+adt
+abn
+abn
 aab
 aab
 aab
@@ -51221,14 +51646,14 @@ aFb
 aFJ
 aBz
 aGR
-aGR
-aGR
-aHZ
+aHX
+aIb
+aKH
 aIE
-aJc
+aID
 aGR
-aHZ
-aKI
+aGR
+aGR
 aDP
 aMc
 aMc
@@ -51245,20 +51670,20 @@ adt
 adt
 adt
 adt
+abn
+abn
+abn
+abn
+adt
+adt
+adt
+adt
 adt
 abn
 abn
 abn
 adt
-adt
-adt
-adt
-adt
-adt
-adt
-adt
-adt
-adt
+abn
 aab
 aab
 aab
@@ -51283,6 +51708,8 @@ bgU
 abn
 abn
 abn
+abn
+abn
 aab
 aab
 aab
@@ -51293,26 +51720,24 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (117,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+aeG
+ehI
 aab
 aab
 aab
@@ -51364,11 +51789,11 @@ aFK
 aGt
 aGV
 aGV
-aGV
+aJb
 aIc
 aII
 aJd
-aIa
+yiF
 aJW
 aGR
 aDP
@@ -51386,7 +51811,7 @@ aLY
 adt
 adt
 adt
-adt
+abn
 abn
 abn
 abn
@@ -51398,9 +51823,9 @@ abn
 abn
 abn
 aab
-adt
-adt
-adt
+abn
+abn
+abn
 aab
 aab
 aab
@@ -51437,24 +51862,24 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (118,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+ehI
+ehI
 aab
 aab
 aab
@@ -51505,13 +51930,13 @@ aFd
 aFL
 aBz
 aGW
-aGR
+aID
 aHC
-aGR
-aGR
-aGR
+aID
+aKI
+aID
 aHC
-aGR
+aID
 aKJ
 aDP
 abn
@@ -51528,11 +51953,11 @@ aLY
 adt
 adt
 adt
-adt
-adt
-abn
-abn
-abn
+aeG
+aeG
+aab
+aab
+aab
 aab
 aab
 abn
@@ -51579,25 +52004,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+abn
+abn
+abn
+abn
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (119,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+ehI
+ehI
+sue
 aab
 aab
 aab
@@ -51670,10 +52095,8 @@ abn
 abn
 abn
 abn
-abn
-abn
-abn
-abn
+aeG
+aeG
 aab
 aab
 aab
@@ -51695,11 +52118,8 @@ aab
 aab
 aab
 aab
-abn
-abn
-abn
-abn
-abn
+aab
+aab
 abn
 abn
 abn
@@ -51707,6 +52127,11 @@ abn
 abn
 abn
 abn
+abn
+abn
+abn
+abn
+abn
 aab
 aab
 aab
@@ -51721,25 +52146,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+oPK
+arl
+aeG
+aac
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (120,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+aeG
+ehI
+nlA
 aab
 aab
 aab
@@ -51812,38 +52237,38 @@ abn
 abn
 abn
 abn
+aeG
+aeG
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
 abn
 abn
 abn
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-abn
-abn
-abn
 abn
 aab
 aab
@@ -51863,25 +52288,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+oPK
+ehI
+arl
+aac
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (121,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+ehI
+ehI
+nlA
 aab
 aab
 aab
@@ -51954,8 +52379,8 @@ abn
 abn
 abn
 abn
-abn
-abn
+aeG
+aeG
 aab
 aab
 aab
@@ -52005,25 +52430,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+uYv
+nwI
+ehI
+aac
+dpF
+dpF
+dpF
+uiV
+dpF
+gUK
 "}
 (122,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+ehI
+ehI
+rrr
 aab
 aab
 aab
@@ -52086,7 +52511,6 @@ abn
 abn
 aac
 aac
-abn
 abn
 abn
 abn
@@ -52098,6 +52522,28 @@ abn
 abn
 abn
 aeG
+aeG
+aab
+aab
+aab
+aab
+hRU
+bSE
+bSE
+bSE
+bSE
+bSE
+bSE
+buW
+buW
+buW
+bSE
+buW
+bSE
+bSE
+bSE
+bSE
+iFX
 aab
 aab
 aab
@@ -52126,46 +52572,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+uYv
+nwI
+nwI
+aac
+dpF
+dpF
+oZh
+oZh
+dpF
+gUK
 "}
 (123,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+aeG
+ehI
+rrr
 aab
 aab
 aab
@@ -52228,7 +52653,6 @@ abn
 abn
 aac
 aac
-abn
 abn
 abn
 abn
@@ -52240,6 +52664,28 @@ abn
 abn
 aeG
 aeG
+aeG
+aab
+aab
+aab
+aab
+jLj
+mpW
+elS
+elS
+elS
+mpW
+mpW
+mpW
+elS
+elS
+elS
+mpW
+mpW
+mpW
+mpW
+mpW
+whG
 aab
 aab
 aab
@@ -52268,46 +52714,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+oPK
+ehI
+arl
+aac
+dpF
+kjM
+oZh
+oZh
+dpF
+gUK
 "}
 (124,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+ehI
+ehI
+nlA
 aab
 aab
 aab
@@ -52386,6 +52811,23 @@ aab
 aab
 aab
 aab
+ccf
+mpW
+mpW
+elS
+elS
+mpW
+mpW
+mpW
+elS
+elS
+elS
+elS
+mpW
+mpW
+mpW
+lWO
+uzX
 aab
 aab
 aab
@@ -52414,42 +52856,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+oPK
+ehI
+aeG
+aac
+dpF
+oZh
+oZh
+dpF
+dpF
+gUK
 "}
 (125,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+aeG
+ehI
+rrr
 aab
 aab
 aab
@@ -52520,10 +52945,31 @@ abn
 abn
 abn
 abn
-abn
 aeG
 aeG
 aeG
+aeG
+aab
+aab
+aab
+aab
+ccf
+mpW
+elS
+elS
+elS
+mpW
+mpW
+elS
+mpW
+mpW
+elS
+elS
+elS
+mpW
+mpW
+mpW
+uzX
 aab
 aab
 aab
@@ -52552,46 +52998,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+uYv
+ehI
+nwI
+aac
+oZh
+oZh
+oZh
+dpF
+dpF
+gUK
 "}
 (126,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+aeG
+ehI
+rrr
 aab
 aab
 aab
@@ -52662,10 +53087,31 @@ abn
 abn
 abn
 abn
-abn
 aeG
 aeG
 aeG
+aeG
+aab
+aab
+aab
+aab
+jLj
+mpW
+elS
+elS
+mpW
+elS
+mpW
+mpW
+mpW
+mpW
+elS
+mpW
+elS
+elS
+fyr
+gdk
+vXH
 aab
 aab
 aab
@@ -52694,46 +53140,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+uYv
+nwI
+nwI
+aac
+kjM
+oZh
+dpF
+dpF
+dpF
+gUK
 "}
 (127,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+ehI
+ehI
+nlA
 aab
 aab
 aab
@@ -52803,11 +53228,30 @@ abn
 aeG
 abn
 abn
-abn
 aeG
 aeG
 aeG
 aeG
+aeG
+aab
+aab
+aab
+aab
+jLj
+mpW
+elS
+elS
+mpW
+mpW
+elS
+elS
+elS
+mpW
+elS
+elS
+elS
+elS
+whG
 aab
 aab
 aab
@@ -52838,44 +53282,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+oPK
+ehI
+aeG
+aac
+oZh
+oZh
+kjM
+dpF
+dpF
+gUK
 "}
 (128,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+ehI
+ehI
+rrr
 aab
 aab
 aab
@@ -52954,6 +53379,21 @@ aab
 aab
 aab
 aab
+jLj
+mpW
+elS
+elS
+mpW
+elS
+elS
+rEz
+elS
+elS
+mpW
+elS
+elS
+mpW
+whG
 aab
 aab
 aab
@@ -52984,40 +53424,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+oPK
+nwI
+nwI
+aac
+arl
+oZh
+aac
+dpF
+dpF
+gUK
 "}
 (129,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+ehI
+aeG
+rrr
 aab
 aab
 aab
@@ -53096,6 +53521,21 @@ aab
 aab
 aab
 aab
+jLj
+mpW
+mpW
+elS
+elS
+mpW
+elS
+elS
+elS
+elS
+elS
+mpW
+mpW
+mpW
+whG
 aab
 aab
 aab
@@ -53126,40 +53566,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+uYv
+nwI
+ehI
+aac
+arl
+arl
+aac
+dpF
+dpF
+gUK
 "}
 (130,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+ehI
+ehI
+rrr
 aab
 aab
 aab
@@ -53238,6 +53663,21 @@ aab
 aab
 aab
 aab
+iNK
+gdk
+gdk
+gdk
+mrH
+mrH
+mrH
+mrH
+mrH
+mrH
+mrH
+mrH
+fvp
+mrH
+vXH
 aab
 aab
 aab
@@ -53268,40 +53708,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+uYv
+nwI
+aeG
+aac
+arl
+arl
+aac
+dpF
+dpF
+gUK
 "}
 (131,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+ehI
+ehI
+nlA
 aab
 aab
 aab
@@ -53425,25 +53850,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+uYv
+ehI
+nwI
+aac
+arl
+arl
+aac
+dpF
+dpF
+gUK
 "}
 (132,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+ehI
+ehI
+rrr
 aab
 aab
 aab
@@ -53567,25 +53992,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+uYv
+nwI
+nwI
+aac
+arl
+arl
+aac
+dpF
+dpF
+gUK
 "}
 (133,1,1) = {"
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
+gUK
+adt
+adt
+aac
+ehI
+ehI
+vGp
 aab
 aab
 aab
@@ -53709,19 +54134,24 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+gLR
+ehI
+arl
+xQs
+arl
+arl
+aac
+dpF
+dpF
+gUK
 "}
 (134,1,1) = {"
-aaa
+gUK
+adt
+adt
+aac
+ehI
+ehI
 aab
 aab
 aab
@@ -53847,23 +54277,23 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+nwI
+aeG
+aac
+aac
+aac
+aac
+dpF
+dpF
+gUK
 "}
 (135,1,1) = {"
-aaa
+gUK
+adt
+adt
+aac
+ehI
+aeG
 aab
 aab
 aab
@@ -53989,23 +54419,23 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+ehI
+arl
+aac
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (136,1,1) = {"
-aaa
+gUK
+adt
+adt
+adt
+abn
+abn
 aab
 aab
 aab
@@ -54129,25 +54559,27 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+bpR
+rsG
+ehI
+aeG
+aac
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (137,1,1) = {"
-aaa
+gUK
+adt
+adt
+adt
+adt
+abn
+abn
+abn
 aab
 aab
 aab
@@ -54269,27 +54701,28 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (138,1,1) = {"
-aaa
+gUK
+adt
+adt
+adt
+adt
+adt
+abn
+abn
+abn
 aab
 aab
 aab
@@ -54409,29 +54842,30 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (139,1,1) = {"
-aaa
+gUK
+adt
+adt
+adt
+adt
+adt
+adt
+abn
+abn
+abn
 aab
 aab
 aab
@@ -54550,29 +54984,28 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+dpF
+gUK
 "}
 (140,1,1) = {"
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
 aaa
 aaa
 aaa
@@ -54692,25 +55125,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
+gUK
 "}

--- a/_maps/map_files/tether/tether-03-surface3.dmm
+++ b/_maps/map_files/tether/tether-03-surface3.dmm
@@ -389,10 +389,10 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/breakroom)
 "aaH" = (
-/obj/structure/catwalk,
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/outside/outside3)
+/obj/structure/table/bench/wooden,
+/obj/effect/mist,
+/turf/simulated/floor/wood,
+/area/crew_quarters/recreation_area_restroom)
 "aaI" = (
 /obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
 /obj/machinery/atmospherics/portables_connector,
@@ -3998,8 +3998,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/grass,
 /area/hydroponics)
@@ -7238,8 +7237,8 @@
 /turf/simulated/wall,
 /area/tether/surfacebase/north_stairs_three)
 "ald" = (
-/obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/north_stairs_three)
 "ale" = (
@@ -10289,6 +10288,7 @@
 /area/rnd/xenobiology/xenoflora)
 "aqV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "aqW" = (
@@ -10794,6 +10794,7 @@
 "arR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/light,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "arS" = (
@@ -11029,7 +11030,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/grass,
 /area/hydroponics)
@@ -11039,9 +11041,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/grass,
 /area/hydroponics)
@@ -11112,19 +11114,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"asx" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/super;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/grass,
-/area/hydroponics/cafegarden)
 "asy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11305,9 +11294,6 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "asN" = (
-/obj/machinery/alarm{
-	pixel_y = 25
-	},
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
 /area/hydroponics/cafegarden)
@@ -11411,9 +11397,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
 /obj/structure/table/woodentable,
 /turf/simulated/floor/grass,
 /area/hydroponics)
@@ -11489,11 +11472,7 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "ath" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/vending/hydronutrients{
-	dir = 8
-	},
+/obj/structure/flora/ausbushes/genericbush,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "ati" = (
@@ -11510,15 +11489,8 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "atk" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/biogenerator,
 /turf/simulated/floor/grass,
 /area/hydroponics)
@@ -11538,10 +11510,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "atn" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_x = 30
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/smartfridge/drying_rack{
@@ -11651,11 +11619,6 @@
 "aty" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass,
 /area/hydroponics/cafegarden)
@@ -12351,6 +12314,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "auV" = (
@@ -12466,9 +12432,6 @@
 	desc = "Damn, looks like it's on the clown world channel. I wonder what else is on?";
 	icon_state = "frame";
 	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
 	},
 /obj/structure/table/woodentable,
 /turf/simulated/floor/grass,
@@ -12602,6 +12565,7 @@
 "avr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "avs" = (
@@ -13444,6 +13408,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/machinery/light,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "awR" = (
@@ -13811,6 +13776,10 @@
 /area/tether/surfacebase/bar_backroom)
 "axv" = (
 /mob/living/simple_mob/animal/passive/cow,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor/grass,
 /area/hydroponics/cafegarden)
 "axw" = (
@@ -14208,12 +14177,8 @@
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "aya" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
-"ayb" = (
-/obj/structure/bed/chair/comfy/beige,
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/obj/structure/flora/pottedplant/tall,
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/barbackmaintenance)
 "ayc" = (
 /obj/structure/cable/green{
@@ -14225,7 +14190,8 @@
 	pixel_x = -25;
 	range = 15
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/obj/structure/flora/pottedplant/flower,
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/barbackmaintenance)
 "ayd" = (
 /obj/machinery/power/apc{
@@ -14237,7 +14203,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/barbackmaintenance)
 "aye" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14445,8 +14411,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
@@ -14506,14 +14471,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/tether/surfacebase/barbackmaintenance)
-"ayE" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "ayF" = (
-/obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14526,7 +14486,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/machinery/door/airlock{
+	desc = "It opens and closes.";
+	name = "Game Room"
+	},
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/barbackmaintenance)
 "ayG" = (
 /obj/structure/bed/chair/comfy/black{
@@ -14834,7 +14798,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "azf" = (
@@ -15201,7 +15164,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "azK" = (
@@ -15514,15 +15476,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/rnd/outpost/xenobiology/outpost_office)
-"aAl" = (
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/structure/table/rack/steel,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
 "aAm" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -16312,16 +16265,13 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "aBE" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/eris/cafe,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "aBF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -16523,7 +16473,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "aBY" = (
@@ -16655,18 +16604,9 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/botanystorage)
 "aCh" = (
-/obj/machinery/door/airlock{
-	name = "Service";
-	req_one_access = list(35,28)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/servicebackroom)
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "aCi" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 10
@@ -16712,7 +16652,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/barbackmaintenance)
 "aCo" = (
 /obj/structure/grille,
@@ -17455,6 +17395,10 @@
 /area/tether/surfacebase/public_garden_three)
 "aDI" = (
 /obj/machinery/camera/network/civilian,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 5;
+	pixel_y = 28
+	},
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "aDJ" = (
@@ -18450,12 +18394,6 @@
 /obj/item/storage/belt/utility/full,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/shuttle_pad)
-"aFy" = (
-/obj/structure/bed/chair/comfy/beige{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/tether/surfacebase/barbackmaintenance)
 "aFz" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18469,7 +18407,7 @@
 /obj/structure/bed/chair/comfy/beige{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_light,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "aFB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18634,10 +18572,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/testingrange)
 "aFO" = (
-/obj/machinery/door/airlock{
-	name = "Service";
-	req_one_access = list(35,28)
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -18647,15 +18581,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/servicebackroom)
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "aFP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18663,8 +18593,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/servicebackroom)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "aFQ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18832,11 +18763,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/machinery/requests_console{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/servicebackroom)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "aGe" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/borderfloor{
@@ -18877,12 +18806,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/camera/network/civilian,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/servicebackroom)
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "aGh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/freezer{
@@ -19022,6 +18951,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "aGr" = (
@@ -19057,9 +18991,9 @@
 /area/rnd/outpost/xenobiology/outpost_south_airlock)
 "aGt" = (
 /obj/structure/cable/green{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass,
 /area/hydroponics/cafegarden)
@@ -19224,29 +19158,35 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aGG" = (
-/obj/machinery/vending/cigarette,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 5;
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "aGH" = (
 /obj/structure/table/woodentable,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "aGI" = (
-/obj/machinery/vending/cola,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
@@ -19621,8 +19561,8 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/servicebackroom)
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "aHq" = (
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
@@ -19678,20 +19618,14 @@
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
 "aHw" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/servicebackroom)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "aHx" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "aHy" = (
@@ -19719,13 +19653,12 @@
 /turf/simulated/floor/lino,
 /area/tether/surfacebase/entertainment/stage)
 "aHA" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/servicebackroom)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "aHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -19737,7 +19670,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "aHD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -20066,16 +19999,14 @@
 /area/hallway/lower/third_south)
 "aId" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/barbackmaintenance)
 "aIe" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
+/obj/machinery/atm{
+	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "aIf" = (
 /obj/structure/cable/green{
@@ -20117,13 +20048,13 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aIj" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "aIk" = (
@@ -20789,8 +20720,8 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/servicebackroom)
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "aJv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -20802,6 +20733,11 @@
 "aJw" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/grass,
 /area/hydroponics/cafegarden)
 "aJx" = (
@@ -20924,11 +20860,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 2
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/servicebackroom)
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "aJK" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
@@ -21056,9 +20994,6 @@
 /obj/item/destTagger{
 	pixel_x = 4;
 	pixel_y = 3
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
@@ -21198,11 +21133,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -21215,6 +21145,16 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	name = "Service";
+	req_one_access = list(35,28)
+	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "aKm" = (
@@ -21584,13 +21524,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/shuttle_pad)
 "aLb" = (
-/obj/structure/closet/crate,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/servicebackroom)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "aLc" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/effect/landmark/start{
@@ -21631,9 +21569,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/civilian{
-	dir = 1
-	},
+/obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "aLh" = (
@@ -21861,18 +21797,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "aLG" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/requests_console{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/item/radio/intercom{
-	pixel_y = -24
-	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "aLH" = (
@@ -22768,11 +22693,9 @@
 /area/crew_quarters/captain)
 "aND" = (
 /obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
 	dir = 1
 	},
+/obj/structure/lattice,
 /turf/simulated/open/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "aNE" = (
@@ -23007,14 +22930,11 @@
 /turf/simulated/wall/r_wall,
 /area/rnd/outpost/xenobiology/outpost_south_airlock)
 "aOg" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/servicebackroom)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "aOh" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
@@ -24283,7 +24203,7 @@
 /obj/machinery/camera/network/outside{
 	dir = 9
 	},
-/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "aQV" = (
 /obj/machinery/power/apc{
@@ -25064,12 +24984,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "aSy" = (
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/flora/ausbushes/palebush,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "aSz" = (
@@ -25662,9 +25584,6 @@
 /area/crew_quarters/barrestroom)
 "aTF" = (
 /obj/structure/closet/crate/plastic,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "aTG" = (
@@ -25689,12 +25608,11 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "aTI" = (
-/obj/structure/closet/crate,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/servicebackroom)
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "aTJ" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -27620,15 +27538,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aXh" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/servicebackroom)
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "aXi" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/borderfloor{
@@ -27807,6 +27721,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "aXw" = (
@@ -30498,9 +30413,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"bcd" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
 "bce" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -30908,6 +30820,15 @@
 /obj/machinery/camera/network/civilian{
 	dir = 9
 	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
 /turf/simulated/floor/grass,
 /area/hydroponics/cafegarden)
 "bcG" = (
@@ -31247,6 +31168,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "bdm" = (
@@ -31412,15 +31336,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bdH" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "bdI" = (
@@ -31430,6 +31346,9 @@
 	dir = 4;
 	layer = 3.3;
 	pixel_x = 26
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
 /turf/simulated/floor/grass,
 /area/hydroponics/cafegarden)
@@ -31445,10 +31364,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bdK" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/flora/pottedplant/smalltree,
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/barbackmaintenance)
 "bdM" = (
 /obj/structure/cable/green{
@@ -31524,7 +31441,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/barbackmaintenance)
 "bdZ" = (
 /obj/structure/cable/green{
@@ -31535,14 +31452,11 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/tether/surfacebase/barbackmaintenance)
-"bea" = (
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/barbackmaintenance)
 "beb" = (
 /obj/structure/bed/chair/comfy/beige,
-/turf/simulated/floor/tiled/eris/steel/bar_light,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "bec" = (
 /obj/structure/grille,
@@ -31656,7 +31570,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/barbackmaintenance)
 "ben" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -31667,14 +31581,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/barbackmaintenance)
 "beo" = (
 /obj/structure/table/gamblingtable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "bep" = (
 /obj/structure/table/gamblingtable,
@@ -31682,7 +31596,7 @@
 	dir = 8
 	},
 /obj/item/storage/pill_bottle/dice,
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "beq" = (
 /obj/machinery/door/airlock/freezer{
@@ -31835,9 +31749,6 @@
 /obj/effect/landmark/start{
 	name = "Botanist"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "beD" = (
@@ -31845,6 +31756,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
+/obj/machinery/vending/cola,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "beE" = (
@@ -32043,14 +31955,15 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "bfb" = (
-/obj/machinery/door/airlock/freezer{
-	name = "Service";
-	req_one_access = list(35,28)
-	},
-/obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
 /area/hydroponics/cafegarden)
 "bfc" = (
 /obj/structure/table/woodentable,
@@ -32176,7 +32089,7 @@
 /area/crew_quarters/kitchen)
 "bfo" = (
 /obj/structure/table/gamblingtable,
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "bfp" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -32206,25 +32119,21 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "bft" = (
-/obj/machinery/light,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "bfu" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "bfv" = (
@@ -32249,10 +32158,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "bfz" = (
-/obj/structure/bed/chair/comfy/beige{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "bfA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -32278,7 +32184,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/barbackmaintenance)
 "bfD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -32292,22 +32198,24 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/barbackmaintenance)
 "bfE" = (
-/obj/structure/bed/chair/wood,
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "bfF" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "bfG" = (
 /obj/structure/table/gamblingtable,
 /obj/item/storage/pill_bottle/dice_nerd,
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "bfH" = (
 /obj/machinery/light/small,
@@ -32352,9 +32260,10 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/southhall)
 "bfK" = (
-/obj/structure/table/gamblingtable,
-/obj/item/deck/cards,
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/obj/machinery/door/window{
+	name = "Dealer's Seat"
+	},
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "bfL" = (
 /obj/structure/grille,
@@ -32391,8 +32300,7 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bfP" = (
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/barbackmaintenance)
 "bfQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -32402,7 +32310,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/barbackmaintenance)
 "bfR" = (
 /obj/machinery/computer/arcade/battle{
@@ -32417,7 +32325,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "bfT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -32522,6 +32430,7 @@
 /obj/machinery/requests_console{
 	pixel_x = -30
 	},
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "bgf" = (
@@ -32590,7 +32499,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "bgm" = (
 /obj/machinery/alarm{
@@ -32737,7 +32646,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/barbackmaintenance)
 "bgz" = (
 /obj/effect/floor_decal/spline/plain{
@@ -32761,6 +32670,7 @@
 	pixel_y = -25;
 	target_temperature = 270
 	},
+/obj/structure/closet/crate,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "bgB" = (
@@ -32781,12 +32691,10 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/structure/table/marble,
-/obj/machinery/door/blast/shutters{
+/obj/machinery/door/window/brigdoor/northleft{
 	dir = 2;
-	id = "bar";
-	layer = 3.3;
-	name = "Bar Shutters"
+	name = "Bar";
+	req_access = list(25)
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
@@ -32800,7 +32708,6 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 6
 	},
-/obj/item/stool/padded,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -32826,7 +32733,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/obj/item/deck/cards,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "bgH" = (
 /obj/structure/grille,
@@ -32850,6 +32758,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/structure/closet/crate,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "bgJ" = (
@@ -32981,8 +32890,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance/common,
-/turf/simulated/floor/tiled/techmaint,
+/obj/machinery/door/airlock{
+	desc = "It opens and closes.";
+	name = "Game Room"
+	},
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/barbackmaintenance)
 "bgT" = (
 /obj/structure/grille,
@@ -36182,6 +36094,11 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/robotics)
+"bVi" = (
+/obj/structure/railing,
+/obj/structure/lattice,
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "bZQ" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
@@ -36364,13 +36281,9 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "cxH" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized/full{
-	id = "saunatint"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/recreation_area)
+/obj/effect/mist,
+/turf/simulated/floor/water/indoors,
+/area/crew_quarters/recreation_area_restroom)
 "cAG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -36711,23 +36624,20 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "dhG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/door/airlock/multi_tile/glass/polarized{
-	dir = 2;
-	id_tint = "saunatint";
-	name = "Sauna"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/recreation_area)
+/obj/effect/mist,
+/turf/simulated/floor/water/indoors,
+/area/crew_quarters/recreation_area_restroom)
 "dhK" = (
 /obj/machinery/door/airlock{
 	name = "Sauna"
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area_restroom)
 "dlX" = (
@@ -36961,9 +36871,6 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -37269,11 +37176,12 @@
 /turf/simulated/floor/tiled/eris/dark/golden,
 /area/shuttle/tourbus/general)
 "fes" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/food/drinks/bottle/patron,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/wood,
-/area/crew_quarters/recreation_area)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/mist,
+/turf/simulated/floor/water/deep/indoors,
+/area/crew_quarters/recreation_area_restroom)
 "feu" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -37451,10 +37359,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
-"fXt" = (
-/obj/effect/mist,
-/turf/simulated/floor/water/deep/pool,
-/area/crew_quarters/recreation_area)
 "fZy" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -37463,28 +37367,13 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/wood,
-/area/crew_quarters/recreation_area)
+/area/crew_quarters/recreation_area_restroom)
 "gae" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/security/breakroom)
-"geo" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/drinks/bottle/limejuice,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/recreation_area)
 "geQ" = (
 /obj/machinery/holoposter{
 	pixel_y = -30
@@ -37535,6 +37424,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
+"glj" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "glT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -37615,6 +37508,10 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
+"gEc" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
+/area/hydroponics/cafegarden)
 "gHh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
@@ -37884,10 +37781,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officea)
 "hBx" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
+	},
 /obj/effect/mist,
-/obj/effect/floor_decal/spline/plain,
-/turf/simulated/floor/water/pool,
-/area/crew_quarters/recreation_area)
+/turf/simulated/floor/water/indoors,
+/area/crew_quarters/recreation_area_restroom)
 "hCr" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -38120,6 +38019,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/panic_shelter)
+"ipW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/simulated/wall,
+/area/hydroponics)
 "isl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38186,6 +38091,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
+"iDc" = (
+/obj/structure/flora/pottedplant/decorative,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/barbackmaintenance)
 "iFr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
@@ -38253,6 +38162,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/testingrange)
+"iRe" = (
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 8
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics/cafegarden)
 "iRX" = (
 /obj/machinery/light{
 	dir = 1
@@ -38293,15 +38214,19 @@
 /obj/structure/window/reinforced,
 /turf/simulated/wall,
 /area/tether/surfacebase/medical/storage)
+"iUU" = (
+/obj/effect/mist,
+/turf/simulated/floor/wood,
+/area/crew_quarters/recreation_area_restroom)
+"iVH" = (
+/obj/structure/lattice,
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "iXM" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -38341,6 +38266,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
+"joo" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "jpB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
@@ -38378,11 +38309,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
-"jvk" = (
-/obj/structure/table/bench/wooden,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/crew_quarters/recreation_area)
 "jvK" = (
 /turf/simulated/wall/shull,
 /area/shuttle/tourbus/cockpit)
@@ -38446,6 +38372,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/surfacebase/southhall)
+"jEH" = (
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics/cafegarden)
 "jFq" = (
 /obj/structure/table/reinforced,
 /obj/item/folder{
@@ -38747,13 +38682,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
-"kjU" = (
-/obj/structure/table/bench/wooden,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/recreation_area)
 "kku" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -38843,13 +38771,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officea)
-"kta" = (
-/obj/effect/mist,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/turf/simulated/floor/water/pool,
-/area/crew_quarters/recreation_area)
 "kun" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
@@ -39091,6 +39012,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/research/testingrange)
+"lku" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "llH" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -39297,6 +39231,14 @@
 /obj/item/clothing/head/helmet/space/void/security,
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/security/hos)
+"lOl" = (
+/obj/structure/table/bench/wooden,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/recreation_area_restroom)
 "lSv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -39365,12 +39307,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "lZP" = (
-/obj/structure/table/bench/wooden,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/recreation_area)
+/obj/effect/mist,
+/turf/simulated/floor/water/indoors,
+/area/crew_quarters/recreation_area_restroom)
 "mdE" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -39393,7 +39335,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
@@ -39735,6 +39676,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research)
+"nnV" = (
+/obj/structure/table/glass,
+/obj/machinery/door/window/westright{
+	req_one_access = list(35,28)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "nnY" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -39841,11 +39790,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
@@ -39920,13 +39869,6 @@
 /obj/item/duct_tape_roll,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/robotics)
-"nNu" = (
-/obj/effect/mist,
-/obj/effect/floor_decal/spline/plain{
-	dir = 6
-	},
-/turf/simulated/floor/water/pool,
-/area/crew_quarters/recreation_area)
 "nQA" = (
 /obj/machinery/camera/network/security{
 	dir = 8
@@ -39961,14 +39903,10 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "nWp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/recreation_area)
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/mist,
+/turf/simulated/floor/water/indoors,
+/area/crew_quarters/recreation_area_restroom)
 "nXZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -40409,12 +40347,11 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "pll" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/railing,
 /obj/effect/mist,
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/turf/simulated/floor/water/pool,
-/area/crew_quarters/recreation_area)
+/turf/simulated/floor/water/deep/indoors,
+/area/crew_quarters/recreation_area_restroom)
 "pnq" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -40653,11 +40590,11 @@
 /obj/structure/table/woodentable,
 /obj/item/towel/random,
 /obj/item/towel/random,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/item/towel/random,
+/obj/item/towel/random,
+/obj/item/reagent_containers/food/drinks/bottle/limejuice,
 /turf/simulated/floor/wood,
-/area/crew_quarters/recreation_area)
+/area/crew_quarters/recreation_area_restroom)
 "pPs" = (
 /obj/machinery/light{
 	dir = 1
@@ -40715,6 +40652,15 @@
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
+"qeb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "qem" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -40740,29 +40686,21 @@
 /obj/structure/closet/hydrant{
 	pixel_x = 32
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized/full{
-	id = "saunatint"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/recreation_area)
+/turf/simulated/wall,
+/area/crew_quarters/recreation_area_restroom)
 "qkf" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	name = "Research";
-	sortType = "Research"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "qkx" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/wood,
-/area/crew_quarters/recreation_area)
+/area/crew_quarters/recreation_area_restroom)
 "qnv" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -40925,13 +40863,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/cafeteria)
-"qLS" = (
-/obj/effect/mist,
-/obj/effect/floor_decal/spline/plain{
-	dir = 9
-	},
-/turf/simulated/floor/water/pool,
-/area/crew_quarters/recreation_area)
 "qNv" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/super;
@@ -41054,6 +40985,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet,
 /area/tether/surfacebase/security/hos)
+"ros" = (
+/obj/machinery/vending/hydronutrients{
+	dir = 8
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "rrG" = (
 /obj/structure/table/steel,
 /obj/item/folder/red{
@@ -41230,6 +41167,17 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/robotics/surgeryroom1)
+"rVP" = (
+/obj/machinery/door/window/westright{
+	dir = 1;
+	name = "interior door";
+	req_access = list(28,35)
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics/cafegarden)
 "rWd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
@@ -41669,11 +41617,8 @@
 /area/tether/surfacebase/surface_three_hall)
 "tdZ" = (
 /obj/effect/mist,
-/obj/effect/floor_decal/spline/plain{
-	dir = 5
-	},
-/turf/simulated/floor/water/pool,
-/area/crew_quarters/recreation_area)
+/turf/simulated/floor/water/deep/indoors,
+/area/crew_quarters/recreation_area_restroom)
 "tfD" = (
 /obj/machinery/chemical_dispenser/full,
 /obj/structure/table/reinforced,
@@ -41819,10 +41764,6 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "txo" = (
@@ -41850,10 +41791,6 @@
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -41906,14 +41843,15 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "tCZ" = (
-/obj/structure/table/woodentable,
-/obj/machinery/button/windowtint/multitint{
-	id = "saunatint";
-	name = "Privacy Control";
-	pixel_x = -28
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/recreation_area)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/mist,
+/turf/simulated/floor/water/indoors,
+/area/crew_quarters/recreation_area_restroom)
 "tEV" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -42051,13 +41989,14 @@
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/security/hos)
 "tXn" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced/polarized/full{
-	id = "saunatint"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/recreation_area)
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/food/drinks/bottle/patron,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/turf/simulated/floor/wood,
+/area/crew_quarters/recreation_area_restroom)
 "tYE" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -42256,10 +42195,9 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/robotics)
 "uuy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "uxT" = (
@@ -42286,6 +42224,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/briefingroom)
+"uzr" = (
+/obj/machinery/camera/network/outside{
+	dir = 5
+	},
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "uAI" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -43029,12 +42973,12 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/robotics)
 "wHb" = (
-/obj/effect/mist,
-/obj/effect/floor_decal/spline/plain{
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/water/pool,
-/area/crew_quarters/recreation_area)
+/obj/effect/mist,
+/turf/simulated/floor/water/deep/indoors,
+/area/crew_quarters/recreation_area_restroom)
 "wIw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
@@ -43107,13 +43051,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/briefingroom)
-"wQZ" = (
-/obj/effect/mist,
-/obj/effect/floor_decal/spline/plain{
-	dir = 10
-	},
-/turf/simulated/floor/water/pool,
-/area/crew_quarters/recreation_area)
 "wRO" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 9
@@ -43146,6 +43083,34 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"wZe" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/mauve/bordercorner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/machinery/camera/network/research{
+	dir = 5
+	},
+/obj/structure/disposalpipe/sortjunction/flipped{
+	name = "Research";
+	sortType = "Research"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/research/researchdivision)
 "xaU" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -43351,6 +43316,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
+"xAU" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "xBf" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -43785,11 +43761,53 @@ aaa
 "}
 (2,1,1) = {"
 aaa
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
 aab
 aab
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
@@ -43797,12 +43815,22 @@ aab
 aab
 aab
 aab
+aac
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
 aab
 aab
 aab
+aac
+aac
+aac
+aac
 aab
 aab
 aab
@@ -43824,113 +43852,87 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (3,1,1) = {"
 aaa
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
 aab
+aac
+aac
+aac
+aac
 aab
 aab
 aab
@@ -43941,6 +43943,11 @@ aab
 aab
 aab
 aab
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
@@ -43951,6 +43958,10 @@ aab
 aab
 aab
 aab
+aac
+aac
+aac
+aac
 aab
 aab
 aab
@@ -43959,6 +43970,8 @@ aab
 aab
 aab
 aab
+aac
+aac
 aab
 aab
 aab
@@ -43981,98 +43994,75 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (4,1,1) = {"
 aaa
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
 aab
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
@@ -44147,75 +44137,69 @@ aab
 aab
 aab
 aab
+aac
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (5,1,1) = {"
 aaa
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
 aab
 aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -44296,63 +44280,60 @@ aab
 aab
 aab
 aab
+aac
+aac
+aac
+aac
 aab
 aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (6,1,1) = {"
 aaa
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
@@ -44452,49 +44433,49 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aab
+aab
+aab
+aab
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (7,1,1) = {"
 aaa
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
@@ -44595,6 +44576,11 @@ aab
 aab
 aab
 aab
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
@@ -44603,40 +44589,35 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (8,1,1) = {"
 aaa
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
@@ -44752,33 +44733,33 @@ aab
 aab
 aab
 aab
+aac
+aac
+aac
 aab
 aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (9,1,1) = {"
 aaa
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
@@ -44905,22 +44886,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (10,1,1) = {"
 aaa
+aac
+aac
+aac
+aac
 aab
 aab
 aab
@@ -45049,20 +45029,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (11,1,1) = {"
 aaa
+aac
+aac
+aac
 aab
 aab
 aab
@@ -45194,17 +45173,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
 aaa
 "}
 (12,1,1) = {"
 aaa
+aac
+aac
+aac
 aab
 aab
 aab
@@ -45336,17 +45315,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
 aaa
 "}
 (13,1,1) = {"
 aaa
+aac
+aac
 aab
 aab
 aab
@@ -45480,15 +45458,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (14,1,1) = {"
 aaa
+aac
+aac
 aab
 aab
 aab
@@ -45622,15 +45600,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (15,1,1) = {"
 aaa
+aac
+aac
 aab
 aab
 aab
@@ -45765,14 +45743,14 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (16,1,1) = {"
 aaa
+aac
+aac
 aab
 aab
 aab
@@ -45907,14 +45885,14 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (17,1,1) = {"
 aaa
+aac
+aac
 aab
 aab
 aab
@@ -46048,15 +46026,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (18,1,1) = {"
 aaa
+aac
+aac
 aab
 aab
 aab
@@ -46190,15 +46168,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (19,1,1) = {"
 aaa
+aac
+aac
 aab
 aab
 aab
@@ -46332,17 +46310,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (20,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -46476,15 +46452,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (21,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -46617,16 +46593,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
 aaa
 "}
 (22,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -46758,17 +46734,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (23,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -46900,17 +46876,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (24,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -47043,16 +47019,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
 aaa
 "}
 (25,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -47185,16 +47161,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
 aaa
 "}
 (26,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -47328,14 +47304,14 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (27,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -47423,8 +47399,6 @@ aac
 aac
 aac
 aac
-aab
-aab
 aab
 aab
 aab
@@ -47472,12 +47446,14 @@ aab
 aab
 aab
 aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (28,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -47565,8 +47541,6 @@ aac
 aac
 aac
 aac
-aab
-aab
 aab
 aab
 aab
@@ -47614,12 +47588,14 @@ aab
 aab
 aab
 aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (29,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -47754,14 +47730,14 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (30,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -47897,13 +47873,13 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (31,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -48040,12 +48016,12 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (32,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -48187,7 +48163,7 @@ aaa
 "}
 (33,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -48329,8 +48305,8 @@ aaa
 "}
 (34,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -48471,8 +48447,8 @@ aaa
 "}
 (35,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -48613,8 +48589,8 @@ aaa
 "}
 (36,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -48703,11 +48679,11 @@ aac
 aac
 aac
 aMG
-aMG
-aMG
-aMG
-aMG
-aNU
+aab
+aab
+aab
+aab
+aOm
 adG
 adG
 aQD
@@ -48755,7 +48731,7 @@ aaa
 "}
 (37,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -48845,11 +48821,11 @@ aac
 aac
 aaq
 adG
-adG
-adG
-adG
-adG
-adG
+aab
+aab
+aab
+aab
+aab
 adG
 aOf
 aOf
@@ -48897,7 +48873,7 @@ aaa
 "}
 (38,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -49039,7 +49015,7 @@ aaa
 "}
 (39,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -49318,7 +49294,7 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (41,1,1) = {"
@@ -49459,8 +49435,8 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (42,1,1) = {"
@@ -49601,13 +49577,13 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (43,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -49696,12 +49672,12 @@ aac
 aac
 aac
 aac
-aac
-adG
-adG
-adG
-adG
-adG
+aaq
+aab
+aab
+aab
+aab
+aab
 adG
 aOf
 aOf
@@ -49743,13 +49719,13 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (44,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -49838,16 +49814,16 @@ aac
 aac
 aac
 aac
-aac
+aaq
+aOi
+aab
+aab
+aab
+aOm
 adG
-aNB
-aNM
-aNM
-aNW
-adG
-adG
-aRh
-adG
+aOi
+uzr
+aab
 aOW
 aEf
 aPG
@@ -49884,14 +49860,14 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (45,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -49980,16 +49956,16 @@ aac
 aac
 aac
 aac
-aac
-adG
+aaq
 aOi
 aab
 aab
 aab
-aNM
-aNM
-aOt
+aOm
 adG
+aOi
+aab
+aab
 aOY
 aPl
 aPH
@@ -50026,14 +50002,14 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (46,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -50122,16 +50098,16 @@ aac
 aac
 aac
 aac
-aac
-adG
-aND
-aMG
-aMG
-aMG
-aMG
+aaq
+aOi
+aab
+aab
 aab
 aOm
 adG
+aOi
+aab
+aab
 aOY
 aPm
 aPI
@@ -50168,15 +50144,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (47,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -50265,15 +50241,15 @@ aac
 aac
 aac
 aQU
+aND
+iVH
+iVH
+iVH
+bVi
 adG
-adG
-adG
-adG
-adG
-adG
-aOi
-aOm
-adG
+aND
+iVH
+iVH
 aOZ
 aPn
 aPJ
@@ -50310,15 +50286,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (48,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -50413,9 +50389,9 @@ azL
 azL
 azL
 adG
-aOi
-aOm
-adG
+aOs
+aMG
+aMG
 aOW
 aPK
 aPK
@@ -50453,14 +50429,14 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (49,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -50555,21 +50531,12 @@ azL
 azL
 azL
 adG
-aOi
-aOm
 adG
 adG
 adG
 adG
 adG
 adG
-adG
-adG
-adG
-adG
-adG
-adG
-aRh
 adG
 adG
 adG
@@ -50580,6 +50547,15 @@ adG
 adG
 aRh
 adG
+adG
+adG
+adG
+adG
+adG
+adG
+adG
+aRh
+adG
 aOi
 aab
 aab
@@ -50595,14 +50571,14 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (50,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -50697,8 +50673,7 @@ azL
 azL
 azL
 adG
-aOi
-aab
+aOF
 aNM
 aNM
 aNM
@@ -50722,8 +50697,7 @@ aNM
 aNM
 aNM
 aNM
-aab
-aab
+aNM
 aab
 aab
 aab
@@ -50739,11 +50713,13 @@ aab
 aab
 aab
 aab
+aac
+aac
 aaa
 "}
 (51,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -50879,13 +50855,13 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (52,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -51022,12 +50998,12 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (53,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -51164,12 +51140,12 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (54,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -51306,12 +51282,12 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (55,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -51407,6 +51383,7 @@ azL
 azL
 azL
 aaq
+aOi
 aab
 aab
 aab
@@ -51447,13 +51424,12 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
 aaa
 "}
 (56,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -51590,13 +51566,13 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (57,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -51732,14 +51708,14 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (58,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -51874,14 +51850,14 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (59,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -51951,7 +51927,7 @@ ahi
 awA
 awW
 axG
-aHj
+wZe
 aAr
 ayu
 aFm
@@ -52016,14 +51992,14 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (60,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -52163,8 +52139,8 @@ aaa
 "}
 (61,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -52305,8 +52281,8 @@ aaa
 "}
 (62,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -52447,8 +52423,8 @@ aaa
 "}
 (63,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -52589,7 +52565,7 @@ aaa
 "}
 (64,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -52631,14 +52607,14 @@ oEh
 kuQ
 aWF
 akx
-akY
-akY
-akY
-amw
-dhG
-akY
-akY
-akY
+aoX
+aoX
+aoX
+aoX
+aoX
+aoX
+aoX
+aoX
 aix
 apQ
 aqE
@@ -52731,7 +52707,7 @@ aaa
 "}
 (65,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -52773,14 +52749,14 @@ oEh
 kuQ
 aWF
 aWO
-akY
-geo
+aoX
+tdZ
 fes
-cXA
+cxH
 nWp
-tCZ
+aaH
 pPf
-akY
+aoX
 nTi
 apQ
 asS
@@ -52915,14 +52891,14 @@ adR
 aWm
 aWG
 aWS
-akY
-kjU
-jvk
-jvk
+aoX
+tdZ
+tdZ
+dhG
 lZP
-amw
-amw
-cxH
+aaH
+tXn
+aoX
 aps
 apR
 aqG
@@ -53057,14 +53033,14 @@ oEh
 aWn
 aWF
 aWT
-cxH
-qLS
+aoX
+tdZ
 pll
-pll
-wQZ
 qkx
-amw
-cxH
+mNe
+mNe
+mNe
+aoX
 apt
 tdN
 aqH
@@ -53199,12 +53175,12 @@ oEh
 aWn
 aWF
 aWT
-cxH
-kta
-fXt
-fXt
-hBx
+aoX
+tdZ
+pll
 qkx
+mNe
+mNe
 fZy
 aoX
 aoX
@@ -53341,13 +53317,13 @@ adR
 xBf
 aWF
 aWT
-cxH
-kta
-fXt
-fXt
+aoX
+tdZ
+tdZ
+tCZ
 hBx
-qkx
-amw
+iUU
+mNe
 dhK
 mNe
 qNv
@@ -53486,10 +53462,10 @@ aWT
 qjk
 tdZ
 wHb
-wHb
-nNu
-qkx
-amw
+cxH
+nWp
+aaH
+lOl
 aoX
 sfv
 cXR
@@ -53626,12 +53602,12 @@ aWp
 ajM
 akv
 alc
-cxH
-tXn
-akY
-akY
-akY
-akY
+aoX
+aoX
+aoX
+aoX
+aoX
+aoX
 aoX
 rLB
 glT
@@ -54714,7 +54690,7 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (79,1,1) = {"
@@ -54856,7 +54832,7 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (80,1,1) = {"
@@ -54998,7 +54974,7 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (81,1,1) = {"
@@ -55139,8 +55115,8 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (82,1,1) = {"
@@ -55281,8 +55257,8 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (83,1,1) = {"
@@ -55423,8 +55399,8 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (84,1,1) = {"
@@ -55565,8 +55541,8 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (85,1,1) = {"
@@ -55586,7 +55562,7 @@ aab
 aab
 aaq
 bou
-aaH
+ajG
 aac
 aac
 aac
@@ -55708,12 +55684,12 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (86,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -55850,12 +55826,12 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (87,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -55992,13 +55968,13 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (88,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -56134,13 +56110,13 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (89,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -56276,13 +56252,13 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (90,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -56418,13 +56394,13 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (91,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -56560,12 +56536,12 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (92,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -56702,12 +56678,12 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (93,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -56844,12 +56820,12 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (94,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -56986,7 +56962,7 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (95,1,1) = {"
@@ -57127,8 +57103,8 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (96,1,1) = {"
@@ -57269,8 +57245,8 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (97,1,1) = {"
@@ -57411,13 +57387,13 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (98,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -57553,13 +57529,13 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (99,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -57613,9 +57589,9 @@ xUo
 bqs
 xUo
 xUo
+aBE
 aCK
-aCK
-aCK
+aBE
 xUo
 fOj
 ahR
@@ -57694,14 +57670,14 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (100,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -57755,9 +57731,9 @@ apC
 aqf
 aOT
 aFI
+apS
 avP
-avP
-avP
+apS
 apS
 apS
 ajX
@@ -57836,14 +57812,14 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (101,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -57875,7 +57851,7 @@ ajk
 box
 acg
 acg
-aTd
+acg
 acg
 acg
 acg
@@ -57897,9 +57873,9 @@ agw
 aqg
 aqT
 apc
+aXT
 aBF
-aBF
-aBF
+aXT
 aXT
 aXT
 bbN
@@ -57979,14 +57955,14 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (102,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -58041,7 +58017,7 @@ agw
 apc
 asZ
 anN
-aVO
+ate
 ate
 ate
 baB
@@ -58121,14 +58097,14 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (103,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -58183,7 +58159,7 @@ apc
 apc
 avg
 anN
-aVO
+ate
 ate
 ate
 baB
@@ -58263,14 +58239,14 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (104,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -58323,9 +58299,9 @@ adt
 aqj
 aoH
 aww
-asp
+atR
 avq
-aBE
+aEY
 aVR
 aEY
 aZJ
@@ -58352,11 +58328,11 @@ aKr
 beh
 ayM
 aya
-bcd
-bcd
-ayE
+bfz
+aIe
+bfz
 bfP
-aAl
+aCn
 aId
 bdA
 ayM
@@ -58406,12 +58382,12 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (105,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -58467,7 +58443,7 @@ apg
 apc
 aGH
 aVB
-aVO
+ate
 aZQ
 bga
 bgc
@@ -58497,10 +58473,10 @@ bgy
 bgy
 bem
 bfC
-bcd
-bcd
-aIe
+bfP
 bdK
+ayM
+ayM
 ayM
 aac
 aac
@@ -58548,12 +58524,12 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (106,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -58609,7 +58585,7 @@ awP
 awP
 aGH
 aVB
-aVO
+ate
 bdB
 ayL
 baP
@@ -58690,7 +58666,7 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (107,1,1) = {"
@@ -58749,9 +58725,9 @@ avO
 ate
 awr
 aGb
+ate
 aVO
-aVO
-aVO
+ate
 ate
 aFK
 bbI
@@ -58783,7 +58759,7 @@ ben
 bfD
 bfQ
 aCn
-bea
+iDc
 bec
 aac
 aac
@@ -58832,7 +58808,7 @@ aab
 aab
 aab
 aab
-aab
+aac
 aaa
 "}
 (108,1,1) = {"
@@ -58891,9 +58867,9 @@ auO
 auQ
 awR
 asP
+asP
 aHn
-aHn
-aHn
+asP
 asP
 beL
 aru
@@ -58920,12 +58896,12 @@ aAG
 aIS
 ayM
 bdV
-bea
+bfP
 ayD
 bfF
 bfS
-bea
-bea
+bfP
+bfP
 bec
 aac
 aac
@@ -58973,8 +58949,8 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (109,1,1) = {"
@@ -59035,7 +59011,7 @@ asi
 asj
 aJV
 aWE
-aWE
+nnV
 beE
 beM
 amY
@@ -59067,7 +59043,7 @@ beo
 bfG
 bgl
 aFA
-bea
+bfP
 bec
 aac
 aac
@@ -59115,8 +59091,8 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (110,1,1) = {"
@@ -59171,7 +59147,7 @@ anV
 aok
 aSx
 aop
-aop
+bdH
 aop
 aBp
 aCl
@@ -59204,12 +59180,12 @@ aIf
 aIU
 ayM
 ayd
-ayb
+beb
 bep
 bfE
 bgG
-aFy
-bea
+aFA
+bfP
 bec
 aac
 aac
@@ -59257,8 +59233,8 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (111,1,1) = {"
@@ -59317,9 +59293,9 @@ aop
 aqp
 aCj
 aFS
+aFS
 aVP
-aVP
-aVP
+aFS
 aFS
 beO
 aru
@@ -59345,13 +59321,13 @@ bbZ
 aIf
 baT
 ayM
-bea
+bfP
 beb
 bfo
 bfK
 bfo
 aFA
-bea
+bfP
 bec
 aac
 aac
@@ -59399,8 +59375,8 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (112,1,1) = {"
@@ -59455,13 +59431,13 @@ anW
 aok
 aop
 aop
+aCh
 aop
 aop
-aUr
-aWM
-aXj
+aop
+aop
 aVy
-aVy
+aop
 aop
 aKm
 avL
@@ -59487,13 +59463,13 @@ bgE
 aIf
 baW
 ayM
-bea
+bfP
 aHC
 bfz
 bfz
 bfz
 aHC
-bea
+bfP
 bec
 aac
 aac
@@ -59541,8 +59517,8 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (113,1,1) = {"
@@ -59602,8 +59578,8 @@ aEX
 asp
 asq
 aWM
-aXj
-aVy
+joo
+aop
 aop
 aZy
 aru
@@ -59683,13 +59659,13 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aaa
 "}
 (114,1,1) = {"
 aaa
-aab
+aac
 aab
 aab
 aab
@@ -59738,12 +59714,12 @@ ajs
 anY
 aok
 bdi
-aop
+aLG
 bdj
 arQ
 auU
 aXv
-ath
+auk
 afT
 atk
 atn
@@ -59824,15 +59800,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aac
+aac
+aac
 aaa
 "}
 (115,1,1) = {"
 aaa
-aab
-aab
+aac
+aac
 aab
 aab
 aab
@@ -59883,12 +59859,12 @@ aEB
 aop
 aeZ
 arR
-aVy
+ipW
 bdl
-aFM
+glj
 aFO
-aFM
-atb
+ros
+iRe
 bbo
 atb
 aBy
@@ -59965,17 +59941,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
 aaa
 "}
 (116,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -60021,20 +59997,20 @@ ayK
 hfN
 atg
 aSy
-aop
+aCh
 aop
 bdk
 ask
-aVy
+qeb
 aLg
-aFM
+aop
 aJu
-aLb
-atb
-asu
+aop
+jEH
+gEc
 ati
 aFz
-asu
+gEc
 aoJ
 ayh
 aMC
@@ -60107,17 +60083,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
 aaa
 "}
 (117,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -60168,12 +60144,12 @@ aWM
 aWM
 asH
 aXj
-bdH
-aFM
+aso
+aqe
 aFP
 aTI
-atb
-asx
+jEH
+asN
 aty
 aGt
 aKw
@@ -60249,17 +60225,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
 aaa
 "}
 (118,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -60303,7 +60279,7 @@ avB
 awN
 azp
 aop
-aVy
+aHw
 aop
 aop
 aqq
@@ -60311,14 +60287,14 @@ aBG
 asO
 aqe
 bft
-aFM
+aqe
 aGd
 aHp
 bfb
 asI
 aum
 aJw
-asu
+gEc
 aoJ
 aGO
 aTg
@@ -60390,18 +60366,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (119,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -60452,11 +60428,11 @@ aqV
 aDY
 asV
 aqe
-aLG
-aFM
+aso
+aqe
 aGg
 aXh
-atb
+rVP
 asN
 awq
 aJw
@@ -60531,19 +60507,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (120,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -60586,19 +60562,19 @@ auT
 avI
 arL
 aqm
-aop
-aVy
+aCh
+aHA
 aeZ
 ata
 aCI
 aCR
 aEh
 aqe
-aso
-aFM
+lku
+xAU
 aJJ
-aOg
-atb
+aop
+jEH
 asY
 axv
 bcF
@@ -60673,19 +60649,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (121,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -60737,10 +60713,10 @@ aop
 ask
 arK
 bfu
-aCh
+aFM
 aKl
-aHw
-atb
+aFM
+aFM
 atb
 atb
 atb
@@ -60815,19 +60791,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (122,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -60869,12 +60845,12 @@ acV
 avb
 awu
 arL
-aop
+ath
 aop
 asQ
-auk
+aLb
 aEZ
-auk
+aOg
 auk
 avr
 aso
@@ -60957,19 +60933,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (123,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -61023,7 +60999,7 @@ aBd
 aAR
 aFM
 aGG
-aHA
+aHq
 aLD
 aLI
 aMg
@@ -61099,19 +61075,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (124,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -61241,19 +61217,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (125,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -61383,19 +61359,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (126,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -61525,19 +61501,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (127,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -61667,19 +61643,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (128,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -61809,19 +61785,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (129,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -61951,19 +61927,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (130,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -62093,19 +62069,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (131,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -62235,19 +62211,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (132,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -62377,19 +62353,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (133,1,1) = {"
 aaa
-aab
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -62519,16 +62495,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (134,1,1) = {"
 aaa
+aac
+aac
+aac
 aab
 aab
 aab
@@ -62658,19 +62637,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (135,1,1) = {"
 aaa
+aac
+aac
+aac
 aab
 aab
 aab
@@ -62800,19 +62779,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (136,1,1) = {"
 aaa
+aac
+aac
+aac
 aab
 aab
 aab
@@ -62942,19 +62921,20 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (137,1,1) = {"
 aaa
+aac
+aac
+aac
+aac
 aab
 aab
 aab
@@ -63079,24 +63059,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (138,1,1) = {"
 aaa
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
@@ -63219,26 +63200,27 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (139,1,1) = {"
 aaa
+aac
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
@@ -63360,23 +63342,17 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aaa
 "}
 (140,1,1) = {"

--- a/code/modules/mob/living/simple_mob/subtypes/vore/rat.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/rat.dm
@@ -57,6 +57,14 @@
 	desc = "In what passes for a hierarchy among verminous rodents, this one is king. It seems to be more interested on scavenging."
 	var/mob/living/carbon/human/food
 	var/hunger = 0
+
+/mob/living/simple_mob/vore/aggressive/rat/maurice
+	name = "Maurice"
+	desc = "The station's resident vermin supreme, he makes the rules for all maintnence rodents.\
+	He appears to have grown quite chubby off gifts of trash and cheese from the crew."
+
+	ai_holder_type = /datum/ai_holder/simple_mob/retaliate
+
 /*
 /mob/living/simple_mob/vore/aggressive/rat/tame/Life()
 	. = ..()

--- a/maps/tether/tether_areas.dm
+++ b/maps/tether/tether_areas.dm
@@ -162,6 +162,18 @@
 /area/tether/surfacebase/outside/outside3
 	icon_state = "outside3"
 
+/area/tether/surfacebase/old_tram
+	name = "\improper Construction Tram LL-26"
+
+/area/tether/surfacebase/tunnel
+	name = "Orange Line Tram Tunnel"
+
+/area/tether/surfacebase/old_shelter
+	name = "Abandoned Mining Shelter"
+
+/area/tether/surfacebase/cave
+	name = "Shallow Cave"
+
 /area/tether/surfacebase/outside/empty
 	name = "Outside - Empty Area"
 

--- a/maps/tether/tether_turfs.dm
+++ b/maps/tether/tether_turfs.dm
@@ -19,6 +19,10 @@ VIRGO3B_TURF_CREATE(/turf/simulated/floor/reinforced)
 
 VIRGO3B_TURF_CREATE(/turf/simulated/floor/tiled/steel_dirty)
 
+VIRGO3B_TURF_CREATE(/turf/simulated/floor/tiled/techfloor/grid)
+
+VIRGO3B_TURF_CREATE(/turf/simulated/floor/maglev)
+
 VIRGO3B_TURF_CREATE(/turf/simulated/floor/outdoors/dirt)
 /turf/simulated/floor/outdoors/dirt/virgo3b
 	icon = 'icons/turf/flooring/asteroid.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Alright onto the big one...
This PR gives the same treatment to Tether's surface Z levels that I have given to the Tether Periphery. the Tether is now surrounded on three sides by immersive multi-z mountains. The Tram now also has tracks that don't magically end at the blast doors in the station and instead extend outside the station ending in a tunnel on the Z-level's edge. In addition several other immersive additions have been added to Tether's Exterior, such as an abandoned construction Tram some caves and other secret locations. While I was there I did some touchups to Tether itself improving some designs without touching up the general layout of the Tether, along with other miscellaneous fixes. A Full-ish changelog is below, here we go:

## Changelog
:cl:
added: Maurice
Virology: Has been downsized somewhat to make room for the Tram Tracks.
Tram Tracks: A new set of Mag-Levs have been added to the surface running from their terminus south of the Tram station to a tunnel on the map's north end.
Abandoned Tram: South of the Tram station lies an abandoned construction tram. Maybe they left it when they stopped working on the line.
Cliffs: The edge of the map has cliffs that stretch up all three Z levels. They are accessible form several stairwells near Z-level transitions. These cliffs have a handful of small static POIs.
Dressing Room: Now actually has locking dressing room and is not just a room full of lockers that people can stare into as your change.
Cafe: Now has a Glass Airlock leading to a more complex tram station seating area.
Deck 1 Maint: Maint around the Clown and Mime's Office has been adjusted to feature less 1 wide tunnels.
Construction Dorms: Now have tint-able windows for maximum privacy.
Fixed: Heads of Staff Meeting Room: Now has an visible table.
Chapel: Has been slightly redesigned with the pulpit now opposite to the entrances. Its chair have been upgraded to wood.
Deck 2 Maint: Sec's Substation is larger as a means of getting rid of an ugly 1 wide tunnel that dead ends there.
Sauna: Removed the windows and the entrance to the fitness room. Sauna is now on the Restroom APC and has a more accommodating design.
Bar Maint: Now has a proper gambling table with an ATM in the hall leading to it.
Service Back Hall and Botany: The ugly hall jutting into botany that served only to take up space is now gone. As a consequence botany now has more plants and the animal pen is slightly larger with a window wall.
Fixed: Removed duplicate Catwalks on decks 2 and 3.
General: Simplified Disposals and power in a handful of areas. (Apparently Virgo likes its spaghetti)
General: Enforced Area Consistency (There is now no longer gaps of "Outside" in the middle of the station.)


/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
