### PR TITLE
Quick Tourbus fix

### DIFF
--- a/_maps/map_files/tether/tether-03-surface3.dmm
+++ b/_maps/map_files/tether/tether-03-surface3.dmm
@@ -40937,9 +40937,6 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 1
 	},
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 1
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},


### PR DESCRIPTION
## About The Pull Request

Apparently the tiles I used for the shuttle floor are indestructible and really hard to remove. Also for some reason the shuttle tiles stop wires from connecting to devices entirely (I honestly could not tell you why). Tested it ingame with the help of a very smart individual who built walls to remove the tiles, once all the tiles around the SMES were removed it worked properly.

## Why It's Good For The Game

It now functions like it should

## Changelog
:cl:
fix: fixed a few things
/:cl:

