### PR TITLE
Vermin Infestation Now Can Spawn Roaches

### DIFF
--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -11,6 +11,7 @@
 #define VERM_MICE 0
 #define VERM_LIZARDS 1
 #define VERM_SPIDERS 2
+#define VERM_ROACHES 3
 
 /datum/event/infestation
 	announceWhen = 10
@@ -76,7 +77,11 @@
 			spawn_types = list(/obj/effect/spider/spiderling)
 			max_number = 3
 			vermstring = "spiders"
-
+		if(VERM_ROACHES)
+			spawn_types = list(/mob/living/simple_mob/animal/roach/roachling)
+			max_number = 4
+			vermstring = "giant roaches"	
+		
 	spawn(0)
 		var/num = rand(2,max_number)
 		while(turfs.len > 0 && num > 0)
@@ -108,3 +113,4 @@
 #undef VERM_MICE
 #undef VERM_LIZARDS
 #undef VERM_SPIDERS
+#undef VERM_ROACHES 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Because these Roaches should no languish in the Dark
These vermin are so disgusting that people may actually try to eliminate them. Besides its probably good we get some amount of use out of the Eris Roaches, and they provide much needed variety to the vermin infestation space events. The fact that the event will only spawn roachlings should mean that even if the not dealt with its no big issue.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --!>
## Changelog
:cl:
tweak: Infestation Event can spawn roachlings.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
