### PR TITLE
Nerf energy fields.

### DIFF
--- a/code/modules/shieldgen/energy_field.dm
+++ b/code/modules/shieldgen/energy_field.dm
@@ -18,8 +18,7 @@
 	plane = MOB_PLANE
 	layer = ABOVE_MOB_LAYER
 	density = 0
-	var/powered = 0
-	can_atmos_pass = ATMOS_PASS_DENSITY
+	can_atmos_pass = ATMOS_PASS_YES
 	var/obj/machinery/shield_gen/my_gen = null
 	var/strength = 0 // in Renwicks
 	var/ticks_recovering = 10
@@ -76,7 +75,7 @@
 	var/penetrated = TRUE
 	adjust_strength(-max((meteor.wall_power * meteor.hits) / 800, 0)) // One renwick (strength var) equals one r-wall for the purposes of meteor-stopping.
 	sleep(1)
-	if(powered) // Check if we're still up.
+	if(density) // Check if we're still up.
 		penetrated = FALSE
 		explosion(meteor.loc, 0, 0, 0, 0, 0, 0, 0) // For the sound effect.
 
@@ -84,7 +83,7 @@
 	return penetrated // If the shield's still around, the meteor was successfully stopped, otherwise keep going and plow into the station.
 
 /obj/effect/energy_field/proc/adjust_strength(amount, impact = 1)
-	var/old_powered = powered
+	var/old_density = density
 	strength = between(0, strength + amount, max_strength)
 
 	//maptext = "[round(strength, 0.1)]/[max_strength]"
@@ -96,15 +95,15 @@
 
 		ticks_recovering = min(ticks_recovering + 2, 10)
 		if(strength < 1) // We broke
-			powered = 0
+			density = 0
 			ticks_recovering = 10
 			strength = 0
 
 	else if(amount > 0) // Healing damage.
 		if(strength >= 1)
-			powered = 1
+			density = 1
 
-	if(powered != old_powered)
+	if(density != old_density)
 		update_icon()
 		update_nearby_tiles()
 
@@ -120,7 +119,7 @@
 				adjacent_shields_dir |= direction
 				break
 	// Icon_state and Glow
-	if(powered)
+	if(density)
 		icon_state = "shield"
 		set_light(3, 3, "#66FFFF")
 	else


### PR DESCRIPTION
Don't block atmos.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The energy fields from the shield generators no longer block atmos flow.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Was requested, to make Engineering a bit more harrowing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Makes the shields depend on the variable powered, not density, so it doesn't swap density about.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
