### PR TITLE
Fixes Solar-Side UD Entrance

### DIFF
--- a/_maps/map_files/tether/tether-09-solars.dmm
+++ b/_maps/map_files/tether/tether-09-solars.dmm
@@ -7993,7 +7993,7 @@
 /area/mine/explored)
 "tj" = (
 /obj/item/bone/skull/unathi,
-/turf/simulated/mineral/floor/virgo3b,
+/turf/simulated/mineral/floor/ignore_cavegen/virgo3b,
 /area/mine/explored)
 "wj" = (
 /obj/structure/fence{
@@ -8019,11 +8019,11 @@
 /area/mine/explored)
 "AM" = (
 /obj/item/bone,
-/turf/simulated/mineral/floor/virgo3b,
+/turf/simulated/mineral/floor/ignore_cavegen/virgo3b,
 /area/mine/explored)
 "Dm" = (
 /obj/effect/decal/remains/ribcage,
-/turf/simulated/mineral/floor/virgo3b,
+/turf/simulated/mineral/floor/ignore_cavegen/virgo3b,
 /area/mine/explored)
 "DY" = (
 /obj/effect/map_effect/portal/master/side_b{
@@ -8031,27 +8031,21 @@
 	name = "from_solars_to_underdark";
 	portal_id = "solar-udstep"
 	},
-/turf/simulated/mineral/floor/virgo3b,
+/turf/simulated/mineral/floor/ignore_cavegen/virgo3b,
 /area/mine/explored)
 "Hf" = (
 /obj/effect/decal/remains/robot,
-/turf/simulated/mineral/floor/virgo3b,
+/turf/simulated/mineral/floor/ignore_cavegen/virgo3b,
 /area/mine/explored)
 "HI" = (
 /obj/structure/fence,
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/mine/explored)
-"JP" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/mineral/floor/virgo3b,
-/area/mine/explored)
 "Lj" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/outdoors/dirt/virgo3b,
+/turf/simulated/mineral/floor/ignore_cavegen/virgo3b,
 /area/mine/explored)
 "NQ" = (
 /obj/structure/fence/corner{
@@ -8074,7 +8068,7 @@
 /area/mine/explored)
 "QM" = (
 /obj/effect/decal/remains/deer,
-/turf/simulated/mineral/floor/virgo3b,
+/turf/simulated/mineral/floor/ignore_cavegen/virgo3b,
 /area/mine/explored)
 "Su" = (
 /turf/simulated/mineral/ignore_cavegen/virgo3b,
@@ -8096,7 +8090,7 @@
 /turf/simulated/wall/r_wall,
 /area/mine/explored)
 "UW" = (
-/turf/simulated/mineral/floor/virgo3b,
+/turf/simulated/mineral/floor/ignore_cavegen/virgo3b,
 /area/mine/explored)
 "Wq" = (
 /obj/structure/cable/heavyduty{
@@ -8109,7 +8103,7 @@
 /obj/effect/map_effect/portal/line/side_b{
 	dir = 8
 	},
-/turf/simulated/mineral/floor/virgo3b,
+/turf/simulated/mineral/floor/ignore_cavegen/virgo3b,
 /area/mine/explored)
 
 (1,1,1) = {"
@@ -26436,7 +26430,7 @@ Su
 Su
 Su
 TF
-JP
+Lj
 UW
 UW
 Su


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## I made a slight error that was not caught during Testing
As it turns out the way Virgo Generate caves in UD and in solars/mining is different in that it will generate rocks on top of mineral turfs in solars/mining but not in UD. Not realizing this I accidentally gave the entrance to the UD in solars the ability to generate caves. This has been fixed with the use of 'ignore cavegen' mineral turfs which should make certain that the cave entrance to UD generates unblocked every time and miners don't have to deal with Z-levels transitioning them into a rock wall. I admit I probably should have caught this sooner however it appears Cavegen can coincidentally decide to keep the open mineral turfs so during some tests the cave appeared as it should have.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: UD Secondary entrance, in solars region.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
