### PR TITLE
Real Space Trash Have Curves

### DIFF
--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -11,7 +11,7 @@
 	/// Name prior to being scanned if !known
 	var/unknown_name = "unknown sector"
 	/// Icon_state prior to being scanned if !known
-	var/unknown_state = "field"
+	var/unknown_state = "unknown"
 
 	var/list/map_z = list()
 	var/list/extra_z_levels //if you need to manually insist that these z-levels are part of this sector, for things like edge-of-map step trigger transitions rather than multi-z complexes


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For roughly a month I've been unable to locate the 'debris field' POI on the overmap - for a time I thought simply that its obscurity was a product of my failure to locate it in-game, but in time my suspicions grew. My quest has lead me to the following discovery that at round-start debris fields are marked as an 'unknown sector' and does not have an icon associated with it on the overmap.

![image](https://user-images.githubusercontent.com/25857923/136881131-11aaa8cb-cfea-40d4-8326-5e028c0f09da.png)

![image](https://user-images.githubusercontent.com/25857923/136881777-6040d54f-0304-4058-9186-6851c33a3cd6.png)

After bringing this to the attention of Silicons I confirmed that this was erroneous behavior and tracked it down to this file, where the icon state 'field' has no associated icon in the overmaps section. To this end I have made use of the 'unknown' icon to denote unscanned 'unknown sectors'.

![image](https://user-images.githubusercontent.com/25857923/136881289-c5a3f87d-2b0c-4ead-998f-3dd1b2e6bbfc.png)

Further, this fix does not infringe upon the behavior of 'unknown sectors' in that, once scanned by a spacecraft's sensors, they will display their proper icon.

![image](https://user-images.githubusercontent.com/25857923/136881410-23388277-8df9-4341-987b-93972d2db2c5.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Silicon's response to the information that debris fields were without an icon heavily implies to me that it was not an intended change - this rectifies that by addressing the wider issue of all unknown sectors not having a proper overworld icon.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Unknown sectors now have visible icon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
