### PR TITLE
Open Doors QOL

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -117,7 +117,32 @@
 
 /turf/attack_hand(mob/user)
 	. = ..()
-	user.move_pulled_towards(src)
+	//QOL feature, clicking on turf can toggle doors, unless pulling something
+	if(!user.pulling)
+		var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in src.contents
+		if(AL)
+			AL.attack_hand(user)
+			return TRUE
+		var/obj/machinery/door/firedoor/FD = locate(/obj/machinery/door/firedoor) in src.contents
+		if(FD)
+			FD.attack_hand(user)
+			return TRUE
+
+	if(!(user.canmove) || user.restrained() || !(user.pulling))
+		return 0
+	if(user.pulling.anchored || !isturf(user.pulling.loc))
+		return 0
+	if(user.pulling.loc != user.loc && get_dist(user, user.pulling) > 1)
+		return 0
+	if(ismob(user.pulling))
+		var/mob/M = user.pulling
+		var/atom/movable/t = M.pulling
+		M.stop_pulling()
+		step(user.pulling, get_dir(user.pulling.loc, src))
+		M.start_pulling(t)
+	else
+		step(user.pulling, get_dir(user.pulling.loc, src))
+	return 1
 
 /turf/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/storage))


### PR DESCRIPTION
## About The Pull Request

Some door functionality QoL. PR combines [POL7853](https://github.com/PolarisSS13/Polaris/pull/7853) and [POL7968](https://github.com/PolarisSS13/Polaris/pull/7968).

Lightly tested. No runtimes or issues noted whilst running around Engineering clicking on doors like a madman, doesn't interfere with tile removal or other interacts either.

## Why It's Good For The Game

You can now click on an open door's tile with an empty hand to close it, which saves you the time and effort of pixelhunting for the frame when trying to close doors. Works for open firedoors as well.

Doesn't interfere with moving pulled items (if you are pulling something you will still need to frame-hunt) or other interactions.

## Changelog
:cl:
add: You can now close open doors and firedoors by clicking on their floor tile.
/:cl: