### PR TITLE
removes id lock from mining point claiming 

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -133,11 +133,8 @@
 				usr.put_in_hands(inserted_id)
 				inserted_id = null
 			if(href_list["choice"] == "claim")
-				if(access_mining_station in inserted_id.access)
-					inserted_id.mining_points += machine.points
-					machine.points = 0
-				else
-					to_chat(usr, "<span class='warning'>Required access not found.</span>")
+				inserted_id.mining_points += machine.points
+				machine.points = 0
 		else if(href_list["choice"] == "insert")
 			var/obj/item/card/id/I = usr.get_active_hand()
 			if(istype(I))


### PR DESCRIPTION
this is flat out awful to deal with on lowpop
if you can't secure one room or atleast detect when people break in you probably don't have enough crew to justify a hard id lock on a currently perma extended server