### PR TITLE
make it so digestion drops their mirror

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -407,6 +407,12 @@
 					M.remove_from_mob(brain,owner)
 					brain.forceMove(src)
 					items_preserved += brain
+			if(istype(W,/obj/item/organ/external/chest))
+				var/obj/item/organ/external/chest/C = W
+				for (var/obj/item/I in C.implants)
+					if(istype(I,/obj/item/implant/mirror))
+						I.forceMove(src)
+						items_preserved += I // these are undigestable anyway so just add them regardless
 			for(var/slot in slots)
 				var/obj/item/I = M.get_equipped_item(slot = slot)
 				if(I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Was discussing this with someone about how this is one of the only qdel deaths I can find that doesn't make the mirror drop, so figured it should. Also kind of humourous to me to imagine how this works with digesting someone and then pulling the mirror out to revive them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Idk. Maybe not permadying from this if they didn't get their mirror taken out is good?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: dying from digestion now drops your mirror
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
