### PR TITLE
Adds Mecha Components to the Mech Fab

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -81,6 +81,7 @@
 								"Cybernetics",
 								"Implants",
 								"Control Interfaces",
+								"Components",
 								"Other",
 								"Misc",
 								)

--- a/code/modules/research/mechfab_designs.dm
+++ b/code/modules/research/mechfab_designs.dm
@@ -879,6 +879,103 @@
 	category = "Misc"
 
 /*
+* Printable Internal Components
+*/
+
+/datum/design/item/mecha_component
+	name = "Mecha Actuator"
+	id = "mactuator"
+	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 2)
+	build_type = MECHFAB
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 2500)
+	build_path = /obj/item/mecha_parts/component/actuator
+	category = "Components"
+
+/datum/design/item/mecha_component/actuator_high
+	name = "Mecha Actuator - High Speed"
+	id = "mactuatorhigh"
+	req_tech = list(TECH_ENGINEERING = 5, TECH_MATERIAL = 6)
+	materials = list(DEFAULT_WALL_MATERIAL = 7000, "glass" = 4000, "gold" = 10000)
+	build_path = /obj/item/mecha_parts/component/actuator/hispeed
+
+/datum/design/item/mecha_component/armor
+	name = "Mecha Plating"
+	id = "marmor"
+	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 3)
+	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 2000)
+	build_path = /obj/item/mecha_parts/component/armor
+
+/datum/design/item/mecha_component/armor/blast
+	name = "Mecha Plating - Blast Resistant"
+	id = "marmorblast"
+	req_tech = list(TECH_ENGINEERING = 5, TECH_MATERIAL = 4)
+	materials = list(DEFAULT_WALL_MATERIAL = 15000, "glass" = 500, "plasteel" = 2000)
+	build_path = /obj/item/mecha_parts/component/armor/mining
+
+/datum/design/item/mecha_component/armor/lightweight
+	name = "Mecha Plating - Lightweight"
+	id = "marmorlight"
+	req_tech = list(TECH_ENGINEERING = 5, TECH_MATERIAL = 6)
+	materials = list(DEFAULT_WALL_MATERIAL = 7000, "plastic" = 5000, "gold" = 2000)
+	build_path = /obj/item/mecha_parts/component/armor/lightweight
+
+/datum/design/item/mecha_component/armor/reinforced
+	name = "Mecha Plating - Reinforced"
+	id = "marmorreinf"
+	req_tech = list(TECH_ENGINEERING = 5, TECH_MATERIAL = 6, TECH_COMBAT = 5)
+	materials = list(DEFAULT_WALL_MATERIAL = 15000, "plasteel" = 5000, "uranium" = 5000)
+	build_path = /obj/item/mecha_parts/component/armor/reinforced
+
+/datum/design/item/mecha_component/electrical
+	name = "Mecha Electrical Harness"
+	id = "melectrical"
+	req_tech = list(TECH_ENGINEERING = 3, TECH_POWER = 3)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 2000, "plastic" = 1000)
+	build_path = /obj/item/mecha_parts/component/electrical
+
+/datum/design/item/mecha_component/electrical/high_current
+	name = "Mecha Electrical Harness - High Current"
+	id = "melectricalhigh"
+	req_tech = list(TECH_ENGINEERING = 5, TECH_POWER = 5, TECH_MATERIAL = 4)
+	materials = list(DEFAULT_WALL_MATERIAL = 3000, "glass" = 4000, "plastic" = 5000, "gold" = 5000)
+	build_path = /obj/item/mecha_parts/component/electrical
+
+/datum/design/item/mecha_component/hull
+	name = "Mecha Hull"
+	id = "mhull"
+	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 2)
+	materials = list(DEFAULT_WALL_MATERIAL = 7000, "glass" = 500)
+	build_path = /obj/item/mecha_parts/component/hull
+
+/datum/design/item/mecha_component/hull/durable
+	name = "Mecha Hull - Durable"
+	id = "mhulldura"
+	req_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 4)
+	materials = list(DEFAULT_WALL_MATERIAL = 7000, "glass" = 500, "plasteel" = 10000)
+	build_path = /obj/item/mecha_parts/component/hull/durable
+
+/datum/design/item/mecha_component/hull/lightweight
+	name = "Mecha Hull - Lightweight"
+	id = "mhulllight"
+	req_tech = list(TECH_ENGINEERING = 5, TECH_MATERIAL = 5)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 500, "plastic" = 3000)
+	build_path = /obj/item/mecha_parts/component/hull/lightweight
+
+/datum/design/item/mecha_component/gas
+	name = "Mecha Life-Support"
+	id = "mgas"
+	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 2, TECH_BIO = 3)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 3000)
+	build_path = /obj/item/mecha_parts/component/gas
+
+/datum/design/item/mecha_component/gas/reinforced
+	name = "Mecha Life-Support - Reinforced"
+	id = "mgasreinf"
+	req_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 3, TECH_BIO = 5)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 3000, "silver" = 4000)
+	build_path = /obj/item/mecha_parts/component/gas/reinforced
+
+/*
  * Non-Mech Vehicles
  */
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. _Mecha internal components may now be printed at the mech fab._

## Why It's Good For The Game

1. Internal repair of mecha is currently difficult to impossible due to an inability to print out internal components. The baseline may now be printed fairly quickly, and more advanced iterations may be created with more materials. Not all components are available. Most mil-spec components are not included.

## Changelog
:cl:
add: Adds mecha components to mechfab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
