### PR TITLE
Air Alarm alt-click control toggle

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -782,12 +782,11 @@
 //Altclick airalarms to toggle the controlls
 /obj/machinery/alarm/AltClick(mob/user)
 	if(user.Adjacent(src))
-		if(src.allowed(usr) && !isWireCut(APC_WIRE_IDSCAN))
+		if(allowed(usr) && !wires.IsIndexCut(AALARM_WIRE_IDSCAN))
 			locked = !locked
-			to_chat(user,"You [ locked ? "lock" : "unlock"] the APC interface.")
-			update_icon()
+			to_chat(user, "<span class='notice'>You [ locked ? "lock" : "unlock"] the Air Alarm interface.</span>")
 		else
-			to_chat(user,"<span class='warning'>Access denied.</span>")
+			to_chat(user, "<span class='warning'>Access denied.</span>")
 
 /obj/machinery/alarm/power_change()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Alt-clicking an Airalarm unlocks the controlls or locks them, if you have the access requirement
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Speeds interaction with Airalarms up
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Alt-Clicking as engineer now unlocks the controlls of airalarms immidetly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->