### PR TITLE
Mountain (V4 Caves) POI Fixes. This time with less bad ayylien ship variables

### DIFF
--- a/_maps/submaps/mountains/Cliff1.dmm
+++ b/_maps/submaps/mountains/Cliff1.dmm
@@ -4,50 +4,47 @@
 /area/template_noop)
 "b" = (
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/random_cliff)
 "c" = (
 /obj/item/ore,
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/random_cliff)
 "d" = (
 /obj/random/outcrop,
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/random_cliff)
 "e" = (
 /obj/structure/cliff/automatic/corner,
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/random_cliff)
 "f" = (
 /obj/structure/cliff/automatic{
-	icon_state = "cliffbuilder";
 	dir = 5
 	},
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/random_cliff)
 "g" = (
 /obj/structure/cliff/automatic{
-	icon_state = "cliffbuilder";
 	dir = 9
 	},
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/random_cliff)
 "h" = (
 /obj/structure/cliff/automatic,
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/random_cliff)
 "i" = (
 /obj/structure/cliff/automatic/corner{
-	icon_state = "cliffbuilder-corner";
 	dir = 9
 	},
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/random_cliff)
 "j" = (
 /obj/random/humanoidremains{
 	spawn_nothing_percentage = 70
 	},
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/random_cliff)
 
 (1,1,1) = {"
 a

--- a/_maps/submaps/mountains/Geyser1.dmm
+++ b/_maps/submaps/mountains/Geyser1.dmm
@@ -4,20 +4,20 @@
 /area/template_noop)
 "b" = (
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "c" = (
 /obj/random/turf/lava,
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "d" = (
 /obj/random/outcrop,
 /obj/random/turf/lava,
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "e" = (
 /obj/random/outcrop,
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "f" = (
 /obj/effect/map_effect/interval/effect_emitter/steam,
 /obj/effect/map_effect/interval/effect_emitter/smoke/mist{
@@ -33,12 +33,12 @@
 /turf/simulated/floor/water/deep{
 	outdoors = 0
 	},
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "g" = (
 /obj/random/turf/lava,
 /obj/random/outcrop,
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 
 (1,1,1) = {"
 a

--- a/_maps/submaps/mountains/Geyser2.dmm
+++ b/_maps/submaps/mountains/Geyser2.dmm
@@ -5,56 +5,56 @@
 "b" = (
 /obj/random/turf/lava,
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "c" = (
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "d" = (
 /obj/structure/fence/corner{
 	dir = 9
 	},
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "e" = (
 /obj/structure/fence{
 	dir = 8
 	},
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "f" = (
 /obj/structure/fence/corner{
 	dir = 5
 	},
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "g" = (
 /obj/structure/fence/cut/large,
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "h" = (
 /mob/living/simple_mob/mechanical/viscerator,
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "i" = (
 /obj/structure/fence,
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "j" = (
 /obj/structure/fence/corner{
 	dir = 10
 	},
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "k" = (
 /obj/structure/fence/door/locked,
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "l" = (
 /obj/structure/fence/corner{
 	dir = 6
 	},
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "m" = (
 /obj/effect/map_effect/interval/effect_emitter/steam,
 /obj/effect/map_effect/interval/effect_emitter/smoke/mist{
@@ -72,7 +72,7 @@
 /turf/simulated/floor/water/deep{
 	outdoors = 0
 	},
-/area/template_noop)
+/area/submap/cave/random_geyser)
 
 (1,1,1) = {"
 a

--- a/_maps/submaps/mountains/Geyser3.dmm
+++ b/_maps/submaps/mountains/Geyser3.dmm
@@ -7,49 +7,49 @@
 	dir = 9
 	},
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "c" = (
 /obj/structure/cliff/automatic,
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "d" = (
 /obj/random/turf/lava,
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "e" = (
 /obj/structure/cliff/automatic{
 	dir = 5
 	},
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "f" = (
 /obj/structure/cliff/automatic/corner{
 	dir = 9
 	},
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "g" = (
 /turf/simulated/floor/outdoors/lava,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "h" = (
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "i" = (
 /obj/structure/cliff/automatic/corner,
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "j" = (
 /obj/structure/cliff/automatic{
 	dir = 8
 	},
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "k" = (
 /obj/structure/cliff/automatic{
 	dir = 4
 	},
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "l" = (
 /obj/effect/map_effect/interval/effect_emitter/steam,
 /obj/effect/map_effect/interval/effect_emitter/smoke/bad{
@@ -63,41 +63,41 @@
 	interval_upper_bound = 1200
 	},
 /turf/simulated/floor/outdoors/lava,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "m" = (
 /obj/structure/cliff/automatic{
 	dir = 10
 	},
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "n" = (
 /obj/structure/cliff/automatic/corner{
 	dir = 10
 	},
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "o" = (
 /obj/structure/cliff/automatic/corner{
 	dir = 6
 	},
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "p" = (
 /obj/structure/cliff/automatic{
 	dir = 6
 	},
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "q" = (
 /obj/structure/cliff/automatic{
 	dir = 2
 	},
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 "r" = (
 /obj/random/multiple/minevault,
 /turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/cave/random_geyser)
 
 (1,1,1) = {"
 a

--- a/_maps/submaps/mountains/crashed_ufo.dmm
+++ b/_maps/submaps/mountains/crashed_ufo.dmm
@@ -104,7 +104,6 @@
 /area/submap/cave/crashed_ufo)
 "ay" = (
 /obj/structure/prop/alien/computer{
-	 icon_state = "console-c";
 	dir = 4
 	},
 /turf/simulated/shuttle/floor/alienplating,
@@ -138,14 +137,12 @@
 /area/submap/cave/crashed_ufo)
 "aF" = (
 /obj/structure/prop/alien/computer/camera/flipped{
-	 icon_state = "camera_flipped";
 	dir = 4
 	},
 /turf/simulated/shuttle/floor/alien,
 /area/submap/cave/crashed_ufo)
 "aG" = (
 /obj/structure/prop/alien/computer/camera{
-	 icon_state = "camera";
 	dir = 8
 	},
 /turf/simulated/shuttle/floor/alien,
@@ -188,7 +185,6 @@
 /area/submap/cave/crashed_ufo)
 "aO" = (
 /obj/structure/prop/alien/computer{
-	 icon_state = "console-c";
 	dir = 4
 	},
 /turf/simulated/shuttle/floor/alien,
@@ -286,7 +282,6 @@
 /area/submap/cave/crashed_ufo)
 "bj" = (
 /obj/machinery/porta_turret/alien/destroyed{
-	 icon_state = "destroyed_target_prism";
 	dir = 6
 	},
 /turf/simulated/shuttle/floor/alienplating,
@@ -297,7 +292,6 @@
 /area/submap/cave/crashed_ufo)
 "bl" = (
 /obj/machinery/porta_turret/alien/destroyed{
-	 icon_state = "destroyed_target_prism";
 	dir = 10
 	},
 /turf/simulated/shuttle/floor/alienplating,
@@ -346,7 +340,23 @@
 /area/submap/cave/crashed_ufo)
 "bv" = (
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/crashed_ufo_frigate)
+"eP" = (
+/turf/simulated/shuttle/floor/alienplating,
+/area/submap/cave/crashed_ufo_frigate)
+"KG" = (
+/turf/simulated/shuttle/wall/alien/hard_corner,
+/area/submap/cave/crashed_ufo_frigate)
+"Nn" = (
+/obj/machinery/door/airlock/alien/public,
+/turf/simulated/shuttle/floor/alienplating,
+/area/submap/cave/crashed_ufo_frigate)
+"Ql" = (
+/turf/simulated/shuttle/wall/alien,
+/area/submap/cave/crashed_ufo_frigate)
+"St" = (
+/turf/simulated/shuttle/floor/alienplating/external,
+/area/submap/cave/crashed_ufo_frigate)
 
 (1,1,1) = {"
 aa
@@ -751,7 +761,7 @@ af
 af
 ac
 ab
-ab
+St
 bv
 bv
 "}
@@ -788,7 +798,7 @@ ac
 af
 ac
 ac
-ab
+St
 bv
 bv
 "}
@@ -825,7 +835,7 @@ ac
 af
 af
 ac
-ab
+St
 bv
 bv
 "}
@@ -862,8 +872,8 @@ ac
 as
 ag
 as
-ab
-ab
+St
+St
 bv
 "}
 (15,1,1) = {"
@@ -899,8 +909,8 @@ ac
 af
 af
 ac
-ac
-ab
+Ql
+St
 bv
 "}
 (16,1,1) = {"
@@ -936,8 +946,8 @@ bj
 af
 bk
 af
-as
-ab
+KG
+St
 bv
 "}
 (17,1,1) = {"
@@ -973,8 +983,8 @@ bk
 af
 af
 as
-as
-as
+KG
+KG
 bv
 "}
 (18,1,1) = {"
@@ -1010,8 +1020,8 @@ af
 bm
 af
 bt
-af
-bt
+eP
+Nn
 bv
 "}
 (19,1,1) = {"
@@ -1047,8 +1057,8 @@ af
 bn
 bq
 as
-as
-as
+KG
+KG
 bv
 "}
 (20,1,1) = {"
@@ -1084,8 +1094,8 @@ bl
 bo
 br
 bu
-ac
-ab
+Ql
+St
 bv
 "}
 (21,1,1) = {"
@@ -1121,8 +1131,8 @@ ac
 bp
 bs
 ac
-ac
-ab
+Ql
+St
 bv
 "}
 (22,1,1) = {"
@@ -1158,8 +1168,8 @@ ac
 as
 ag
 as
-ab
-ab
+St
+St
 bv
 "}
 (23,1,1) = {"
@@ -1195,7 +1205,7 @@ ac
 af
 af
 ac
-ab
+St
 bv
 bv
 "}
@@ -1232,7 +1242,7 @@ ac
 af
 ac
 ac
-ab
+St
 bv
 bv
 "}
@@ -1269,7 +1279,7 @@ af
 af
 ac
 ab
-ab
+St
 bv
 bv
 "}

--- a/_maps/submaps/mountains/crashed_ufo_frigate.dmm
+++ b/_maps/submaps/mountains/crashed_ufo_frigate.dmm
@@ -10,7 +10,7 @@
 /area/submap/cave/crashed_ufo_frigate)
 "ad" = (
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/crashed_ufo_frigate)
 "ae" = (
 /obj/effect/alien/egg,
 /turf/simulated/shuttle/floor/alienplating,
@@ -35,9 +35,11 @@
 /turf/simulated/shuttle/floor/alienplating,
 /area/submap/cave/crashed_ufo_frigate)
 "aj" = (
-/obj/random/outcrop,
-/turf/simulated/floor/outdoors/ice,
-/area/template_noop)
+/obj/machinery/porta_turret/alien/destroyed{
+	dir = 5
+	},
+/turf/simulated/shuttle/floor/alienplating,
+/area/submap/cave/crashed_ufo_frigate)
 "ak" = (
 /obj/machinery/porta_turret/alien{
 	faction = "xeno"
@@ -92,9 +94,6 @@
 /obj/structure/prop/alien/pod/open,
 /turf/simulated/shuttle/floor/alienplating,
 /area/submap/cave/crashed_ufo_frigate)
-"ax" = (
-/turf/simulated/floor/outdoors/ice,
-/area/template_noop)
 "ay" = (
 /obj/structure/loot_pile/surface/bones,
 /turf/simulated/floor/outdoors/ice,
@@ -205,20 +204,20 @@
 /area/submap/cave/crashed_ufo_frigate)
 "aX" = (
 /obj/structure/prop/alien/computer/camera/flipped{
-	icon_state = "camera_flipped";
 	dir = 4
 	},
 /turf/simulated/shuttle/floor/alienplating,
 /area/submap/cave/crashed_ufo_frigate)
 "aY" = (
 /obj/structure/prop/alien/computer/camera{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/simulated/shuttle/floor/alienplating,
 /area/submap/cave/crashed_ufo_frigate)
 "aZ" = (
-/obj/machinery/porta_turret/alien/destroyed,
+/obj/machinery/porta_turret/alien/destroyed{
+	dir = 6
+	},
 /turf/simulated/shuttle/floor/alienplating,
 /area/submap/cave/crashed_ufo_frigate)
 "ba" = (
@@ -306,7 +305,6 @@
 /area/submap/cave/crashed_ufo_frigate)
 "br" = (
 /obj/structure/prop/alien/computer{
-	icon_state = "console-c";
 	dir = 8
 	},
 /turf/simulated/shuttle/floor/alienplating,
@@ -354,21 +352,19 @@
 "bA" = (
 /obj/item/brokenbug,
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/crashed_ufo_frigate)
 "bB" = (
 /mob/living/simple_mob/animal/space/alien/sentinel,
 /turf/simulated/shuttle/floor/alien,
 /area/submap/cave/crashed_ufo_frigate)
 "bC" = (
 /obj/structure/prop/alien/computer/camera/flipped{
-	icon_state = "camera_flipped";
 	dir = 4
 	},
 /turf/simulated/shuttle/floor/alien,
 /area/submap/cave/crashed_ufo_frigate)
 "bD" = (
 /obj/structure/prop/alien/computer/camera{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/simulated/shuttle/floor/alien,
@@ -381,10 +377,6 @@
 /obj/structure/prop/blackbox/xenofrigate,
 /turf/simulated/shuttle/floor/alienplating,
 /area/submap/cave/crashed_ufo_frigate)
-"bG" = (
-/obj/random/outcrop,
-/turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
 "bH" = (
 /obj/structure/loot_pile/maint/junk,
 /turf/simulated/shuttle/floor/alienplating,
@@ -396,7 +388,6 @@
 /area/submap/cave/crashed_ufo_frigate)
 "bJ" = (
 /obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
 	dir = 8
 	},
 /turf/simulated/shuttle/floor/alienplating,
@@ -463,7 +454,6 @@
 /area/submap/cave/crashed_ufo_frigate)
 "bT" = (
 /obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
 	dir = 8
 	},
 /obj/structure/window/phoronreinforced,
@@ -543,13 +533,6 @@
 (1,1,1) = {"
 aa
 aa
-ad
-aa
-aa
-aa
-aa
-aa
-ad
 aa
 aa
 aa
@@ -559,17 +542,24 @@ aa
 aa
 aa
 aa
-ad
-ad
-ad
-ax
-ax
 aa
 aa
 aa
-ax
-ax
-ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -584,15 +574,6 @@ aa
 (2,1,1) = {"
 aa
 aa
-bG
-ax
-aa
-aa
-ad
-ax
-bG
-ad
-ad
 aa
 aa
 aa
@@ -605,18 +586,27 @@ aa
 aa
 aa
 aa
-ad
 aa
 aa
 aa
-ad
-bG
-ax
 aa
 aa
-ad
-ad
-ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -624,14 +614,14 @@ aa
 "}
 (3,1,1) = {"
 aa
-ax
-ad
-ax
 aa
-ad
-ad
-ax
-ax
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -651,26 +641,26 @@ aa
 aa
 aa
 aa
-ad
-ax
-ax
 aa
 aa
-ax
-ad
-ad
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
 "}
 (4,1,1) = {"
-ax
-ax
-ad
-ad
-ad
-ad
-ax
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -697,20 +687,20 @@ aa
 aa
 aa
 aa
-aj
-ax
-ad
-bG
+aa
+aa
+aa
+aa
 aa
 aa
 "}
 (5,1,1) = {"
-bG
-ad
-ad
-ad
-bG
-ad
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -739,18 +729,18 @@ aa
 aa
 aa
 aa
-ax
-ad
-ax
+aa
+aa
+aa
 aa
 aa
 "}
 (6,1,1) = {"
 aa
-ax
-ad
-ad
-ad
+aa
+aa
+aa
+aa
 aa
 aa
 ab
@@ -780,17 +770,17 @@ ab
 ab
 aa
 aa
-bG
-ad
-ax
-ax
+aa
+aa
+aa
+aa
 aa
 "}
 (7,1,1) = {"
 aa
-ax
-ax
-ad
+aa
+aa
+aa
 aa
 aa
 ab
@@ -822,15 +812,15 @@ ab
 ab
 aa
 aa
-ad
-ad
-ax
+aa
+aa
+aa
 aa
 "}
 (8,1,1) = {"
 aa
-bG
-ax
+aa
+aa
 aa
 aa
 ab
@@ -864,8 +854,8 @@ ab
 ab
 aa
 aa
-bG
-ad
+aa
+aa
 aa
 "}
 (9,1,1) = {"
@@ -906,7 +896,7 @@ ab
 ab
 aa
 aa
-ad
+aa
 aa
 "}
 (10,1,1) = {"
@@ -1686,11 +1676,11 @@ ab
 ab
 aa
 aa
-bG
+aa
 "}
 (29,1,1) = {"
 aa
-aj
+aa
 aa
 aa
 ab
@@ -1726,13 +1716,13 @@ ab
 ab
 aa
 aa
-ad
-ad
+aa
+aa
 "}
 (30,1,1) = {"
 aa
-ax
-ad
+aa
+aa
 aa
 aa
 ab
@@ -1767,14 +1757,14 @@ ab
 aa
 aa
 aa
-ad
+aa
 aa
 "}
 (31,1,1) = {"
 aa
-ad
-ax
-ad
+aa
+aa
+aa
 aa
 aa
 ab
@@ -1807,15 +1797,15 @@ ab
 aa
 aa
 aa
-ad
-ax
+aa
+aa
 aa
 "}
 (32,1,1) = {"
 aa
 aa
-ad
-bG
+aa
+aa
 aa
 aa
 aa
@@ -1847,17 +1837,17 @@ ab
 aa
 aa
 aa
-bG
-ad
-ax
+aa
+aa
+aa
 aa
 "}
 (33,1,1) = {"
 aa
 aa
-ad
-ad
-ad
+aa
+aa
+aa
 aa
 aa
 aa
@@ -1887,22 +1877,22 @@ aa
 aa
 aa
 aa
-ax
-ad
-ad
-bG
+aa
+aa
+aa
+aa
 aa
 "}
 (34,1,1) = {"
 aa
-ad
-ax
-ad
-ad
-ad
-ax
-ax
-aj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 ab
@@ -1927,24 +1917,24 @@ aa
 aa
 aa
 aa
-ad
-ax
-ad
-ad
+aa
+aa
+aa
+aa
 aa
 aa
 "}
 (35,1,1) = {"
 aa
-ax
-ax
 aa
-ad
-ad
-ad
-ad
-ax
-ax
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -1967,52 +1957,52 @@ aa
 aa
 aa
 aa
-ad
-ad
-ad
-ad
-ad
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 "}
 (36,1,1) = {"
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+al
+ad
+ad
+ad
+ad
 aj
-aa
-aa
-ax
-ad
-ad
-aa
-aa
-aa
-aa
-aa
-aa
-ax
-ad
-ad
-ad
-ad
-aZ
 ac
 aZ
 ad
 ad
 ad
-ax
+al
 aa
 aa
 aa
 aa
 aa
 aa
-ad
-ad
-ad
-ad
-ax
-ax
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 "}
@@ -2021,9 +2011,6 @@ aa
 aa
 aa
 aa
-ax
-ax
-ad
 aa
 aa
 aa
@@ -2032,28 +2019,31 @@ aa
 aa
 aa
 aa
-ax
-ax
-ad
-ad
+aa
+aa
+aa
+al
+al
 ad
 ad
 ad
 ad
 ad
-aa
-aa
-aa
-aa
-aa
-aa
-ad
-bG
 ad
 ad
-ad
-ax
-bG
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 "}
@@ -2062,8 +2052,8 @@ aa
 aa
 aa
 aa
-ad
-aj
+aa
+aa
 aa
 aa
 aa
@@ -2079,8 +2069,8 @@ ad
 ad
 bA
 ad
-ax
-ax
+al
+al
 aa
 aa
 aa
@@ -2088,12 +2078,12 @@ aa
 aa
 aa
 aa
-ad
-ad
-ad
 aa
-ad
-ad
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa

--- a/_maps/submaps/mountains/lava_trench.dmm
+++ b/_maps/submaps/mountains/lava_trench.dmm
@@ -138,10 +138,7 @@
 /area/submap/lava_trench)
 "aB" = (
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
-"aC" = (
-/turf/simulated/floor/outdoors/rocks/caves,
-/area/template_noop)
+/area/submap/lava_trench)
 "aD" = (
 /obj/structure/cliff/automatic,
 /obj/structure/railing{
@@ -305,7 +302,7 @@
 /area/submap/lava_trench/outpost)
 "be" = (
 /turf/simulated/mineral/ignore_mapgen,
-/area/template_noop)
+/area/submap/lava_trench)
 "bf" = (
 /obj/structure/railing,
 /turf/simulated/floor/outdoors/rocks/caves,
@@ -1247,7 +1244,7 @@ be
 be
 "}
 (20,1,1) = {"
-aC
+af
 ai
 af
 af
@@ -1279,7 +1276,7 @@ be
 be
 "}
 (21,1,1) = {"
-aC
+af
 aj
 af
 af
@@ -1311,7 +1308,7 @@ be
 be
 "}
 (22,1,1) = {"
-aC
+af
 ai
 af
 af

--- a/_maps/submaps/mountains/vault6.dmm
+++ b/_maps/submaps/mountains/vault6.dmm
@@ -4,106 +4,96 @@
 /area/template_noop)
 "b" = (
 /obj/structure/cliff/automatic/corner{
-	icon_state = "cliffbuilder-corner";
 	dir = 6
 	},
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "c" = (
 /obj/structure/cliff/automatic{
-	icon_state = "cliffbuilder";
 	dir = 2
 	},
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "d" = (
 /obj/structure/cliff/automatic/corner{
-	icon_state = "cliffbuilder-corner";
 	dir = 10
 	},
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "e" = (
 /obj/structure/cliff/automatic{
-	icon_state = "cliffbuilder";
 	dir = 6
 	},
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "f" = (
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "g" = (
 /obj/structure/cliff/automatic{
-	icon_state = "cliffbuilder";
 	dir = 10
 	},
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "h" = (
 /obj/structure/cliff/automatic{
-	icon_state = "cliffbuilder";
 	dir = 4
 	},
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "i" = (
 /mob/living/simple_mob/humanoid/merc/ranged/grenadier,
 /turf/simulated/floor/cult,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "j" = (
 /turf/simulated/floor/cult,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "k" = (
 /obj/random/tool/power,
 /obj/random/tech_supply,
 /turf/simulated/floor/cult,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "l" = (
 /obj/structure/cliff/automatic{
-	icon_state = "cliffbuilder";
 	dir = 8
 	},
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "m" = (
 /obj/structure/bonfire/permanent/sifwood,
 /obj/structure/grille/rustic,
 /turf/simulated/floor/cult,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "n" = (
 /obj/random/multiple/minevault,
 /turf/simulated/floor/cult,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "o" = (
 /obj/structure/cliff/automatic/corner,
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "p" = (
 /obj/structure/cliff/automatic{
-	icon_state = "cliffbuilder";
 	dir = 5
 	},
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "q" = (
 /obj/structure/cliff/automatic{
-	icon_state = "cliffbuilder";
 	dir = 9
 	},
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "r" = (
 /obj/structure/cliff/automatic/corner{
-	icon_state = "cliffbuilder-corner";
 	dir = 9
 	},
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 "s" = (
 /obj/structure/cliff/automatic,
 /turf/simulated/mineral/floor/ignore_mapgen,
-/area/template_noop)
+/area/submap/cave/misc_poi)
 
 (1,1,1) = {"
 a

--- a/code/modules/maps/generic/submaps/mountains/mountains_areas.dm
+++ b/code/modules/maps/generic/submaps/mountains/mountains_areas.dm
@@ -136,6 +136,15 @@
 	requires_power = FALSE
 	icon_state = "submap2"
 
+/area/submap/cave/random_geyser
+	name = "POI - Geyser"
+
+/area/submap/cave/random_cliff
+	name = "POI = Cliffs"
+
+/area/submap/cave/misc_poi
+
+
 //Citadel change
 /area/submap/cave/cultmine
 	name = "Cult Mine"


### PR DESCRIPTION
## About The Pull Request

Aight now this SHOULD work, cleaned up bad variables and added proper zones to POI's that were missing them. This should stop these POI's from overlapping with others while the map is being seeded (The four main culprits being the three gysers and the cliffs but a few others were missing zones on placed turfs as well)

## Why It's Good For The Game

Makes POI's seed as intended, *not* on top of eachother

## Changelog
:cl:
del: Removed old things
tweak: tweaked a few things
fix: fixed a few things
/:cl:
