### PR TITLE
lets chaplains set custom holy book names

### DIFF
--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -82,7 +82,9 @@
 			if("starlit path of angessa martei")
 				B.name = "Quotations of Exalted Martei"
 			else
-				B.name = "The Holy Book of [new_religion]"
+				var/book_name = sanitize(input(H, "What would you like your holy book to be called? Default is The Holy Book of <religion>", "Holy book name", "The Holy Book of [new_religion]"), MAX_NAME_LEN)
+				B.name = book_name
+				//B.name = "The Holy Book of [new_religion]" -- replaced by the above line
 		feedback_set_details("religion_name","[new_religion]")
 	spawn(1)
 		var/deity_name = "Hashem"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

makes it so that chaplains who set a custom religion can set the name of their holy book, as opposed to it being "The Holy Book of (insert religion here)"

## Why It's Good For The Game

yay flexibility and customizability for religions that don't have a typical holy book, or a holy book with a specific name that isn't already hard-coded in

## Changelog
:cl:
tweak: chaplains can now input a name for their holy book if they have a custom religion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
