### PR TITLE
""small"" xenobio QoL update

### DIFF
--- a/code/modules/food/kitchen/smartfridge.dm
+++ b/code/modules/food/kitchen/smartfridge.dm
@@ -22,7 +22,7 @@
 	var/locked = 0
 	var/scan_id = 1
 	var/is_secure = 0
-	var/wrenchable = 0
+	var/wrenchable = TRUE
 	var/datum/wires/smartfridge/wires = null
 
 /obj/machinery/smartfridge/secure
@@ -71,7 +71,6 @@
 	if(istype(O, /obj/item/slimepotion))
 		return TRUE
 	return FALSE
-
 
 /obj/machinery/smartfridge/secure/medbay
 	name = "\improper Refrigerated Medicine Storage"

--- a/code/modules/xenobio/machinery/processor.dm
+++ b/code/modules/xenobio/machinery/processor.dm
@@ -8,15 +8,21 @@
 	icon_state = "processor1"
 	density = TRUE
 	anchored = TRUE
+	/// Autointaking
+	var/auto_mode = FALSE
 	var/processing = FALSE // So I heard you like processing.
 	var/list/to_be_processed = list()
 	var/monkeys_recycled = 0
-	description_info = "Clickdrag dead slimes or monkeys to it to insert them.  It will make a new monkey cube for every four monkeys it processes."
+	description_info = "Clickdrag dead slimes or monkeys to it to insert them.  It will make a new monkey cube for every four monkeys it processes. Alt click to enable auto-intake."
 
 /obj/item/circuitboard/processor
 	name = T_BOARD("slime processor")
 	build_path = /obj/machinery/processor
 	origin_tech = list(TECH_DATA = 2, TECH_BIO = 2)
+
+/obj/machinery/processor/examine(mob/user)
+	. = ..()
+	. += "<span class='boldnotice'>The automatic intake switch is in the [auto_mode? "On" : "Off"] position.</span>"
 
 /obj/machinery/processor/attack_hand(mob/living/user)
 	if(processing)
@@ -30,6 +36,11 @@
 		playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, 1)
 		return
 
+/obj/machinery/processor/attackby(obj/item/W, mob/user, params, attack_modifier)
+	if(default_unfasten_wrench(user, W, 40))
+		return
+	return ..()
+
 // Verb to remove everything.
 /obj/machinery/processor/verb/eject()
 	set category = "Object"
@@ -42,6 +53,17 @@
 	add_fingerprint(usr)
 	return
 
+/obj/machinery/processor/AltClick(mob/user)
+	. = ..()
+	if(user.stat || user.incapacitated(INCAPACITATION_DISABLED) || !Adjacent(user))
+		return
+	auto_mode = !auto_mode
+	to_chat(user, "<span class='notice'>You turn the automatic intake [auto_mode? "On" : "Off"].</span>")
+	if(auto_mode)
+		START_PROCESSING(SSobj, src)
+	else
+		STOP_PROCESSING(SSobj, src)
+
 // Ejects all the things out of the machine.
 /obj/machinery/processor/proc/empty()
 	for(var/atom/movable/AM in to_be_processed)
@@ -50,7 +72,7 @@
 
 // Ejects all the things out of the machine.
 /obj/machinery/processor/proc/insert(var/atom/movable/AM, var/mob/living/user)
-	if(!Adjacent(AM))
+	if((!Adjacent(user) && !Adjacent(AM)) || !user.Adjacent(AM))
 		return
 	if(!can_insert(AM))
 		to_chat(user, "<span class='warning'>\The [src] cannot process \the [AM] at this time.</span>")
@@ -59,6 +81,21 @@
 	to_be_processed.Add(AM)
 	AM.forceMove(src)
 	visible_message("<span class='notice'>\the [user] places [AM] inside \the [src].</span>")
+
+/obj/machinery/processor/proc/auto_insert(atom/movable/AM)
+	if(!can_insert(AM))
+		return
+	to_be_processed.Add(AM)
+	AM.forceMove(src)
+	visible_message("<span class='notice'>[src] sucks up [AM].</span>")
+
+/obj/machinery/processor/process(delta_time)
+	if(!auto_mode)
+		return PROCESS_KILL
+	for(var/mob/living/simple_mob/slime/AM in range(1, src))
+		auto_insert(AM)
+	for(var/mob/living/carbon/human/AM in range(1, src))
+		auto_insert(AM)
 
 /obj/machinery/processor/proc/begin_processing()
 	if(processing)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Processor can now be set to auto intake mode with alt click
- Fridges and processors are unwrenchable
- You no longer need the thing you'rei nserting to be adjacent, just either it, or yourself
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

the most obnoxious part of xenobio is the wild amount of movement.
you still have to do that a lot, it's just quite easier now.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: xenobio qol: alt click processor to auto intake, unwrenchable, etc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
