### PR TITLE
reverts shield power usage nerfs

### DIFF
--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -13,7 +13,7 @@
 	var/average_field_strength = 0
 	var/strengthen_rate = 0.2
 	var/max_strengthen_rate = 0.9	//the maximum rate that the generator can increase the average field strength
-	var/dissipation_rate = 0.070	//the percentage of the shield strength that needs to be replaced each second
+	var/dissipation_rate = 0.030	//the percentage of the shield strength that needs to be replaced each second
 	var/min_dissipation = 0.01		//will dissipate by at least this rate in renwicks per field tile (otherwise field would never dissipate completely as dissipation is a percentage)
 	var/powered = 0
 	var/check_powered = 1
@@ -28,7 +28,7 @@
 /obj/machinery/shield_gen/advanced
 	name = "advanced bubble shield generator"
 	desc = "A machine that generates a field of energy optimized for blocking meteorites when activated.  This version comes with a more efficent shield matrix."
-	energy_conversion_rate = 0.0020
+	energy_conversion_rate = 0.0012
 
 /obj/machinery/shield_gen/Initialize(mapload)
 	if(anchored)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

back to the values prenerf when they were nerfed on triumph
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

unlike the triumph, the tether isn't powercreeped to every way imaginable
having shields be more than 2x as shitty as they should be is pretty awful when the map was designed around the values upstream uses

infact upstream shields are different now but until we port those, this is the next best thing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

