### PR TITLE
Lets You Mount Cloaks/OUTER to the Laconic Coat - AKA: Nepotism

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -1113,7 +1113,9 @@ obj/item/clothing/suit/kamishimo
 	icon_state = "laconic"
 	item_state_slots = list(slot_r_hand_str = "labcoat", slot_l_hand_str = "labcoat")
 	body_parts_covered = UPPER_TORSO|ARMS
-	valid_accessory_slots = ACCESSORY_SLOT_UTILITY
+	valid_accessory_slots = (\
+		ACCESSORY_SLOT_OVER\
+		|ACCESSORY_SLOT_UTILITY)
 
 /obj/item/clothing/suit/imperial_replica
 	name = "replica imperial soldier armor"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. _Allows the Laconic Coat to mount more accessories._

## Why It's Good For The Game

1. Player request.

## Changelog
:cl:
tweak: Adds more accessory types to the allowed for the Laconic Coat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
