### PR TITLE
Offduty Command spawns no longer with command headsets

### DIFF
--- a/code/game/jobs/job/offduty.dm
+++ b/code/game/jobs/job/offduty.dm
@@ -125,7 +125,7 @@
 	selection_color = "#9b633e"
 	access = list(access_maint_tunnels, access_external_airlocks)
 	minimal_access = list(access_maint_tunnels, access_external_airlocks)
-	outfit_type = /decl/hierarchy/outfit/job/secretary
+	outfit_type = /decl/hierarchy/outfit/job/assistant
 	job_description = "Off-duty crew has no responsibilities or authority and is just there to spend their \"well-deserved\" time off."
 	pto_type = PTO_COMMAND
 	economic_modifier = 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See #3209 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Off-Duty command no longer spawns with a command headset.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
