### PR TITLE
Remaps the Armory - Replaces Specialized Armor Sets with Specialized Plate Carrier Sets

### DIFF
--- a/_maps/map_files/tether/tether-02-surface2.dmm
+++ b/_maps/map_files/tether/tether-02-surface2.dmm
@@ -3773,16 +3773,91 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/outfitting/storage)
 "afQ" = (
-/obj/machinery/mech_recharger,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/door/window/brigdoor/southleft{
+	req_access = list(3)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "afR" = (
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "afS" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/obj/structure/closet/crate{
+	name = "Carrier Tags"
+	},
+/obj/item/clothing/accessory/armor/tag/opos{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/clothing/accessory/armor/tag/opos{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/clothing/accessory/armor/tag/oneg{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/clothing/accessory/armor/tag/oneg{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/clothing/accessory/armor/tag/bpos{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/clothing/accessory/armor/tag/bpos{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/clothing/accessory/armor/tag/bneg{
+	pixel_x = 5;
+	pixel_y = -6
+	},
+/obj/item/clothing/accessory/armor/tag/bneg{
+	pixel_x = 5;
+	pixel_y = -6
+	},
+/obj/item/clothing/accessory/armor/tag/apos{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/clothing/accessory/armor/tag/apos{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/clothing/accessory/armor/tag/aneg{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/clothing/accessory/armor/tag/aneg{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/clothing/accessory/armor/tag/abpos{
+	pixel_y = 6
+	},
+/obj/item/clothing/accessory/armor/tag/abpos{
+	pixel_y = 6
+	},
+/obj/item/clothing/accessory/armor/tag/abneg{
+	pixel_y = -5
+	},
+/obj/item/clothing/accessory/armor/tag/abneg{
+	pixel_y = -5
+	},
+/obj/item/clothing/accessory/armor/tag/sec,
+/obj/item/clothing/accessory/armor/tag/sec,
+/obj/item/clothing/accessory/armor/tag/sec,
+/obj/item/clothing/accessory/armor/tag/sec,
+/obj/item/clothing/accessory/armor/tag/sec,
+/obj/item/clothing/accessory/armor/tag/sec,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "afT" = (
@@ -3798,6 +3873,12 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "afU" = (
@@ -3805,6 +3886,12 @@
 /obj/item/gun/energy/ionrifle,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/camera/network/security,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "afV" = (
@@ -4261,14 +4348,22 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/outfitting/storage)
 "agI" = (
-/obj/machinery/door/window/brigdoor/westleft{
-	name = "Armory Access";
-	req_access = list(3)
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/bordercorner{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "agJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "agK" = (
@@ -4683,13 +4778,26 @@
 /area/tether/surfacebase/security/outfitting)
 "ahu" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/glasses/hud/security,
-/obj/item/clothing/glasses/hud/security,
-/obj/item/clothing/glasses/hud/security,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24;
 	pixel_y = -8
+	},
+/obj/item/clothing/accessory/armor/helmcover/nt{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/obj/item/clothing/accessory/armor/helmcover/nt{
+	pixel_x = 5;
+	pixel_y = -6
+	},
+/obj/item/clothing/accessory/armor/helmcover/nt{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/clothing/accessory/armor/helmcover/nt{
+	pixel_x = 5;
+	pixel_y = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/outfitting/storage)
@@ -4711,68 +4819,111 @@
 /area/tether/surfacebase/security/outfitting/storage)
 "ahx" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/suit/storage/vest/heavy/officer{
-	pixel_x = -4;
-	pixel_y = -6
-	},
-/obj/item/clothing/suit/storage/vest/heavy/officer{
-	pixel_x = 5;
-	pixel_y = -6
-	},
-/obj/item/clothing/suit/storage/vest/heavy/officer{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/suit/storage/vest/heavy/officer{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/light{
+/obj/item/clothing/suit/armor/pcarrier/medium/security{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/pcarrier/medium/security{
+	pixel_x = 5;
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/pcarrier/medium/security{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/clothing/suit/armor/pcarrier/medium/security{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/clothing/accessory/armor/armorplate/medium,
+/obj/item/clothing/accessory/armor/armorplate/medium,
+/obj/item/clothing/accessory/armor/armorplate/medium,
+/obj/item/clothing/accessory/armor/armorplate/medium,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "ahy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "ahz" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/gun/projectile/shotgun/pump{
-	ammo_type = /obj/item/ammo_casing/a12g/pellet;
-	pixel_x = 2;
-	pixel_y = -6
+/obj/item/gunbox/lethal{
+	pixel_y = -3
 	},
-/obj/item/gun/projectile/shotgun/pump{
-	ammo_type = /obj/item/ammo_casing/a12g/pellet;
-	pixel_x = 1;
-	pixel_y = 4
+/obj/item/gunbox/lethal{
+	pixel_y = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "ahA" = (
-/obj/structure/table/steel,
-/obj/item/storage/box/shotgunshells{
-	pixel_x = -2;
-	pixel_y = 7
-	},
-/obj/item/storage/box/shotgunshells{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/storage/box/shotgunshells{
-	pixel_x = 6;
-	pixel_y = -1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/accessory/storage/pouches{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/clothing/accessory/storage/pouches{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/storage/pouches{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/clothing/accessory/storage/pouches{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/armor/legguards{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/clothing/accessory/armor/legguards{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/clothing/accessory/armor/legguards{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/armor/legguards{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/armor/armguards{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/clothing/accessory/armor/armguards{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/clothing/accessory/armor/armguards{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/armor/armguards{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "ahB" = (
@@ -5194,17 +5345,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/outfitting/storage)
 "ail" = (
-/obj/structure/table/steel,
-/obj/item/ammo_magazine/m45/rubber{
-	pixel_y = 9
-	},
-/obj/item/ammo_magazine/m45/rubber{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/ammo_magazine/m45/rubber{
-	pixel_y = -3
-	},
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -25;
 	pixel_y = 2
@@ -5213,28 +5353,29 @@
 	pixel_x = -25;
 	pixel_y = -9
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/structure/closet/bombcloset/double,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "aim" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "ain" = (
-/obj/machinery/door/window/brigdoor/westleft{
-	name = "Armory Access";
-	req_access = list(3)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/floor_decal/borderfloorblack/full,
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "aio" = (
@@ -5252,6 +5393,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
@@ -5992,18 +6142,21 @@
 /area/tether/surfacebase/security/outfitting)
 "ajp" = (
 /obj/structure/table/steel,
-/obj/item/cell/device/weapon{
-	pixel_x = -3
-	},
-/obj/item/cell/device/weapon{
-	pixel_x = 3
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = -24
+	},
+/obj/item/clothing/glasses/hud/security,
+/obj/item/clothing/glasses/hud/security,
+/obj/item/clothing/glasses/hud/security,
+/obj/item/cell/device/weapon{
+	pixel_x = -3
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/outfitting/storage)
@@ -6031,20 +6184,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/outfitting/storage)
 "ajs" = (
-/obj/structure/table/steel,
-/obj/item/storage/box/stunshells{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/flashshells{
-	pixel_x = 1
-	},
-/obj/item/storage/box/beanbags{
-	pixel_x = 4;
-	pixel_y = -5
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
@@ -6053,52 +6200,66 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "aju" = (
 /obj/structure/table/rack/steel,
-/obj/item/clothing/gloves/arm_guard/riot,
-/obj/item/clothing/shoes/leg_guard/riot,
-/obj/item/clothing/suit/armor/riot/alt,
+/obj/item/clothing/suit/armor/pcarrier/medium/security,
+/obj/item/clothing/accessory/storage/pouches,
+/obj/item/clothing/accessory/armor/legguards/riot,
+/obj/item/clothing/accessory/armor/armguards/riot,
+/obj/item/clothing/accessory/armor/armorplate/stab,
 /obj/item/clothing/head/helmet/riot,
 /obj/item/shield/riot,
-/obj/item/clothing/gloves/arm_guard/riot,
-/obj/item/clothing/shoes/leg_guard/riot,
-/obj/item/clothing/suit/armor/riot/alt,
+/obj/item/clothing/suit/armor/pcarrier/medium/security,
+/obj/item/clothing/accessory/storage/pouches,
+/obj/item/clothing/accessory/armor/legguards/riot,
+/obj/item/clothing/accessory/armor/armguards/riot,
+/obj/item/clothing/accessory/armor/armorplate/stab,
 /obj/item/clothing/head/helmet/riot,
 /obj/item/shield/riot,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "ajv" = (
 /obj/structure/table/rack/steel,
-/obj/item/clothing/gloves/arm_guard/bulletproof,
-/obj/item/clothing/shoes/leg_guard/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof/alt,
+/obj/item/clothing/suit/armor/pcarrier/green,
+/obj/item/clothing/accessory/storage/pouches/green,
+/obj/item/clothing/accessory/armor/legguards/bulletproof{
+	icon_state = "legguards_green"
+	},
+/obj/item/clothing/accessory/armor/armguards/bulletproof{
+	icon_state = "armguards_green"
+	},
+/obj/item/clothing/accessory/armor/armorplate/bulletproof,
 /obj/item/clothing/head/helmet/bulletproof,
-/obj/item/clothing/gloves/arm_guard/bulletproof,
-/obj/item/clothing/shoes/leg_guard/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof/alt,
-/obj/item/clothing/head/helmet/bulletproof,
-/obj/structure/window/reinforced,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "ajw" = (
 /obj/structure/table/rack/steel,
-/obj/item/clothing/gloves/arm_guard/laserproof,
-/obj/item/clothing/shoes/leg_guard/laserproof,
-/obj/item/clothing/suit/armor/laserproof,
-/obj/item/clothing/head/helmet/laserproof,
-/obj/item/clothing/gloves/arm_guard/laserproof,
-/obj/item/clothing/shoes/leg_guard/laserproof,
-/obj/item/clothing/suit/armor/laserproof,
-/obj/item/clothing/head/helmet/laserproof,
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/item/clothing/suit/armor/pcarrier/blue,
+/obj/item/clothing/accessory/storage/pouches/blue,
+/obj/item/clothing/accessory/armor/legguards/laserproof{
+	icon_state = "legguards_blue"
+	},
+/obj/item/clothing/accessory/armor/armguards/laserproof{
+	icon_state = "armguards_blue"
+	},
+/obj/item/clothing/accessory/armor/armorplate/laserproof,
+/obj/item/clothing/head/helmet/laserproof,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
@@ -6516,56 +6677,41 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/outfitting/storage)
 "akk" = (
-/obj/structure/table/steel,
-/obj/item/cell/device/weapon{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/cell/device/weapon,
-/obj/item/cell/device/weapon{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/cell/device/weapon{
-	pixel_x = -1;
-	pixel_y = 4
-	},
-/obj/item/cell/device/weapon{
-	pixel_x = -6;
-	pixel_y = -3
+/obj/machinery/door/blast/regular{
+	id = "armoryaccess_red";
+	name = "Armory"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "akl" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/blast/regular{
+	id = "armoryaccess_red";
+	name = "Armory"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "akm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/borderfloorblack/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "akn" = (
-/obj/effect/floor_decal/borderfloorblack/full,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
+/obj/machinery/mech_recharger,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "ako" = (
-/obj/effect/floor_decal/borderfloorblack/full,
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/floor_decal/industrial/outline,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "akp" = (
@@ -7382,43 +7528,32 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "alz" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "alA" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/accessory/armor/helmcover/nt{
-	pixel_x = -4;
-	pixel_y = -6
-	},
-/obj/item/clothing/accessory/armor/helmcover/nt{
-	pixel_x = 5;
-	pixel_y = -6
-	},
-/obj/item/clothing/accessory/armor/helmcover/nt{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/accessory/armor/helmcover/nt{
-	pixel_x = 5;
-	pixel_y = 4
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "alB" = (
-/obj/effect/floor_decal/borderfloorblack/full,
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/portables_connector{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -8100,36 +8235,29 @@
 	dir = 6
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "amB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "amC" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
@@ -8588,50 +8716,90 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/evastorage)
 "ant" = (
-/obj/structure/closet/l3closet/security,
+/obj/machinery/flasher/portable,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "anu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 1;
+	name = "Code Blue Armory"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "anv" = (
-/obj/structure/window/reinforced{
+/obj/structure/table/steel,
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/structure/table/rack/shelf/steel,
-/obj/item/gunbox{
-	pixel_y = 6
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
 	},
-/obj/item/gunbox{
+/obj/item/cell/device/weapon{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/cell/device/weapon,
+/obj/item/cell/device/weapon{
+	pixel_x = -6;
 	pixel_y = -3
 	},
+/obj/item/cell/device/weapon{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = 5;
+	pixel_y = 3
+	},
 /obj/structure/window/reinforced{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "anw" = (
+/obj/structure/table/steel,
+/obj/item/storage/box/stunshells{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/flashshells{
+	pixel_x = 1
+	},
+/obj/item/storage/box/beanbags{
+	pixel_x = 4;
+	pixel_y = -5
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 5
+	},
 /obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/structure/table/rack/shelf/steel,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/item/gun/energy/gun{
-	pixel_y = 7
-	},
-/obj/item/gun/energy/gun{
-	pixel_y = -5
-	},
-/obj/item/gun/energy/gun{
-	pixel_y = -5
-	},
-/obj/item/gun/energy/gun{
-	pixel_y = 7
-	},
-/obj/item/gun/energy/gun{
-	pixel_y = -5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
@@ -9177,6 +9345,13 @@
 	pixel_x = -55;
 	pixel_y = 26
 	},
+/obj/machinery/button/remote/blast_door{
+	id = "surfbriglockdown";
+	name = "Brig Lockdown";
+	pixel_x = -56;
+	pixel_y = 36;
+	req_access = list(3)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/warden)
 "aow" = (
@@ -9194,7 +9369,7 @@
 /obj/machinery/button/remote/blast_door{
 	dir = 4;
 	id = "armoryaccess";
-	name = "Armory Access";
+	name = "Blue Armory Access";
 	pixel_x = 8;
 	pixel_y = 37;
 	req_access = list(3)
@@ -9208,18 +9383,19 @@
 /obj/effect/floor_decal/corner/red/bordercorner2{
 	dir = 1
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "surfbriglockdown";
-	name = "Brig Lockdown";
-	pixel_x = 7;
-	pixel_y = 27;
-	req_access = list(3)
-	},
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/bordercorner2{
 	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "armoryaccess_red";
+	name = "Red Armory Access";
+	pixel_x = 8;
+	pixel_y = 27;
+	req_access = list(3)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/warden)
@@ -9328,44 +9504,67 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/evastorage)
 "aoC" = (
-/obj/structure/closet/bombcloset/double,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/flasher/portable,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "aoD" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "aoE" = (
-/obj/machinery/door/window/brigdoor/westleft{
-	name = "Armory Access";
-	req_access = list(3)
+/obj/structure/table/steel,
+/obj/item/storage/box/shotgunshells{
+	pixel_x = -2;
+	pixel_y = 7
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/storage/box/shotgunshells{
+	pixel_x = 2;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/item/storage/box/shotgunshells{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/ammo_magazine/m45/rubber{
+	pixel_y = 9
+	},
+/obj/item/ammo_magazine/m45/rubber{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/ammo_magazine/m45/rubber{
+	pixel_y = -3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "aoF" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
@@ -10105,39 +10304,57 @@
 "apQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "apR" = (
-/obj/structure/window/reinforced,
 /obj/structure/table/rack/shelf/steel,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/item/gunbox{
+	pixel_y = 6
 	},
-/obj/item/gun/energy/phasegun/rifle{
+/obj/item/storage/box/trackimp{
+	pixel_x = 5;
 	pixel_y = -6
 	},
-/obj/item/gun/energy/phasegun/rifle{
-	pixel_y = 6
+/obj/item/storage/box/trackimp{
+	pixel_x = 5;
+	pixel_y = -6
+	},
+/obj/item/gunbox{
+	pixel_y = -3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "apS" = (
-/obj/structure/window/reinforced,
 /obj/structure/table/rack/shelf/steel,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/item/gun/energy/gun{
+	pixel_y = -5
 	},
-/obj/item/storage/box/trackimp{
-	pixel_x = 5;
-	pixel_y = -6
+/obj/item/gun/energy/gun{
+	pixel_y = 7
 	},
-/obj/item/storage/box/trackimp{
-	pixel_x = 5;
-	pixel_y = -6
+/obj/item/gun/energy/gun{
+	pixel_y = -5
 	},
-/obj/item/gun/energy/ionrifle/pistol{
-	pixel_x = 1;
-	pixel_y = 8
+/obj/item/gun/energy/gun{
+	pixel_y = 7
+	},
+/obj/item/gun/energy/gun{
+	pixel_y = -5
+	},
+/obj/item/gun/energy/gun{
+	pixel_y = 7
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
@@ -10678,33 +10895,53 @@
 /area/tether/surfacebase/security/evastorage)
 "aqR" = (
 /obj/effect/floor_decal/borderfloorblack/full,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/deployable/barrier,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/deployable/barrier,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "aqS" = (
 /obj/effect/floor_decal/borderfloorblack/full,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/deployable/barrier,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/deployable/barrier,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "aqT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "aqU" = (
-/obj/effect/floor_decal/borderfloorblack/full,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/flasher/portable,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "aqV" = (
@@ -11105,10 +11342,6 @@
 	dir = 8;
 	layer = 2.6
 	},
-/obj/item/clothing/suit/space/void/security,
-/obj/item/clothing/head/helmet/space/void/security,
-/obj/item/clothing/suit/space/void/security,
-/obj/item/clothing/head/helmet/space/void/security,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
@@ -11122,6 +11355,12 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/clothing/suit/space/void/security,
+/obj/item/clothing/head/helmet/space/void/security,
+/obj/item/clothing/suit/space/void/security,
+/obj/item/clothing/head/helmet/space/void/security,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/evastorage)
 "arK" = (
@@ -11155,42 +11394,67 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/evastorage)
 "arM" = (
-/obj/effect/floor_decal/borderfloorblack/full,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/deployable/barrier,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+	dir = 4
 	},
+/obj/machinery/deployable/barrier,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorblack/full,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "arN" = (
 /obj/effect/floor_decal/borderfloorblack/full,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/deployable/barrier,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/camera/network/security{
 	dir = 10
 	},
+/obj/machinery/deployable/barrier,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "arO" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -28
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "arP" = (
-/obj/effect/floor_decal/borderfloorblack/full,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/flasher/portable,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table/rack/shelf/steel,
+/obj/item/gun/projectile/shotgun/pump{
+	ammo_type = /obj/item/ammo_casing/a12g/pellet;
+	pixel_x = 2;
+	pixel_y = -6
+	},
+/obj/item/gun/projectile/shotgun/pump{
+	ammo_type = /obj/item/ammo_casing/a12g/pellet;
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
@@ -11686,12 +11950,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/warden)
 "asJ" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.6
-	},
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/carbondioxide,
 /obj/machinery/camera/network/security{
 	dir = 5
 	},
@@ -11701,6 +11959,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 10
 	},
+/obj/structure/closet/l3closet/security,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/evastorage)
 "asK" = (
@@ -33836,6 +34095,28 @@
 	},
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/tether/surfacebase/outside/outside2)
+"iwL" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/armory)
 "iyz" = (
 /obj/item/reagent_containers/glass/bottle/left4zed,
 /turf/simulated/mineral/floor/virgo3b,
@@ -33910,6 +34191,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/reading_room)
+"jSV" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/gun/energy/phasegun/rifle{
+	pixel_y = -6
+	},
+/obj/item/gun/energy/phasegun/rifle{
+	pixel_y = 6
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/blue/border,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/armory)
 "jZK" = (
 /obj/structure/stairs/spawner/south,
 /obj/structure/catwalk,
@@ -34007,6 +34300,12 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/tiled/techfloor/grid/virgo3b,
 /area/tether/surfacebase/old_tram)
+"lXj" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/armory)
 "mnt" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -34392,6 +34691,20 @@
 /obj/effect/floor_decal/corner_techfloor_grid,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
+"twq" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/flasher/portable,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/armory)
 "tED" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 10
@@ -34660,6 +34973,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
+"yaP" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/flasher/portable,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/armory)
 "yiF" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
@@ -44784,8 +45102,8 @@ ajr
 akj
 alw
 amz
-afR
-afR
+twq
+yaP
 afR
 aqS
 arN
@@ -45059,20 +45377,20 @@ aac
 aab
 aab
 ael
-aeX
+ain
 afQ
-afQ
+alB
 ahx
 ail
 ajs
 akk
 aly
-amB
+aio
 anv
-aoE
+afR
 apR
 aqU
-aqU
+jSV
 aeX
 aeX
 anb
@@ -45201,9 +45519,9 @@ aac
 aab
 aab
 ael
-aeX
-afR
-afR
+akm
+ako
+amB
 ahy
 aim
 ajt
@@ -45213,7 +45531,7 @@ amC
 anw
 aoF
 apS
-aqU
+iwL
 arP
 aeX
 aeX
@@ -45346,12 +45664,12 @@ adX
 aeX
 afS
 agI
-afS
-ain
+aoE
+aio
 aju
-akm
-alA
 aeX
+alA
+lXj
 aeX
 aeX
 aeX
@@ -45491,9 +45809,9 @@ afR
 ahz
 aio
 ajv
-akn
-akn
 aeX
+akn
+akn
 aeX
 aeX
 aeX
@@ -45633,8 +45951,8 @@ agJ
 ahA
 aip
 ajw
-ako
-alB
+aeX
+aeX
 aeX
 aeX
 aau

--- a/_maps/map_files/tether/tether-02-surface2.dmm
+++ b/_maps/map_files/tether/tether-02-surface2.dmm
@@ -3773,9 +3773,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/outfitting/storage)
 "afQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/machinery/door/window/brigdoor/southleft{
-	req_access = list(3)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
@@ -3783,77 +3791,31 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "afS" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 9
-	},
 /obj/structure/closet/crate{
 	name = "Carrier Tags"
 	},
-/obj/item/clothing/accessory/armor/tag/opos{
-	pixel_x = -6;
-	pixel_y = 8
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/obj/item/clothing/accessory/armor/tag/opos{
-	pixel_x = -6;
-	pixel_y = 8
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
 	},
-/obj/item/clothing/accessory/armor/tag/oneg{
-	pixel_x = -6;
-	pixel_y = 1
-	},
-/obj/item/clothing/accessory/armor/tag/oneg{
-	pixel_x = -6;
-	pixel_y = 1
-	},
-/obj/item/clothing/accessory/armor/tag/bpos{
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/obj/item/clothing/accessory/armor/tag/bpos{
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/obj/item/clothing/accessory/armor/tag/bneg{
-	pixel_x = 5;
-	pixel_y = -6
-	},
-/obj/item/clothing/accessory/armor/tag/bneg{
-	pixel_x = 5;
-	pixel_y = -6
-	},
-/obj/item/clothing/accessory/armor/tag/apos{
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/item/clothing/accessory/armor/tag/apos{
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/item/clothing/accessory/armor/tag/aneg{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/clothing/accessory/armor/tag/aneg{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/clothing/accessory/armor/tag/abpos{
-	pixel_y = 6
-	},
-/obj/item/clothing/accessory/armor/tag/abpos{
-	pixel_y = 6
-	},
-/obj/item/clothing/accessory/armor/tag/abneg{
-	pixel_y = -5
-	},
-/obj/item/clothing/accessory/armor/tag/abneg{
-	pixel_y = -5
-	},
-/obj/item/clothing/accessory/armor/tag/sec,
-/obj/item/clothing/accessory/armor/tag/sec,
+/obj/item/clothing/accessory/armor/tag/opos,
+/obj/item/clothing/accessory/armor/tag/opos,
+/obj/item/clothing/accessory/armor/tag/oneg,
+/obj/item/clothing/accessory/armor/tag/oneg,
+/obj/item/clothing/accessory/armor/tag/bpos,
+/obj/item/clothing/accessory/armor/tag/bpos,
+/obj/item/clothing/accessory/armor/tag/bneg,
+/obj/item/clothing/accessory/armor/tag/bneg,
+/obj/item/clothing/accessory/armor/tag/apos,
+/obj/item/clothing/accessory/armor/tag/apos,
+/obj/item/clothing/accessory/armor/tag/aneg,
+/obj/item/clothing/accessory/armor/tag/aneg,
+/obj/item/clothing/accessory/armor/tag/abpos,
+/obj/item/clothing/accessory/armor/tag/abpos,
+/obj/item/clothing/accessory/armor/tag/abneg,
+/obj/item/clothing/accessory/armor/tag/abneg,
 /obj/item/clothing/accessory/armor/tag/sec,
 /obj/item/clothing/accessory/armor/tag/sec,
 /obj/item/clothing/accessory/armor/tag/sec,
@@ -3868,7 +3830,7 @@
 	},
 /obj/item/gun/energy/laser{
 	pixel_x = -1;
-	pixel_y = 2
+	pixel_y = -2
 	},
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -3878,6 +3840,14 @@
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
+	},
+/obj/item/gun/energy/laser{
+	pixel_x = -1;
+	pixel_y = -8
+	},
+/obj/item/gun/energy/laser{
+	pixel_x = -1;
+	pixel_y = 2
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
@@ -4348,12 +4318,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/outfitting/storage)
 "agI" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 1
-	},
+/obj/effect/floor_decal/borderfloorblack/full,
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "agJ" = (
@@ -4838,10 +4806,6 @@
 	pixel_x = 5;
 	pixel_y = 4
 	},
-/obj/item/clothing/accessory/armor/armorplate/medium,
-/obj/item/clothing/accessory/armor/armorplate/medium,
-/obj/item/clothing/accessory/armor/armorplate/medium,
-/obj/item/clothing/accessory/armor/armorplate/medium,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -4860,10 +4824,16 @@
 "ahz" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/gunbox/lethal{
-	pixel_y = -3
+	pixel_y = 6
 	},
 /obj/item/gunbox/lethal{
-	pixel_y = 6
+	pixel_y = -3
+	},
+/obj/item/gun/projectile/shotgun/pump/combat{
+	pixel_y = -6
+	},
+/obj/item/gun/projectile/shotgun/pump/combat{
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
@@ -5359,7 +5329,11 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
-/obj/structure/closet/bombcloset/double,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/material/knife/machete,
+/obj/item/material/knife/machete,
+/obj/item/clothing/accessory/holster/machete,
+/obj/item/clothing/accessory/holster/machete,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "aim" = (
@@ -5372,10 +5346,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "ain" = (
-/obj/effect/floor_decal/borderfloorblack/full,
-/obj/effect/floor_decal/industrial/outline,
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/door/window/brigdoor/southleft{
+	req_access = list(3)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "aio" = (
@@ -6693,13 +6667,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "akm" = (
-/obj/effect/floor_decal/borderfloorblack/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "akn" = (
@@ -6707,11 +6679,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "ako" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/structure/window/reinforced,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "akp" = (
@@ -7544,17 +7521,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "alB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 9
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 9
-	},
-/obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/autolathe{
+	hacked = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
@@ -8242,16 +8216,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "amB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "amC" = (
@@ -9547,14 +9513,14 @@
 	pixel_x = 6;
 	pixel_y = -1
 	},
-/obj/item/ammo_magazine/m45/rubber{
+/obj/item/ammo_magazine/m45/flash{
 	pixel_y = 9
 	},
-/obj/item/ammo_magazine/m45/rubber{
+/obj/item/ammo_magazine/m45/flash{
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/ammo_magazine/m45/rubber{
+/obj/item/ammo_magazine/m45/flash{
 	pixel_y = -3
 	},
 /turf/simulated/floor/tiled/dark,
@@ -11391,6 +11357,12 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
+/obj/item/gps/security{
+	pixel_y = 3
+	},
+/obj/item/gps/security{
+	pixel_x = -3
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/evastorage)
 "arM" = (
@@ -11969,19 +11941,13 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/evastorage)
 "asL" = (
-/obj/structure/table/reinforced,
-/obj/item/gps/security{
-	pixel_y = 3
-	},
-/obj/item/gps/security{
-	pixel_x = -3
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 6
 	},
+/obj/structure/closet/bombcloset/double,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/evastorage)
 "asM" = (
@@ -34857,6 +34823,16 @@
 /obj/structure/railing,
 /turf/simulated/open/virgo3b,
 /area/tether/surfacebase/outside/outside2)
+"vPv" = (
+/obj/effect/floor_decal/borderfloorblack/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/armory)
 "vTb" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -45233,7 +45209,7 @@ aab
 aab
 acp
 aab
-aab
+ael
 ael
 aeW
 aeW
@@ -45375,8 +45351,8 @@ aab
 aac
 aac
 aab
-aab
 ael
+agI
 ain
 afQ
 alB
@@ -45517,8 +45493,8 @@ aab
 aac
 aac
 aab
-aab
 ael
+vPv
 akm
 ako
 amB
@@ -45663,7 +45639,7 @@ ahc
 adX
 aeX
 afS
-agI
+afR
 aoE
 aio
 aju

--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -44,6 +44,7 @@
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "Plate Carrier crate"
+	access = access_armory
 
 /datum/supply_pack/security/carriertags
 	name = "Armor - Plate carrier tags"
@@ -97,6 +98,7 @@
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "Armor plate crate"
+	access = access_armory
 
 /datum/supply_pack/randomised/security/carrierarms
 	name = "Armor - Security armguard attachments"
@@ -114,6 +116,7 @@
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "Armor plate crate"
+	access = access_armory
 
 /datum/supply_pack/randomised/security/carrierlegs
 	name = "Armor - Security legguard attachments"
@@ -131,6 +134,7 @@
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "Armor plate crate"
+	access = access_armory
 
 /datum/supply_pack/randomised/security/carrierbags
 	name = "Armor - Security pouch attachments"
@@ -150,6 +154,7 @@
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "Armor plate crate"
+	access = access_armory
 
 /datum/supply_pack/security/riot_gear
 	name = "Gear - Riot"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. _Remaps the Armory so it isn't so terrible._
2. _Replaces Special Armor sets with specialized Plate Carrier sets._

## Why It's Good For The Game

1. I'm mad at the old Armory and I'm here to fix it.
2. After an extensive series of debates, I'm testing this compromise now so everyone can feel very special and pretty during emergencies without obliterating every minor threat they come across.

## Changelog
:cl:
add: New Armory layout for QOL.
balance: Swaps specialized armor sets out for plate carrier patterns of equivalent design.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
