### PR TITLE
[RFM] Necroxadone now heals dead bodies inside cryotubes

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -226,6 +226,11 @@
 		return
 	if(occupant)
 		if(occupant.stat >= DEAD)
+			if(beaker.reagents.has_any_reagent(list("Necroxadone"=1)))
+				occupant.adjustOxyLoss(-10)
+				occupant.heal_organ_damage(10, 10)
+				occupant.adjustToxLoss(-10)
+				beaker.reagents.remove_reagent("Necroxadone",1))
 			return
 		occupant.bodytemperature += 2*(air_contents.temperature - occupant.bodytemperature)*current_heat_capacity/(current_heat_capacity + air_contents.heat_capacity())
 		occupant.bodytemperature = max(occupant.bodytemperature, air_contents.temperature) // this is so ugly i'm sorry for doing it i'll fix it later i promise

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -230,7 +230,7 @@
 				occupant.adjustOxyLoss(-10)
 				occupant.heal_organ_damage(10, 10)
 				occupant.adjustToxLoss(-10)
-				beaker.reagents.remove_reagent("Necroxadone",1))
+				beaker.reagents.remove_reagent("Necroxadone",1)
 			return
 		occupant.bodytemperature += 2*(air_contents.temperature - occupant.bodytemperature)*current_heat_capacity/(current_heat_capacity + air_contents.heat_capacity())
 		occupant.bodytemperature = max(occupant.bodytemperature, air_contents.temperature) // this is so ugly i'm sorry for doing it i'll fix it later i promise


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If you are wondering 'WFT is Necroxadone?' thats the reason for this PR
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives medical a fast way to fix dead people up again, getting them back into the round decently fast.
Exact damage healed and how much should be progressed each tick needs to be tweaked,
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Necroxadone now heals dead bodies inside cryotubes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
