### PR TITLE
Removes V.O.R.E. Lobby Screens From Our Rotation

### DIFF
--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -33,12 +33,15 @@
 /datum/map/tether/New()
 	..()
 	var/choice = pickweight(list(
-		"title" = 10,
-		"tether" = 50,
-		"tether_night" = 50,
-		"tether2_night" = 50,
-		"tether2_dog" = 1,
-		"tether2_love" = 1
+		"title1" = 50,
+		"title2" = 10,
+		"title3" = 50,
+		"title4" = 50,
+		"title5" = 20,
+		"title6" = 20,
+		"title7" = 20,
+		"title8" = 1,
+		"title9" = 1
 	))
 	if(choice)
 		lobby_screens = list(choice)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. _Removes V.O.R.E./Virgo branded lobby screens from our code.

## Why It's Good For The Game

1. I'm over advertising for an upstream I'm trying to shift away from every round. There's no reason for us to be using these. If someone likes them, commission replacements that aren't tied to their server instead of ours.

## Changelog
:cl:
del: Removes all Virgo screens.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
