### PR TITLE
APC alt-click to unlock controls

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -688,6 +688,18 @@
 
 // attack with hand - remove cell (if cover open) or interact with the APC
 
+//Altclick APCs to toggle the controlls
+/obj/machinery/power/apc/AltClick(mob/user)
+	if(user.Adjacent(src))
+		if(src.allowed(usr) && !isWireCut(APC_WIRE_IDSCAN))
+			locked = !locked
+			to_chat(user,"You [ locked ? "lock" : "unlock"] the APC interface.")
+			update_icon()
+		else
+			to_chat(user,"<span class='warning'>Access denied.</span>")
+
+
+
 /obj/machinery/power/apc/emag_act(var/remaining_charges, var/mob/user)
 	if (!(emagged || hacker))		// trying to unlock with an emag card
 		if(opened)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Alt-clicking an APC unlocks the controlls or locks them, if you have the access requirement
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Speeds interaction with APCs up
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Alt-Clicking as engineer now unlocks the controlls of APCs immidetly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
