### PR TITLE
Medical hound parity

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station/medical.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/medical.dm
@@ -113,6 +113,9 @@
 	src.modules += new /obj/item/dogborg/jaws/small(src) //In case a patient is being attacked by carp.
 	src.modules += new /obj/item/dogborg/boop_module(src) //Boop the crew.
 	src.modules += new /obj/item/healthanalyzer(src) // See who's hurt specificially.
+	src.modules += new /obj/item/autopsy_scanner(src)
+	src.modules += new /obj/item/roller_holder(src) // Sometimes you just can't buckle someone to yourself because of taurcode. this is for those times.
+	src.modules += new /obj/item/reagent_scanner/adv(src)
 	src.modules += new /obj/item/reagent_containers/syringe(src) //In case the chemist is nice!
 	src.modules += new /obj/item/reagent_containers/glass/beaker/large(src)//For holding the chemicals when the chemist is nice
 	// src.modules += new /obj/item/sleevemate(src) //Lets them scan people.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
These three modules were omitted from medical hounds. this PR enforces parity between them to an extent to ensure they are capable of roughly the same things.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Medical hounds. contrary to popular belief. actually need a rollerbed to buckle subjects to due to Taurcode forbidding hound-buckling from any carbon mob with a tauric tail-style. including shadekin. without interacting with vore mechanics. and borgs cannot grab. only drag. so they would kill a critical patient trying to retrieve them otherwise (without interacting with vore mechanics) the other two modules were omitted from the medical hound for unknown reasons.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added three modules to the medical hound equipment lineup, enforcing some parity between the medical modules.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
