### PR TITLE
Fixes Roaches becoming Jesus

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/roach/roach.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/roach/roach.dm
@@ -173,7 +173,7 @@
 		amount_grown = 1
 	get_light_and_color(parent)
 
-/mob/living/simple_mob/animal/roach/roachling/Destroy()
+/mob/living/simple_mob/animal/roach/roachling/death()
 	STOP_PROCESSING(SSobj, src)
 	walk(src, 0) // Because we might have called walk_to, we must stop the walk loop or BYOND keeps an internal reference to us forever.
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It turns out that spiderlings have a bunch of snowflake code when it comes to processing their deaths in order to make it so they don't leave a corpse. However, this caused a issue in which when the code was...borrowed without intent to return...from the spiderlings, it would cause any roach that had to chance to grow up to _always_ grow up unless the roach was killed and gibbed.

## Why It's Good For The Game

 I'd rather not have roachlings starting any religions about coming back from the dead, and it makes no sense for a dead creature to suddenly come back to life new and improved.

## Changelog
:cl:
fix: Roaches no longer come back from the dead by becoming swole
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
