### PR TITLE
Update tether-03-surface3.dmm

### DIFF
--- a/_maps/map_files/tether/tether-03-surface3.dmm
+++ b/_maps/map_files/tether/tether-03-surface3.dmm
@@ -40836,16 +40836,20 @@
 /turf/simulated/open,
 /area/tether/surfacebase/surface_three_hall)
 "qjk" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
 /obj/structure/closet/hydrant{
-	pixel_x = 32
+	pixel_y = -32
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized/full{
-	id = "saunatint"
-	},
-/turf/simulated/floor/plating,
-/area/triumph/surfacebase/sauna)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "qkf" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -53874,7 +53878,7 @@ adR
 aWn
 aWF
 aWT
-qjk
+tCZ
 pEq
 wHb
 wHb
@@ -54015,7 +54019,7 @@ aVL
 adR
 aWp
 ajM
-akv
+qjk
 awT
 tCZ
 keM


### PR DESCRIPTION
Fireman cosplay locker should open into the hall not behind the glass.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fire locker was opening up to the west in the glass window of the sauna instead of into the hallway. This PR corrects that. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency is nice and no one should have to meld with glass windows to pick stuff up. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed the direction the fire cabinet by the sauna opens towards.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
