### PR TITLE
Removes the Labcoat from Roboticists at Spawn, Repaths RD to Spawn with RD Labcoat, Repaths Scientist to Spawn with Science Labcoat.

### DIFF
--- a/code/datums/autolathe/devices.dm
+++ b/code/datums/autolathe/devices.dm
@@ -35,6 +35,10 @@
 	path =/obj/item/radio/electropack
 	hidden = 1
 
+/datum/category_item/autolathe/devices/geiger
+	name = "geiger counter"
+	path =/obj/item/geiger
+
 //VR FILE MERGE
 
 /datum/category_item/autolathe/devices/sleevecard

--- a/code/datums/outfits/jobs/science.dm
+++ b/code/datums/outfits/jobs/science.dm
@@ -1,7 +1,6 @@
 /decl/hierarchy/outfit/job/science
 	hierarchy_type = /decl/hierarchy/outfit/job/science
 	l_ear = /obj/item/radio/headset/headset_sci
-	suit = /obj/item/clothing/suit/storage/toggle/labcoat
 	shoes = /obj/item/clothing/shoes/white
 	pda_type = /obj/item/pda/science
 	backpack = /obj/item/storage/backpack/toxins
@@ -16,6 +15,7 @@
 	l_hand = /obj/item/clipboard
 	id_type = /obj/item/card/id/science/head
 	pda_type = /obj/item/pda/heads/rd
+	suit = /obj/item/clothing/suit/storage/toggle/labcoat/rd
 
 /decl/hierarchy/outfit/job/science/scientist
 	name = OUTFIT_JOB_NAME("Scientist")

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -13,6 +13,8 @@
 	var/radiation_count = 0
 	var/datum/looping_sound/geiger/soundloop
 
+	matter = list(DEFAULT_WALL_MATERIAL = 200,"glass" = 100)
+
 /obj/item/geiger/Initialize(mapload)
 	soundloop = new(list(src), FALSE)
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'm tired of having to take off a labcoat I'll never wear when I join as a Roboticist.

## Why It's Good For The Game

QOL

## Changelog
:cl:
tweak: Adjusts labcoat dispersion.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
