### PR TITLE
Skateboard Duping Fix and Assorted Bugfixes

### DIFF
--- a/_maps/map_files/tether/tether-03-surface3.dmm
+++ b/_maps/map_files/tether/tether-03-surface3.dmm
@@ -23314,6 +23314,10 @@
 /obj/machinery/camera/network/command{
 	dir = 4
 	},
+/obj/machinery/keycard_auth{
+	pixel_x = -28;
+	pixel_y = 28
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "aPj" = (
@@ -29859,6 +29863,9 @@
 	dir = 1;
 	pixel_x = -8;
 	pixel_y = -26
+	},
+/obj/machinery/keycard_auth{
+	pixel_y = -36
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/hop)

--- a/code/datums/outfits/jobs/civilian.dm
+++ b/code/datums/outfits/jobs/civilian.dm
@@ -97,6 +97,17 @@
 	id_type = /obj/item/card/id/civilian/librarian
 	pda_type = /obj/item/pda/librarian
 
+/decl/hierarchy/outfit/job/librarian/reporter
+	name = OUTFIT_JOB_NAME("Reporter")
+	uniform = /obj/item/clothing/under/suit_jacket/red
+	id_type = /obj/item/card/id/civilian/librarian
+	pda_type = /obj/item/pda/librarian
+	belt = /obj/item/camera
+	backpack_contents = list(/obj/item/clothing/accessory/badge/corporate_tag/press = 1,
+							/obj/item/tape_recorder = 1,
+							/obj/item/camera_film = 1
+							)
+
 /decl/hierarchy/outfit/job/internal_affairs_agent
 	name = OUTFIT_JOB_NAME("Internal affairs agent")
 	l_ear = /obj/item/radio/headset/ia

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -186,6 +186,11 @@
 		"Philosopher" = /datum/alt_title/philosopher
 	)
 
+/datum/alt_title/librarian/reporter
+	title = "Reporter"
+	title_blurb = "Although NanoTrasen's official Press outlet is managed by Central Command, they often hire freelance journalists for local coverage."
+	title_outfit = /decl/hierarchy/outfit/job/librarian/reporter
+
 // Librarian Alt Titles
 /datum/alt_title/journalist
 	title = "Journalist"

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -105,6 +105,23 @@
 	listening_objects |= src
 
 /obj/item/melee/skateboard
+	name = "skaetbord"
+	desc = "You shouldn't be seeing this. Contact an Admin."
+	icon_state = "skateboard"
+	icon = 'icons/obj/weapons.dmi'
+	slot_flags = SLOT_BELT
+	force = 10
+	throwforce = 7
+	var/board_item_type = null
+
+/obj/item/melee/skateboard/dropped(mob/user as mob)
+	..()
+	var/turf/T = get_turf(src)
+	new /obj/vehicle/skateboard(T)
+	user.drop_item(src)
+	qdel(src)
+
+/obj/item/melee/skateboard/improv
 	name = "improvised skateboard"
 	desc = "A skateboard. It can be placed on its wheels and ridden, or used as a radical weapon."
 	icon_state = "skateboard"
@@ -112,12 +129,12 @@
 	slot_flags = SLOT_BELT
 	force = 10
 	throwforce = 7
-	var/board_item_type = /obj/vehicle/skateboard
+	var/board_item_type = /obj/vehicle/skateboard/improv
 
-/obj/item/melee/skateboard/dropped(mob/user as mob)
+/obj/item/melee/skateboard/improv/dropped(mob/user as mob)
 	..()
 	var/turf/T = get_turf(src)
-	new /obj/vehicle/skateboard(T)
+	new /obj/vehicle/skateboard/improv(T)
 	user.drop_item(src)
 	qdel(src)
 
@@ -157,5 +174,19 @@
 	..()
 	var/turf/T = get_turf(src)
 	new /obj/vehicle/skateboard/hoverboard/admin(T)
+	user.drop_item(src)
+	qdel(src)
+
+/obj/item/melee/skateboard/scooter
+	name = "scooter"
+	desc = "A fun way to get around."
+	icon = 'icons/obj/vehicles.dmi'
+	icon_state = "scooter_frame"
+	board_item_type = /obj/vehicle/skateboard/scooter
+
+/obj/item/melee/skateboard/scooter/dropped(mob/user as mob)
+	..()
+	var/turf/T = get_turf(src)
+	new /obj/vehicle/skateboard/scooter(T)
 	user.drop_item(src)
 	qdel(src)

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -109,6 +109,7 @@
 	desc = "You shouldn't be seeing this. Contact an Admin."
 	icon_state = "skateboard"
 	icon = 'icons/obj/weapons.dmi'
+	w_class = ITEMSIZE_HUGE
 	slot_flags = SLOT_BELT
 	force = 10
 	throwforce = 7
@@ -116,8 +117,9 @@
 
 /obj/item/melee/skateboard/dropped(mob/user as mob)
 	..()
+	..()
 	var/turf/T = get_turf(src)
-	new /obj/vehicle/skateboard(T)
+	new board_item_type(T)
 	user.drop_item(src)
 	qdel(src)
 
@@ -131,25 +133,11 @@
 	throwforce = 7
 	board_item_type = /obj/vehicle/skateboard/improv
 
-/obj/item/melee/skateboard/improv/dropped(mob/user as mob)
-	..()
-	var/turf/T = get_turf(src)
-	new /obj/vehicle/skateboard/improv(T)
-	user.drop_item(src)
-	qdel(src)
-
 /obj/item/melee/skateboard/pro
 	name = "skateboard"
 	desc = "A RaDSTORMz brand professional skateboard. Looks a lot more stable than the average board."
 	icon_state = "skateboard2"
 	board_item_type = /obj/vehicle/skateboard/pro
-
-/obj/item/melee/skateboard/pro/dropped(mob/user as mob)
-	..()
-	var/turf/T = get_turf(src)
-	new /obj/vehicle/skateboard/pro(T)
-	user.drop_item(src)
-	qdel(src)
 
 /obj/item/melee/skateboard/hoverboard
 	name = "hoverboard"
@@ -157,25 +145,11 @@
 	icon_state = "hoverboard_red"
 	board_item_type = /obj/vehicle/skateboard/hoverboard
 
-/obj/item/melee/skateboard/hoverboard/dropped(mob/user as mob)
-	..()
-	var/turf/T = get_turf(src)
-	new /obj/vehicle/skateboard/hoverboard(T)
-	user.drop_item(src)
-	qdel(src)
-
 /obj/item/melee/skateboard/hoverboard/admin
 	name = "Board of Directors"
 	desc = "The engineering complexity of a spaceship concentrated inside of a board. Just as expensive, too."
 	icon_state = "hoverboard_nt"
 	board_item_type = /obj/vehicle/skateboard/hoverboard/admin
-
-/obj/item/melee/skateboard/hoverboard/admin/dropped(mob/user as mob)
-	..()
-	var/turf/T = get_turf(src)
-	new /obj/vehicle/skateboard/hoverboard/admin(T)
-	user.drop_item(src)
-	qdel(src)
 
 /obj/item/melee/skateboard/scooter
 	name = "scooter"
@@ -183,10 +157,3 @@
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "scooter_frame"
 	board_item_type = /obj/vehicle/skateboard/scooter
-
-/obj/item/melee/skateboard/scooter/dropped(mob/user as mob)
-	..()
-	var/turf/T = get_turf(src)
-	new /obj/vehicle/skateboard/scooter(T)
-	user.drop_item(src)
-	qdel(src)

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -129,7 +129,7 @@
 	slot_flags = SLOT_BELT
 	force = 10
 	throwforce = 7
-	var/board_item_type = /obj/vehicle/skateboard/improv
+	board_item_type = /obj/vehicle/skateboard/improv
 
 /obj/item/melee/skateboard/improv/dropped(mob/user as mob)
 	..()

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -44,7 +44,7 @@
 	item_state_slots = list(slot_r_hand_str = "eng_helm_con", slot_l_hand_str = "eng_helm_con")
 
 /obj/item/clothing/suit/space/void/engineering/construction
-	name = "contstruction voidsuit"
+	name = "construction voidsuit"
 	icon_state = "rig-engineering_con"
 	item_state_slots = list(slot_r_hand_str = "eng_voidsuit_con", slot_l_hand_str = "eng_voidsuit_con")
 

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -258,7 +258,7 @@
 
 /obj/item/clothing/under/rank/pilot2
 	name = "\improper NanoTrasen flight suit"
-	desc = "A dark blue NanoTrasen flight suit. Warm and practical, seveal patches are scattered across it."
+	desc = "A dark blue NanoTrasen flight suit. Warm and practical, several patches are scattered across it."
 	icon_state = "pilot2"
 	worn_state = "pilot2"
 	rolled_down = 0

--- a/code/modules/vehicles/skateboard.dm
+++ b/code/modules/vehicles/skateboard.dm
@@ -202,7 +202,7 @@
 /obj/vehicle/skateboard/improv
 	name = "improvised skateboard"
 	desc = "A crude assembly which can only barely be called a skateboard. It's still rideable, but probably unsafe. Looks like you'll need to add a few rods to make handlebars."
-	board_item_type = /obj/item/melee/skateboard/hoverboard
+	board_item_type = /obj/item/melee/skateboard/improv
 	icon_state = "skateboard"
 	board_icon = "skateboard"
 

--- a/code/modules/vehicles/skateboard.dm
+++ b/code/modules/vehicles/skateboard.dm
@@ -1,6 +1,6 @@
 /obj/vehicle/skateboard
-	name = "improvised skateboard"
-	desc = "A crude assembly which can only barely be called a skateboard. It's still rideable, but probably unsafe. Looks like you'll need to add a few rods to make handlebars."
+	name = "skaetbord"
+	desc = "You shouldn't be seeing this. Contact an Admin."
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "skateboard"
 
@@ -19,7 +19,7 @@
 	var/grinding = FALSE
 	var/next_crash
 	var/board_icon = "skateboard"
-	var/board_item_type = /obj/item/melee/skateboard
+	var/board_item_type = null
 	var/rough_terrain = FALSE
 
 /obj/vehicle/skateboard/Initialize()
@@ -198,6 +198,13 @@
 */
 
 //Subsets
+
+/obj/vehicle/skateboard/improv
+	name = "improvised skateboard"
+	desc = "A crude assembly which can only barely be called a skateboard. It's still rideable, but probably unsafe. Looks like you'll need to add a few rods to make handlebars."
+	board_item_type = /obj/item/melee/skateboard/hoverboard
+	icon_state = "skateboard"
+	board_icon = "skateboard"
 
 /obj/vehicle/skateboard/pro
 	name = "skateboard"
@@ -402,7 +409,7 @@
 				to_chat(user, "<span class='notice'>You complete the skateboard assembly.</span>")
 				playsound(src, 'sound/items/screwdriver.ogg', 40, TRUE)
 				var/turf/T = get_turf(src)
-				new /obj/vehicle/skateboard(T)
+				new /obj/vehicle/skateboard/improv(T)
 				user.drop_from_inventory(src)
 				qdel(src)
 
@@ -480,6 +487,7 @@
 	name = "scooter"
 	desc = "A fun way to get around."
 	icon_state = "scooter"
+	board_item_type = /obj/item/melee/skateboard/scooter
 
 /obj/vehicle/skateboard/scooter/Initialize()
 	. = ..()

--- a/code/modules/vore/appearance/sprite_accessories_vr.dm
+++ b/code/modules/vore/appearance/sprite_accessories_vr.dm
@@ -2069,6 +2069,7 @@ datum/sprite_accessory/ears/tesh_pattern_ear_male
 	desc = ""
 	icon_state = "tail_smooth"
 	ani_state = "tail_smooth_w"
+	do_colouration = 1
 
 /datum/sprite_accessory/tail/wartacosushi_tail //brightened +20RGB from matching roboparts
 	name = "Ward-Takahashi Tail"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. _Fixes the bug where a dropped skateboard reverts to its basic state._
2. _Working on fixing backpack issue._
3. _Adds coloration to a tail that's meant to have it._
4. _Adds Keycard scanners to HoP and Captain's Offices._
5. _Fixes typos in Construction and Flight suits._
6. _Adds reporter gear to the Reporter alt title._

## Why It's Good For The Game

1. Aggravating issue.
2. Duping issue.
3. Blatant fault.
4. These were just missing.
5. Standard quality control.
6. I added this stuff a long time ago and just totally forgot to implement it.

## Changelog
:cl:
add: Keycard scanners to HoP/Cap's room.
add: Reporter gear to Librarian Alt.
fix: Skateboard faults/duping.
fix: Lizard tail coloration.
fix: Typo correction in flight suit and construction void.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
