### PR TITLE
Fix shuttle sensor console printing out blank paper

### DIFF
--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -92,7 +92,7 @@
 		if("scan")
 			var/obj/effect/overmap/O = locate(params["scan"])
 			if(istype(O) && !QDELETED(O) && (O in view(7,linked)))
-				var/obj/item/paper/P = new /obj/item/paper/(get_turf(src))
+				var/obj/item/paper/P = new /obj/item/paper(get_turf(src))
 				P.name = "paper (Sensor Scan - [O])"
 				P.info = O.get_scan_data(usr)
 				P.Initialize() // has to be called because the scanner desc uses a combination of html and markdown for some reason

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -92,7 +92,10 @@
 		if("scan")
 			var/obj/effect/overmap/O = locate(params["scan"])
 			if(istype(O) && !QDELETED(O) && (O in view(7,linked)))
-				new/obj/item/paper/(get_turf(src), O.get_scan_data(usr), "paper (Sensor Scan - [O])")
+				var/obj/item/paper/P = new /obj/item/paper/(get_turf(src))
+				P.name = "paper (Sensor Scan - [O])"
+				P.info = O.get_scan_data(usr)
+				P.Initialize() // has to be called because the scanner desc uses a combination of html and markdown for some reason
 				playsound(src, "sound/machines/printer.ogg", 30, 1)
 			. = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The paper that came out of the sensor console was blank every time.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Let people actually see the sensor descriptions???
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: sensor console no longer prints out blank paper
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
