### PR TITLE
Code BLUE Armory Edit

### DIFF
--- a/_maps/map_files/tether/tether-02-surface2.dmm
+++ b/_maps/map_files/tether/tether-02-surface2.dmm
@@ -11410,12 +11410,12 @@
 "arP" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/gun/projectile/shotgun/pump{
-	ammo_type = /obj/item/ammo_casing/a12g/pellet;
+	ammo_type = /obj/item/ammo_casing/a12g/beanbag;
 	pixel_x = 2;
 	pixel_y = -6
 	},
 /obj/item/gun/projectile/shotgun/pump{
-	ammo_type = /obj/item/ammo_casing/a12g/pellet;
+	ammo_type = /obj/item/ammo_casing/a12g/beanbag;
 	pixel_x = 1;
 	pixel_y = 4
 	},


### PR DESCRIPTION
Swaps pellets for beanbags round for shotguns in the BLUE armory.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changed the ammo in the shotguns in the Code BLUE **from** pellets **to** beanbag.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having lethal rounds in the nonlethal section of the armory is bad mkay.... 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Tweaked shotguns in Code BLUE armory to have beanbag rounds instead of pellet rounds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
