### PR TITLE
Fixes Lever Action Rifles

### DIFF
--- a/code/modules/projectiles/guns/projectile/boltaction.dm
+++ b/code/modules/projectiles/guns/projectile/boltaction.dm
@@ -69,7 +69,7 @@
 	item_state = "leveraction"
 	icon_state = "leveraction"
 	max_shells = 10
-	caliber = "357"
+	caliber = ".357"
 	load_method = SINGLE_CASING
 	ammo_type = /obj/item/ammo_casing/a357
 	action_sound = 'sound/weapons/riflebolt.ogg'
@@ -92,7 +92,7 @@
 			item_state = "mareleg"
 			icon_state = "mareleg"
 			w_class = ITEMSIZE_NORMAL
-			caliber = "357"
+			caliber = ".357"
 			load_method = SINGLE_CASING
 			ammo_type = /obj/item/ammo_casing/a357
 			recoil = 1 // Less Ouch
@@ -113,7 +113,7 @@
 	item_state = "levercarabine" // That isn't how carbine is spelled ya knob! :U
 	icon_state = "levercarabine"
 	max_shells = 10
-	caliber = "44"
+	caliber = ".44"
 	load_method = SINGLE_CASING
 	ammo_type = /obj/item/ammo_casing/a44
 	animated_pump = 1
@@ -136,7 +136,7 @@
 			item_state = "mareleg"
 			icon_state = "mareleg"
 			w_class = ITEMSIZE_NORMAL
-			caliber = "44"
+			caliber = ".44"
 			load_method = SINGLE_CASING
 			ammo_type = /obj/item/ammo_casing/a44
 			recoil = 1 // Less Ouch


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Apparently these have been broken since they were added
Which was quite embarassing considering I added them. However since I was not aware they were broke, until someone mentioned them being broke over radio, I was not able to fix to add the four "." to make them work.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: lever actions now accept proper ".357" and ".44" rather then nonexistent "357" and "44"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
