### PR TITLE
Of lattices and artifacts.

### DIFF
--- a/_maps/submaps/mountains/cultmine.dmm
+++ b/_maps/submaps/mountains/cultmine.dmm
@@ -270,8 +270,8 @@
 /area/submap/cave/cultmine)
 "bb" = (
 /obj/machinery/porta_turret/alien/destroyed{
-	icon_state = "destroyed_target_prism";
-	dir = 6
+	dir = 6;
+	icon_state = "destroyed_target_prism"
 	},
 /turf/simulated/mineral/floor/ignore_mapgen,
 /area/submap/cave/cultmine)
@@ -288,8 +288,8 @@
 "be" = (
 /obj/effect/decal/remains/ribcage,
 /obj/machinery/porta_turret/alien/destroyed{
-	icon_state = "destroyed_target_prism";
-	dir = 10
+	dir = 10;
+	icon_state = "destroyed_target_prism"
 	},
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/mineral/floor/ignore_mapgen,
@@ -393,7 +393,6 @@
 /area/submap/cave/cultmine)
 "bA" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	autoclose = 1;
 	dir = 2;
 	id_tag = null;
 	name = "Cafe";
@@ -522,8 +521,7 @@
 /area/submap/cave/cultmine)
 "bX" = (
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/submap/cave/cultmine)
@@ -701,17 +699,12 @@
 /obj/structure/cult/forge,
 /turf/simulated/floor/cult,
 /area/submap/cave/cultmine)
-"cJ" = (
-/obj/item/archaeological_find,
-/turf/simulated/floor/cult,
-/area/submap/cave/cultmine)
 "cK" = (
 /obj/structure/cult/tome,
 /turf/simulated/floor/cult,
 /area/submap/cave/cultmine)
 "cL" = (
 /obj/structure/bed/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /obj/effect/decal/remains/mummy1,
@@ -719,7 +712,6 @@
 /area/submap/cave/cultmine)
 "cM" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	autoclose = 1;
 	dir = 2;
 	id_tag = null;
 	name = "Medbay";
@@ -756,9 +748,7 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /obj/machinery/light/small,
 /obj/random/toy,
@@ -771,9 +761,7 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /obj/random/soap,
 /obj/machinery/light/small,
@@ -1678,7 +1666,7 @@ cu
 cu
 cu
 cD
-cJ
+cx
 cx
 cL
 cu
@@ -1714,7 +1702,7 @@ cA
 cx
 di
 cx
-cJ
+cx
 cu
 ct
 "}
@@ -1815,7 +1803,7 @@ cu
 cu
 cE
 cx
-cJ
+cx
 cu
 ct
 ct

--- a/_maps/submaps/wilderness/DJOutpost3.dmm
+++ b/_maps/submaps/wilderness/DJOutpost3.dmm
@@ -69,8 +69,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/submap/DJOutpost1)
@@ -94,13 +93,11 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/clothing/under/frontier,
 /obj/random_multi/single_item/sfr_headset,
-/obj/item/archaeological_find,
 /turf/simulated/floor/tiled/techfloor,
 /area/submap/DJOutpost1)
 "ar" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/radio/intercom{
-	icon_state = "intercom";
 	dir = 8
 	},
 /obj/random/firstaid,
@@ -119,7 +116,6 @@
 "at" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/radio/intercom{
-	icon_state = "intercom";
 	dir = 8
 	},
 /obj/item/book/codex/lore/news,
@@ -127,9 +123,7 @@
 /area/submap/DJOutpost1)
 "au" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -232,7 +226,6 @@
 "aH" = (
 /obj/item/reagent_containers/food/snacks/unajerky,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/random_multi/single_item/sfr_headset,
@@ -241,9 +234,7 @@
 /area/submap/DJOutpost1)
 "aI" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/tiled/techfloor,
@@ -279,7 +270,6 @@
 "aO" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 15
 	},
 /turf/simulated/floor/tiled/techfloor,

--- a/_maps/submaps/wilderness/DJOutpost4.dmm
+++ b/_maps/submaps/wilderness/DJOutpost4.dmm
@@ -110,7 +110,6 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/clothing/under/frontier,
 /obj/random_multi/single_item/sfr_headset,
-/obj/item/archaeological_find,
 /turf/simulated/floor/tiled/techfloor,
 /area/submap/DJOutpost1)
 "av" = (
@@ -120,7 +119,6 @@
 "aw" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/radio/intercom{
-	icon_state = "intercom";
 	dir = 8
 	},
 /obj/random/firstaid,
@@ -142,8 +140,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/submap/DJOutpost1)
@@ -161,7 +158,6 @@
 "aA" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/radio/intercom{
-	icon_state = "intercom";
 	dir = 8
 	},
 /obj/item/book/codex/lore/news,
@@ -176,9 +172,7 @@
 /area/submap/DJOutpost1)
 "aC" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -280,7 +274,6 @@
 "aP" = (
 /obj/item/reagent_containers/food/snacks/unajerky,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/random_multi/single_item/sfr_headset,
@@ -289,9 +282,7 @@
 /area/submap/DJOutpost1)
 "aQ" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/tiled/techfloor,
@@ -331,7 +322,6 @@
 "aX" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 15
 	},
 /turf/simulated/floor/tiled/techfloor,

--- a/code/game/objects/random/mapping.dm
+++ b/code/game/objects/random/mapping.dm
@@ -401,9 +401,9 @@
 				/obj/item/vampiric,
 				/obj/structure/closet/crate/science
 			),
-			prob(1);list(
-				/obj/item/archaeological_find
-			),
+			//prob(1);list(
+			//	/obj/item/archaeological_find
+			//),
 			prob(1);list(
 				/obj/item/melee/energy/sword,
 				/obj/item/melee/energy/sword,

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -16,7 +16,7 @@
 
 	for(var/obj/structure/lattice/LAT in src.loc)
 		if(LAT != src)
-			stack_trace("Found multiple lattices at '[log_info_line(loc)]'")
+			//stack_trace("Found multiple lattices at '[log_info_line(loc)]'")
 			return INITIALIZE_HINT_QDEL
 	icon = 'icons/obj/smoothlattice.dmi'
 	icon_state = "latticeblank"


### PR DESCRIPTION
Disables a redundant error report and xenoarchaeology items from ruins.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
In an effort to fix the CI Integration check constantly failing, I've done two things.
1: Disabled the error report when multiple lattices are spawned in the same spot. I mean, why does it report it if it just fixes the issue?
2: Disabled xenoarchaeology from existing in ruins. Only way to get them is via admin spawning or... Xenoarchaeology. This is a bandaid to the issue of them sometimes having a bad index on Initialize. If that's fixed, map them back in freely.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
SHOULD stop the checks from failing randomly, and help determine if they failed due to the actual PR.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: CI integration check shouldn't fail randomly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
