### PR TITLE
Improves Headphones and subtypes with Alt-click on and off

### DIFF
--- a/code/modules/clothing/ears/ears.dm
+++ b/code/modules/clothing/ears/ears.dm
@@ -37,14 +37,13 @@
 
 	update_clothing_icon()
 
-/obj/item/clothing/ears/earmuffs/headphones/AltClick(mob/user as mob)
+/obj/item/clothing/ears/earmuffs/headphones/AltClick(mob/user)
 	if(!Adjacent(user))
 		return
 	else if(!headphones_on)
 		togglemusic()
 	else
 		togglemusic()
-		
 /*
 	Skrell tentacle wear
 */


### PR DESCRIPTION
Not perfect. Can still telepathically toggle them, but I can't figure out how to make them not right now.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds alt-clicking to turn headphones, and any subtypes of headphones, on and off for music
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Not needing to go into the right click menu for an on and off toggle is really nice.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

