### PR TITLE
Fixes Bulk Contraband crate, lowers contraband price

### DIFF
--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -109,7 +109,7 @@
 /datum/supply_pack/supply/stolen
 	name = "Stolen Supply Crate"
 	contains = list(/obj/item/stolenpackage = 1)
-	cost = 150
+	cost = 75
 	containertype = /obj/structure/closet/crate
 	containername = "shady crate"
 	contraband = 1
@@ -125,6 +125,7 @@
 	containertype = /obj/structure/closet/crate
 	containername = "shadier crate"
 	contraband = 1
+	group = "Supplies"
 
 /datum/supply_pack/supply/wolfgirl
 	name = "Wolfgirl Crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turns out that the Bulk Stolen Supply Crate wasn't formatted correctly and not appearing. Also, 150 points for a single, non-curated stolen package is outright absurd

## Why It's Good For The Game

Cargo is really, really, really bored, and at least playing lootbox simulator is something to do

## Changelog
:cl:
tweak: Lowered Stolen Supply Crate price
fix: fixed Bulk Stolen Supply Crate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
