### PR TITLE
Changes fryer's oil to Tallow, and associated changes

### DIFF
--- a/code/datums/supplypacks/hospitality.dm
+++ b/code/datums/supplypacks/hospitality.dm
@@ -162,11 +162,11 @@
 	cost = 50
 
 /datum/supply_pack/hospitality/cookingoil
-	name = "Cooking oil tank crate"
-	contains = list(/obj/structure/reagent_dispensers/cookingoil)
+	name = "Tallow tank crate"
+	contains = list(/obj/structure/reagent_dispensers/tallow)
 	cost = 10
 	containertype = /obj/structure/largecrate
-	containername = "cooking oil tank crate"
+	containername = "Tallow tank crate"
 
 /datum/supply_pack/hospitality/vampcarepackage
 	name = "Vampire Care package"

--- a/code/modules/food/kitchen/cooking_machines/fryer.dm
+++ b/code/modules/food/kitchen/cooking_machines/fryer.dm
@@ -42,7 +42,7 @@
 		//Sometimes the fryer will start with much less than full oil, significantly impacting efficiency until filled
 		//hm yes 20% of the time we will make fryers start with less this is very fun and interactive
 		variance = rand()*0.5
-	oil.add_reagent("cornoil", optimal_oil*(1 - variance))
+	oil.add_reagent("tallow", optimal_oil*(1 - variance))
 
 /obj/machinery/appliance/cooker/fryer/heat_up()
 	if (..())

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -4053,6 +4053,11 @@ End Citadel Change */
 	id = "cornoil"
 	description = "An oil derived from various types of corn."
 
+/datum/reagent/nutriment/triglyceride/oil/tallow
+	name = "Tallow"
+	id = "tallow"
+	description = "An liquidized form of animal fat, useful for adding that extra heart stopping potential to any of your deep fried food products."
+
 //Protein! Get your mind out of the gutter.
 /datum/reagent/nutriment/protein // Bad for Skrell!
 	name = "animal protein"

--- a/code/modules/reagents/Food-Recipes.dm
+++ b/code/modules/reagents/Food-Recipes.dm
@@ -175,3 +175,10 @@
 	for(var/i = 1, i <= created_volume, i++)
 		new /obj/item/reagent_containers/food/snacks/spreads/butter(location)
 	return
+
+/datum/chemical_reaction/food/tallow
+	name = "Tallow"
+	id = "tallow"
+	result = "tallow"
+	required_reagents = list("protein" = 3, "nutriment" = 1)
+	result_amount = 4

--- a/code/modules/reagents/machinery/dispenser/reagent_tank.dm
+++ b/code/modules/reagents/machinery/dispenser/reagent_tank.dm
@@ -438,16 +438,16 @@
 	reagents.add_reagent("sacid", 1000)
 
 //Cooking oil refill tank
-/obj/structure/reagent_dispensers/cookingoil
-	name = "cooking oil tank"
-	desc = "A fifty-litre tank of commercial-grade corn oil, intended for use in large scale deep fryers. Store in a cool, dark place"
+/obj/structure/reagent_dispensers/tallow
+	name = "tallow tank"
+	desc = "A fifty-litre tank of commercial-grade tallow, intended for use in large scale deep fryers. Store in a cool, dark place"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "oiltank"
 	amount_per_transfer_from_this = 120
 
-/obj/structure/reagent_dispensers/cookingoil/Initialize()
+/obj/structure/reagent_dispensers/tallow/Initialize()
 	. = ..()
-	reagents.add_reagent("cornoil", 5000)
+	reagents.add_reagent("tallow", 5000)
 
 /obj/structure/reagent_dispensers/cookingoil/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.get_structure_damage())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This changes the default oil the fryer starts with and the oil tank to tallow instead of corn oil

## Why It's Good For The Game

While this seems like a asinine change, the issue with the fryer's current oil, corn oil, is the fact that it is meant to be a limiting factor for the production of Nitroglycerin, and being able to buy 5000u roundstart from cargo(or just steal it from the kitchen) has trivialized mining and science

## Changelog
:cl:
add: Tallow, a new oil subtype
balance: Changed fryer oil to tallow from corn oil
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
