### PR TITLE
QOL changes+fixes for mirrors

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -477,3 +477,7 @@
 					src.imp = null
 	else
 		to_chat(usr, "You must target the torso.")
+
+/obj/item/dogborg/mirrortool/afterattack(var/obj/machinery/computer/transhuman/resleeving/target, mob/user)
+	target.active_mr = imp.stored_mind
+	. = ..()

--- a/code/modules/resleeving/computers.dm
+++ b/code/modules/resleeving/computers.dm
@@ -94,6 +94,28 @@
 		W.forceMove(src)
 		hasmirror = W
 		user.visible_message("[user] inserts the [W] into the [src].", "You insert the [W] into the [src].")
+	if(istype(W, /obj/item/mirrortool))
+		var/obj/item/mirrortool/MT = W
+		if(MT.imp)
+			active_mr = MT.imp.stored_mind
+			hasmirror = MT.imp
+			MT.imp = null
+			user.visible_message("Mirror successfully transferred.")
+		else
+			if(!MT.imp)
+				user.visible_message("This Mirror Installation Tool is empty.")
+	if(istype(W, /obj/item/dogborg/mirrortool))
+		var/obj/item/mirrortool/MT = W
+		if(MT.imp)
+			active_mr = MT.imp.stored_mind
+			hasmirror = MT.imp
+			MT.imp = null
+			user.visible_message("Mirror successfully transferred.")
+		else
+			if(!MT.imp)
+				user.visible_message("This Mirror Installation Tool is empty.")
+
+
 	return ..()
 
 /obj/machinery/computer/transhuman/resleeving/verb/eject_mirror()

--- a/code/modules/resleeving/mirror.dm
+++ b/code/modules/resleeving/mirror.dm
@@ -60,6 +60,15 @@
 			user.drop_from_inventory(src)
 			forceMove(MT)
 			MT.imp = src
+		else
+			if(istype(I, /obj/item/dogborg/mirrortool))
+				var/obj/item/dogborg/mirrortool/MT = I
+				if(MT.imp)
+					to_chat(usr, "The mirror tool already contains a mirror.")
+					return // It's full.
+				user.drop_from_inventory(src)
+				forceMove(MT)
+				MT.imp = src
 
 
 /obj/item/implant/mirror/positronic


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The borg mirror tool is now fully functional after fixing some oversights
Mirror tools can now pick up mirrors off the floor directly rather than having to pick it up and put it in by hand.
You can now click the resleeving console with a loaded mirror tool to automatically transfer the mirror to the console rather than having to eject it and do it by hand. This goes for the borg version, meaning borgs can now carry out  a full resleeve procedure alone.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

qol good bugs bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: mirror tools can load directly into a console
fix: fixed some missing functions of borg mirror tool
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
