### PR TITLE
Creates Virgo3b Atmos Subsets for Wood and Sifwood Turfs for POI Mapping.

### DIFF
--- a/maps/tether/tether_turfs.dm
+++ b/maps/tether/tether_turfs.dm
@@ -29,6 +29,12 @@ VIRGO3B_TURF_CREATE(/turf/simulated/floor/maglev)
 /turf/simulated/floor/maglev/virgo3b
 	outdoors = TRUE
 
+/turf/simulated/floor/wood/virgo3b
+	initial_gas_mix = ATMOSPHERE_ID_VIRGO3B
+
+/turf/simulated/floor/wood/sif/virgo3b
+	initial_gas_mix = ATMOSPHERE_ID_VIRGO3B
+
 VIRGO3B_TURF_CREATE(/turf/simulated/floor/outdoors/dirt)
 /turf/simulated/floor/outdoors/dirt/virgo3b
 	icon = 'icons/turf/flooring/asteroid.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. _Adds Wood and Sifwood turfs configured for V3b's atmos._

## Why It's Good For The Game

1. The Southern Plains POIs all look terrible because they're spawning interior air mixes and clashing with V3b's phoron atmosphere. This is possibly also contributing to our perpetual active edge concerns.

## Changelog
:cl:
add: Adds V3b Wood and Sifwood variants.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
