### PR TITLE
jukes, timeclocks, and extinguishers oh my! also unus

### DIFF
--- a/_maps/map_files/tether/tether-01-surface1.dmm
+++ b/_maps/map_files/tether/tether-01-surface1.dmm
@@ -10679,6 +10679,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/computer/timeclock/premade/west,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "ask" = (
@@ -15560,6 +15561,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
+/obj/machinery/computer/timeclock/premade/south,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "azP" = (
@@ -36435,6 +36437,15 @@
 "pNR" = (
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/tunnel)
+"pQk" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/media/jukebox,
+/turf/simulated/floor/wood,
+/area/crew_quarters/visitor_dining)
 "pUI" = (
 /obj/structure/railing{
 	dir = 1
@@ -38674,6 +38685,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
+"wjD" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/machinery/computer/timeclock/premade/north,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "wnS" = (
 /obj/machinery/computer{
 	dir = 1
@@ -50954,7 +50979,7 @@ aAI
 aAI
 aAI
 aef
-aeS
+wjD
 afO
 aBC
 aCr
@@ -54699,7 +54724,7 @@ aHI
 aIt
 aJn
 aJV
-kxU
+pQk
 aLj
 aLU
 aMF

--- a/_maps/map_files/tether/tether-02-surface2.dmm
+++ b/_maps/map_files/tether/tether-02-surface2.dmm
@@ -17231,6 +17231,7 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
+/obj/machinery/computer/timeclock/premade/north,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_two_hall)
 "aDr" = (

--- a/_maps/map_files/tether/tether-03-surface3.dmm
+++ b/_maps/map_files/tether/tether-03-surface3.dmm
@@ -36329,6 +36329,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/deck/unus,
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/barbackmaintenance)
 "ddl" = (
@@ -36875,6 +36876,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
+"exR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/closet/hydrant{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/security/upperhall)
 "eCG" = (
 /obj/machinery/computer/ship/helm,
 /turf/simulated/floor/tiled/eris/white/orangecorner,
@@ -37284,6 +37300,11 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/hydroponics)
+"glm" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/media/jukebox,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/entertainment/stage)
 "glT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -39904,6 +39925,21 @@
 "nJe" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/teleporter/departing)
+"nJo" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/computer/timeclock/premade/south,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "nKy" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
@@ -53161,7 +53197,7 @@ cVg
 bzK
 aWW
 adW
-qAt
+exR
 iHX
 vqv
 bJV
@@ -56719,7 +56755,7 @@ ahL
 aUU
 xIO
 isl
-bhu
+nJo
 alo
 alo
 alo
@@ -56895,7 +56931,7 @@ bdm
 bdg
 bdo
 beJ
-bgk
+glm
 bbk
 bgB
 aYC

--- a/_maps/map_files/tether/tether-04-transit.dmm
+++ b/_maps/map_files/tether/tether-04-transit.dmm
@@ -299,6 +299,7 @@
 /area/tether/midpoint)
 "xw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/computer/timeclock/premade/east,
 /turf/simulated/floor/tiled/dark,
 /area/tether/midpoint)
 "xR" = (
@@ -320,6 +321,13 @@
 /obj/structure/disposalpipe/up,
 /turf/simulated/floor/plating,
 /area/maintenance/tether_midpoint)
+"yD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/media/jukebox,
+/turf/simulated/floor/wood,
+/area/tether/midpoint)
 "yJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/dark,
@@ -368,6 +376,15 @@
 "Ag" = (
 /obj/machinery/vending/snack{
 	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/tether/midpoint)
+"At" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
 /turf/simulated/floor/wood,
 /area/tether/midpoint)
@@ -10958,12 +10975,12 @@ Xu
 HT
 MA
 BQ
-Mq
+At
 AM
 AM
 AM
 AM
-Go
+yD
 wI
 MA
 HT

--- a/_maps/map_files/tether/tether-06-station2.dmm
+++ b/_maps/map_files/tether/tether-06-station2.dmm
@@ -19513,6 +19513,13 @@
 	dir = 8
 	},
 /area/hallway/station/port)
+"jpG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/media/jukebox,
+/turf/simulated/floor/tiled/steel_grid,
+/area/quartermaster/foyer)
 "jqe" = (
 /obj/machinery/conveyor{
 	id = "shuttle_inbound"
@@ -40348,7 +40355,7 @@ aWq
 aWq
 vdL
 aTU
-aXr
+jpG
 aGA
 rPb
 aTU


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

sprinkles jukeboxes and timeclocks around in a few spots in addition to adding an unus deck to the game room, a fire cabinet inside security, and an extinguisher to the midpoint

## Why It's Good For The Game

people wanted more jukeboxes, finding a timeclock was harder than it had any right to be, and security burning down due to a lack of firefighting shit is a meme and a half. also unus is based fuck you.

## Changelog
:cl:
add: jukebox to entertainment area, cafe, and cargo rec area
add: more timeclocks to decks 1-3
add: extinguisher to midpoint and a fire cabinet to security
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
