### PR TITLE
Autoinjectors Can Now be Crafted at Chemistry (Redux)

### DIFF
--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -61,5 +61,6 @@ var/list/cheartstopper = list("potassium_chloride")                       // Thi
 #define MAX_UNITS_PER_PILL 60 // Max amount of units in a pill
 #define MAX_UNITS_PER_PATCH 60 // Max amount of units in a patch
 #define MAX_UNITS_PER_LOLLI 20 // Max amount of units in a lollipop.
+#define MAX_UNITS_PER_AUTO 5 // Max amount of units in an autoinjector.
 #define MAX_UNITS_PER_BOTTLE 60 // Max amount of units in a bottle (it's volume)
 #define MAX_CUSTOM_NAME_LEN 64 // Max length of a custom pill/condiment/whatever

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -1,6 +1,6 @@
 /obj/machinery/chem_master
 	name = "ChemMaster 3000"
-	desc = "Used to seperate and package chemicals in to lollipops, patches, pills, or bottles. Warranty void if used to create Space Drugs."
+	desc = "Used to seperate and package chemicals in to autoinjectors, lollipops, patches, pills, or bottles. Warranty void if used to create Space Drugs."
 	density = 1
 	anchored = 1
 	icon = 'icons/obj/chemical.dmi'
@@ -15,12 +15,15 @@
 	var/useramount = 15 // Last used amount
 	var/pillamount = 10
 	var/lolliamount = 5
+	var/autoamount = 5
 	var/list/bottle_styles
 	var/bottlesprite = 1
 	var/pillsprite = 1
 	var/lollisprite = 1
+	var/autosprite = 1
 	var/max_pill_count = 20
 	var/max_lolli_count = 10
+	var/max_auto_count = 5
 	var/printing = FALSE
 	flags = OPENCONTAINER
 	clicksound = "button"
@@ -123,6 +126,7 @@
 	data["pillsprite"] = pillsprite
 	data["bottlesprite"] = bottlesprite
 	data["lollisprite"] = lollisprite
+	data["autosprite"] = autosprite
 	data["mode"] = mode
 	data["printing"] = printing
 
@@ -242,6 +246,21 @@
 					if(condi || !reagents.total_volume)
 						return
 					ui_modal_input(src, id, "Please enter the amount of lollipops to make (max [MAX_MULTI_AMOUNT] at a time):", null, arguments, lolliamount, 5)
+				if("create_autoinjector")
+					if(condi || !reagents.total_volume)
+						return
+					var/num = round(text2num(arguments["num"] || 1))
+					if(!num)
+						return
+					arguments["num"] = num
+					var/amount_per_auto = clamp(reagents.total_volume / num, 0, MAX_UNITS_PER_AUTO)
+					var/default_name = "[reagents.get_master_reagent_name()] ([amount_per_auto]u)"
+					var/auto_text = num == 1 ? "new autoinjector" : "[num] new autoinjectors"
+					ui_modal_input(src, id, "Please name your [auto_text]:", null, arguments, default_name, MAX_CUSTOM_NAME_LEN)
+				if("create_autoinjector_multiple")
+					if(condi || !reagents.total_volume)
+						return
+					ui_modal_input(src, id, "Please enter the amount of autoinjectors to make (max [MAX_MULTI_AMOUNT] at a time):", null, arguments, autoamount, 5)
 				if("create_bottle")
 					if(condi || !reagents.total_volume)
 						return
@@ -390,6 +409,31 @@
 					if(condi || !reagents.total_volume)
 						return
 					ui_act("modal_open", list("id" = "create_lollipop", "arguments" = list("num" = answer)), ui, state)
+				if("create_autoinjector")
+					if(condi || !reagents.total_volume)
+						return
+					var/count = clamp(round(text2num(arguments["num"]) || 0), 0, MAX_MULTI_AMOUNT)
+					if(!count)
+						return
+
+					if(!length(answer))
+						answer = reagents.get_master_reagent_name()
+					var/amount_per_auto = clamp(reagents.total_volume / count, 0, MAX_UNITS_PER_AUTO)
+					// var/is_medical_patch = chemical_safety_check(reagents)
+					while(count--)
+						if(reagents.total_volume <= 0)
+							to_chat(usr, "<span class='notice'>Not enough reagents to create these injectors!</span>")
+							return
+
+						var/obj/item/reagent_containers/hypospray/autoinjector/A = new(loc)
+						A.name = "[answer] autoinjector"
+						A.pixel_x = rand(-7, 7) // random position
+						A.pixel_y = rand(-7, 7)
+						reagents.trans_to_obj(A, amount_per_auto)
+				if("create_autoinjector_multiple")
+					if(condi || !reagents.total_volume)
+						return
+					ui_act("modal_open", list("id" = "create_autoinjector", "arguments" = list("num" = answer)), ui, state)
 				if("create_bottle")
 					if(condi || !reagents.total_volume)
 						return

--- a/tgui/packages/tgui/interfaces/ChemMaster.js
+++ b/tgui/packages/tgui/interfaces/ChemMaster.js
@@ -376,6 +376,19 @@ const ChemMasterProductionChemical = (props, context) => {
           onClick={() => modalOpen(context, 'create_lollipop_multiple')}
         />
       </LabeledList.Item>
+      <LabeledList.Item label="Autoinjectors">
+        <Button
+          icon="square"
+          content="One (5u max)"
+          mr="0.5rem"
+          onClick={() => modalOpen(context, 'create_autoinjector')}
+        />
+        <Button
+          icon="plus-square"
+          content="Multiple"
+          onClick={() => modalOpen(context, 'create_autoinjector_multiple')}
+        />
+      </LabeledList.Item>
       <LabeledList.Item label="Bottle">
         <Button
           icon="wine-bottle"

--- a/tgui/packages/tgui/interfaces/ChemPress.js
+++ b/tgui/packages/tgui/interfaces/ChemPress.js
@@ -43,6 +43,13 @@ export const ChemPress = (props, context) => {
                 })}
               />
               <Button.Checkbox
+                content="Autoinjectors"
+                checked={product === "autoinjector"}
+                onClick={() => act('change_product', {
+                  product: "autoinjector",
+                })}
+              />
+              <Button.Checkbox
                 content="Bottles"
                 checked={product === "bottle"}
                 onClick={() => act('change_product', {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. _Autoinjectors can now be crafted at Chemistry._

## Why It's Good For The Game

1. Production, yay. I wish I knew what TGUI icons we had available, because the UI is just a stack of squares now.

## Changelog
:cl:
add: Autoinjectors can be produced at chem now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
