### PR TITLE
Remaps Red Armory Plate Carriers

### DIFF
--- a/_maps/map_files/tether/tether-02-surface2.dmm
+++ b/_maps/map_files/tether/tether-02-surface2.dmm
@@ -6180,38 +6180,31 @@
 /area/tether/surfacebase/security/armory)
 "aju" = (
 /obj/structure/table/rack/steel,
-/obj/item/clothing/suit/armor/pcarrier/medium/security,
-/obj/item/clothing/accessory/storage/pouches,
-/obj/item/clothing/accessory/armor/legguards/riot,
-/obj/item/clothing/accessory/armor/armguards/riot,
-/obj/item/clothing/accessory/armor/armorplate/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/shield/riot,
-/obj/item/clothing/suit/armor/pcarrier/medium/security,
-/obj/item/clothing/accessory/storage/pouches,
-/obj/item/clothing/accessory/armor/legguards/riot,
-/obj/item/clothing/accessory/armor/armguards/riot,
-/obj/item/clothing/accessory/armor/armorplate/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/shield/riot,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/red/border,
+/obj/item/clothing/accessory/storage/pouches,
+/obj/item/clothing/accessory/armor/legguards/riot,
+/obj/item/clothing/accessory/armor/armguards/riot,
+/obj/item/clothing/suit/armor/pcarrier/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/shield/riot,
+/obj/item/clothing/accessory/storage/pouches,
+/obj/item/clothing/accessory/armor/legguards/riot,
+/obj/item/clothing/accessory/armor/armguards/riot,
+/obj/item/clothing/suit/armor/pcarrier/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/shield/riot,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "ajv" = (
 /obj/structure/table/rack/steel,
-/obj/item/clothing/suit/armor/pcarrier/green,
-/obj/item/clothing/accessory/storage/pouches/green,
-/obj/item/clothing/accessory/armor/legguards/bulletproof{
-	icon_state = "legguards_green"
-	},
-/obj/item/clothing/accessory/armor/armguards/bulletproof{
-	icon_state = "armguards_green"
-	},
-/obj/item/clothing/accessory/armor/armorplate/bulletproof,
-/obj/item/clothing/head/helmet/bulletproof,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/red/border,
+/obj/item/clothing/accessory/storage/pouches/green,
+/obj/item/clothing/accessory/armor/legguards/bulletproof,
+/obj/item/clothing/accessory/armor/armguards/bulletproof,
+/obj/item/clothing/suit/armor/pcarrier/bulletproof,
+/obj/item/clothing/head/helmet/bulletproof,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "ajw" = (
@@ -6219,22 +6212,17 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/item/clothing/suit/armor/pcarrier/blue,
-/obj/item/clothing/accessory/storage/pouches/blue,
-/obj/item/clothing/accessory/armor/legguards/laserproof{
-	icon_state = "legguards_blue"
-	},
-/obj/item/clothing/accessory/armor/armguards/laserproof{
-	icon_state = "armguards_blue"
-	},
-/obj/item/clothing/accessory/armor/armorplate/laserproof,
-/obj/item/clothing/head/helmet/laserproof,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 6
 	},
+/obj/item/clothing/accessory/storage/pouches/blue,
+/obj/item/clothing/accessory/armor/legguards/laserproof,
+/obj/item/clothing/accessory/armor/armguards/laserproof,
+/obj/item/clothing/suit/armor/pcarrier/laserproof,
+/obj/item/clothing/head/helmet/laserproof,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "ajx" = (
@@ -11410,12 +11398,10 @@
 "arP" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/gun/projectile/shotgun/pump{
-	ammo_type = /obj/item/ammo_casing/a12g/beanbag;
 	pixel_x = 2;
 	pixel_y = -6
 	},
 /obj/item/gun/projectile/shotgun/pump{
-	ammo_type = /obj/item/ammo_casing/a12g/beanbag;
 	pixel_x = 1;
 	pixel_y = 4
 	},

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -626,6 +626,26 @@
 /obj/item/clothing/suit/armor/pcarrier/merc
 	starting_accessories = list(/obj/item/clothing/accessory/armor/armorplate/merc, /obj/item/clothing/accessory/armor/armguards/merc, /obj/item/clothing/accessory/armor/legguards/merc, /obj/item/clothing/accessory/storage/pouches/large)
 
+//Brig Spec Variants
+/obj/item/clothing/suit/armor/pcarrier/bulletproof
+	name = "ballistic plate carrier"
+	desc = "A lightweight ballistic vest. Equipped with a ballistic armor plate by default, this armor consists of a kevlar weave augmented by a non-Newtonian gel layer."
+	icon_state = "ballistic"
+	starting_accessories = list(/obj/item/clothing/accessory/armor/armorplate/bulletproof, /obj/item/clothing/accessory/armor/tag/sec)
+
+/obj/item/clothing/suit/armor/pcarrier/laserproof
+	name = "ablative plate carrier"
+	desc = "A lightweight deflector vest. Equipped with an ablative armor plate by default, this armor consists of a polished Cartesian Glance Plating and an inset network of heat sink channels."
+	icon_state = "ablative"
+	starting_accessories = list(/obj/item/clothing/accessory/armor/armorplate/laserproof, /obj/item/clothing/accessory/armor/tag/sec)
+
+/obj/item/clothing/suit/armor/pcarrier/riot
+	name = "riot suppression plate carrier"
+	desc = "A lightweight padded vest. Equipped with a padded armor plate by default, this armor consists of a stab resistant kevlar weave and hardened fleximat padding."
+	icon_state = "riot"
+	starting_accessories = list(/obj/item/clothing/accessory/armor/armorplate/riot, /obj/item/clothing/accessory/armor/tag/sec)
+
+
 //PARA Armor
 /obj/item/clothing/suit/armor/vest/para
 	name = "PARA light armor"

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -138,7 +138,7 @@
 /obj/item/clothing/accessory/armor/armorplate/laserproof
 	name = "ablative armor plate"
 	desc = "A durasteel-scaled synthetic armor plate, providing good protection against lasers. Attaches to a plate carrier."
-	icon_state = "armor_medium"
+	icon_state = "armor_ablative"
 	slowdown = 0.6
 	armor = list(melee = 10, bullet = 10, laser = 70, energy = 50, bomb = 0, bio = 0, rad = 0)
 	armorsoak = list(melee = 0, bullet = 0, laser = 10, energy = 15, bomb = 0, bio = 0, rad = 0)
@@ -205,7 +205,7 @@
 /obj/item/clothing/accessory/armor/armguards/laserproof
 	name = "ablative arm guards"
 	desc = "These arm guards will protect your arms from energy weapons."
-	icon_state = "armguards_laser"
+	icon_state = "armguards_ablative"
 	item_state_slots = list(slot_r_hand_str = "swat", slot_l_hand_str = "swat")
 	siemens_coefficient = 0.4 //This is worse than the other ablative pieces, to avoid this from becoming the poor warden's insulated gloves.
 	armor = list(melee = 10, bullet = 10, laser = 80, energy = 50, bomb = 0, bio = 0, rad = 0)
@@ -213,7 +213,7 @@
 /obj/item/clothing/accessory/armor/armguards/bulletproof
 	name = "bullet resistant arm guards"
 	desc = "These arm guards will protect your arms from ballistic weapons."
-	icon_state = "armguards_bullet"
+	icon_state = "armguards_ballistic"
 	item_state_slots = list(slot_r_hand_str = "swat", slot_l_hand_str = "swat")
 	siemens_coefficient = 0.7
 	armor = list(melee = 10, bullet = 80, laser = 10, energy = 50, bomb = 0, bio = 0, rad = 0)
@@ -264,7 +264,7 @@
 /obj/item/clothing/accessory/armor/legguards/laserproof
 	name = "ablative leg guards"
 	desc = "These will protect your legs from energy weapons."
-	icon_state = "legguards_laser"
+	icon_state = "legguards_ablative"
 	item_state_slots = list(slot_r_hand_str = "jackboots", slot_l_hand_str = "jackboots")
 	siemens_coefficient = 0.1
 	armor = list(melee = 10, bullet = 10, laser = 80, energy = 50, bomb = 0, bio = 0, rad = 0)
@@ -272,7 +272,7 @@
 /obj/item/clothing/accessory/armor/legguards/bulletproof
 	name = "bullet resistant leg guards"
 	desc = "These will protect your legs from ballistic weapons."
-	icon_state = "legguards_bullet"
+	icon_state = "legguards_ballistic"
 	item_state_slots = list(slot_r_hand_str = "jackboots", slot_l_hand_str = "jackboots")
 	siemens_coefficient = 0.7
 	armor = list(melee = 10, bullet = 80, laser = 10, energy = 10, bomb = 0, bio = 0, rad = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. _Adds preset Ablative, Ballistic, and Riot plate carriers._
2. _Replaces workaround carriers in the Red Armory with these presets._

## Why It's Good For The Game

1. I was updating the Wiki and I found these sprites in the code. I find them preferable to the basic renamed color variants I originally put in for use.
2. See the above.

## Changelog
:cl:
add: Added Ablative, Ballistic, and Riot plate carrier presets.
tweak: Replaced Red Armory carriers with new presets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
