### PR TITLE
Talon's loadout gear

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_role_restricted.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_role_restricted.dm
@@ -10,7 +10,7 @@
 //*Single Departments
 //Security
 /datum/gear/restricted/security
-	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Detective")
+	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Detective", "Talon Guard")
 
 /datum/gear/restricted/security/eyes
 	slot = slot_glasses
@@ -35,7 +35,7 @@
 
 //Medical
 /datum/gear/restricted/medical
-	allowed_roles = list("Medical Doctor", "Chief Medical Officer", "Chemist", "Paramedic", "Geneticist", "Psychiatrist", "Field Medic")
+	allowed_roles = list("Medical Doctor", "Chief Medical Officer", "Chemist", "Paramedic", "Geneticist", "Psychiatrist", "Field Medic", "Talon Doctor")
 
 /datum/gear/restricted/medical/eyes
 	slot = slot_glasses
@@ -60,7 +60,7 @@
 
 //Engineering
 /datum/gear/restricted/engineering
-	allowed_roles = list("Station Engineer", "Chief Engineer", "Atmospheric Technician")
+	allowed_roles = list("Station Engineer", "Chief Engineer", "Atmospheric Technician", "Talon Engineer")
 
 /datum/gear/restricted/engineering/eyes
 	slot = slot_glasses
@@ -85,7 +85,7 @@
 
 //Command
 /datum/gear/restricted/command
-	allowed_roles = list("Facility Director", "Head of Personnel", "Chief Medical Officer", "Head of Security", "Research Director", "Chief Engineer", "Command Secretary")
+	allowed_roles = list("Facility Director", "Head of Personnel", "Chief Medical Officer", "Head of Security", "Research Director", "Chief Engineer", "Command Secretary", "Talon Captain")
 
 /datum/gear/restricted/command/eyes
 	slot = slot_glasses


### PR DESCRIPTION
## About The Pull Request

Lets Talon roles apply their respective department's gear to their loadouts.

## Why It's Good For The Game

Spawning with department huds and stuff can be very helpful.

## Changelog
:cl:
tweak: Allowed Talon crew to spawn with their role-restricted gear.
/:cl:
