### PR TITLE
Talon Restored/Tradified 

### DIFF
--- a/_maps/map_levels/140x140/talon/talon1.dmm
+++ b/_maps/map_levels/140x140/talon/talon1.dmm
@@ -298,6 +298,7 @@
 "aE" = (
 /obj/machinery/camera/network/talon,
 /obj/structure/table/rack/steel,
+/obj/item/inducer/syndicate,
 /obj/item/gps,
 /obj/item/gps,
 /obj/item/gps,
@@ -368,10 +369,8 @@
 /area/talon/maintenance/deckone_port)
 "aN" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/suit/space/void/refurb/talon,
-/obj/item/clothing/suit/space/void/refurb/talon,
-/obj/item/clothing/head/helmet/space/void/refurb/talon,
-/obj/item/clothing/head/helmet/space/void/refurb/talon,
+/obj/item/clothing/suit/space/void/mining,
+/obj/item/clothing/head/helmet/space/void/mining,
 /turf/simulated/floor/tiled/eris/dark/danger,
 /area/talon/deckone/secure_storage)
 "aO" = (
@@ -421,12 +420,12 @@
 /area/talon/maintenance/deckone_port)
 "aW" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/carbondioxide,
 /obj/machinery/alarm/talon{
 	dir = 1;
 	pixel_y = -25
 	},
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide,
 /turf/simulated/floor/tiled/eris/dark/danger,
@@ -759,7 +758,7 @@
 	},
 /obj/structure/table/rack/steel,
 /obj/item/spaceflare,
-/obj/item/storage/box/flare,
+/obj/item/storage/box/flashshells/large,
 /obj/item/gun/projectile/shotgun/flare,
 /turf/simulated/floor/tiled/eris/white/danger,
 /area/talon/deckone/armory)
@@ -1295,8 +1294,16 @@
 /area/talon/maintenance/deckone_port)
 "cI" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/storage/box/shotgunshells,
-/obj/item/gun/projectile/shotgun/doublebarrel,
+/obj/item/cell/device/weapon{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/cell/device/weapon,
+/obj/item/gun/energy/gun/burst,
 /turf/simulated/floor/tiled/eris/white/danger,
 /area/talon/deckone/armory)
 "cJ" = (
@@ -1392,6 +1399,14 @@
 /area/talon/deckone/port_eng)
 "cQ" = (
 /obj/structure/table/rack/shelf/steel,
+/obj/item/gun/energy/frontier/locked/holdout{
+	desc = "A minaturized weapon designed for the purpose of expeditionary support to defend themselves on the field. Includes a built-in crank charger for recharging away from civilization.";
+	pin = /obj/item/firing_pin
+	},
+/obj/item/gun/energy/frontier/locked/holdout{
+	desc = "A minaturized weapon designed for the purpose of expeditionary support to defend themselves on the field. Includes a built-in crank charger for recharging away from civilization.";
+	pin = /obj/item/firing_pin
+	},
 /obj/item/gun/energy/frontier,
 /obj/item/gun/energy/frontier,
 /obj/item/gun/energy/frontier,
@@ -2538,7 +2553,11 @@
 /area/talon/deckone/central_hallway)
 "oc" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/inducer/syndicate,
+/obj/item/clothing/accessory/holster/armpit,
+/obj/item/clothing/accessory/holster/armpit,
+/obj/item/clothing/accessory/holster/armpit,
+/obj/item/clothing/accessory/holster/armpit,
+/obj/item/clothing/accessory/holster/armpit,
 /turf/simulated/floor/tiled/eris/white/danger,
 /area/talon/deckone/armory)
 "oh" = (
@@ -2946,9 +2965,16 @@
 /area/talon/maintenance/deckone_starboard)
 "sS" = (
 /obj/structure/table/rack/shelf/steel,
+/obj/item/cell/device/weapon{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 5;
+	pixel_y = 1
+	},
 /obj/item/cell/device/weapon,
-/obj/item/cell/device/weapon,
-/obj/item/gun/energy/netgun,
+/obj/item/gun/energy/gun,
 /turf/simulated/floor/tiled/eris/white/danger,
 /area/talon/deckone/armory)
 "sY" = (
@@ -4214,6 +4240,16 @@
 "Hp" = (
 /turf/simulated/floor/tiled/eris/dark/brown_perforated,
 /area/talon/deckone/starboard_eng_store)
+"Hq" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/suit/space/void/refurb/talon,
+/obj/item/clothing/suit/space/void/refurb/talon,
+/obj/item/clothing/suit/space/void/refurb/talon,
+/obj/item/clothing/head/helmet/space/void/refurb/talon,
+/obj/item/clothing/head/helmet/space/void/refurb/talon,
+/obj/item/clothing/head/helmet/space/void/refurb/talon,
+/turf/simulated/floor/tiled/eris/dark/danger,
+/area/talon/deckone/secure_storage)
 "Hy" = (
 /turf/simulated/floor/tiled/eris/dark/orangecorner,
 /area/talon/deckone/brig)
@@ -5176,6 +5212,16 @@
 	pixel_x = 5;
 	pixel_y = 24
 	},
+/obj/structure/table/standard,
+/obj/item/cell/device/weapon{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/cell/device/weapon,
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/deckone/brig)
 "SF" = (
@@ -5341,8 +5387,16 @@
 /area/talon/maintenance/deckone_port)
 "TX" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/gun/energy/frontier/locked/holdout,
-/obj/item/gun/energy/frontier/locked/holdout,
+/obj/item/cell/device/weapon{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/cell/device/weapon,
+/obj/item/gun/energy/netgun,
 /turf/simulated/floor/tiled/eris/white/danger,
 /area/talon/deckone/armory)
 "Uq" = (
@@ -14943,7 +14997,7 @@ ab
 ac
 wj
 kN
-aN
+Hq
 kN
 LO
 aR

--- a/_maps/map_levels/140x140/talon/talon2.dmm
+++ b/_maps/map_levels/140x140/talon/talon2.dmm
@@ -668,8 +668,6 @@
 /obj/random/multiple/treasure,
 /obj/random/multiple/treasure,
 /obj/random/multiple/treasure,
-/obj/item/stolenpackageplus,
-/obj/item/stolenpackageplus,
 /turf/simulated/floor/reinforced,
 /area/talon/decktwo/vault)
 "bC" = (
@@ -708,6 +706,16 @@
 /obj/machinery/camera/network/talon{
 	dir = 9
 	},
+/obj/item/stolenpackageplus,
+/obj/item/stolenpackageplus,
+/obj/item/stolenpackageplus,
+/obj/item/stolenpackageplus,
+/obj/item/stolenpackageplus,
+/obj/item/stolenpackageplus,
+/obj/item/stolenpackageplus,
+/obj/item/stolenpackageplus,
+/obj/item/stolenpackageplus,
+/obj/item/stolenpackageplus,
 /turf/simulated/floor/reinforced,
 /area/talon/decktwo/vault)
 "bF" = (
@@ -1356,8 +1364,8 @@
 /obj/structure/table/rack/shelf/steel,
 /obj/item/cell/device/weapon/empty,
 /obj/item/cell/device/weapon/empty,
-/obj/random/energy/sec,
-/obj/random/energy/sec,
+/obj/random/energy,
+/obj/random/energy,
 /turf/simulated/floor/reinforced,
 /area/talon/decktwo/vault)
 "ev" = (


### PR DESCRIPTION
## About The Pull Request

-Deck 1
Moved the inducer to make space.
Replaced a crew voidsuit with a mining voidsuit for species like Teshari, where there isn't a cyclable Talon crew variant.
Changed jetpack layers.
Added the correct flaregun ammunition instead of standard flares.
Replaced the shotgun and it's buckshot with the burst laser that was there at the virgo port.
Moved the holdout pistols, replaced their pins and fixed their descriptions to fit with the existing phasers.
Readded holsters.
Moved the netgun, and readded the egun that was there at the virgo port.
Added spare weapon cells to brig.

-Deck 2
Moved packages into the locker, and added more
Removed sec restriction from egun spawner to add variety where previously only the egun, and laser rifle were spawning.

## Why It's Good For The Game
Having cyclable suits is important for every species, and a spare mining suit+cycler would be easily salvageable.
Burstguns have disablers, replacing it with lethal buckshot to 'demilitarize' is odd, and wont alter the way Talon is played. Guidelines and such are better at doing that.
Eguns are almost identical to frontier phasers in terms of base function, unsure why this was removed as well.
Holsters are QOL.
Three cells in brig for miscellaneous usage, so that weapon storage isn't picked of it's cells.
Curated packages have interesting, valuable loot that *usually* isn't just a weapon outright. These make trading with the talon something other than buy guns, or buy useless toys. (At some point I should just make an item spawner with similar objects loaded instead of having packages to unwrap..)
The sec restricted gun spawners are limited to only the energy pistol and laser rifle. Two guns that NT already has access to isn't great for selling.

## Changelog
:cl:
tweak: Altered Talon's shipside gear, and vault contents.
/:cl:
