### PR TITLE
Readded some lost alt_titles, added some new ones, and ported the Xenobotanist job

### DIFF
--- a/code/game/jobs/access_datum.dm
+++ b/code/game/jobs/access_datum.dm
@@ -405,6 +405,12 @@ var/const/access_pilot = 67
 	desc = "Entertainment Backstage"
 	region = ACCESS_REGION_GENERAL
 
+/var/const/access_xenobotany = 77
+/datum/access/xenobotany
+	id = access_xenobotany
+	desc = "Xenobotany Garden"
+	region = ACCESS_REGION_RESEARCH
+
 /var/const/access_mime = 138
 /datum/access/mime
 	id = access_mime

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -1,8 +1,8 @@
 //////////////////////////////////
 //			Assistant
 //////////////////////////////////
-/datum/job/assistant
-	title = "Assistant"
+/datum/job/assistant	// Visitor
+	title = USELESS_JOB
 	flag = ASSISTANT
 	departments = list(DEPARTMENT_CIVILIAN)
 	sorting_order = -1
@@ -10,11 +10,12 @@
 	faction = "Station"
 	total_positions = -1
 	spawn_positions = -1
-	supervisors = "absolutely everyone"
+	supervisors = "nobody! You don't work here"
 	selection_color = "#515151"
 	economic_modifier = 1
 	access = list()			//See /datum/job/assistant/get_access()
 	minimal_access = list()	//See /datum/job/assistant/get_access()
+	timeoff_factor = 0
 
 	outfit_type = /decl/hierarchy/outfit/job/assistant
 	alt_titles = list("Visitor" = /datum/alt_title/visitor, "Server" = /datum/alt_title/server, "Morale Officer" = /datum/alt_title/morale_officer)
@@ -24,11 +25,6 @@
 		return list(access_maint_tunnels)
 	else
 		return list()
-
-/datum/job/assistant		// Visitor
-	title = USELESS_JOB
-	supervisors = "nobody! You don't work here"
-	timeoff_factor = 0
 
 /datum/job/assistant/New()
 	..()

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -97,17 +97,17 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	)
 
 	access = list(access_security, access_sec_doors, access_brig, access_forensics_lockers,
-			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
-			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
-			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
-			            access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
-			            access_hop, access_RC_announce, access_keycard_auth, access_gateway)
+						access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
+						access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
+						access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
+						access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
+						access_hop, access_RC_announce, access_keycard_auth, access_gateway)
 	minimal_access = list(access_security, access_sec_doors, access_brig, access_forensics_lockers,
-			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
-			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
-			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
-			            access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
-			            access_hop, access_RC_announce, access_keycard_auth, access_gateway)
+						access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
+						access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
+						access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
+						access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
+						access_hop, access_RC_announce, access_keycard_auth, access_gateway)
 
 // HOP Alt Titles
 /datum/alt_title/cro

--- a/code/game/jobs/job/cargo.dm
+++ b/code/game/jobs/job/cargo.dm
@@ -50,6 +50,11 @@
 	outfit_type = /decl/hierarchy/outfit/job/cargo/cargo_tech
 	job_description = "A Cargo Technician fills and delivers cargo orders. They are encouraged to return delivered crates to the Cargo Shuttle, \
 						because Central Command gives a partial refund."
+	alt_titles = list("Logistics Specialist" = /datum/alt_title/logi_spec)
+
+// Cargo Technician Alt Titles
+/datum/alt_title/logi_spec
+	title = "Logistics Specialist"
 
 //////////////////////////////////
 //			Shaft Miner

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -276,9 +276,17 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/assistant
 	job_description = "An entertainer does just that, entertains! Put on plays, play music, sing songs, tell stories, or read your favorite fanfic."
-	alt_titles = list("Performer" = /datum/alt_title/performer, "Musician" = /datum/alt_title/musician, "Stagehand" = /datum/alt_title/stagehand,
-						"Actor" = /datum/alt_title/actor, "Dancer" = /datum/alt_title/dancer, "Singer" = /datum/alt_title/singer,
-						"Magician" = /datum/alt_title/magician, "Comedian" = /datum/alt_title/comedian, "Tragedian" = /datum/alt_title/tragedian)
+	alt_titles = list(
+		"Performer" = /datum/alt_title/performer,
+		"Musician" = /datum/alt_title/musician,
+		"Stagehand" = /datum/alt_title/stagehand,
+		"Actor" = /datum/alt_title/actor,
+		"Dancer" = /datum/alt_title/dancer,
+		"Singer" = /datum/alt_title/singer,
+		"Magician" = /datum/alt_title/magician,
+		"Comedian" = /datum/alt_title/comedian,
+		"Tragedian" = /datum/alt_title/tragedian
+		)
 
 // Entertainer Alt Titles
 /datum/alt_title/actor

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -1,4 +1,4 @@
-//Due to how large this one is it gets its own file
+// Due to how large this one is it gets its own file
 /datum/job/chaplain
 	title = "Chaplain"
 	flag = CHAPLAIN
@@ -15,8 +15,11 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/chaplain
 	job_description = "The Chaplain ministers to the spiritual needs of the crew."
-	alt_titles = list("Counselor" = /datum/alt_title/counselor, "Religious Affairs Advisor" = /datum/alt_title/chaplain/advisor,
-	"Paracausal Scholar" = /datum/alt_title/chaplain/scholar, "Exorcist" = /datum/alt_title/chaplain/scholar)
+	alt_titles = list(
+		"Counselor" = /datum/alt_title/counselor,
+		"Religious Affairs Advisor" = /datum/alt_title/chaplain/advisor,
+		"Paracausal Scholar" = /datum/alt_title/chaplain/scholar
+		)
 
 // Chaplain Alt Titles
 /datum/alt_title/counselor
@@ -108,5 +111,3 @@
 	GLOB.bible_name = B.name
 	GLOB.deity = B.deity_name
 	feedback_set_details("religion_deity","[new_deity]")
-
-

--- a/code/game/jobs/job/department.dm
+++ b/code/game/jobs/job/department.dm
@@ -78,3 +78,10 @@
 	color = "#A52A2A"
 	sorting_order = 20 // Above Command.
 	centcom_only = TRUE
+
+/datum/department/misc
+	name = "Off-Duty"
+	short_name = "Offduty"
+	color = "#666666"
+	sorting_order = -5
+	assignable = FALSE

--- a/code/game/jobs/job/department_vr.dm
+++ b/code/game/jobs/job/department_vr.dm
@@ -1,6 +1,0 @@
-/datum/department/misc
-	name = "Off-Duty"
-	short_name = "Offduty"
-	color = "#666666"
-	sorting_order = -5
-	assignable = FALSE

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -17,27 +17,30 @@
 	idtype = /obj/item/card/id/engineering/head
 	req_admin_notify = 1
 	economic_modifier = 10
+	pto_type = PTO_ENGINEERING
 
 	minimum_character_age = 25
 	ideal_character_age = 50
 
-
 	access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
-			            access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
-			            access_heads, access_construction, access_sec_doors,
-			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
+						access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
+						access_heads, access_construction, access_sec_doors,
+						access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
 	minimal_access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
-			            access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
-			            access_heads, access_construction, access_sec_doors,
-			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
+						access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
+						access_heads, access_construction, access_sec_doors,
+						access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
 	minimal_player_age = 7
-	alt_titles = list("Head Engineer" = /datum/alt_title/head_engineer, "Maintenance Manager" = /datum/alt_title/maintenance_manager, "Engineering Director" = /datum/alt_title/engineering_director)
+	alt_titles = list(
+		"Head Engineer" = /datum/alt_title/head_engineer,
+		"Maintenance Manager" = /datum/alt_title/maintenance_manager,
+		"Engineering Director" = /datum/alt_title/engineering_director
+		)
 
 	outfit_type = /decl/hierarchy/outfit/job/engineering/chief_engineer
 	job_description = "The Chief Engineer manages the Engineering Department, ensuring that the Engineers work on what needs to be done, handling distribution \
 						of manpower as much as they handle hands-on operations and repairs. They are also expected to keep the rest of the station informed of \
 						any structural threats to the station that may be hazardous to health or disruptive to work."
-	pto_type = PTO_ENGINEERING
 
 /datum/alt_title/engineering_director
 	title = "Engineering Director"
@@ -63,18 +66,24 @@
 	selection_color = "#5B4D20"
 	idtype = /obj/item/card/id/engineering/engineer
 	economic_modifier = 5
+	pto_type = PTO_ENGINEERING
+
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics)
 	minimal_access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction)
-	alt_titles = list("Maintenance Technician" = /datum/alt_title/maint_tech,
-						"Engine Technician" = /datum/alt_title/engine_tech, "Electrician" = /datum/alt_title/electrician,
-						"Apprentice Engineer" = /datum/alt_title/apprentice_engineer)
+
+	alt_titles = list(
+		"Maintenance Technician" = /datum/alt_title/maint_tech,
+		"Engine Technician" = /datum/alt_title/engine_tech,
+		"Electrician" = /datum/alt_title/electrician,
+		"Apprentice Engineer" = /datum/alt_title/apprentice_engineer,
+		"Construction Engineer" = /datum/alt_title/construction_engi
+		)
 
 	minimal_player_age = 3
 
 	outfit_type = /decl/hierarchy/outfit/job/engineering/engineer
 	job_description = "An Engineer keeps the station running. They repair damages, keep the atmosphere stable, and ensure that power is being \
 						generated and distributed. On quiet shifts, they may be called upon to make cosmetic alterations to the station."
-	pto_type = PTO_ENGINEERING
 
 // Engineer Alt Titles
 /datum/alt_title/maint_tech
@@ -95,6 +104,11 @@
 /datum/alt_title/apprentice_engineer
 	title = "Apprentice Engineer"
 
+/datum/alt_title/construction_engi
+	title = "Construction Engineer"
+	title_blurb = "A Construction Engineer fulfills similar duties to other engineers, but usually occupies spare time with construction of extra facilities in dedicated areas or \
+					as additions to station layout."
+
 //////////////////////////////////
 //			Atmos Tech
 //////////////////////////////////
@@ -110,6 +124,8 @@
 	selection_color = "#5B4D20"
 	idtype = /obj/item/card/id/engineering/atmos
 	economic_modifier = 5
+	pto_type = PTO_ENGINEERING
+
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics, access_external_airlocks)
 	minimal_access = list(access_eva, access_engine, access_atmospherics, access_maint_tunnels, access_emergency_storage, access_construction, access_external_airlocks)
 
@@ -119,8 +135,19 @@
 	job_description = "An Atmospheric Technician is primarily concerned with keeping the station's atmosphere breathable. They are expected to have a good \
 						understanding of the pipes, vents, and scrubbers that move gasses around the station, and to be familiar with proper firefighting procedure."
 
-	alt_titles = list("Atmospherics Maintainer" = /datum/alt_title/atmos_maint)
-	pto_type = PTO_ENGINEERING
+	alt_titles = list(
+		"Atmospherics Maintainer" = /datum/alt_title/atmos_maint,
+		"Pipe Network Specialist" = /datum/alt_title/pipe_spec,
+		"Disposals Technician" = /datum/alt_title/disposals_tech
+		)
 
+// Atmos Tech Alt Titles
 /datum/alt_title/atmos_maint
 	title = "Atmospherics Maintainer"
+
+/datum/alt_title/pipe_spec
+	title = "Pipe Network Specialist"
+
+/datum/alt_title/disposals_tech
+	title = "Disposals Technician"
+	title_blurb = "A Disposals Technician is an Atmospheric Technician still and can fulfill all the same duties, although specializes more in disposals delivery system's operations and configurations."

--- a/code/game/jobs/job/exploration.dm
+++ b/code/game/jobs/job/exploration.dm
@@ -64,8 +64,11 @@
 	minimal_access = list(access_eva, access_maint_tunnels, access_external_airlocks, access_pilot, access_explorer, access_research, access_gateway, access_pathfinder)
 	outfit_type = /decl/hierarchy/outfit/job/pathfinder
 	job_description = "The Pathfinder's job is to lead and manage expeditions, and is the primary authority on all off-station expeditions."
-	alt_titles = list("Expedition Lead" = /datum/alt_title/expedition_lead, "Exploration Manager" = /datum/alt_title/exploration_manager,
-	"Lead Pioneer" = /datum/alt_title/pathfinder/pioneer)
+	alt_titles = list(
+		"Expedition Lead" = /datum/alt_title/expedition_lead,
+		"Exploration Manager" = /datum/alt_title/exploration_manager,
+		"Lead Pioneer" = /datum/alt_title/pathfinder/pioneer
+		)
 
 /datum/alt_title/expedition_lead
 	title = "Expedition Lead"
@@ -95,7 +98,10 @@
 	minimal_access = list(access_pilot, access_external_airlocks)
 	outfit_type = /decl/hierarchy/outfit/job/pilot
 	job_description = "A Pilot flies the various shuttles in the Virgo-Erigone System."
-	alt_titles = list("Co-Pilot" = /datum/alt_title/co_pilot, "Navigator" = /datum/alt_title/navigator)
+	alt_titles = list(
+		"Co-Pilot" = /datum/alt_title/co_pilot,
+		"Navigator" = /datum/alt_title/navigator
+		)
 
 /datum/alt_title/co_pilot
 	title = "Co-Pilot"
@@ -122,9 +128,13 @@
 	minimal_access = list(access_explorer, access_external_airlocks, access_research, access_pilot, access_gateway)
 	outfit_type = /decl/hierarchy/outfit/job/explorer2
 	job_description = "An Explorer searches for interesting things, and returns them to the station."
-	alt_titles = list("Surveyor" = /datum/alt_title/surveyor, "Offsite Scout" = /datum/alt_title/offsite_scout,
-	"Field Scout" = /datum/alt_title/explorer/field_scout, "Pioneer" = /datum/alt_title/explorer/pioneer,
-	"Jr. Explorer" = /datum/alt_title/explorer/junior)
+	alt_titles = list(
+		"Surveyor" = /datum/alt_title/surveyor,
+		"Offsite Scout" = /datum/alt_title/offsite_scout,
+		"Field Scout" = /datum/alt_title/explorer/field_scout,
+		"Pioneer" = /datum/alt_title/explorer/pioneer,
+		"Jr. Explorer" = /datum/alt_title/explorer/junior
+		)
 
 /datum/alt_title/surveyor
 	title = "Surveyor"
@@ -159,7 +169,10 @@
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_pilot)
 	outfit_type = /decl/hierarchy/outfit/job/medical/sar
 	job_description = "A Field medic works as the field doctor of expedition teams."
-	alt_titles = list("Expedition Medic" = /datum/alt_title/expedition_medic, "Search and Rescue" = /datum/alt_title/field_medic/sar)
+	alt_titles = list(
+		"Expedition Medic" = /datum/alt_title/expedition_medic,
+		"Search and Rescue" = /datum/alt_title/field_medic/sar
+		)
 
 /datum/alt_title/expedition_medic
 	title = "Expedition Medic"

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -1,56 +1,56 @@
 /datum/job
 
-	//The name of the job
+	// The name of the job
 	var/title = "NOPE"
-	//Job access. The use of minimal_access or access is determined by a config setting: config.jobs_have_minimal_access
-	var/list/minimal_access = list()      // Useful for servers which prefer to only have access given to the places a job absolutely needs (Larger server population)
-	var/list/access = list()              // Useful for servers which either have fewer players, so each person needs to fill more than one role, or servers which like to give more access, so players can't hide forever in their super secure departments (I'm looking at you, chemistry!)
-	var/flag = 0 	                      // Bitflags for the job
+	// Job access. The use of minimal_access or access is determined by a config setting: config.jobs_have_minimal_access
+	var/list/minimal_access = list()		// Useful for servers which prefer to only have access given to the places a job absolutely needs (Larger server population)
+	var/list/access = list()				// Useful for servers which either have fewer players, so each person needs to fill more than one role, or servers which like to give more access, so players can't hide forever in their super secure departments (I'm looking at you, chemistry!)
+	var/flag = 0 							// Bitflags for the job
 	var/department_flag = 0
-	var/faction = "None"	              // Players will be allowed to spawn in as jobs that are set to "Station"
-	var/total_positions = 0               // How many players can be this job
-	var/spawn_positions = 0               // How many players can spawn in as this job
-	var/current_positions = 0             // How many players have this job
-	var/supervisors = null                // Supervisors, who this person answers to directly
+	var/faction = "None"					// Players will be allowed to spawn in as jobs that are set to "Station"
+	var/total_positions = 0					// How many players can be this job
+	var/spawn_positions = 0					// How many players can spawn in as this job
+	var/current_positions = 0				// How many players have this job
+	var/supervisors = null					// Supervisors, who this person answers to directly
 	/// Type of ID that the player will have. This is banned. Use outfits, this is only kept in for legacy.
 	var/idtype = /obj/item/card/id
-	var/selection_color = "#ffffff"       // Selection screen color
-	var/list/alt_titles = null            // List of alternate titles; There is no need for an alt-title datum for the base job title.
-	var/req_admin_notify                  // If this is set to 1, a text is printed to the player when jobs are assigned, telling him that he should let admins know that he has to disconnect.
-	var/minimal_player_age = 0            // If you have use_age_restriction_for_jobs config option enabled and the database set up, this option will add a requirement for players to be at least minimal_player_age days old. (meaning they first signed in at least that many days before.)
-	var/list/departments = list()         // List of departments this job belongs to, if any. The first one on the list will be the 'primary' department.
-	var/sorting_order = 0                 // Used for sorting jobs so boss jobs go above regular ones, and their boss's boss is above that. Higher numbers = higher in sorting.
-	var/departments_managed = null        // Is this a management position?  If yes, list of departments managed.  Otherwise null.
-	var/department_accounts = null        // Which department accounts should people with this position be given the pin for?
-	var/assignable = TRUE                 // Should it show up on things like the ID computer?
+	var/selection_color = COLOR_WHITE		// Selection screen color
+	var/list/alt_titles = null				// List of alternate titles; There is no need for an alt-title datum for the base job title.
+	var/req_admin_notify					// If this is set to 1, a text is printed to the player when jobs are assigned, telling him that he should let admins know that he has to disconnect.
+	var/minimal_player_age = 0				// If you have use_age_restriction_for_jobs config option enabled and the database set up, this option will add a requirement for players to be at least minimal_player_age days old. (meaning they first signed in at least that many days before.)
+	var/list/departments = list()			// List of departments this job belongs to, if any. The first one on the list will be the 'primary' department.
+	var/sorting_order = 0					// Used for sorting jobs so boss jobs go above regular ones, and their boss's boss is above that. Higher numbers = higher in sorting.
+	var/departments_managed = null			// Is this a management position?  If yes, list of departments managed.  Otherwise null.
+	var/department_accounts = null			// Which department accounts should people with this position be given the pin for?
+	var/assignable = TRUE					// Should it show up on things like the ID computer?
 	var/minimum_character_age = 0
 	var/ideal_character_age = 30
-	var/has_headset = TRUE                //Do people with this job need to be given headsets and told how to use them?  E.g. Cyborgs don't.
+	var/has_headset = TRUE					//Do people with this job need to be given headsets and told how to use them?  E.g. Cyborgs don't.
 
-	var/account_allowed = 1				  // Does this job type come with a station account?
-	var/economic_modifier = 2			  // With how much does this job modify the initial account amount?
+	var/account_allowed = 1					// Does this job type come with a station account?
+	var/economic_modifier = 2				// With how much does this job modify the initial account amount?
 
-	var/outfit_type						  // What outfit datum does this job use in its default title?
+	var/outfit_type							// What outfit datum does this job use in its default title?
 
-	var/offmap_spawn = FALSE			  // Do we require weird and special spawning and datacore handling?
-	var/mob_type = JOB_CARBON 		      // Bitflags representing mob type this job spawns
+	var/offmap_spawn = FALSE				// Do we require weird and special spawning and datacore handling?
+	var/mob_type = JOB_CARBON				// Bitflags representing mob type this job spawns
 
 	// Description of the job's role and minimum responsibilities.
 	var/job_description = "This Job doesn't have a description! Please report it!"
 
-	//Requires a ckey to be whitelisted in jobwhitelist.txt
+	// Requires a ckey to be whitelisted in jobwhitelist.txt
 	var/whitelist_only = 0
 
-	//Does not display this job on the occupation setup screen
+	// Does not display this job on the occupation setup screen
 	var/latejoin_only = 0
 
-	//Every hour playing this role gains this much time off. (Can be negative for off duty jobs!)
+	// Every hour playing this role gains this much time off. (Can be negative for off duty jobs!)
 	var/timeoff_factor = 3
 
-	//What type of PTO is that job earning?
+	// What type of PTO is that job earning?
 	var/pto_type
 
-	//Disallow joining as this job midround from off-duty position via going on-duty
+	// Disallow joining as this job midround from off-duty position via going on-duty
 	var/disallow_jobhop = FALSE
 
 /datum/job/New()
@@ -85,7 +85,7 @@
 			if(CLASS_LOWMID)	income = 0.75
 			if(CLASS_LOWER)		income = 0.50
 
-	//give them an account in the station database
+	// Give them an account in the station database
 	var/money_amount = (rand(15,40) + rand(15,40)) * income * economic_modifier * ECO_MODIFIER //VOREStation Edit - Smoothed peaks, ECO_MODIFIER rather than per-species ones.
 	var/datum/money_account/M = create_account(H.real_name, money_amount, null, offmap_spawn)
 	if(H.mind)
@@ -103,7 +103,7 @@
 
 	to_chat(H, "<span class='notice'><b>Your account number is: [M.account_number], your account pin is: [M.remote_access_pin]</b></span>")
 
-// overrideable separately so AIs/borgs can have cardborg hats without unneccessary new()/qdel()
+// Overrideable separately so AIs/borgs can have cardborg hats without unneccessary new()/qdel()
 /datum/job/proc/equip_preview(mob/living/carbon/human/H, var/alt_title)
 	var/decl/hierarchy/outfit/outfit = get_outfit(H, alt_title)
 	if(!outfit)
@@ -116,9 +116,9 @@
 	else
 		return src.access.Copy()
 
-//If the configuration option is set to require players to be logged as old enough to play certain jobs, then this proc checks that they are, otherwise it just returns 1
+// If the configuration option is set to require players to be logged as old enough to play certain jobs, then this proc checks that they are, otherwise it just returns 1
 /datum/job/proc/player_old_enough(client/C)
-	return (available_in_days(C) == 0) //Available in 0 days = available right now = player is old enough to play.
+	return (available_in_days(C) == 0)	// Available in 0 days = available right now = player is old enough to play.
 
 /datum/job/proc/available_in_days(client/C)
 	if(C && config_legacy.use_age_restriction_for_jobs && isnum(C.player_age) && isnum(minimal_player_age))
@@ -164,7 +164,7 @@
 		COMPILE_OVERLAYS(mannequin)
 		var/icon/preview_icon = getFlatIcon(mannequin)
 
-		preview_icon.Scale(preview_icon.Width() * 2, preview_icon.Height() * 2) // Scaling here to prevent blurring in the browser.
+		preview_icon.Scale(preview_icon.Width() * 2, preview_icon.Height() * 2)	// Scaling here to prevent blurring in the browser.
 		job_master.job_icons[title] = preview_icon
 
 	return job_master.job_icons[title]

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -81,7 +81,7 @@
 		"Orderly" = /datum/alt_title/orderly
 		)
 
-//Medical Doctor Alt Titles
+// Medical Doctor Alt Titles
 /datum/alt_title/surgeon
 	title = "Surgeon"
 	title_blurb = "A Surgeon specializes in providing surgical aid to injured patients, up to and including amputation and limb reattachement. They are expected \
@@ -144,12 +144,19 @@
 	outfit_type = /decl/hierarchy/outfit/job/medical/chemist
 	job_description = "A Chemist produces and maintains a stock of basic to advanced chemicals for medical and occasionally research use. \
 						They are likely to know the use and dangers of many lab-produced chemicals."
-	alt_titles = list("Pharmacist" = /datum/alt_title/pharmacist)
+	alt_titles = list(
+		"Pharmacist" = /datum/alt_title/pharmacist,
+		"Pharmacologist" = /datum/alt_title/pharmacologist
+		)
 
 // Chemist Alt Titles
 /datum/alt_title/pharmacist
 	title = "Pharmacist"
 	title_blurb = "A Pharmacist focuses on the chemical needs of the Medical Department, and often offers to fill crew prescriptions at their discretion."
+
+/datum/alt_title/pharmacologist
+	title = "Pharmacologist"
+	title_blurb = "A Pharmacologist focuses on the chemical needs of the Medical Department, primarily specializing in producing more advanced forms of medicine."
 
 /* I'm commenting out Geneticist so you can't actually see it in the job menu, given that you can't play as one - Jon.
 //////////////////////////////////
@@ -199,11 +206,10 @@
 					ails the mentally unwell, frequently under Security supervision. They understand the effects of various psychoactive drugs."
 	alt_titles = list(
 		"Psychologist" = /datum/alt_title/psychologist,
-		"Therapist" = /datum/alt_title/psychiatrist/therapist,
+		"Psychoanalyst" = /datum/alt_title/psychologist/psychoanalyst,
+		"Counselor" = /datum/alt_title/counselor,
+		"Therapist" = /datum/alt_title/therapist
 		)
-
-/datum/alt_title/psychiatrist/therapist
-	title = "Therapist"
 
 //Psychiatrist Alt Titles
 /datum/alt_title/psychologist
@@ -211,6 +217,17 @@
 	title_blurb =  "A Psychologist provides mental health services to crew members in need, focusing more on therapy than medication. They may also be \
 					called upon to determine whatever ails the mentally unwell, frequently under Security supervision."
 	title_outfit = /decl/hierarchy/outfit/job/medical/psychiatrist/psychologist
+
+/datum/alt_title/psychologist/psychoanalyst
+	title = "Psychoanalyst"
+	title_blurb =  "A Psychoanalyst provides mental health services to crew members in need, focusing more on therapy than medication. They may also be \
+					called upon to determine whatever ails the mentally unwell, frequently under Security supervision."
+
+/datum/alt_title/counselor
+	title = "Counselor"
+
+/datum/alt_title/therapist
+	title = "Therapist"
 
 //////////////////////////////////
 //			Paramedic
@@ -233,11 +250,20 @@
 	outfit_type = /decl/hierarchy/outfit/job/medical/paramedic
 	job_description = "A Paramedic is primarily concerned with the recovery of patients who are unable to make it to the Medical Department on their own. \
 						They may also be called upon to keep patients stable when Medical is busy or understaffed."
-	alt_titles = list("Emergency Medical Technician" = /datum/alt_title/emt)
+	alt_titles = list(
+		"Emergency Medical Technician" = /datum/alt_title/emt,
+		"Medical Responder" = /datum/alt_title/medical_responder
+		)
 
 // Paramedic Alt Titles
 /datum/alt_title/emt
 	title = "Emergency Medical Technician"
 	title_blurb = "An Emergency Medical Technician is primarily concerned with the recovery of patients who are unable to make it to the Medical Department on their \
+					own. They are capable of keeping a patient stabilized until they reach the hands of someone with more training."
+	title_outfit = /decl/hierarchy/outfit/job/medical/paramedic/emt
+
+/datum/alt_title/medical_responder
+	title = "Medical Responder"
+	title_blurb = "A Medical Responder is primarily concerned with the recovery of patients who are unable to make it to the Medical Department on their \
 					own. They are capable of keeping a patient stabilized until they reach the hands of someone with more training."
 	title_outfit = /decl/hierarchy/outfit/job/medical/paramedic/emt

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -19,13 +19,13 @@
 	req_admin_notify = 1
 	economic_modifier = 15
 	access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
-			            access_tox_storage, access_teleporter, access_sec_doors,
-			            access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
-			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network)
+						access_tox_storage, access_teleporter, access_sec_doors,
+						access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
+						access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network)
 	minimal_access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
-			            access_tox_storage, access_teleporter, access_sec_doors,
-			            access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
-			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network)
+						access_tox_storage, access_teleporter, access_sec_doors,
+						access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
+						access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network)
 
 	minimum_character_age = 25
 	minimal_player_age = 14
@@ -36,11 +36,21 @@
 						at least with regards to anything occuring in the Research department, and to inform the crew of any disruptions that \
 						might originate from Research. The Research Director often has at least passing knowledge of most of the Research department, but \
 						are encouraged to allow their staff to perform their own duties."
-	alt_titles = list("Research Supervisor" = /datum/alt_title/research_supervisor)
+	alt_titles = list(
+		"Research Supervisor" = /datum/alt_title/research_supervisor,
+		"Head of Development" = /datum/alt_title/head_of_development,
+		"Head Scientist" = /datum/alt_title/head_scientist
+		)
 
 // Research Director Alt Titles
 /datum/alt_title/research_supervisor
 	title = "Research Supervisor"
+
+/datum/alt_title/head_of_development
+	title = "Head of Development"
+
+/datum/alt_title/head_scientist
+	title = "Head Scientist"
 
 //////////////////////////////////
 //			Scientist
@@ -67,12 +77,31 @@
 	job_description = "A Scientist is a generalist working in the Research department, with general knowledge of the scientific process, as well as \
 						the principles and requirements of Research and Development. They may also formulate experiments of their own devising, if \
 						they find an appropriate topic."
-	alt_titles = list("Xenoarchaeologist" = /datum/alt_title/xenoarch, "Anomalist" = /datum/alt_title/anomalist, \
-						"Phoron Researcher" = /datum/alt_title/phoron_research, "Lab Assistant" = /datum/alt_title/scientist/assistant,
-						"Junior Scientist" = /datum/alt_title/scientist/junior, "Circuit Designer" = /datum/alt_title/scientist/circuit,
-						"Research Field Technician" = /datum/alt_title/scientist/fieldtech)
+	alt_titles = list(
+		"Junior Scientist" = /datum/alt_title/scientist/junior,
+		"Lab Assistant" = /datum/alt_title/scientist/assistant,
+		"Researcher" = /datum/alt_title/researcher,
+		"Xenoarchaeologist" = /datum/alt_title/xenoarch,
+		"Anomalist" = /datum/alt_title/anomalist, \
+		"Phoron Researcher" = /datum/alt_title/phoron_research,
+		"Circuit Designer" = /datum/alt_title/scientist/circuit,
+		"Research Field Technician" = /datum/alt_title/scientist/fieldtech
+		)
 
 // Scientist Alt Titles
+/datum/alt_title/scientist/junior
+	title = "Junior Scientist"
+	title_blurb = "A Junior Scientist is a lower-level member of research staff, whose main purpose is to help scientists with their specialized work in more menial fashion, while also \
+					learning the specializations in process."
+
+/datum/alt_title/scientist/assistant
+	title = "Lab Assistant"
+	title_blurb = "A Lab Assistant is a lower-level member of research staff, whose main purpose is to help scientists with their specialized work in more menial fashion, while also \
+					learning the specializations in process."
+
+/datum/alt_title/researcher
+	title = "Researcher"
+
 /datum/alt_title/xenoarch
 	title = "Xenoarchaeologist"
 	title_blurb = "A Xenoarchaeologist enters digsites in search of artifacts of alien origin. These digsites are frequently in vacuum or other inhospitable \
@@ -89,14 +118,10 @@
 					Many Phoron Researchers are interested in the combustability and explosive properties of gaseous phoron, as well as the specific hazards \
 					of working with the substance in that state."
 
-/datum/alt_title/scientist/junior
-	title = "Junior Scientist"
-
-/datum/alt_title/scientist/assistant
-	title = "Lab Assistant"
-
 /datum/alt_title/scientist/circuit
 	title = "Circuit Designer"
+	title_blurb = "A Circuit Designer is a Scientist whose expertise is working with integrated circuits. They are familar with the workings and programming of those devices. \
+					They work to create various useful devices using the capabilities of integrated circuitry."
 
 /datum/alt_title/scientist/fieldtech
 	title = "Research Field Technician"
@@ -125,15 +150,54 @@
 	outfit_type = /decl/hierarchy/outfit/job/science/xenobiologist
 	job_description = "A Xenobiologist studies esoteric lifeforms, usually in the relative safety of their lab. They attempt to find ways to benefit \
 						from the byproducts of these lifeforms, and their main subject at present is the Giant Slime."
-/*VR edit start
-	alt_titles = list("Xenobotanist" = /datum/alt_title/xenobot)
 
- Xenibiologist Alt Titles
-/datum/alt_title/xenobot
+	alt_titles = list(
+		"Xenozoologist" = /datum/alt_title/xenozoologist,
+		"Xenoanthropologist" = /datum/alt_title/xenoanthropologist
+		)
+
+// Xenibiologist Alt Titles
+/datum/alt_title/xenozoologist
+	title = "Xenozoologist"
+	title_blurb = "Xenozoologists are well versed in their study of extra-terrestrial life." // Someone make a better blurb please
+
+/datum/alt_title/xenoanthropologist
+	title = "Xenoanthropologist"
+	title_blurb = "Xenoanthropologist still heavily focuses their study on alien lifeforms, but their specialty leans more towards fellow sapient beings than simple animals."
+
+//////////////////////////////////
+//			Xenobotanist
+//////////////////////////////////
+/datum/job/xenobotanist
 	title = "Xenobotanist"
-	title_blurb = "A Xenobotanist grows and cares for a variety of abnormal, custom made, and frequently dangerous plant life. When the products of these plants \
-					is both safe and beneficial to the station, they may choose to introduce it to the rest of the crew."
-VR edit end*/
+	flag = XENOBOTANIST
+	departments = list(DEPARTMENT_RESEARCH)
+	department_flag = MEDSCI
+	faction = "Station"
+	total_positions = 2
+	spawn_positions = 2
+	supervisors = "the Research Director"
+	selection_color = "#633D63"
+	economic_modifier = 7
+	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobotany, access_hydroponics)
+	minimal_access = list(access_research, access_xenobotany, access_hydroponics, access_tox_storage)
+	pto_type = PTO_SCIENCE
+
+	minimal_player_age = 14
+
+	outfit_type = /decl/hierarchy/outfit/job/science/xenobiologist
+	job_description = "A Xenobotanist grows and cares for a variety of abnormal, custom made, and frequently dangerous plant life. When the products of these plants \
+					are both safe and beneficial to the station, they may choose to introduce it to the rest of the crew."
+	alt_titles = list(
+		"Xenohydroponicist" = /datum/alt_title/xenohydroponicist,
+		"Xenoflorist" = /datum/alt_title/xenoflorist
+		)
+
+/datum/alt_title/xenoflorist
+	title = "Xenoflorist"
+
+/datum/alt_title/xenohydroponicist
+	title = "Xenohydroponicist"
 
 //////////////////////////////////
 //			Roboticist
@@ -157,7 +221,11 @@ VR edit end*/
 	outfit_type = /decl/hierarchy/outfit/job/science/roboticist
 	job_description = "A Roboticist maintains and repairs the station's synthetics, including crew with prosthetic limbs. \
 						They can also assist the station by producing simple robots and even pilotable exosuits."
-	alt_titles = list("Biomechanical Engineer" = /datum/alt_title/biomech, "Mechatronic Engineer" = /datum/alt_title/mech_tech)
+	alt_titles = list(
+		"Biomechanical Engineer" = /datum/alt_title/biomech,
+		"Mechatronic Engineer" = /datum/alt_title/mech_tech,
+		"Prosthetists" = /datum/alt_title/prosthetists
+		)
 
 // Roboticist Alt Titles
 /datum/alt_title/biomech
@@ -169,3 +237,8 @@ VR edit end*/
 	title = "Mechatronic Engineer"
 	title_blurb = "A Mechatronic Engineer focuses on the construction and maintenance of Exosuits, and should be well versed in their use. \
 					They may also be called upon to work on synthetics and prosthetics, if needed."
+
+/datum/alt_title/prosthetists
+	title = "Prosthetists"
+	title_blurb = "Prosthetists design and fabricate medical supportive devices and measure and fit patients for them. These devices \
+					include artificial limbs (arms, hands, legs, and feet), braces, and other medical or surgical devices."

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -20,13 +20,13 @@
 	req_admin_notify = 1
 	economic_modifier = 10
 	access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory,
-			            access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
-			            access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
-			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_external_airlocks)
+						access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
+						access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
+						access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_external_airlocks)
 	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory,
-			            access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
-			            access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
-			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_external_airlocks)
+						access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
+						access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
+						access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_external_airlocks)
 	minimum_character_age = 25
 	minimal_player_age = 14
 
@@ -34,8 +34,11 @@
 	job_description = "	The Head of Security manages the Security Department, keeping the station safe and making sure the rules are followed. They are expected to \
 						keep the other Department Heads, and the rest of the crew, aware of developing situations that may be a threat. If necessary, the HoS may \
 						perform the duties of absent Security roles, such as distributing gear from the Armory."
-	alt_titles = list("Security Commander" = /datum/alt_title/hos/commander, "Chief of Security" = /datum/alt_title/hos/chief,
-		"Defense Director" = /datum/alt_title/hos/director)
+	alt_titles = list(
+		"Security Commander" = /datum/alt_title/hos/commander,
+		"Chief of Security" = /datum/alt_title/hos/chief,
+		"Defense Director" = /datum/alt_title/hos/director
+		)
 
 // Head of Security Alt Titles
 /datum/alt_title/hos/commander
@@ -96,7 +99,10 @@
 	outfit_type = /decl/hierarchy/outfit/job/security/detective
 	job_description = "A Detective works to help Security find criminals who have not properly been identified, through interviews and forensic work. \
 						For crimes only witnessed after the fact, or those with no survivors, they attempt to piece together what they can from pure evidence."
-	alt_titles = list("Forensic Technician" = /datum/alt_title/detective/forensics_tech, "Crime Scene Investigator" = /datum/alt_title/detective/csi)
+	alt_titles = list(
+		"Forensic Technician" = /datum/alt_title/detective/forensics_tech,
+		"Crime Scene Investigator" = /datum/alt_title/detective/csi
+		)
 
 /datum/alt_title/detective/csi
 	title = "Crime Scene Investigator"
@@ -131,8 +137,11 @@
 	job_description = "A Security Officer is concerned with maintaining the safety and security of the station as a whole, dealing with external threats and \
 						apprehending criminals. A Security Officer is responsible for the health, safety, and processing of any prisoner they arrest. \
 						No one is above the Law, not Security or Command."
-	alt_titles = list("Junior Officer" = /datum/alt_title/security_officer/junior, "Security Cadet" = /datum/alt_title/security_officer/cadet,
-		"Security Guard" = /datum/alt_title/security_officer/guard)
+	alt_titles = list(
+		"Junior Officer" = /datum/alt_title/security_officer/junior,
+		"Security Cadet" = /datum/alt_title/security_officer/cadet,
+		"Security Guard" = /datum/alt_title/security_officer/guard
+		)
 
 // Security Officer Alt Titles
 /datum/alt_title/security_officer/junior

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -16,6 +16,7 @@
 	minimal_player_age = 7
 	account_allowed = 0
 	economic_modifier = 0
+	pto_type = PTO_CIVILIAN
 	has_headset = FALSE
 	assignable = FALSE
 	mob_type = JOB_SILICON_AI
@@ -24,7 +25,6 @@
 						The AI is required to follow its Laws, and Lawbound Synthetics that are linked to it are expected to follow \
 						the AI's commands, and their own Laws."
 	disallow_jobhop = TRUE
-	pto_type = PTO_CIVILIAN
 
 // AI procs
 /datum/job/ai/equip(var/mob/living/carbon/human/H)
@@ -49,21 +49,24 @@
 	departments = list(DEPARTMENT_SYNTHETIC)
 	department_flag = ENGSEC
 	faction = "Station"
-	total_positions = 4
-	spawn_positions = 3
+	total_positions = 4			// Along with one able to spawn later in the round.
+	spawn_positions = 3			// Let's have 3 able to spawn in roundstart
 	supervisors = "your laws and the AI"	//Nodrak
 	selection_color = "#254C25"
-	minimal_player_age = 1
+	minimal_player_age = 3		// 1 day is a little too little time
 	account_allowed = 0
 	economic_modifier = 0
+	pto_type = PTO_CYBORG
 	has_headset = FALSE
 	assignable = FALSE
 	mob_type = JOB_SILICON_ROBOT
 	outfit_type = /decl/hierarchy/outfit/job/silicon/cyborg
 	job_description = "A Cyborg is a mobile station synthetic, piloted by a cybernetically preserved brain. It is considered a person, but is still required \
 						to follow its Laws."
-	alt_titles = list("Robot" = /datum/alt_title/robot, "Drone" = /datum/alt_title/drone)
-	pto_type = PTO_CYBORG
+	alt_titles = list(
+		"Robot" = /datum/alt_title/robot,
+		"Drone" = /datum/alt_title/drone
+		)
 
 // Cyborg Alt Titles
 /datum/alt_title/robot

--- a/code/game/jobs/job/special.dm
+++ b/code/game/jobs/job/special.dm
@@ -62,6 +62,8 @@
 	supervisors = "the spirit of laughter"
 	selection_color = "#515151"
 	economic_modifier = 1
+	access = list(access_entertainment)
+	minimal_access = list(access_entertainment)
 	job_description = "A Clown is there to entertain the crew and keep high morale using various harmless pranks and ridiculous jokes!"
 	whitelist_only = 1
 	latejoin_only = 0
@@ -92,6 +94,8 @@
 	supervisors = "the spirit of performance"
 	selection_color = "#515151"
 	economic_modifier = 1
+	access = list(access_entertainment)
+	minimal_access = list(access_entertainment)
 	job_description = "A Mime is there to entertain the crew and keep high morale using unbelievable performances and acting skills!"
 	alt_titles = list("Poseur" = /datum/alt_title/poseur)
 	whitelist_only = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Read the title
+ Ports VOREStation/VOREStation/pull/8419

## Why It's Good For The Game
Xenobotany is on the other side of the station from Xenobiology, they're not going to be working together normally anymore.
ALSO MORE NICE ALT_TITLES

## Changelog
:cl:
add: Xenobotanist Job
add: Lots of other Job Names
del: Xenobotanist alt_title for Xenobio
fix: Moreso readding values we SHOULD'VE had but were missed in someone's port or something
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
