### PR TITLE
Moves docking arm to D2 below cargo+ useful customs and shop

### DIFF
--- a/_maps/map_files/tether/tether-05-station1.dmm
+++ b/_maps/map_files/tether/tether-05-station1.dmm
@@ -1283,9 +1283,6 @@
 /obj/machinery/camera/network/engineering,
 /turf/simulated/floor,
 /area/maintenance/substation/engineering)
-"acP" = (
-/turf/simulated/wall,
-/area/crew_quarters/sleep/spacedorm1)
 "acQ" = (
 /turf/simulated/wall,
 /area/maintenance/station/spacecommandmaint)
@@ -11368,24 +11365,6 @@
 "awu" = (
 /turf/simulated/wall,
 /area/hallway/station/docks)
-"awv" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock{
-	id_tag = "spacedorm1";
-	name = "Room 1"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/sleep/spacedorm1)
-"aww" = (
-/turf/simulated/wall,
-/area/crew_quarters/sleep/spacedorm2)
 "awx" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11455,10 +11434,6 @@
 /area/hallway/station/docks)
 "awG" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock{
-	id_tag = "spacedorm2";
-	name = "Room 2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -11466,8 +11441,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled,
-/area/crew_quarters/sleep/spacedorm2)
+/area/maintenance/station/spacecommandmaint)
 "awH" = (
 /obj/structure/flora/pottedplant,
 /obj/machinery/firealarm{
@@ -11482,38 +11458,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm1)
-"awJ" = (
-/obj/machinery/button/remote/airlock{
-	id = "spacedorm1";
-	name = "Room 1 Lock";
-	pixel_x = -28;
-	pixel_y = 26;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm1)
-"awK" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/clothing/shoes/black,
-/obj/item/clothing/suit/storage/hooded/wintercoat,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm1)
-"awL" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/clothing/shoes/black,
-/obj/item/clothing/suit/storage/hooded/wintercoat,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm2)
+/area/maintenance/station/spacecommandmaint)
 "awM" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -11746,23 +11691,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
-"axf" = (
-/obj/machinery/button/remote/airlock{
-	id = "spacedorm2";
-	name = "Room 2 Lock";
-	pixel_x = 28;
-	pixel_y = 26;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm2)
 "axg" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -11770,7 +11698,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm2)
+/area/maintenance/station/spacecommandmaint)
 "axh" = (
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
@@ -11781,13 +11709,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
-"axj" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm1)
 "axk" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light{
@@ -11818,18 +11739,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm1)
-"axo" = (
-/obj/structure/table/woodentable,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm1)
+/area/maintenance/station/spacecommandmaint)
 "axp" = (
 /obj/structure/table/woodentable,
 /obj/machinery/alarm{
@@ -11840,7 +11750,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm2)
+/area/maintenance/station/spacecommandmaint)
 "axq" = (
 /obj/machinery/computer/teleporter{
 	dir = 8
@@ -11956,7 +11866,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm2)
+/area/maintenance/station/spacecommandmaint)
 "axG" = (
 /obj/machinery/atmospherics/pipe/tank{
 	dir = 1;
@@ -12016,18 +11926,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm2)
-"axN" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm1)
+/area/maintenance/station/spacecommandmaint)
 "axO" = (
 /obj/structure/table/reinforced,
 /obj/fiftyspawner/glass,
@@ -12073,7 +11972,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm1)
+/area/maintenance/station/spacecommandmaint)
 "axT" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/bluedouble,
@@ -12081,7 +11980,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm1)
+/area/maintenance/station/spacecommandmaint)
 "axU" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -12119,7 +12018,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm2)
+/area/maintenance/station/spacecommandmaint)
 "axY" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -12175,7 +12074,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm2)
+/area/maintenance/station/spacecommandmaint)
 "aye" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -12187,7 +12086,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm2)
+/area/maintenance/station/spacecommandmaint)
 "ayg" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -14078,10 +13977,7 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 1
 	},
-/obj/machinery/door/airlock/glass_science{
-	name = "Exploration";
-	req_one_access = list(19,43,67)
-	},
+/obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled,
 /area/tether/exploration/hallway)
 "aCv" = (
@@ -14121,6 +14017,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "aCy" = (
+/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/tether/exploration/hallway)
 "aCz" = (
@@ -21199,6 +21096,7 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 1
 	},
+/obj/random/junk,
 /turf/simulated/floor/tiled,
 /area/tether/exploration/hallway)
 "gAd" = (
@@ -22164,7 +22062,7 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/bridge/meeting_room)
 "iPt" = (
-/obj/structure/stairs/spawner/east,
+/obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/tether/exploration/hallway)
 "iUL" = (
@@ -37720,11 +37618,11 @@ awu
 awu
 avK
 awf
-acP
-acP
-acP
-acP
-acP
+acQ
+acQ
+acQ
+acQ
+acQ
 acQ
 acQ
 acQ
@@ -37862,11 +37760,11 @@ awU
 awu
 avK
 awq
-acP
+acQ
 awI
-axj
-axN
-acP
+aBn
+ayg
+acQ
 ayg
 aBn
 aBs
@@ -38004,11 +37902,11 @@ auU
 aJo
 avK
 awi
-awv
-awJ
+awG
+aBI
 axn
 axS
-acP
+acQ
 ayh
 ayJ
 aBI
@@ -38146,11 +38044,11 @@ amW
 awu
 avM
 awj
-acP
-awK
-axo
+acQ
+aBv
+aBr
 axT
-acP
+acQ
 ayj
 aBk
 aBv
@@ -38288,11 +38186,11 @@ avt
 avE
 avN
 awo
-acP
-acP
-acP
-acP
-acP
+acQ
+acQ
+acQ
+acQ
+acQ
 acQ
 acQ
 acQ
@@ -38430,11 +38328,11 @@ avu
 awu
 avO
 awq
-aww
-awL
+acQ
+aBv
 axp
 axX
-aww
+acQ
 aBs
 aBn
 aBv
@@ -38573,10 +38471,10 @@ aJo
 avK
 aqg
 awG
-axf
+aBI
 axF
 ayd
-aww
+acQ
 ayn
 aBo
 aBI
@@ -38714,11 +38612,11 @@ avA
 awu
 avT
 aqx
-aww
+acQ
 axg
 axM
 aye
-aww
+acQ
 ayr
 aBr
 aBs
@@ -38856,11 +38754,11 @@ avC
 awu
 awu
 asB
-aww
-aww
-aww
-aww
-aww
+acQ
+acQ
+acQ
+acQ
+acQ
 acQ
 acQ
 acQ

--- a/_maps/map_files/tether/tether-05-station1.dmm
+++ b/_maps/map_files/tether/tether-05-station1.dmm
@@ -18531,23 +18531,9 @@
 /turf/simulated/floor/tiled/eris/dark/techfloor_grid,
 /area/shuttle/securiship/engines)
 "bHt" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1;
-	frequency = 1380;
-	id_tag = "dock_d1l_pump"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "dock_d1l_sensor";
-	pixel_x = 30;
-	pixel_y = 8
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
 /area/hallway/station/docks)
 "bHu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -18698,19 +18684,12 @@
 /turf/simulated/floor,
 /area/tether/station/stairs_one)
 "bQx" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
 	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 8;
-	frequency = 1380;
-	id_tag = "dock_d1l";
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
 /area/hallway/station/docks)
 "bQD" = (
 /obj/machinery/door/firedoor/glass,
@@ -18723,9 +18702,6 @@
 /area/hallway/station/docks)
 "bQF" = (
 /obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	pixel_x = 30
@@ -18787,9 +18763,14 @@
 /turf/simulated/floor/plating,
 /area/hallway/station/docks)
 "bXm" = (
-/obj/machinery/door/airlock/glass_external,
-/obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/hallway/station/docks)
 "bXn" = (
 /obj/machinery/door/firedoor/glass,
@@ -18865,9 +18846,6 @@
 /area/vacant/vacant_restaurant_lower)
 "bYr" = (
 /obj/effect/floor_decal/sign/dock/one,
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
 "bYt" = (
@@ -19378,8 +19356,8 @@
 /area/engineering/gravity_gen)
 "cEA" = (
 /obj/effect/floor_decal/sign/dock/one,
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
@@ -19714,10 +19692,13 @@
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_lobby)
 "dlV" = (
-/obj/machinery/door/airlock/glass_external,
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/station/docks)
 "dnP" = (
 /obj/structure/cable/green{
@@ -20678,16 +20659,8 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/ai_upload_foyer)
 "fAr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/item/radio/beacon,
+/turf/simulated/floor/tiled,
 /area/hallway/station/docks)
 "fAA" = (
 /obj/structure/cable/cyan{
@@ -21186,21 +21159,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/staircase)
-"gOd" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 8;
-	frequency = 1380;
-	id_tag = "dock_d2l";
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docks)
 "gOv" = (
 /obj/machinery/turretid/stun{
 	control_area = /area/ai_upload;
@@ -21865,11 +21823,6 @@
 /obj/random/junk,
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
-"ipk" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
 "ipv" = (
 /turf/simulated/floor/tiled/eris/dark/techfloor_grid,
 /area/shuttle/securiship/cockpit)
@@ -22205,18 +22158,6 @@
 "jkm" = (
 /turf/simulated/floor/tiled/white,
 /area/shuttle/medivac/general)
-"jln" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1;
-	frequency = 1380;
-	id_tag = "dock_d1l_pump"
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docks)
 "jmi" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -22536,8 +22477,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
@@ -22734,25 +22675,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/hallway)
-"kCH" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1;
-	frequency = 1380;
-	id_tag = "dock_d1l_pump"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "dock_d2l_sensor";
-	pixel_x = 30;
-	pixel_y = 8
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docks)
 "kER" = (
 /turf/simulated/floor/wood,
 /area/maintenance/station/eng_lower)
@@ -22810,22 +22732,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload)
-"kLN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK"
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/hallway/station/docks)
 "kMF" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -23111,11 +23017,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
-"lGA" = (
-/obj/machinery/door/airlock/glass_external,
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docks)
 "lGX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23478,20 +23379,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_cyborg_station)
-"mNU" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1380;
-	master_tag = "dock_d1l";
-	name = "exterior access button";
-	pixel_x = 28;
-	pixel_y = -6;
-	req_access = list(13)
-	},
-/obj/machinery/door/airlock/glass_external,
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docks)
 "mPj" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -24008,16 +23895,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/gravity_gen)
-"odO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/hallway/station/docks)
 "odW" = (
 /obj/machinery/light{
 	dir = 1
@@ -26008,16 +25885,6 @@
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
 "sFB" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1380;
-	master_tag = "dock_d2l";
-	name = "interior access button";
-	pixel_x = -28;
-	pixel_y = -26;
-	req_access = list(13)
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -26
@@ -33804,10 +33671,10 @@ aJo
 aFY
 aJo
 awu
-awu
-bzq
-bzq
-kLN
+aFZ
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -33946,10 +33813,10 @@ gVQ
 kZv
 bPX
 sFB
-bXm
-fAr
-jln
-lGA
+aCJ
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -34086,12 +33953,12 @@ aDJ
 bHu
 bHu
 cEA
-bHu
-ipk
-dlV
-bQx
-bHt
-mNU
+aBi
+aBi
+aCJ
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -34230,10 +34097,10 @@ aBi
 aBi
 aBi
 bQF
-aJo
-aJi
-aJi
-odO
+aCJ
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -34372,7 +34239,7 @@ aJi
 aJi
 aJi
 awu
-awu
+bXm
 aaa
 aaa
 aaa
@@ -36649,11 +36516,11 @@ awu
 bzq
 bzq
 col
-awu
-awu
-bzq
-bzq
-kLN
+aFZ
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -36791,11 +36658,11 @@ nYL
 aBi
 aBi
 aBi
-sFB
-bXm
-fAr
-jln
-lGA
+aCJ
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -36924,20 +36791,20 @@ fMv
 fMv
 nSf
 jXa
-fMv
-cuX
-fMv
-fMv
-jtH
-mzB
-bHu
-bYr
-bHu
-ipk
+bHt
+bQx
+bHt
+bHt
 dlV
-gOd
-kCH
-mNU
+fAr
+aBi
+bYr
+aBi
+aCJ
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -37075,11 +36942,11 @@ aBi
 aBi
 aBi
 aBi
-bQF
-aJo
-aJi
-aJi
-odO
+aCJ
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -37217,8 +37084,8 @@ bQD
 bQD
 bQD
 bQD
-awu
-awu
+bXm
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/tether/tether-05-station1.dmm
+++ b/_maps/map_files/tether/tether-05-station1.dmm
@@ -1074,11 +1074,6 @@
 "ack" = (
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
-"acl" = (
-/obj/machinery/camera/network/civilian,
-/obj/machinery/gear_painter,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
 "acm" = (
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
@@ -2887,9 +2882,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/bridge/secondary)
-"afI" = (
-/turf/simulated/wall,
-/area/tether/station/visitorhallway/office)
 "afJ" = (
 /obj/machinery/vending/snack,
 /obj/machinery/light{
@@ -3191,12 +3183,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
-"agk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/tether/station/visitorhallway/office)
 "agl" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4118,8 +4104,8 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "ahD" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4147,8 +4133,8 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "ahF" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
@@ -4283,8 +4269,8 @@
 /obj/machinery/status_display{
 	pixel_y = 30
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "ahR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4307,8 +4293,8 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "ahV" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -4362,8 +4348,8 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
 "aic" = (
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "aid" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -4375,8 +4361,8 @@
 /area/engineering/engine_monitoring)
 "aie" = (
 /obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "aif" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -4384,8 +4370,8 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "aig" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4560,8 +4546,8 @@
 "aiv" = (
 /obj/structure/table/woodentable,
 /obj/item/folder/yellow,
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "aiw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4614,8 +4600,8 @@
 /area/engineering/engine_airlock)
 "aiA" = (
 /obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "aiB" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -6384,8 +6370,8 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "amX" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/disposalpipe/segment,
@@ -8018,7 +8004,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "aqh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 6
@@ -8246,7 +8232,7 @@
 /obj/effect/floor_decal/borderfloor/corner2,
 /obj/effect/floor_decal/corner/lightgrey/bordercorner2,
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "aqy" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb,
@@ -9132,21 +9118,21 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "asC" = (
 /obj/structure/table/woodentable,
 /obj/item/flashlight/lamp/green{
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "asE" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "asF" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/effect/floor_decal/borderfloor{
@@ -9367,8 +9353,8 @@
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/item/folder/red,
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "ata" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/blue/border,
@@ -9429,8 +9415,8 @@
 /obj/structure/table/woodentable,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "atf" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
@@ -9464,8 +9450,8 @@
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/item/paicard,
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "atj" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -9519,28 +9505,28 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "atm" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "atn" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "atr" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "ats" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -9601,8 +9587,8 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "atw" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -9614,8 +9600,8 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "atx" = (
 /obj/effect/landmark{
 	name = "JoinLateCryo"
@@ -9780,8 +9766,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "atM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -9880,8 +9866,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "atW" = (
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
@@ -10026,11 +10012,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass{
-	name = "Visitor Office"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "auo" = (
 /obj/machinery/light{
 	dir = 8
@@ -10080,8 +10064,8 @@
 /obj/effect/floor_decal/corner/lightgrey/bordercorner2{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "aur" = (
 /turf/simulated/floor,
 /area/crew_quarters/sleep/cryo)
@@ -10165,8 +10149,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "auy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -10209,8 +10193,8 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "auD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10417,8 +10401,8 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "auM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10478,8 +10462,8 @@
 /obj/effect/floor_decal/corner/lightgrey/bordercorner2{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "auS" = (
 /obj/machinery/vending/tool{
 	dir = 4
@@ -10505,8 +10489,8 @@
 "auU" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "auW" = (
 /obj/machinery/atmospherics/omni/mixer{
 	tag_east = 1;
@@ -10701,8 +10685,8 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "avq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -10750,8 +10734,8 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "avu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10763,8 +10747,8 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/effect/floor_decal/borderfloor/corner2,
 /obj/effect/floor_decal/corner/lightgrey/bordercorner2,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "avv" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -10806,8 +10790,8 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "avz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10832,8 +10816,8 @@
 /obj/structure/closet,
 /obj/item/storage/pill_bottle/dice_nerd,
 /obj/random/coin,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "avB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -10855,8 +10839,8 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "avD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10882,7 +10866,7 @@
 	name = "Visitor Office"
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/area/hallway/station/docks)
 "avF" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10902,13 +10886,13 @@
 "avG" = (
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "avH" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "avI" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 1
@@ -10940,7 +10924,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "avK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10956,7 +10940,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "avL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chemical_dispenser/bar_soft/full{
@@ -10992,7 +10976,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "avN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -11012,7 +10996,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "avO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11035,7 +11019,7 @@
 	},
 /obj/machinery/camera/network/civilian,
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "avQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -11077,10 +11061,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
-"avU" = (
-/turf/simulated/wall,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "avV" = (
 /obj/effect/landmark/start{
 	name = "Assistant"
@@ -11197,7 +11178,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "awg" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/blue/border,
@@ -11250,7 +11231,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "awj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -11275,7 +11256,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "awk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 5
@@ -11331,7 +11312,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "awp" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Stairwell"
@@ -11368,7 +11349,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "awr" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -11376,8 +11357,8 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "aws" = (
 /turf/simulated/wall,
 /area/tether/station/stairs_one)
@@ -11471,7 +11452,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "awG" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock{
@@ -11646,8 +11627,8 @@
 /obj/machinery/vending/fitness{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "awV" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/tiled/dark,
@@ -11735,7 +11716,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "axb" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12151,21 +12132,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor,
 /area/hallway/station/docks)
-"aya" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
 "ayb" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
@@ -12195,20 +12161,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "ayd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -12233,9 +12188,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/spacedorm2)
-"ayf" = (
-/turf/simulated/wall,
-/area/crew_quarters/sleep/spacedorm3)
 "ayg" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -12246,7 +12198,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm3)
+/area/maintenance/station/spacecommandmaint)
 "ayh" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/iandouble,
@@ -12260,7 +12212,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm3)
+/area/maintenance/station/spacecommandmaint)
 "ayi" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -12280,10 +12232,7 @@
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm3)
-"ayk" = (
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm4)
+/area/maintenance/station/spacecommandmaint)
 "ayl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -12310,7 +12259,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm4)
+/area/maintenance/station/spacecommandmaint)
 "ayo" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -12320,31 +12269,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
-"ayp" = (
-/obj/machinery/door/airlock/glass,
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/tether/station/dock_one)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "ayq" = (
 /obj/machinery/computer/card{
 	dir = 1
@@ -12373,10 +12299,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm4)
-"ayt" = (
-/turf/simulated/wall,
-/area/crew_quarters/sleep/spacedorm4)
+/area/maintenance/station/spacecommandmaint)
 "ayu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -12392,20 +12315,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green,
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "ayv" = (
 /obj/machinery/teleport/station{
 	dir = 2
@@ -12444,20 +12355,11 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/effect/floor_decal/borderfloor{
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "ayB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -12514,13 +12416,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/bridge/secondary/teleporter)
-"ayI" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm3)
 "ayJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -12532,7 +12427,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm3)
+/area/maintenance/station/spacecommandmaint)
 "ayK" = (
 /obj/machinery/teleport/hub{
 	dir = 2
@@ -12552,38 +12447,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
-"ayM" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "ayN" = (
 /obj/structure/reagent_dispensers/water_cooler/full{
 	dir = 8
@@ -12605,20 +12470,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "ayP" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark{
@@ -12635,18 +12488,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner{
-	dir = 4
-	},
-/obj/machinery/vending/nifsoft_shop{
-	pixel_x = 12;
-	pixel_y = 2
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "ayQ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12664,18 +12507,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "ayR" = (
 /turf/simulated/floor/tiled,
 /area/bridge/secondary/teleporter)
@@ -12698,65 +12534,8 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
-"ayT" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
-"ayU" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "ayV" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -12774,24 +12553,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "ayW" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12810,44 +12573,19 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "ayX" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
-"ayY" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor,
-/area/tether/station/visitorhallway)
+/area/maintenance/station/spacecommandmaint)
 "ayZ" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/obj/random/trash_pile,
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aza" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -12969,22 +12707,14 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 9
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "azn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -13003,49 +12733,8 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
-"azo" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
-"azp" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
-"azq" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "azr" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13060,39 +12749,17 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
-"azs" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "azt" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-21"
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 6
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/machinery/camera/network/civilian{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "azu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -13103,9 +12770,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/spacecommandmaint)
-"azv" = (
-/turf/simulated/wall,
-/area/tether/station/visitorhallway/lounge)
 "azw" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -13125,9 +12789,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/secondary/teleporter)
-"azx" = (
-/turf/simulated/wall,
-/area/tether/station/visitorhallway/laundry)
 "azy" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood,
@@ -13149,24 +12810,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/spacecommandmaint)
-"azA" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/machinery/camera/network/civilian{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
 "azC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13176,8 +12819,8 @@
 	pixel_x = 6;
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "azD" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -13204,24 +12847,20 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "azF" = (
 /obj/machinery/vending/fitness,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "azG" = (
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
 	},
 /obj/machinery/vending/cigarette,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
-"azH" = (
-/obj/machinery/washing_machine,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "azI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13254,16 +12893,16 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "azL" = (
 /obj/machinery/light_switch{
 	name = "light switch ";
 	pixel_x = -6;
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "azM" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
@@ -13294,9 +12933,6 @@
 /obj/random/tech_supply,
 /turf/simulated/floor/tiled,
 /area/storage/tools)
-"azP" = (
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
 "azR" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
@@ -13309,23 +12945,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
-"azS" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
 "azT" = (
-/obj/machinery/washing_machine,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "azU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13334,18 +12959,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
-"azV" = (
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "azW" = (
-/obj/machinery/washing_machine,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "azX" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
@@ -13361,8 +12982,8 @@
 	pixel_x = -24
 	},
 /obj/structure/bed/chair/comfy/brown,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "azZ" = (
 /obj/effect/landmark{
 	name = "lightsout"
@@ -13375,16 +12996,8 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
-"aAa" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aAb" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -13396,8 +13009,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/bed/chair/comfy/brown,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aAc" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13410,24 +13023,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aAd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13436,18 +13033,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aAe" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aAf" = (
-/obj/structure/closet/wardrobe/suit,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -13457,8 +13053,8 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aAg" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -13467,8 +13063,8 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aAh" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
@@ -13476,8 +13072,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aAi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -13485,8 +13081,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aAj" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -13494,8 +13090,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aAk" = (
 /turf/simulated/wall,
 /area/crew_quarters/toilet)
@@ -13507,8 +13103,8 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aAm" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -13687,8 +13283,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "aAE" = (
 /obj/machinery/keycard_auth{
 	pixel_x = -24
@@ -13702,8 +13298,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "aAG" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13715,8 +13311,8 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "aAH" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -13758,12 +13354,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "aAK" = (
-/obj/structure/closet/wardrobe/black,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aAL" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13799,8 +13394,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/obj/random/trash_pile,
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aAQ" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -13868,12 +13464,11 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_eva)
 "aAU" = (
-/obj/structure/closet/wardrobe/xenos,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aAV" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled,
@@ -13881,17 +13476,6 @@
 "aAW" = (
 /turf/simulated/wall,
 /area/crew_quarters/sleep/engi_wash)
-"aAX" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
-"aAY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/tether/station/visitorhallway/lounge)
 "aAZ" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -13918,8 +13502,8 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aBd" = (
 /obj/structure/bed/chair,
 /obj/machinery/atm{
@@ -13929,8 +13513,8 @@
 /area/hallway/station/docks)
 "aBe" = (
 /obj/structure/table/bench/standard,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aBf" = (
 /obj/structure/bed/chair,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -13952,7 +13536,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/tether/station/visitorhallway/laundry)
+/area/maintenance/station/spacecommandmaint)
 "aBk" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -13962,7 +13546,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm3)
+/area/maintenance/station/spacecommandmaint)
 "aBl" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -13987,7 +13571,7 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm4)
+/area/maintenance/station/spacecommandmaint)
 "aBo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -13999,7 +13583,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm4)
+/area/maintenance/station/spacecommandmaint)
 "aBp" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -14039,45 +13623,17 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm4)
+/area/maintenance/station/spacecommandmaint)
 "aBs" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -28
-	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm3)
-"aBt" = (
-/obj/machinery/button/remote/airlock{
-	id = "spacedorm3";
-	name = "Room 3 Lock";
-	pixel_x = -28;
-	pixel_y = -26;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm3)
-"aBu" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/clothing/shoes/black,
-/obj/item/clothing/suit/storage/hooded/wintercoat,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm3)
+/area/maintenance/station/spacecommandmaint)
 "aBv" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/shoes/black,
 /obj/item/clothing/suit/storage/hooded/wintercoat,
 /obj/random/maintenance/clean,
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm4)
+/area/maintenance/station/spacecommandmaint)
 "aBw" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -14207,13 +13763,6 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/substation/civilian)
 "aBI" = (
-/obj/machinery/button/remote/airlock{
-	id = "spacedorm4";
-	name = "Room 4 Lock";
-	pixel_x = 28;
-	pixel_y = -26;
-	specialfunctions = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -14222,15 +13771,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm4)
-"aBJ" = (
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 26;
-	pixel_y = 8
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm4)
+/area/maintenance/station/spacecommandmaint)
 "aBK" = (
 /obj/random/junk,
 /turf/simulated/floor,
@@ -14239,27 +13780,8 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor,
 /area/maintenance/station/spacecommandmaint)
-"aBM" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock{
-	id_tag = "spacedorm3";
-	name = "Room 3"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/sleep/spacedorm3)
 "aBN" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock{
-	id_tag = "spacedorm4";
-	name = "Room 4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -14267,8 +13789,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/sleep/spacedorm4)
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aBO" = (
 /obj/machinery/keycard_auth{
 	pixel_x = 24
@@ -14285,11 +13808,6 @@
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor,
 /area/maintenance/station/spacecommandmaint)
-"aBQ" = (
-/obj/machinery/door/airlock/glass_external,
-/obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_one)
 "aBR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -14441,16 +13959,16 @@
 /obj/machinery/camera/network/civilian{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "aCl" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /obj/machinery/disposal,
 /obj/machinery/camera/network/civilian,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aCm" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -14560,6 +14078,10 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 1
 	},
+/obj/machinery/door/airlock/glass_science{
+	name = "Exploration";
+	req_one_access = list(19,43,67)
+	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/hallway)
 "aCv" = (
@@ -14614,7 +14136,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "aCB" = (
 /obj/machinery/door/airlock/glass_external{
 	frequency = 1379;
@@ -14653,9 +14175,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_eva)
-"aCF" = (
-/turf/simulated/wall,
-/area/tether/station/dock_one)
 "aCH" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/door/firedoor/glass,
@@ -14663,13 +14182,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/tether/station/dock_two)
-"aCI" = (
-/obj/machinery/door/airlock/glass,
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/firedoor/glass/hidden/steel,
-/turf/simulated/floor/tiled/steel_grid,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "aCJ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -14677,9 +14190,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/hallway/station/docks)
-"aCK" = (
-/turf/simulated/wall,
-/area/tether/station/dock_two)
 "aCM" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_engineering{
@@ -14693,14 +14203,14 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled/steel_grid,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "aCO" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "aCP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -14998,7 +14508,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "aDw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15015,7 +14525,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "aDx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -15037,7 +14547,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "aDy" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -15065,22 +14575,6 @@
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/engi_wash)
-"aDE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
-"aDG" = (
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
-"aDH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/tether/station/dock_one)
 "aDI" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 8
@@ -15093,10 +14587,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
-"aDL" = (
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "aDM" = (
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - Civilian Subgrid";
@@ -15177,7 +14668,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "aDX" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/alarm{
@@ -15284,8 +14775,8 @@
 /obj/machinery/door/airlock/glass{
 	name = "Visitor Lounge"
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aEj" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
@@ -15298,8 +14789,8 @@
 /obj/machinery/door/airlock/glass{
 	name = "Visitor Laundry"
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aEk" = (
 /obj/machinery/light{
 	dir = 4
@@ -15308,14 +14799,13 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "aEo" = (
 /obj/effect/shuttle_landmark{
 	base_area = /area/space;
 	base_turf = /turf/space;
-	docking_controller = "dock_d1a1";
-	landmark_tag = "tether_dockarm_d1a1";
-	name = "Tether Dock D1A1"
+	landmark_tag = "tether_space_SE";
+	name = "Near Tether (SE)"
 	},
 /turf/space,
 /area/space)
@@ -15332,7 +14822,7 @@
 /obj/machinery/door/airlock/glass_external,
 /obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "aEq" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -15520,8 +15010,8 @@
 /obj/effect/landmark{
 	name = "morphspawn"
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aED" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -15623,8 +15113,8 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "aER" = (
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 1
@@ -15647,14 +15137,6 @@
 /obj/structure/curtain/open/shower/engineering,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/engi_wash)
-"aES" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	desc = "Looks like its Fawkes News, I wonder what else is on?";
-	icon_state = "frame";
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
 "aET" = (
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 1
@@ -15784,13 +15266,7 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_one)
-"aFU" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "aFX" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15814,7 +15290,7 @@
 /obj/machinery/door/airlock/glass_external,
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "aFZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -15824,7 +15300,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "aGs" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
@@ -15889,14 +15365,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/tether/station/dock_one)
-"aHc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "aHe" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/yellow/border,
@@ -15942,20 +15411,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_eva)
-"aIb" = (
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_x = 30
-	},
-/obj/machinery/camera/network/tether{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
 "aIf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16046,12 +15501,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
-"aIA" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
 "aIC" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -16096,7 +15545,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "aJk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -16144,12 +15593,7 @@
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/tether/station/dock_two)
-"aJr" = (
-/obj/machinery/door/airlock/glass_external,
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "aJs" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/storage)
@@ -17948,7 +17392,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "bbs" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -18723,7 +18167,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "bnl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -18805,7 +18249,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "bpd" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18978,7 +18422,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "brV" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19068,18 +18512,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
-"bwb" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/tether/station/dock_two)
 "bwo" = (
 /obj/machinery/blackbox_recorder,
 /turf/simulated/floor/tiled/techfloor,
@@ -19098,15 +18530,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
-"bzn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/tether/station/dock_one)
 "bzq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -19115,7 +18538,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "bzw" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/regular{
@@ -19198,27 +18621,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
-"bGo" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/tether/station/dock_two)
-"bGy" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1;
-	frequency = 1380;
-	id_tag = "dock_d1l_pump"
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_one)
 "bHf" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -19249,86 +18651,11 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "bHu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
-"bHw" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
-"bHG" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK"
-	},
-/turf/simulated/floor/plating,
-/area/tether/station/dock_two)
-"bHN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK"
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/tether/station/dock_one)
-"bHO" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1380;
-	master_tag = "dock_d1l";
-	name = "exterior access button";
-	pixel_x = 28;
-	pixel_y = -6;
-	req_access = list(13)
-	},
-/obj/machinery/door/airlock/glass_external,
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_one)
-"bJl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/tether/station/dock_one)
-"bJm" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
-"bKo" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "bLM" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/borderfloor{
@@ -19376,67 +18703,14 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "bPl" = (
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
-"bPp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1380;
-	master_tag = "dock_d1a3";
-	name = "interior access button";
-	pixel_x = 28;
-	pixel_y = 26;
-	req_one_access = list(13)
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
-"bPq" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	frequency = 1380;
-	id_tag = "dock_d1a3_pump"
-	},
-/obj/machinery/light/small,
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "dock_d1a3_sensor";
-	pixel_y = -25
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1380;
-	id_tag = "dock_d1a3";
-	pixel_y = 28
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_two)
-"bPr" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1380;
-	master_tag = "dock_d1a3";
-	name = "exterior access button";
-	pixel_x = -5;
-	pixel_y = -26;
-	req_one_access = list(13)
-	},
-/obj/machinery/door/airlock/glass_external,
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "bPt" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -19450,7 +18724,7 @@
 /obj/machinery/door/airlock/glass_external,
 /obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "bPx" = (
 /obj/machinery/door/airlock/glass_external,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -19458,7 +18732,7 @@
 	},
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "bPz" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -19479,7 +18753,7 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "bPD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -19497,7 +18771,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "bPE" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -19507,23 +18781,13 @@
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "bPO" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
-"bPS" = (
-/obj/effect/shuttle_landmark{
-	base_area = /area/space;
-	base_turf = /turf/space;
-	docking_controller = "dock_d1a3";
-	landmark_tag = "tether_dockarm_d1a3";
-	name = "Tether Dock D1A3"
-	},
-/turf/space,
-/area/space)
+/area/hallway/station/docks)
 "bPX" = (
 /obj/machinery/light{
 	dir = 8
@@ -19532,83 +18796,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "bQa" = (
 /turf/simulated/floor,
 /area/tether/station/stairs_one)
-"bQc" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
-"bQd" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/tether/station/dock_two)
-"bQk" = (
-/obj/effect/shuttle_landmark{
-	base_area = /area/space;
-	base_turf = /turf/space;
-	docking_controller = "dock_d1l";
-	landmark_tag = "tether_dockarm_d1l";
-	name = "Tether Dock D1L"
-	},
-/turf/space,
-/area/space)
-"bQl" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1380;
-	master_tag = "dock_d2l";
-	name = "interior access button";
-	pixel_x = -28;
-	pixel_y = -26;
-	req_access = list(13)
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
-"bQm" = (
-/obj/machinery/door/airlock/glass_external,
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_one)
-"bQt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
-"bQu" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
-"bQv" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
 "bQx" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -19623,30 +18814,16 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_one)
-"bQz" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_one)
-"bQC" = (
-/obj/item/radio/beacon,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "bQD" = (
-/obj/machinery/computer/shuttle_control/tether_backup{
-	dir = 8
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/turf/simulated/floor/plating,
+/area/hallway/station/docks)
 "bQF" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -19660,7 +18837,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "bTx" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -19711,19 +18888,19 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "bXm" = (
 /obj/machinery/door/airlock/glass_external,
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "bXn" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "bXG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
@@ -19795,7 +18972,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "bYt" = (
 /obj/structure/window/reinforced,
 /obj/structure/bed/chair{
@@ -20053,7 +19230,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "cqQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -20132,7 +19309,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "cwR" = (
 /obj/structure/railing,
 /obj/random/mouseremains,
@@ -20308,7 +19485,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "cHm" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -20644,7 +19821,7 @@
 /obj/effect/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "dnP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -21126,7 +20303,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "eAN" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -21201,7 +20378,7 @@
 	pixel_x = -30
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "ePb" = (
 /turf/simulated/wall/rshull,
 /area/shuttle/medivac/engines)
@@ -21376,7 +20553,7 @@
 	pixel_x = 30
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "fjd" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -21592,12 +20769,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_cyborg_station)
-"fyk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
 "fyA" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -21620,7 +20791,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "fAA" = (
 /obj/structure/cable/cyan{
 	d2 = 2;
@@ -21730,7 +20901,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "fMF" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 5
@@ -22056,7 +21227,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "gFx" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -22131,7 +21302,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "gOv" = (
 /obj/machinery/turretid/stun{
 	control_area = /area/ai_upload;
@@ -22243,7 +21414,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "gXg" = (
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 4
@@ -22800,7 +21971,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "ipv" = (
 /turf/simulated/floor/tiled/eris/dark/techfloor_grid,
 /area/shuttle/securiship/cockpit)
@@ -23075,7 +22246,7 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "jbj" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -23147,7 +22318,7 @@
 	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "jmi" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -23183,7 +22354,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "juf" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23255,12 +22426,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint/science)
-"jFv" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
 "jGC" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/masks,
@@ -23477,7 +22642,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "jXR" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -23588,7 +22753,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "ksv" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -23652,7 +22817,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "kzz" = (
 /obj/structure/sign/department/ai,
 /turf/simulated/wall/r_wall,
@@ -23689,7 +22854,7 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "kER" = (
 /turf/simulated/floor/wood,
 /area/maintenance/station/eng_lower)
@@ -23736,7 +22901,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "kKs" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -23762,7 +22927,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "kMF" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -23798,26 +22963,18 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "kUl" = (
 /obj/structure/closet/firecloset/full/double,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_lower)
 "kWQ" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
 /obj/machinery/holoposter{
 	pixel_y = -30
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "kXK" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -23863,7 +23020,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "lbW" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -23974,7 +23131,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "lAJ" = (
 /obj/machinery/power/apc{
 	alarms_hidden = 1;
@@ -24060,7 +23217,7 @@
 /obj/machinery/door/airlock/glass_external,
 /obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "lGX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24250,15 +23407,6 @@
 	},
 /turf/simulated/floor/outdoors/grass/heavy/interior,
 /area/tether/exploration/hallway)
-"mnt" = (
-/obj/effect/shuttle_landmark{
-	base_area = /area/space;
-	base_turf = /turf/space;
-	landmark_tag = "tether_space_SW";
-	name = "Near Tether (SW)"
-	},
-/turf/space,
-/area/space)
 "mnM" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -24342,7 +23490,7 @@
 /obj/item/radio/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "mAd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -24445,7 +23593,7 @@
 /obj/machinery/door/airlock/glass_external,
 /obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "mPj" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -24463,7 +23611,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "mPs" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -24860,7 +24008,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "nTL" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -24935,7 +24083,7 @@
 	pixel_x = -23
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "nZR" = (
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -24971,7 +24119,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "odW" = (
 /obj/machinery/light{
 	dir = 1
@@ -25067,7 +24215,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "ort" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -25131,7 +24279,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "ozk" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -25359,7 +24507,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "oYy" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -25558,7 +24706,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "pzR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26464,7 +25612,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "rJq" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -26977,7 +26125,7 @@
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "sFI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -27255,7 +26403,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "tpy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -28150,17 +27298,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
-"vmt" = (
-/obj/effect/shuttle_landmark{
-	base_area = /area/space;
-	base_turf = /turf/space;
-	docking_controller = "dock_d2a1";
-	landmark_tag = "tether_dockarm_d2a1";
-	name = "Tether Dock D2A1"
-	},
-/turf/space,
-/area/space)
+/area/hallway/station/docks)
 "vni" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28504,7 +27642,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "wmr" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/cardboard,
@@ -28609,7 +27747,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "wBw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -28620,7 +27758,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "wBG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -28839,7 +27977,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
+/area/hallway/station/docks)
 "xit" = (
 /turf/simulated/wall/r_wall,
 /area/ai_cyborg_station)
@@ -28945,16 +28083,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
-"xra" = (
-/obj/effect/shuttle_landmark{
-	base_area = /area/space;
-	base_turf = /turf/space;
-	docking_controller = "dock_d2l";
-	landmark_tag = "tether_dockarm_d2l";
-	name = "Tether Dock D2L"
-	},
-/turf/space,
-/area/space)
 "xrN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29059,7 +28187,7 @@
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "xDU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29093,7 +28221,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "xEG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/rshull,
@@ -29287,7 +28415,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "xTP" = (
 /obj/machinery/door/airlock/glass_external,
 /obj/structure/cable/green{
@@ -34207,7 +33335,7 @@ aaa
 aaa
 aaa
 aaa
-aEo
+aaa
 aaa
 aaa
 aaa
@@ -34634,7 +33762,7 @@ aaa
 aaa
 aGZ
 aFT
-aHc
+aCJ
 aaa
 aaa
 aaa
@@ -34758,30 +33886,30 @@ awu
 nnZ
 tBA
 aCv
-aCF
-aCF
-bzn
-bzn
-bzn
-aCF
-aDH
-aDH
-aDH
-aCF
-bzn
-bzn
-bzn
-aCF
-aCF
-bzn
-aFU
+awu
+awu
+bzq
+bzq
+bzq
+awu
+aJi
+aJi
+aJi
+awu
+bzq
+bzq
+bzq
+awu
+awu
+bzq
+aJo
 aFY
-aFU
-aCF
-aCF
-bzn
-bzn
-bHN
+aJo
+awu
+awu
+bzq
+bzq
+kLN
 aaa
 aaa
 aaa
@@ -34900,32 +34028,32 @@ awu
 iAa
 btt
 fkj
-aCI
+aCN
 eMS
-aDG
-aDG
-aDG
+aBi
+aBi
+aBi
 bqT
 gVQ
 mPj
-jFv
+oYk
 knR
-aDG
-aDG
+aBi
+aBi
 rIz
 nYL
 aCO
-aDG
+aBi
 gVQ
 kZv
 bPX
 sFB
-aBQ
-bQz
-bGy
-aJr
+bXm
+fAr
+jln
+lGA
 aaa
-bQk
+aaa
 aaa
 aaa
 aaa
@@ -35057,15 +34185,15 @@ fMv
 jtH
 mzB
 aDJ
-aDE
-aDE
+bHu
+bHu
 cEA
-aDE
+bHu
 ipk
-bQm
+dlV
 bQx
 bHt
-bHO
+mNU
 aaa
 aaa
 aaa
@@ -35184,30 +34312,30 @@ aeF
 bZZ
 rCQ
 xqo
-ayp
+aCH
 aDU
-aDG
-aDG
-aDG
+aBi
+aBi
+aBi
 pyX
-aDG
-aDG
-aDG
-bKo
-aDG
-aDG
+aBi
+aBi
+aBi
+bPO
+aBi
+aBi
 kJJ
-aDG
+aBi
 aEk
-aDG
-aDG
-aDG
-aDG
-aIb
-aFU
-aDH
-aDH
-bJl
+aBi
+aBi
+aBi
+aBi
+bQF
+aJo
+aJi
+aJi
+odO
 aaa
 aaa
 aaa
@@ -35326,27 +34454,27 @@ aeF
 aAV
 rKn
 vQf
-aCF
-aCF
-aDH
-aDH
-aDH
-aCF
-aDH
-aDH
-aDH
-aCF
-aDH
-aDH
-aFU
-aCF
-aCF
-aDH
-aDH
-aDH
-aDH
-aCF
-aCF
+awu
+awu
+aJi
+aJi
+aJi
+awu
+aJi
+aJi
+aJi
+awu
+aJi
+aJi
+aJo
+awu
+awu
+aJi
+aJi
+aJi
+aJi
+awu
+awu
 aaa
 aaa
 aaa
@@ -37045,7 +36173,7 @@ aaa
 aaa
 aaa
 aaa
-vmt
+aaa
 aaa
 aaa
 aaa
@@ -37598,33 +36726,33 @@ awu
 bFf
 rKn
 vQf
-aCK
-aCK
+awu
+awu
 bzq
 bzq
 bzq
-aCK
-bzq
-bzq
-col
-aCK
+awu
 bzq
 bzq
 col
-aCK
+awu
+bzq
+bzq
+col
+awu
 bXl
 bPx
 bXl
-aCK
+awu
 bzq
 bzq
 bzq
-aCK
+awu
 bzq
 bzq
 col
-aCK
-aCK
+awu
+awu
 bzq
 bzq
 kLN
@@ -37742,36 +36870,36 @@ rKn
 cYF
 aCN
 xTB
-aDL
-aDL
-aDL
-aDL
+aBi
+aBi
+aBi
+aBi
 xEm
-aDL
-aDL
+aBi
+aBi
 xDA
-aDL
-aDL
-aDL
-aDL
+aBi
+aBi
+aBi
+aBi
 boV
 lzl
 oYk
 xDA
-aDL
-aDL
-aIA
-bJm
-aDL
-aDL
-aDL
-bQl
+aBi
+aBi
+rIz
+nYL
+aBi
+aBi
+aBi
+sFB
 bXm
 fAr
 jln
 lGA
 aaa
-xra
+aaa
 aaa
 aaa
 aaa
@@ -37884,30 +37012,30 @@ lnN
 gUX
 oxI
 wBw
-fyk
+fMv
 oqY
 bne
 bne
 wlB
 gBl
-fyk
+fMv
 cuX
-fyk
-fyk
-fyk
-fyk
+fMv
+fMv
+fMv
+fMv
 nSf
 jXa
-fyk
+fMv
 cuX
-fyk
-fyk
-bQt
-bQC
+fMv
+fMv
+jtH
+mzB
 bHu
 bYr
 bHu
-bQv
+ipk
 dlV
 gOd
 kCH
@@ -38026,29 +37154,29 @@ aBi
 aDu
 aCH
 bPO
-aDL
+aBi
 jbc
 fil
 bPl
 kzv
-aDL
-aDL
+aBi
+aBi
 aCA
-aDL
-aDL
+aBi
+aBi
 fil
 jbc
 kRp
-aDL
-aDL
+aBi
+aBi
 aCA
-aDL
-aDL
-bQu
-aDL
-bHw
-bPp
-bQc
+aBi
+aBi
+kJJ
+aBi
+aBi
+aBi
+aBi
 bQF
 aJo
 aJi
@@ -38166,33 +37294,33 @@ awu
 awu
 avG
 aDv
-aCK
-aCK
-aCK
-aCK
-aCK
-aCK
-aCK
-aCK
-aCK
-aCK
-aCK
-aCK
-aCK
-aCK
-aCK
-aCK
-aCK
-aCK
+awu
+awu
+awu
+awu
+awu
+awu
+awu
+awu
+awu
+awu
+awu
+awu
+awu
+awu
+awu
+awu
+awu
+awu
 aJi
 aJi
-aJo
 bQD
-bXl
-bPx
-bXl
-aCK
-aCK
+bQD
+bQD
+bQD
+bQD
+awu
+awu
 aaa
 aaa
 aaa
@@ -38309,30 +37437,30 @@ awu
 avH
 aDw
 awF
-aya
-aya
-aya
-azA
-aya
-aya
-ayA
-ayM
-aya
+acQ
 ayZ
-azv
+azT
+aBL
+ail
+ail
+ayA
+aAK
+ail
+ayZ
+acQ
 aCl
-azP
+ail
 azY
 aAg
-aAY
+aBj
 ahW
 aaa
 aaa
-bwb
-bGo
-bXl
-bPq
-bXn
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -38453,28 +37581,28 @@ aDx
 axa
 ayc
 ayo
-ayc
+ayo
 ayu
-ayc
+ayo
 ayo
 ayL
 ayO
 ayP
 azm
-azv
+acQ
 azC
-azP
-azP
+aBL
+ail
 aAh
-aAY
+aBj
 ahW
 aaa
 aaa
 aaa
 aaa
-bHG
-bPr
-bQd
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -38581,15 +37709,15 @@ afC
 agY
 ahG
 aip
-afI
-afI
-afI
-afI
-afI
-afI
-afI
-afI
-afI
+awu
+awu
+awu
+awu
+awu
+awu
+awu
+awu
+awu
 avK
 awf
 acP
@@ -38597,18 +37725,18 @@ acP
 acP
 acP
 acP
-ayf
-ayf
-ayf
-ayf
+acQ
+acQ
+acQ
+acQ
 ayQ
 azn
 aEi
 azE
-azS
+azU
 azZ
 aAi
-aAY
+aBj
 ahW
 aaa
 aaa
@@ -38723,7 +37851,7 @@ afn
 ahF
 aio
 afW
-agk
+aeF
 auq
 ahU
 aCk
@@ -38731,7 +37859,7 @@ ahU
 ahU
 atw
 awU
-afI
+awu
 avK
 awq
 acP
@@ -38740,24 +37868,24 @@ axj
 axN
 acP
 ayg
-ayI
+aBn
 aBs
-ayf
+acQ
 aAc
-azo
-azv
+ail
+acQ
 azF
-azP
-aAa
+ail
+aAe
 aAj
-aAY
+aBj
 ahW
 aaa
 aaa
 aaa
 aaa
 aaa
-bPS
+aaa
 aaa
 aaa
 aaa
@@ -38873,7 +38001,7 @@ awr
 avp
 aAD
 auU
-agk
+aJo
 avK
 awi
 awv
@@ -38883,16 +38011,16 @@ axS
 acP
 ayh
 ayJ
-aBt
-aBM
+aBI
+aBN
 ayS
-azp
-azv
+ail
+acQ
 azG
-aES
+ail
 aAb
 aAl
-aAY
+aBj
 ahW
 ahW
 aaa
@@ -39007,7 +38135,7 @@ gnz
 oNx
 acp
 ain
-agk
+aeF
 auR
 aie
 aiv
@@ -39015,7 +38143,7 @@ asZ
 atm
 aAF
 amW
-afI
+awu
 avM
 awj
 acP
@@ -39025,17 +38153,17 @@ axT
 acP
 ayj
 aBk
-aBu
-ayf
-ayT
+aBv
+acQ
+aAc
 kWQ
-azx
-azx
-azx
-azx
-azx
-azx
-azx
+acQ
+acQ
+acQ
+acQ
+acQ
+acQ
+acQ
 ahW
 aaa
 aaa
@@ -39149,7 +38277,7 @@ agg
 ago
 acp
 aCq
-afI
+aic
 ahE
 aie
 aiA
@@ -39165,16 +38293,16 @@ acP
 acP
 acP
 acP
-ayf
-ayf
-ayf
-ayf
-ayU
-azq
-azx
-azH
+acQ
+acQ
+acQ
+acQ
+aAc
+aBL
+acQ
+ail
 azT
-aAX
+ail
 aAK
 aBc
 aBj
@@ -39291,7 +38419,7 @@ afC
 agw
 air
 aAw
-afI
+aic
 aEP
 aie
 asC
@@ -39299,7 +38427,7 @@ aiA
 atn
 atL
 avu
-afI
+awu
 avO
 awq
 aww
@@ -39307,10 +38435,10 @@ awL
 axp
 axX
 aww
-ayk
+aBs
 aBn
 aBv
-ayt
+acQ
 ayV
 azr
 aEj
@@ -39433,7 +38561,7 @@ agh
 czm
 acp
 atM
-agk
+aeF
 ahC
 aie
 aiA
@@ -39441,7 +38569,7 @@ ati
 atr
 atV
 avy
-agk
+aJo
 avK
 aqg
 awG
@@ -39454,10 +38582,10 @@ aBo
 aBI
 aBN
 ayW
-azs
-azx
+ail
+acQ
 azL
-azV
+ail
 aAe
 aAN
 aBe
@@ -39575,7 +38703,7 @@ acm
 agj
 acp
 atM
-agk
+aeF
 ahC
 aic
 asE
@@ -39583,7 +38711,7 @@ asE
 aic
 aux
 avA
-afI
+awu
 avT
 aqx
 aww
@@ -39593,12 +38721,12 @@ aye
 aww
 ayr
 aBr
-aBJ
-ayt
+aBs
+acQ
 ayX
 azt
-azx
-acl
+acQ
+aBL
 azW
 aAf
 aAU
@@ -39717,7 +38845,7 @@ yje
 mAd
 lGX
 sVZ
-afI
+awu
 ahQ
 aif
 aif
@@ -39725,27 +38853,27 @@ atl
 atv
 auC
 avC
-afI
-avU
+awu
+awu
 asB
 aww
 aww
 aww
 aww
 aww
-ayt
-ayt
-ayt
-ayt
-ayY
-avU
-azx
-azx
-azx
-azx
-azx
-azx
-azx
+acQ
+acQ
+acQ
+acQ
+aBP
+acQ
+acQ
+acQ
+acQ
+acQ
+acQ
+acQ
+acQ
 ahW
 aaa
 aaa
@@ -39859,15 +38987,15 @@ afo
 ahI
 ais
 aAx
-afI
-afI
-afI
-afI
-afI
-afI
-afI
-afI
-afI
+awu
+awu
+awu
+awu
+awu
+awu
+awu
+awu
+awu
 aAn
 asH
 aDR
@@ -45440,7 +44568,7 @@ aaa
 aaa
 aaa
 aaa
-mnt
+aaa
 aaa
 aaa
 aaa
@@ -45583,7 +44711,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aEo
 aaa
 aaa
 aaa

--- a/_maps/map_files/tether/tether-06-station2.dmm
+++ b/_maps/map_files/tether/tether-06-station2.dmm
@@ -89,6 +89,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "abe" = (
@@ -152,11 +157,8 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/shaft)
 "abY" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
 /obj/structure/railing,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "acg" = (
@@ -753,11 +755,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -768,11 +765,6 @@
 /obj/item/stamp/denied{
 	pixel_x = 4;
 	pixel_y = -2
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
@@ -789,6 +781,11 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
@@ -1234,11 +1231,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2100,11 +2092,6 @@
 /turf/simulated/wall/r_wall,
 /area/security/nuke_storage)
 "akC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -3743,6 +3730,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "anQ" = (
@@ -3757,6 +3749,11 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
@@ -3793,6 +3790,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "anW" = (
@@ -4073,10 +4075,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "aoC" = (
@@ -4165,7 +4163,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "aoM" = (
 /turf/simulated/open,
 /area/engineering/foyer_mezzenine)
@@ -4220,17 +4218,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
 "aoT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals6,
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 4
 	},
 /obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "aoU" = (
@@ -4261,7 +4259,6 @@
 "apa" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/hallway/station/starboard)
 "apd" = (
@@ -4289,11 +4286,6 @@
 /turf/simulated/floor,
 /area/chapel/office)
 "aph" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -4304,9 +4296,9 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
@@ -4615,12 +4607,12 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/foyer_mezzenine)
 "apM" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm2)
 "apN" = (
 /obj/machinery/requests_console{
 	department = "Tech storage";
@@ -4746,6 +4738,12 @@
 	id_tag = "customs"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "apZ" = (
@@ -4840,6 +4838,7 @@
 /obj/machinery/door/airlock/maintenance/sec{
 	req_one_access = list(38,63)
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/tether/station/visitorhallway/lounge)
 "aql" = (
@@ -5461,28 +5460,7 @@
 	},
 /turf/simulated/shuttle/floor/yellow/airless,
 /area/shuttle/belter)
-"arB" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/cargo)
 "arE" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -5818,11 +5796,12 @@
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
 "asq" = (
-/obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Cargo Substation Bypass"
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -28
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/cargo)
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm1)
 "asr" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/grille,
@@ -6306,8 +6285,13 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/wall,
-/area/quartermaster/office)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "atC" = (
 /obj/item/storage/briefcase/inflatable{
 	pixel_x = 3;
@@ -6384,7 +6368,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "atK" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -6546,6 +6530,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "aum" = (
@@ -6597,8 +6586,13 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 5
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "auz" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/lightgrey/bordercorner,
@@ -7057,7 +7051,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "avM" = (
 /obj/machinery/light,
 /turf/simulated/open,
@@ -7124,13 +7118,8 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "avW" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 1
 	},
@@ -7141,11 +7130,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -7525,13 +7509,8 @@
 /turf/simulated/wall,
 /area/chapel/chapel_morgue)
 "axQ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/spacedorm3)
 "axR" = (
@@ -7599,6 +7578,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
 "ayi" = (
@@ -7663,11 +7647,8 @@
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "ayr" = (
@@ -7702,6 +7683,9 @@
 /area/tether/station/stairs_two)
 "ays" = (
 /obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "ayu" = (
@@ -7856,16 +7840,8 @@
 /obj/machinery/camera/network/cargo{
 	dir = 8
 	},
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	pixel_y = 30
-	},
-/obj/machinery/computer/shuttle_control/tether_backup{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "ayS" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -8120,11 +8096,6 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/belterdock/refinery)
 "azN" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -8409,9 +8380,19 @@
 /turf/simulated/wall,
 /area/mine/explored/upper_level)
 "aBN" = (
-/obj/structure/table/woodentable,
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/area/quartermaster/storage)
 "aBO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -8423,11 +8404,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
 "aBP" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -8448,9 +8424,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/burial)
 "aCc" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/spacedorm3)
@@ -8681,21 +8661,14 @@
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
 "aDw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/vending/fitness{
-	dir = 4
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/area/quartermaster/storage)
 "aDy" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -8953,11 +8926,6 @@
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
 "aEC" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -8969,9 +8937,19 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
@@ -9301,12 +9279,17 @@
 /turf/simulated/floor/bluegrid,
 /area/ai)
 "aFU" = (
-/obj/structure/railing,
-/obj/structure/closet/crate,
-/obj/random/maintenance/medical,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm1)
 "aFV" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -9322,18 +9305,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/refinery)
-"aFX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"aFY" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
-"aFY" = (
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
 "aFZ" = (
@@ -9377,11 +9358,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/burial)
 "aGd" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -9396,6 +9372,11 @@
 	},
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
@@ -9490,11 +9471,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/shaft)
 "aGq" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -9507,15 +9483,16 @@
 /turf/simulated/shuttle/floor/yellow/airless,
 /area/shuttle/belter)
 "aGt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/area/quartermaster/storage)
 "aGu" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -9617,11 +9594,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/chapel/chapel_morgue)
 "aGI" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/wall,
 /area/maintenance/substation/cargo)
 "aGJ" = (
@@ -9652,16 +9624,18 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/belterdock)
 "aGL" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
-	icon_state = "0-4"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm3)
+/turf/simulated/floor/tiled,
+/area/quartermaster/delivery)
 "aGN" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -9703,42 +9677,29 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock)
 "aGS" = (
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "aGU" = (
-/obj/machinery/power/sensor{
-	name = "Powernet Sensor - Cargo Subgrid";
-	name_tag = "Cargo Subgrid"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/green,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/cargo)
+/obj/structure/closet/secure_closet/personal,
+/obj/item/clothing/shoes/black,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm1)
 "aGV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "aGW" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor,
@@ -9762,9 +9723,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/general)
 "aGZ" = (
+/obj/structure/window/reinforced/polarized/full{
+	id = "visitor_meeting"
+	},
+/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/glass_command,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor,
 /area/tether/station/visitorhallway/office)
 "aHa" = (
 /obj/structure/bed/chair/office/dark,
@@ -9796,11 +9760,6 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/refinery)
 "aHe" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
@@ -9885,6 +9844,10 @@
 	dir = 1
 	},
 /obj/structure/flora/pottedplant/tropical,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "aHl" = (
@@ -9954,6 +9917,11 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "aHq" = (
@@ -10248,6 +10216,11 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
 "aIg" = (
@@ -10626,8 +10599,15 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "aJe" = (
-/turf/simulated/wall,
-/area/maintenance/substation/cargo)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aJf" = (
 /obj/machinery/mineral/processing_unit,
 /turf/simulated/floor/plating,
@@ -10741,10 +10721,12 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 2
-	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "aJu" = (
@@ -10765,6 +10747,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "aJw" = (
@@ -10853,18 +10840,6 @@
 "aJI" = (
 /turf/simulated/wall,
 /area/quartermaster/delivery)
-"aJK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
 "aJM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -10881,19 +10856,20 @@
 /turf/simulated/floor/wood,
 /area/tether/exploration/pathfinder_office)
 "aJP" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock{
+	id_tag = "spacedorm2";
+	name = "Room 2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/area/crew_quarters/sleep/spacedorm2)
 "aJQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -10901,11 +10877,6 @@
 /turf/simulated/wall/r_wall,
 /area/quartermaster/belterdock)
 "aJR" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -10941,7 +10912,9 @@
 /area/quartermaster/belterdock)
 "aJW" = (
 /obj/structure/railing,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "aJX" = (
@@ -10960,16 +10933,15 @@
 	sortType = "Cargo Bay"
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "aJZ" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/structure/flora/pottedplant{
-	icon_state = "plant-21"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor/plating,
+/area/maintenance/substation/cargo)
 "aKc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -11041,23 +11013,22 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/belterdock/refinery)
 "aKl" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Cargo";
-	output_attempt = 0
+/obj/machinery/button/remote/airlock{
+	id = "spacedorm1";
+	name = "Room 1 Lock";
+	pixel_x = -28;
+	pixel_y = 26;
+	specialfunctions = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/camera/network/engineering{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/cargo)
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm1)
 "aKm" = (
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/adv{
@@ -11267,20 +11238,24 @@
 /area/quartermaster/belterdock/gear)
 "aKM" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "packageSort1"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/delivery)
+/turf/simulated/floor/plating,
+/area/maintenance/substation/cargo)
 "aKN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
@@ -11370,17 +11345,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1380;
-	master_tag = "dock_cshutt";
-	name = "interior access button";
-	pixel_x = 28;
-	pixel_y = 26;
-	req_one_access = list(13)
-	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "aLa" = (
 /obj/machinery/mech_recharger,
 /turf/simulated/floor/tiled,
@@ -11507,16 +11473,6 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/belterdock)
 "aLv" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -11667,16 +11623,7 @@
 	pixel_y = 7
 	},
 /obj/item/megaphone,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
 "aLO" = (
@@ -11888,10 +11835,13 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/belterdock/refinery)
 "aMD" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/clothing/shoes/black,
-/obj/item/clothing/suit/storage/hooded/wintercoat,
-/obj/random/maintenance/clean,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/spacedorm3)
 "aME" = (
@@ -11900,8 +11850,13 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "aMF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12028,12 +11983,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/excursion/cargo)
 "aMX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm2)
 "aMY" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/cyan{
@@ -12100,9 +12056,9 @@
 "aNh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
@@ -12452,18 +12408,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
-"aOg" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Cargo Substation";
-	req_one_access = list(11,24,50)
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/cargo)
 "aOi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/firealarm{
@@ -12494,10 +12438,21 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/cargo)
 "aOm" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm3)
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/cargo)
 "aOn" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -12574,20 +12529,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/eng_upper)
-"aOB" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/cargo)
 "aOC" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
@@ -12970,13 +12911,25 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/large_escape_pod1)
 "aPx" = (
-/obj/structure/cable/green{
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/rust,
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall,
-/area/security/customs)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/cargo)
 "aPy" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -13154,9 +13107,6 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/public_meeting_room)
 "aPT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/effect/floor_decal/borderfloor/corner2,
@@ -13173,6 +13123,11 @@
 /obj/structure/disposalpipe/junction{
 	dir = 2;
 	icon_state = "pipe-j2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
@@ -13702,6 +13657,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Visitor Office"
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/office)
 "aRn" = (
@@ -13870,6 +13826,11 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
 "aRQ" = (
@@ -13910,7 +13871,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
 "aRX" = (
-/turf/simulated/open,
+/obj/structure/table/woodentable,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "aRY" = (
 /obj/effect/floor_decal/borderfloor{
@@ -13974,6 +13940,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "aSe" = (
@@ -13999,6 +13970,11 @@
 /area/maintenance/station/eng_upper)
 "aSh" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "aSi" = (
@@ -14009,15 +13985,16 @@
 /turf/simulated/floor,
 /area/maintenance/station/eng_upper)
 "aSj" = (
+/obj/structure/table/woodentable,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/table/rack{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm2)
 "aSk" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14104,8 +14081,11 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "aSv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -14181,11 +14161,6 @@
 /turf/simulated/floor/wood,
 /area/tether/station/burial)
 "aSE" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
 	},
@@ -14193,6 +14168,16 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "aSF" = (
@@ -14349,14 +14334,6 @@
 /obj/effect/floor_decal/corner/brown/border,
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/gear)
-"aSY" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE"
-	},
-/turf/simulated/wall,
-/area/maintenance/substation/cargo)
 "aSZ" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
@@ -14488,9 +14465,6 @@
 /turf/simulated/floor,
 /area/maintenance/station/eng_upper)
 "aTn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
@@ -14498,6 +14472,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
@@ -14563,16 +14540,6 @@
 /turf/simulated/floor,
 /area/maintenance/station/eng_upper)
 "aTx" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/computer/guestpass{
 	pixel_y = 32
 	},
@@ -14921,7 +14888,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table/woodentable,
-/obj/item/paper_bin,
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "aUx" = (
@@ -15305,6 +15271,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "aVv" = (
@@ -15345,6 +15316,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
@@ -15523,22 +15499,18 @@
 /turf/simulated/floor/bluegrid,
 /area/ai_core_foyer)
 "aVV" = (
-/obj/structure/bed/double/padded,
-/obj/item/bedsheet/browndouble,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
+/obj/machinery/door/airlock/glass_mining{
+	name = "Cargo Bay";
+	req_access = list(31);
+	req_one_access = list()
 	},
 /obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm4)
+/turf/simulated/floor/tiled,
+/area/quartermaster/delivery)
 "aVW" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -15556,7 +15528,9 @@
 	dir = 4
 	},
 /obj/structure/table/woodentable,
-/obj/item/folder/red,
+/obj/machinery/button/windowtint{
+	id = "visitor_meeting"
+	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "aWa" = (
@@ -15639,6 +15613,7 @@
 	name = "Trading Security Station";
 	req_one_access = list(38,63)
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled,
 /area/security/customs)
 "aWi" = (
@@ -15662,11 +15637,6 @@
 /turf/simulated/floor/wood,
 /area/tether/exploration/pathfinder_office)
 "aWn" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -15674,11 +15644,6 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
@@ -15720,9 +15685,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 2
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "aWv" = (
@@ -15740,18 +15702,20 @@
 /turf/simulated/floor,
 /area/maintenance/station/eng_upper)
 "aWz" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock{
+	id_tag = "spacedorm1";
+	name = "Room 1"
 	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/rust,
-/obj/structure/cable,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/cargo)
+/turf/simulated/floor/tiled,
+/area/crew_quarters/sleep/spacedorm1)
 "aWA" = (
 /obj/machinery/door/airlock{
 	name = "Chapel Morgue";
@@ -15768,13 +15732,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/general)
 "aWC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/door/airlock/engineering{
+	name = "Cargo Substation";
+	req_one_access = list(11,24,50)
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/turf/simulated/floor/plating,
+/area/maintenance/substation/cargo)
 "aWD" = (
 /obj/structure/cable/green{
 	icon_state = "32-2"
@@ -15805,11 +15768,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -15904,6 +15862,11 @@
 	req_one_access = list()
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/qm)
 "aWW" = (
@@ -15911,6 +15874,16 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
 "aWX" = (
@@ -16034,6 +16007,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "aXq" = (
@@ -16129,9 +16107,6 @@
 /turf/simulated/floor,
 /area/maintenance/station/eng_upper)
 "aXB" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
 	},
@@ -16156,11 +16131,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/gateway/prep_room)
 "aXE" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
 	},
@@ -16292,8 +16262,13 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "aXW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -16332,11 +16307,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/vehicle/train/engine{
 	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -16609,11 +16579,6 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
@@ -16776,11 +16741,6 @@
 	},
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -17036,11 +16996,6 @@
 /obj/vehicle/train/trolley{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -17095,11 +17050,16 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "aZX" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
@@ -17125,6 +17085,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/tether/exploration)
+"bdI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "bgE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -17166,6 +17135,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
+"boj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm2)
 "bpS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17242,6 +17223,13 @@
 /obj/item/flame/candle/candelabra/everburn,
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"byu" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/item/clothing/shoes/black,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm4)
 "byT" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -17258,18 +17246,28 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "bHG" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "bKy" = (
@@ -17419,6 +17417,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
+"cbn" = (
+/obj/machinery/vending/loadout/accessory,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "cdk" = (
 /obj/structure/flora/pottedplant/orientaltree,
 /obj/effect/floor_decal/corner/lightgrey{
@@ -17443,27 +17445,8 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
-"cjl" = (
-/obj/structure/table/woodentable,
-/obj/item/folder/yellow,
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
-"cjr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/railing,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
 "cqy" = (
 /obj/effect/floor_decal/sign/dock/two,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
@@ -17585,19 +17568,16 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "cIj" = (
-/obj/structure/cable/green{
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall,
-/area/quartermaster/delivery)
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
 "cJQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
@@ -17727,18 +17707,24 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "deM" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/corner/lightgrey{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lightgrey{
-	dir = 6
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/table/woodentable,
+/obj/item/cassette_tape/random,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
+"dfX" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/plating,
+/area/security/customs)
+"dit" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/item/clothing/shoes/black,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm3)
 "diC" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -17748,6 +17734,14 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
+"dlD" = (
+/obj/structure/bed/double/padded,
+/obj/item/bedsheet/bluedouble,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm1)
 "doI" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -17770,9 +17764,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"dpy" = (
+/obj/machinery/vending/loadout/overwear,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "drb" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/airlock/engineering{
+	name = "Cargo Substation";
+	req_one_access = list(11,24,50)
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17780,21 +17785,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/area/maintenance/substation/cargo)
 "drE" = (
-/obj/structure/bed/double/padded,
-/obj/item/bedsheet/iandouble,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm3)
+/turf/simulated/wall,
+/area/quartermaster/foyer)
 "dvk" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
@@ -17853,15 +17847,13 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/large_escape_pod1)
 "dzg" = (
-/obj/effect/shuttle_landmark{
-	base_area = /area/space;
-	base_turf = /turf/space;
-	docking_controller = "dock_cshutt";
-	landmark_tag = "tether_customs_shuttle";
-	name = "Tether Customs To Surface Dock"
+/obj/machinery/door/airlock/glass_external,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/turf/space,
-/area/space)
+/obj/effect/map_helper/airlock/door/int_door,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "dzD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17926,6 +17918,17 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/exploration)
+"dLB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_command,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/office)
 "dPi" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18149,6 +18152,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 22
+	},
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
 "emB" = (
@@ -18211,11 +18218,6 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18250,6 +18252,17 @@
 /obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
+"etw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/foyer)
 "ewX" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
@@ -18261,12 +18274,16 @@
 /turf/simulated/floor/wood,
 /area/tether/exploration/pathfinder_office)
 "eyQ" = (
-/obj/structure/railing,
-/obj/structure/closet,
-/obj/random/maintenance/medical,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm1)
 "eAf" = (
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
@@ -18401,13 +18418,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"eRS" = (
+/obj/structure/table/woodentable,
+/obj/item/storage/box/glasses/meta,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "eSz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_one)
@@ -18470,6 +18492,16 @@
 	},
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
@@ -18540,13 +18572,6 @@
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/excursion/general)
-"foT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
 "fpH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18595,6 +18620,11 @@
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
@@ -18693,10 +18723,16 @@
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/mining_outpost/shuttle)
 "fLT" = (
-/obj/structure/table/woodentable,
-/obj/item/storage/box/glasses/meta,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
 "fMG" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -18835,6 +18871,14 @@
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor,
 /area/hallway/station/port)
+"gen" = (
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/obj/structure/table/woodentable,
+/obj/item/folder/red,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "gew" = (
 /obj/machinery/newscaster{
 	pixel_x = 28
@@ -18853,6 +18897,16 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
@@ -18876,19 +18930,16 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "ggX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/spacedorm4)
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
 "ghE" = (
 /obj/structure/bed/chair/shuttle,
 /obj/effect/floor_decal/borderfloorblack,
@@ -18938,10 +18989,10 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "gpa" = (
-/obj/structure/railing{
+/obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "gpL" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -18972,11 +19023,11 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/exploration)
 "gra" = (
-/obj/item/radio/intercom{
-	pixel_y = -24
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
+/turf/simulated/wall,
+/area/maintenance/station/cargo)
 "gtq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -19022,7 +19073,7 @@
 "gEi" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
@@ -19041,12 +19092,12 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
+"gEJ" = (
+/obj/structure/table/woodentable,
+/obj/item/folder/blue,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "gHB" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -19095,6 +19146,12 @@
 /area/tether/exploration)
 "gQZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "gSf" = (
@@ -19119,11 +19176,6 @@
 /turf/simulated/floor/plating,
 /area/tether/exploration/pathfinder_office)
 "gWE" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -19172,13 +19224,19 @@
 /turf/space,
 /area/space)
 "hav" = (
-/obj/structure/table/woodentable,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/structure/bed/double/padded,
+/obj/item/bedsheet/browndouble,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/spacedorm4)
@@ -19296,12 +19354,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_one)
-"htA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
 "htD" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -19324,23 +19376,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "htR" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK"
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "hvk" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -19372,6 +19412,17 @@
 /obj/item/material/ashtray/glass,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
+"hxg" = (
+/obj/structure/table/woodentable,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm1)
 "hyt" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 5
@@ -19386,7 +19437,30 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
 "hBP" = (
-/turf/simulated/floor/wood,
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
+"hBY" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock{
+	id_tag = "spacedorm4";
+	name = "Room 4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/spacedorm4)
 "hFT" = (
 /obj/structure/table/standard,
@@ -19399,11 +19473,6 @@
 /obj/item/stamp/denied{
 	pixel_x = 4;
 	pixel_y = -2
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -19576,9 +19645,16 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/excursion/general)
 "hYE" = (
-/obj/machinery/vending/loadout/accessory,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/quartermaster/foyer)
 "iaU" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -19646,19 +19722,18 @@
 "itE" = (
 /turf/simulated/floor/outdoors/grass/forest,
 /area/tether/exploration/pathfinder_office)
-"iwd" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
+"iuq" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm2)
 "iwD" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -19838,6 +19913,11 @@
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/excursion/cargo)
+"iPF" = (
+/obj/structure/table/woodentable,
+/obj/item/folder/yellow,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "iQJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19917,20 +19997,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
-"jmD" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1380;
-	master_tag = "dock_cshutt";
-	name = "exterior access button";
-	pixel_x = -5;
-	pixel_y = -26;
-	req_one_access = list(13)
-	},
-/obj/machinery/door/airlock/glass_external,
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/dark,
-/area/quartermaster/office)
 "jmU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -19947,8 +20013,13 @@
 /area/chapel/main)
 "jog" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "jpv" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/map_helper/airlock/door/simple,
@@ -20015,12 +20086,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
-"jxq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
 "jxZ" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -20050,11 +20115,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
@@ -20073,12 +20133,18 @@
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
 "jCo" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/quartermaster/office)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
+"jFq" = (
+/obj/structure/table/woodentable,
+/obj/item/paicard,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "jGz" = (
 /obj/structure/flora/pottedplant/stoutbush,
 /obj/machinery/light{
@@ -20195,7 +20261,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
@@ -20269,11 +20335,11 @@
 /turf/simulated/floor/outdoors/grass/forest,
 /area/tether/exploration/pathfinder_office)
 "kkq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/tether/station/visitorhallway/office)
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/quartermaster/foyer)
 "kkI" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -20335,11 +20401,6 @@
 /turf/simulated/wall,
 /area/quartermaster/delivery)
 "kpE" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -20429,9 +20490,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/item/radio/intercom{
-	pixel_y = -24
-	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "kCk" = (
@@ -20450,6 +20508,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "kDq" = (
@@ -20458,11 +20519,6 @@
 	},
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20478,6 +20534,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
+"kFb" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -28
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm3)
 "kIj" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -20573,11 +20636,6 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_one)
 "lla" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -20608,7 +20666,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "lpR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -20799,15 +20857,35 @@
 /area/hallway/station/port)
 "mcY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "mdh" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 22
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/foyer)
+"mdj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /obj/random/trash_pile,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "mdX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -20820,7 +20898,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "met" = (
 /obj/structure/bed/chair,
@@ -20853,17 +20931,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
 "miw" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/clothing/shoes/black,
-/obj/item/clothing/suit/storage/hooded/wintercoat,
-/obj/random/maintenance/clean,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/spacedorm4)
 "mjk" = (
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 26;
-	pixel_y = 8
+/obj/structure/table/woodentable,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/spacedorm4)
@@ -20890,10 +20971,12 @@
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
 "mvF" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock{
-	id_tag = "spacedorm3";
-	name = "Room 3"
+/obj/machinery/button/remote/airlock{
+	id = "spacedorm3";
+	name = "Room 3 Lock";
+	pixel_x = -28;
+	pixel_y = -26;
+	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -20902,14 +20985,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood,
 /area/crew_quarters/sleep/spacedorm3)
 "mwj" = (
 /turf/simulated/floor/carpet/oracarpet,
@@ -20975,7 +21051,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "mIh" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
@@ -21029,10 +21105,6 @@
 /area/tether/station/visitorhallway/laundry)
 "mPL" = (
 /obj/structure/table/woodentable,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
-	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "mPN" = (
@@ -21075,6 +21147,16 @@
 /obj/structure/table/wooden_reinforced,
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"nbo" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/quartermaster/foyer)
 "ncy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -21114,14 +21196,24 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 10
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "niu" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "nmt" = (
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 1
@@ -21158,7 +21250,7 @@
 "npD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "npO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -21175,26 +21267,11 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "nqH" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	frequency = 1380;
-	id_tag = "dock_d1a3_pump"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/obj/machinery/light/small,
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "dock_cshutt_sensor";
-	pixel_y = -25
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1380;
-	id_tag = "dock_cshutt";
-	pixel_y = 28
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/turf/simulated/floor/tiled/dark,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "nsJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -21208,21 +21285,16 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_one)
 "nvK" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/glass_security{
 	name = "Trading Security Station";
 	req_one_access = list(38,63)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/security/customs)
@@ -21330,35 +21402,44 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "nDO" = (
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
-"nEg" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Substation - Cargo";
+	output_attempt = 0
 	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/cargo)
+"nEg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
@@ -21378,11 +21459,6 @@
 /obj/machinery/camera/network/cargo{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -21398,7 +21474,7 @@
 "nKk" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "nLF" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -21458,16 +21534,21 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
@@ -21500,10 +21581,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
 "nUG" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -21513,6 +21590,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -21554,9 +21634,6 @@
 /turf/simulated/wall/rshull,
 /area/shuttle/excursion/cargo)
 "nWw" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
@@ -21564,8 +21641,12 @@
 /area/tether/station/visitorhallway/office)
 "nYg" = (
 /obj/random/junk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "oaC" = (
@@ -21653,6 +21734,7 @@
 /obj/machinery/door/airlock/maintenance/sec{
 	req_one_access = list(38,63)
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/tether/station/visitorhallway/lounge)
 "ois" = (
@@ -21737,6 +21819,18 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/general)
+"ony" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm1)
 "ooM" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -21768,8 +21862,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/wall,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
 "osM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21777,11 +21871,6 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "ouP" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -21789,6 +21878,11 @@
 /obj/machinery/disposal,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
@@ -21798,10 +21892,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/exploration)
 "owJ" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/structure/flora/pottedplant/smallcactus,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
@@ -21824,6 +21914,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
@@ -21979,16 +22074,20 @@
 /turf/simulated/floor/outdoors/grass/heavy/interior,
 /area/tether/station/visitorhallway/lounge)
 "oSb" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "dock_cshutt";
+	name = "interior access button";
+	pixel_x = 28;
+	pixel_y = 26;
+	req_one_access = list(13)
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/area/quartermaster/foyer)
 "oSf" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -22088,8 +22187,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
+"pdH" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm1)
 "pdQ" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -22186,6 +22297,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "pkL" = (
@@ -22264,6 +22380,14 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/exploration)
+"pCp" = (
+/obj/structure/bed/double/padded,
+/obj/item/bedsheet/reddouble,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm2)
 "pDq" = (
 /obj/machinery/vending/snack{
 	dir = 1
@@ -22291,6 +22415,12 @@
 	id_tag = "customs"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "pGy" = (
@@ -22360,15 +22490,10 @@
 /turf/simulated/floor/outdoors/grass/heavy/interior,
 /area/tether/exploration/pilot_office)
 "pQw" = (
-/obj/machinery/button/remote/airlock{
-	id = "spacedorm3";
-	name = "Room 3 Lock";
-	pixel_x = -28;
-	pixel_y = -26;
-	specialfunctions = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -22438,15 +22563,24 @@
 /turf/simulated/floor/plating,
 /area/tether/station/visitorhallway/lounge)
 "qbe" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Cargo Subgrid";
+	name_tag = "Cargo Subgrid"
 	},
-/obj/structure/railing{
-	dir = 1
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/random/trash_pile,
+/obj/structure/cable/green,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/area/maintenance/substation/cargo)
 "qbr" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/machinery/portable_atmospherics/canister/phoron,
@@ -22461,12 +22595,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance/cargo{
-	req_access = list(50);
-	req_one_access = list(48)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/maintenance/cargo,
 /turf/simulated/floor/plating,
-/area/quartermaster/office)
+/area/maintenance/substation/cargo)
+"qfu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "qfQ" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/spline/plain{
@@ -22478,14 +22619,27 @@
 	},
 /area/tether/exploration)
 "qgB" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/area/maintenance/substation/cargo)
 "qgU" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/large,
@@ -22533,6 +22687,11 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
@@ -22612,9 +22771,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "qsR" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
+/obj/structure/table/woodentable,
+/obj/item/paper_bin,
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "qsV" = (
@@ -22674,6 +22832,7 @@
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/excursion/general)
 "qxU" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
@@ -22714,6 +22873,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
+"qGw" = (
+/obj/machinery/camera/network/cargo{
+	dir = 1;
+	name = "security camera"
+	},
+/obj/structure/table/woodentable,
+/obj/item/folder/white,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "qMH" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -22768,11 +22936,16 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "qQV" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
@@ -22788,16 +22961,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"qTw" = (
+/obj/machinery/computer/shuttle_control/tether_backup{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "qVM" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "qWJ" = (
-/obj/machinery/atmospherics/binary/passive_gate/on{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/turf/simulated/wall,
+/area/crew_quarters/sleep/spacedorm2)
 "qXI" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -22817,23 +22993,46 @@
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
 "qZe" = (
-/obj/structure/table/woodentable,
-/obj/machinery/chemical_dispenser/bar_coffee/full,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
-"qZi" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1380;
+	id_tag = "dock_d1a3_pump"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
+/obj/machinery/light/small,
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "dock_cshutt_sensor";
+	pixel_y = -25
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1380;
+	id_tag = "dock_cshutt";
+	pixel_y = 28
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
+"qZi" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "dock_cshutt";
+	name = "exterior access button";
+	pixel_x = -5;
+	pixel_y = -26;
+	req_one_access = list(13)
+	},
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "qZT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/table/woodentable,
-/obj/machinery/button/windowtint{
-	id = "visitor_meeting"
+/obj/structure/bed/chair/office/dark{
+	dir = 1
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
@@ -22850,18 +23049,18 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "reE" = (
-/obj/machinery/button/remote/airlock{
-	id = "spacedorm4";
-	name = "Room 4 Lock";
-	pixel_x = 28;
-	pixel_y = -26;
-	specialfunctions = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -22908,7 +23107,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "rii" = (
 /obj/effect/floor_decal/borderfloor{
@@ -22976,6 +23175,11 @@
 	},
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 5
+	},
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	departmentType = 2;
+	pixel_y = 30
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -23064,6 +23268,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
+"ryP" = (
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm4)
 "rAd" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -23078,14 +23290,22 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/exploration)
 "rAE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/button/remote/airlock{
+	id = "spacedorm2";
+	name = "Room 2 Lock";
+	pixel_x = 28;
+	pixel_y = 26;
+	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm2)
 "rAY" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -23108,11 +23328,21 @@
 /area/mine/explored/upper_level)
 "rCQ" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "rDx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
@@ -23121,12 +23351,17 @@
 /turf/space,
 /area/space)
 "rFd" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "rGT" = (
@@ -23149,9 +23384,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -23210,14 +23442,23 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "rLt" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/area/maintenance/substation/cargo)
 "rMK" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/hatch{
@@ -23366,11 +23607,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
 "sgO" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/turf/simulated/floor/plating,
-/area/quartermaster/office)
+/obj/effect/shuttle_landmark{
+	base_area = /area/space;
+	base_turf = /turf/space;
+	docking_controller = "dock_cshutt";
+	landmark_tag = "tether_customs_shuttle";
+	name = "Tether Customs To Surface Dock"
+	},
+/turf/space,
+/area/space)
 "shy" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -23392,6 +23637,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
+"sjZ" = (
+/obj/structure/table/woodentable,
+/obj/machinery/chemical_dispenser/bar_coffee/full,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "sll" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 5
@@ -23399,6 +23649,11 @@
 /obj/structure/bed/chair/sofa/brown/corner,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
@@ -23412,10 +23667,12 @@
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
 "sro" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock{
-	id_tag = "spacedorm4";
-	name = "Room 4"
+/obj/machinery/button/remote/airlock{
+	id = "spacedorm4";
+	name = "Room 4 Lock";
+	pixel_x = 28;
+	pixel_y = -26;
+	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -23424,14 +23681,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood,
 /area/crew_quarters/sleep/spacedorm4)
 "ssu" = (
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -23460,14 +23710,16 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "swD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
+/obj/structure/bed/double/padded,
+/obj/item/bedsheet/iandouble,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/spacedorm3)
@@ -23561,6 +23813,11 @@
 /area/hallway/station/port)
 "sNQ" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/station/starboard)
 "sOy" = (
@@ -23716,12 +23973,21 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "tes" = (
-/obj/machinery/light_switch{
+/obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -28
+	pixel_x = -22
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/spacedorm3)
+"tfy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "thG" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -23817,11 +24083,6 @@
 /obj/item/stamp{
 	pixel_x = -3;
 	pixel_y = 3
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -23939,6 +24200,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "tAi" = (
@@ -24008,10 +24274,17 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/wood,
 /area/tether/exploration/pilot_office)
+"tGN" = (
+/turf/simulated/wall,
+/area/space)
 "tGP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "tIc" = (
@@ -24021,17 +24294,19 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_one)
 "tIA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "tIP" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/floor_decal/industrial/warning,
@@ -24075,11 +24350,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -24237,6 +24507,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"udJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "ueB" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -24305,9 +24584,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 2
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "uhG" = (
@@ -24345,20 +24621,11 @@
 	dir = 5
 	},
 /obj/structure/table/woodentable,
-/obj/item/paicard,
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "ukj" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/turf/simulated/wall,
+/area/crew_quarters/sleep/spacedorm1)
 "uoA" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -24431,6 +24698,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -24527,6 +24799,11 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "uPQ" = (
@@ -24534,13 +24811,12 @@
 /turf/simulated/wall,
 /area/quartermaster/office)
 "uQo" = (
-/obj/machinery/door/airlock/glass_external,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/tiled/dark,
-/area/quartermaster/office)
+/obj/machinery/door/firedoor/glass/hidden/steel,
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "uTM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -24594,14 +24870,16 @@
 /turf/simulated/floor/tiled,
 /area/security/customs)
 "uWB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/spacedorm4)
@@ -24626,6 +24904,28 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/excursion/cargo)
+"uYU" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock{
+	id_tag = "spacedorm3";
+	name = "Room 3"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/sleep/spacedorm3)
 "vbN" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
@@ -24663,6 +24963,11 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
@@ -24715,6 +25020,11 @@
 	req_access = list(31);
 	req_one_access = list()
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "voG" = (
@@ -24766,29 +25076,27 @@
 	},
 /area/tether/exploration)
 "vAv" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "Cargo Substation Bypass"
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/random/trash_pile,
 /turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/area/maintenance/substation/cargo)
 "vBK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/hallway/station/port)
 "vCl" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/quartermaster/office)
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "vFc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -24808,12 +25116,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "vGb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
@@ -24919,11 +25225,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/railing,
-/obj/machinery/camera/network/cargo{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "vQV" = (
 /obj/structure/sign/directions/evac,
@@ -25045,15 +25347,20 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
+"wdk" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/quartermaster/foyer)
 "wdQ" = (
-/obj/machinery/camera/network/cargo{
-	dir = 4
-	},
-/obj/structure/table/rack{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/obj/structure/closet/secure_closet/personal,
+/obj/item/clothing/shoes/black,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm2)
 "wdV" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -25064,6 +25371,11 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "wgb" = (
@@ -25072,6 +25384,18 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
+"wgT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm2)
 "wkK" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 4
@@ -25140,8 +25464,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "wrn" = (
@@ -25152,18 +25480,14 @@
 /turf/simulated/floor,
 /area/tether/station/visitorhallway/office)
 "wtB" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/window/reinforced/full,
 /obj/structure/grille,
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "wtF" = (
-/turf/simulated/floor/tiled,
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "wyG" = (
 /obj/structure/cable{
@@ -25430,6 +25754,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
 "xee" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -25442,8 +25771,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall,
-/area/quartermaster/office)
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
 "xfD" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
@@ -25468,14 +25803,11 @@
 /turf/simulated/floor/wood,
 /area/tether/exploration/pathfinder_office)
 "xkr" = (
-/obj/machinery/vending/loadout/overwear,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/area/quartermaster/foyer)
 "xlr" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -25519,12 +25851,19 @@
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
 "xtp" = (
-/obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/space,
-/area/space)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
 "xtQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -25580,27 +25919,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/wall,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
 "xya" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "xyD" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/spacedorm4)
 "xBA" = (
@@ -25652,8 +25981,20 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
+"xOz" = (
+/obj/structure/railing,
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
 "xOG" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/stasis_cage,
@@ -25767,8 +26108,22 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"xVD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "xWg" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 4
@@ -25816,6 +26171,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
+"yaB" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "yeY" = (
 /obj/machinery/door/window/northright{
 	dir = 4
@@ -25854,7 +26223,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "yhh" = (
 /obj/machinery/power/apc{
@@ -39310,7 +39679,7 @@ ooM
 afG
 aoA
 apa
-aEB
+aMP
 nUG
 aHC
 aHC
@@ -39588,11 +39957,11 @@ lPe
 lPe
 sEX
 lPe
-lPe
+tIA
 aXw
 aWt
 aJv
-aTn
+apQ
 aDL
 aMP
 xnf
@@ -39608,8 +39977,8 @@ aHC
 aHC
 aHC
 aHC
-aac
-aaP
+aHC
+aHC
 aac
 aac
 aoY
@@ -39730,7 +40099,7 @@ aIL
 aKN
 aSh
 aSh
-aSh
+vCl
 sNQ
 aJt
 uON
@@ -39748,10 +40117,10 @@ bUg
 eLW
 eLW
 tjf
-eqW
+eLW
+mdj
 aHC
-aac
-aaP
+aHC
 aaP
 aac
 aoY
@@ -39872,14 +40241,14 @@ aTU
 aVs
 aTU
 aTU
-aTU
-gra
+xkr
+alJ
 orW
 xvI
-kkq
+wrn
 wEJ
-aHC
-mdh
+wEJ
+wEJ
 aMP
 aMP
 aMP
@@ -39890,10 +40259,10 @@ aLz
 aQf
 aQf
 fWC
-jNP
+aQf
+gEB
+hBP
 aHC
-aac
-aac
 aaP
 aaP
 aaP
@@ -40016,26 +40385,26 @@ wrn
 wrn
 wrn
 wrn
-tjc
-aRX
-aDw
+dLB
+wrn
+wrn
 deM
+jFq
 aUG
 aUG
 aUG
 aUG
 aUG
-vsL
 aqk
-aJe
-aOg
-aSY
-aJe
-aHC
+vsL
 ukj
+ukj
+ukj
+ukj
+ukj
+jNP
+aQf
 aHC
-aHC
-aac
 aac
 rCL
 rCL
@@ -40155,28 +40524,28 @@ krd
 aTU
 aVs
 wrn
-aBN
-qZe
-aBN
+ahl
+ahl
+ahl
 vPY
-aRX
-gpa
-wtF
+ahl
+ahl
+ahl
+deM
 aUG
-aGL
 aCc
 tes
+kFb
 aUG
-aJZ
 eUF
-aJe
-aOB
+sOB
+ukj
 asq
-aJe
+pdH
 eyQ
-foT
+ukj
+jNP
 aQf
-aHC
 aHC
 aaa
 aaa
@@ -40289,34 +40658,34 @@ tpG
 rOs
 rKF
 urw
-viC
+aGL
 ahG
 wkK
 aJI
 iIu
 aTU
-aXr
+hYE
 wrn
-fLT
+ahl
 wtF
-wtF
-cjr
+aRX
+vPY
 aRX
 gpa
-wtF
+ahl
+eRS
 aUG
-drE
 swD
 pQw
 mvF
-okY
+uYU
 nRW
 aJe
 aWz
 aKl
-aJe
+ony
 aFU
-iwd
+ukj
 nYg
 eqW
 aHC
@@ -40439,26 +40808,26 @@ aSF
 wYR
 fvh
 wrn
-wtF
 ahl
+wtF
 qsR
 anl
-qsR
-qsR
+mPL
+gpa
 alU
+sjZ
 aUG
-aOm
 axQ
 aMD
+dit
 aUG
-sOB
 aph
-aGI
-arB
+sOB
+ukj
 aGU
-aJe
-aHC
-aHC
+hxg
+dlD
+ukj
 aHC
 aYi
 aHC
@@ -40575,32 +40944,32 @@ viC
 viC
 viC
 nEg
-aKM
-cIj
+fMG
+aJI
 kDq
 aTU
 aXm
 wrn
-wtF
+ahl
 oBg
 mPL
 aVY
 aIw
 qZT
-qZi
+ahl
+qGw
 aUG
 aUG
 aUG
 aUG
 aUG
-sOB
 aXv
-vsL
-vsL
-vsL
-vsL
-vsL
-htA
+sOB
+ukj
+ukj
+ukj
+ukj
+ukj
 aJW
 krB
 aHC
@@ -40728,20 +41097,20 @@ adA
 aUv
 lpR
 ujt
-cjl
-qZi
+gpa
+ahl
+gEJ
 mQF
-hBP
 xyD
 miw
+byu
 mQF
-sOB
 aXv
 sOB
-aJB
+qWJ
 wdQ
 aSj
-vsL
+pCp
 qWJ
 ays
 jNP
@@ -40865,26 +41234,26 @@ arE
 aTU
 aVs
 wrn
-wtF
+ahl
 ahl
 nWw
 qxU
 vGb
 xya
 kwy
+gen
 mQF
-ggX
 uWB
 reE
 sro
-okY
+hBY
 aEC
 wpU
 aJP
 rAE
-aJB
-vsL
-jxq
+wgT
+boj
+qWJ
 gEi
 jNP
 aHC
@@ -41007,27 +41376,27 @@ aTx
 aIL
 aVs
 wrn
-wtF
-wtF
-wtF
-wtF
+ahl
+ahl
+ahl
+ahl
 mdX
 rhx
 ygD
+iPF
 mQF
-aVV
 hav
 mjk
+ryP
 mQF
-sOB
-sOB
+rfW
 gQZ
-aJK
+qWJ
 aMX
 apM
-vsL
-cMw
-xlI
+iuq
+qWJ
+xOz
 gEB
 aHC
 aaa
@@ -41152,24 +41521,24 @@ wrn
 wrn
 wrn
 wrn
-wEJ
+wrn
 tjc
 aRk
 wEJ
+wrn
 mQF
 mQF
 mQF
 mQF
 mQF
-aJB
-tnK
-aJB
-aFX
-eai
-aNi
-vsL
-cMw
-xlI
+rfW
+bdI
+qWJ
+qWJ
+qWJ
+qWJ
+qWJ
+gEi
 doI
 aHC
 aaa
@@ -41268,25 +41637,25 @@ aRt
 aSM
 cgZ
 aVf
-aWC
-aXE
-aUV
-aUV
-aUV
+aVf
+aBN
+aVf
+aVf
+aVf
 aZX
-gMP
+aDw
 qQV
-gMP
+aDw
 qme
-aUV
-aUV
-osM
+aVf
+aVf
+aGt
 vnO
 xML
 rCQ
 eUH
 nhB
-vGY
+aVV
 aGd
 aQC
 aVs
@@ -41304,8 +41673,8 @@ sOB
 sOB
 sOB
 sOB
-sOB
-sOB
+rfW
+xVD
 ayq
 aoT
 nqk
@@ -41446,9 +41815,9 @@ sOB
 sOB
 sOB
 sOB
+rfW
 sOB
-sOB
-oSb
+eUF
 aDz
 sOB
 vsL
@@ -41578,7 +41947,7 @@ qoX
 gxS
 oyW
 aHp
-aSh
+udJ
 pES
 rFd
 bHG
@@ -41588,15 +41957,15 @@ aSE
 aWP
 aWP
 aWP
-aWP
+yaB
 aWP
 avW
 aVE
 sOB
 vsL
-aQf
+cMw
 abY
-tIA
+gEB
 aHC
 aaa
 aaa
@@ -41718,11 +42087,11 @@ aCf
 rDx
 gxS
 gxS
-rDx
+etw
 aTU
 wLl
 aPb
-rfW
+sOB
 sOB
 qaE
 sOB
@@ -41864,7 +42233,7 @@ vdL
 aTU
 jpG
 aGA
-rfW
+sOB
 sOB
 qaE
 sOB
@@ -42009,7 +42378,7 @@ aLv
 aWn
 aHe
 aBP
-aGt
+emB
 aJR
 aRK
 emB
@@ -42139,17 +42508,17 @@ hvA
 bHs
 izH
 aHl
-aHl
-xeW
+drE
+htR
 aGV
 npD
 npD
 pcr
-npD
+qfu
 avL
 aGq
 aWg
-uam
+dfX
 aSZ
 rPb
 aVp
@@ -42287,12 +42656,12 @@ aXV
 nKk
 aJY
 aME
-hvA
+aTU
 mIc
-aPx
+uam
 iMR
 aum
-uam
+dfX
 sOB
 sFw
 sOB
@@ -42425,12 +42794,12 @@ xtY
 fzv
 aup
 niu
-hvA
-hvA
+jCo
+aTU
 qOP
 jog
-jog
-jog
+tfy
+tfy
 nvK
 oxY
 uVs
@@ -42702,19 +43071,19 @@ aab
 aab
 aab
 aaa
-aHC
-aHl
+aGI
+aGI
 qbA
-aHl
-aHl
+aGI
+aGI
 xeW
-aHl
-aHl
-sgO
+aHC
+aHC
+wYR
 uQo
-sgO
-aHl
-aHl
+wYR
+drE
+drE
 uam
 wAr
 blx
@@ -42726,8 +43095,8 @@ bLa
 bLa
 bLa
 bLa
-xkr
-hYE
+rfW
+sOB
 kLX
 oRK
 fxM
@@ -42844,18 +43213,18 @@ aab
 aab
 aab
 aab
-aHC
-aQf
+aGI
+aJZ
 rLt
 vAv
+aGI
+fLT
+hBP
 aHC
-dzD
-aeM
-aeM
-sgO
+aTU
 nqH
-jCo
-aeM
+aTU
+tGN
 aeM
 uam
 hhw
@@ -42897,9 +43266,9 @@ qnm
 qnm
 qnm
 eSz
-fpH
+kiM
 cqy
-qnm
+kiM
 sTI
 kiM
 kiM
@@ -42986,18 +43355,18 @@ aab
 aab
 aab
 aab
-aHC
-aQf
-jNP
+aGI
+aKM
+aPx
 nDO
+aGI
+fLT
+aQf
 aHC
-dzD
-aeM
-aeM
-htR
-jmD
-vCl
-aeM
+aTU
+nqH
+aTU
+tGN
 aeM
 uam
 kTr
@@ -43014,8 +43383,8 @@ krc
 tkv
 lBN
 xZn
-sOB
-sOB
+cbn
+dpy
 sOB
 poe
 xFu
@@ -43128,19 +43497,19 @@ aab
 aab
 aab
 pEJ
-aHC
-aQf
+aGI
+aOm
 qgB
 qbe
+aWC
+fLT
+aQf
 aHC
-dzD
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aTU
+oSb
+qTw
+tGN
+aeM
 uam
 uam
 uam
@@ -43270,19 +43639,19 @@ aab
 aab
 aab
 aab
-aHC
-aHC
+aGI
+aGI
 drb
-aHC
-aHC
+aGI
+aGI
 xtp
-aaa
-aaa
-aaa
+aQf
+aHC
+kkq
 dzg
-aaa
-aaa
-aaa
+kkq
+tGN
+aeM
 aeM
 aeM
 aeM
@@ -43416,15 +43785,15 @@ aHC
 aQf
 xee
 rex
+cIj
+ggX
+hBP
 aHC
-xtp
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+kkq
+qZe
+wdk
+aeM
+aeM
 aeM
 aeM
 aeM
@@ -43559,14 +43928,14 @@ aQf
 nwo
 bqA
 aHC
-xtp
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gra
+aHC
+aHC
+mdh
+qZi
+nbo
+aeM
+aeM
 aeM
 aeM
 aeM
@@ -43844,13 +44213,13 @@ soU
 soU
 aHC
 dzD
-aeM
-aeM
-aeM
-aeM
-aeM
-aeM
-aeM
+aaa
+aaa
+aaa
+sgO
+aaa
+aaa
+aaa
 aeM
 aeM
 aeM
@@ -43986,13 +44355,13 @@ aaa
 aaa
 aeM
 dzD
-aeM
-aeM
-aeM
-aeM
-aeM
-aeM
-aeM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aeM
 aeM
 aeM

--- a/_maps/map_files/tether/tether-06-station2.dmm
+++ b/_maps/map_files/tether/tether-06-station2.dmm
@@ -8,6 +8,20 @@
 "aac" = (
 /turf/simulated/mineral/vacuum,
 /area/mine/explored/upper_level)
+"aad" = (
+/obj/item/toy/plushie/squid/pink,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/mob/living/simple_mob/animal/sif/fluffy/silky,
+/turf/simulated/floor/outdoors/grass/forest,
+/area/tether/exploration/pathfinder_office)
+"aae" = (
+/obj/structure/table/woodentable,
+/obj/item/cassette_tape/random,
+/obj/machinery/light,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "aah" = (
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
@@ -2696,10 +2710,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
-"alU" = (
-/turf/simulated/floor/carpet/bcarpet,
-/turf/space,
-/area/tether/station/visitorhallway/office)
 "amd" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
@@ -9829,11 +9839,6 @@
 /turf/simulated/floor/bluegrid,
 /area/ai_core_foyer)
 "aHk" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -10880,11 +10885,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
@@ -12384,6 +12384,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
@@ -14173,11 +14178,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "aSF" = (
@@ -14579,11 +14579,12 @@
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
 "aTA" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
+/obj/machinery/light,
+/obj/machinery/power/apc{
+	name = "south bump";
 	pixel_y = -32
 	},
-/obj/machinery/light,
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "aTC" = (
@@ -14595,6 +14596,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
@@ -15242,13 +15248,22 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "aVp" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
@@ -17092,6 +17107,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 5;
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "bgE" = (
@@ -17115,14 +17134,6 @@
 /obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
-"bjw" = (
-/mob/living/simple_mob/animal/sif/fluffy/silky,
-/obj/item/toy/plushie/squid/pink,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/outdoors/grass/forest,
-/area/tether/exploration/pathfinder_office)
 "blx" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -18890,11 +18901,6 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "ggf" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -19916,6 +19922,7 @@
 "iPF" = (
 /obj/structure/table/woodentable,
 /obj/item/folder/yellow,
+/obj/machinery/light,
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "iQJ" = (
@@ -23470,18 +23477,6 @@
 "rOs" = (
 /turf/simulated/wall,
 /area/quartermaster/warehouse)
-"rPb" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
 "rPu" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/tiled,
@@ -40086,7 +40081,7 @@ ayK
 aWk
 eyk
 wzW
-bjw
+aad
 hJP
 fuK
 aJA
@@ -40531,14 +40526,14 @@ vPY
 ahl
 ahl
 ahl
-deM
+aae
 aUG
 aCc
 tes
 kFb
 aUG
 eUF
-sOB
+aJU
 ukj
 asq
 pdH
@@ -40814,7 +40809,7 @@ qsR
 anl
 mPL
 gpa
-alU
+ahl
 sjZ
 aUG
 axQ
@@ -40963,7 +40958,7 @@ aUG
 aUG
 aUG
 aUG
-aXv
+aVp
 sOB
 ukj
 ukj
@@ -41671,7 +41666,7 @@ qaE
 aJB
 sOB
 sOB
-sOB
+tcX
 sOB
 rfW
 xVD
@@ -42095,7 +42090,7 @@ sOB
 sOB
 qaE
 sOB
-rfW
+sOB
 gtq
 aJB
 aJB
@@ -42237,7 +42232,7 @@ sOB
 sOB
 qaE
 sOB
-rfW
+sOB
 wQK
 sOB
 sOB
@@ -42372,7 +42367,7 @@ wdV
 rKN
 rKN
 ggf
-rKN
+aTU
 aHk
 aLv
 aWn
@@ -42520,8 +42515,8 @@ aGq
 aWg
 dfX
 aSZ
-rPb
-aVp
+sOB
+lyF
 sOB
 sOB
 sOB

--- a/_maps/map_files/tether/tether-06-station2.dmm
+++ b/_maps/map_files/tether/tether-06-station2.dmm
@@ -3489,9 +3489,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/storage/tech)
 "anl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -4163,6 +4160,10 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "aoM" = (
@@ -4744,13 +4745,10 @@
 /obj/machinery/door/airlock/glass{
 	id_tag = "customs"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "apZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -7054,7 +7052,6 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/stairs_two)
 "avL" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -7134,9 +7131,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 1
 	},
@@ -7152,6 +7146,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
@@ -7597,6 +7595,9 @@
 	},
 /obj/structure/bed/chair/sofa/brown/corner{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
@@ -9157,9 +9158,6 @@
 "aFw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "aFx" = (
@@ -9497,7 +9495,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -9737,7 +9734,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
 "aGV" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -9888,10 +9884,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/flora/pottedplant/tropical,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
@@ -9961,6 +9953,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "aHq" = (
@@ -10748,13 +10741,10 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "aJu" = (
@@ -10964,8 +10954,10 @@
 /turf/simulated/floor/bluegrid,
 /area/ai_core_foyer)
 "aJY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	name = "Cargo Bay";
+	sortType = "Cargo Bay"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -11286,9 +11278,12 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "aKN" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall,
-/area/security/customs)
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "aKO" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -11365,9 +11360,6 @@
 /turf/simulated/open,
 /area/tether/exploration)
 "aKZ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 25
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -11904,6 +11896,10 @@
 /area/crew_quarters/sleep/spacedorm3)
 "aME" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "aMF" = (
@@ -13975,6 +13971,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "aSe" = (
@@ -13999,9 +13998,7 @@
 /turf/simulated/floor,
 /area/maintenance/station/eng_upper)
 "aSh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "aSi" = (
@@ -14195,6 +14192,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "aSF" = (
@@ -14360,7 +14358,6 @@
 /turf/simulated/wall,
 /area/maintenance/substation/cargo)
 "aSZ" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
@@ -14623,9 +14620,6 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "aTC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -15285,7 +15279,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -15310,11 +15303,10 @@
 /area/engineering/locker_room)
 "aVs" = (
 /obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 4
 	},
-/turf/simulated/wall,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "aVv" = (
 /obj/machinery/button/remote/blast_door{
 	desc = "A remote control-switch for shutters.";
@@ -15557,9 +15549,6 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "aVY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15640,7 +15629,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/excursion/cargo)
 "aWg" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
 	},
@@ -15831,15 +15819,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
-"aWI" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	name = "Cargo Bay";
-	sortType = "Cargo Bay"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
 "aWK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15881,6 +15860,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "aWQ" = (
@@ -16049,6 +16029,9 @@
 /area/tether/station/stairs_two)
 "aXm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -16308,6 +16291,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "aXW" = (
@@ -17284,6 +17268,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"bHG" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "bKy" = (
 /obj/machinery/washing_machine,
 /obj/machinery/light/small{
@@ -17461,9 +17449,6 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "cjr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -18607,11 +18592,12 @@
 /turf/simulated/floor/outdoors/grass/forest,
 /area/quartermaster/qm)
 "fvh" = (
+/obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/area/quartermaster/foyer)
 "fvs" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 8
@@ -18859,6 +18845,17 @@
 /obj/fiftyspawner/glass,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"ggf" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "ggt" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -19961,9 +19958,6 @@
 	},
 /area/hallway/station/port)
 "jpG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/media/jukebox,
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/foyer)
@@ -20616,9 +20610,6 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "lpR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -21166,7 +21157,6 @@
 /area/quartermaster/storage)
 "npD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "npO" = (
@@ -21405,6 +21395,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"nKk" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "nLF" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -21768,9 +21762,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "orW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -21807,9 +21798,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/exploration)
 "owJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -21832,6 +21820,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/security/customs)
+"oyW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/foyer)
 "ozR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22089,8 +22084,10 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
 "pcr" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "pdQ" = (
@@ -22293,6 +22290,7 @@
 /obj/machinery/door/airlock/glass{
 	id_tag = "customs"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "pGy" = (
@@ -22676,9 +22674,6 @@
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/excursion/general)
 "qxU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
@@ -23116,13 +23111,24 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "rDx" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/foyer)
 "rDX" = (
 /obj/effect/overmap/visitable/sector/virgo3b,
 /turf/space,
 /area/space)
+"rFd" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "rGT" = (
 /obj/machinery/photocopier,
 /obj/structure/cable/green{
@@ -23196,17 +23202,13 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "rKN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/tether/station/visitorhallway/office)
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "rLt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -23228,7 +23230,6 @@
 /turf/simulated/wall,
 /area/quartermaster/warehouse)
 "rPb" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -23396,6 +23397,9 @@
 	dir = 5
 	},
 /obj/structure/bed/chair/sofa/brown/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
 "soU" = (
@@ -23556,6 +23560,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
 "sNQ" = (
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/station/starboard)
 "sOy" = (
@@ -24656,6 +24661,9 @@
 /obj/structure/bed/chair/sofa/brown/corner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
 "viC" = (
@@ -24905,9 +24913,6 @@
 /turf/simulated/floor/wood,
 /area/tether/exploration/pathfinder_office)
 "vPY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -25055,7 +25060,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "wgb" = (
@@ -25261,9 +25269,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
@@ -39722,10 +39727,10 @@ wzj
 mIh
 bsY
 aIL
-aTU
-aTU
-aTU
-aTU
+aKN
+aSh
+aSh
+aSh
 sNQ
 aJt
 uON
@@ -39864,7 +39869,7 @@ sZB
 rPF
 krd
 aTU
-aTU
+aVs
 aTU
 aTU
 aTU
@@ -40006,12 +40011,12 @@ rGT
 rPF
 krd
 aTU
-aTU
+aVs
 wrn
 wrn
 wrn
 wrn
-rKN
+tjc
 aRX
 aDw
 deM
@@ -40148,7 +40153,7 @@ aMz
 aTo
 krd
 aTU
-aTU
+aVs
 wrn
 aBN
 qZe
@@ -40290,7 +40295,7 @@ wkK
 aJI
 iIu
 aTU
-aIL
+aXr
 wrn
 fLT
 wtF
@@ -40432,7 +40437,7 @@ cSj
 aJI
 aSF
 wYR
-wYR
+fvh
 wrn
 wtF
 ahl
@@ -40858,7 +40863,7 @@ fMG
 aJI
 arE
 aTU
-aTU
+aVs
 wrn
 wtF
 ahl
@@ -41000,12 +41005,12 @@ jSy
 aJI
 aTx
 aIL
-aTU
+aVs
 wrn
 wtF
 wtF
 wtF
-fvh
+wtF
 mdX
 rhx
 ygD
@@ -41142,12 +41147,12 @@ ayN
 aJI
 azN
 aTD
-aTU
+aVs
 wrn
 wrn
 wrn
 wrn
-kkq
+wEJ
 tjc
 aRk
 wEJ
@@ -41284,7 +41289,7 @@ nhB
 vGY
 aGd
 aQC
-aTU
+aVs
 aTU
 aTU
 aTU
@@ -41568,17 +41573,17 @@ keg
 ddY
 bSu
 aTT
-aWq
+rDx
 qoX
 gxS
-aWq
+oyW
 aHp
 aSh
 pES
-rfW
-sOB
+rFd
+bHG
 apY
-sOB
+bHG
 aSE
 aWP
 aWP
@@ -41710,10 +41715,10 @@ tao
 hjW
 vGB
 aCf
-aWq
+rDx
 gxS
 gxS
-aWq
+rDx
 aTU
 wLl
 aPb
@@ -41727,7 +41732,7 @@ aJB
 aJB
 tnK
 gns
-aFX
+rfW
 aPI
 emB
 nCl
@@ -41869,7 +41874,7 @@ sOB
 sOB
 sOB
 lyF
-aFX
+rfW
 eai
 yeY
 vsL
@@ -41995,10 +42000,10 @@ rXi
 cGk
 sSA
 wdV
-wdV
-wdV
-wdV
-wdV
+rKN
+rKN
+ggf
+rKN
 aHk
 aLv
 aWn
@@ -42135,24 +42140,24 @@ bHs
 izH
 aHl
 aHl
-aVs
+xeW
 aGV
 npD
-aWI
+npD
 pcr
-pcr
+npD
 avL
 aGq
 aWg
-aKN
+uam
 aSZ
 rPb
 aVp
-rDx
-rDx
-rDx
-rDx
-rDx
+sOB
+sOB
+sOB
+sOB
+sOB
 apZ
 sOB
 sOB
@@ -42279,7 +42284,7 @@ eOz
 lno
 aoL
 aXV
-hvA
+nKk
 aJY
 aME
 hvA

--- a/_maps/map_files/tether/tether-06-station2.dmm
+++ b/_maps/map_files/tether/tether-06-station2.dmm
@@ -151,6 +151,14 @@
 "abW" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/shaft)
+"abY" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/structure/railing,
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
 "acg" = (
 /obj/structure/closet,
 /turf/simulated/floor,
@@ -267,9 +275,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/steel_grid,
-/area/tether/exploration/hallway)
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "adF" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central1{
 	dir = 8
@@ -1133,15 +1141,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/gateway)
 "ahl" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "aho" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/shutters{
@@ -2709,25 +2710,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "alU" = (
-/obj/effect/floor_decal/corner/lightgrey{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lightgrey{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 8
-	},
+/turf/simulated/floor/carpet/bcarpet,
 /turf/space,
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/area/tether/station/visitorhallway/office)
 "amd" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
@@ -3504,12 +3489,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/storage/tech)
 "anl" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -3519,8 +3498,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "anm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4178,16 +4160,11 @@
 /turf/simulated/floor/airless,
 /area/quartermaster/belterdock)
 "aoL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "aoM" = (
 /turf/simulated/open,
 /area/engineering/foyer_mezzenine)
@@ -4252,8 +4229,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aoU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -4318,8 +4296,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "api" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4628,8 +4617,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "apN" = (
 /obj/machinery/requests_console{
 	department = "Tech storage";
@@ -4751,10 +4741,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_core_foyer)
 "apY" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/item/barrier_tape_segment/engineering,
+/obj/machinery/door/airlock/glass{
+	id_tag = "customs"
+	},
 /turf/simulated/floor/tiled,
-/area/maintenance/station/cargo)
+/area/tether/station/visitorhallway/lounge)
 "apZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -4763,8 +4754,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aqa" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -4843,8 +4839,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/maintenance/sec{
+	req_one_access = list(38,63)
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/area/tether/station/visitorhallway/lounge)
 "aql" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -5080,12 +5079,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
-"aqG" = (
-/obj/machinery/vending/cola{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
 "aqH" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -6385,18 +6378,11 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/stairs_two)
 "atJ" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "Quartermaster-Office"
-	},
-/obj/structure/table/steel,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/border{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -6566,8 +6552,17 @@
 /area/hallway/station/starboard)
 "aum" = (
 /obj/machinery/light,
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/security/customs)
 "aun" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -6602,7 +6597,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/brown/border{
-	dir = 4
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -7128,14 +7123,7 @@
 /obj/machinery/newscaster{
 	pixel_x = 28
 	},
-/obj/structure/table/standard,
-/obj/item/multitool,
-/obj/fiftyspawner/steel,
-/obj/fiftyspawner/glass,
 /obj/effect/floor_decal/borderfloor{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/brown/border{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
@@ -7160,8 +7148,13 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "awa" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
@@ -7534,12 +7527,15 @@
 /turf/simulated/wall,
 /area/chapel/chapel_morgue)
 "axQ" = (
-/obj/random/maintenance/medical,
-/obj/structure/table/rack{
-	dir = 1
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm3)
 "axR" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
@@ -7671,8 +7667,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "ayr" = (
 /obj/machinery/light{
 	dir = 4
@@ -7705,13 +7701,6 @@
 /area/tether/station/stairs_two)
 "ays" = (
 /obj/structure/railing,
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "ayu" = (
@@ -7858,9 +7847,6 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/alarm{
 	dir = 8;
@@ -7874,6 +7860,9 @@
 	departmentType = 2;
 	pixel_y = 30
 	},
+/obj/machinery/computer/shuttle_control/tether_backup{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "ayS" = (
@@ -7884,13 +7873,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock)
-"ayT" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
 "ayU" = (
 /obj/machinery/button/remote/driver{
 	id = "chapelgun";
@@ -8388,6 +8370,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"aBz" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/tether/station/dock_one)
 "aBC" = (
 /obj/machinery/light{
 	dir = 1
@@ -8408,12 +8408,9 @@
 /turf/simulated/wall,
 /area/mine/explored/upper_level)
 "aBN" = (
-/obj/machinery/camera/network/cargo{
-	dir = 1;
-	name = "security camera"
-	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/office)
 "aBO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -8438,10 +8435,10 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
-/obj/structure/girder,
-/obj/item/barrier_tape_segment/engineering,
+/obj/structure/window/reinforced/full,
+/obj/structure/grille,
 /turf/simulated/floor/tiled,
-/area/maintenance/station/cargo)
+/area/tether/station/visitorhallway/lounge)
 "aBR" = (
 /obj/structure/closet/coffin,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -8450,12 +8447,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/burial)
 "aCc" = (
-/obj/random/maintenance/engineering,
-/obj/structure/table/rack{
-	dir = 1
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm3)
 "aCd" = (
 /obj/machinery/mineral/output,
 /obj/machinery/conveyor{
@@ -8683,14 +8680,6 @@
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
 "aDw" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -8701,8 +8690,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/vending/fitness{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/area/tether/station/visitorhallway/office)
 "aDy" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -8717,8 +8709,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aDA" = (
 /obj/structure/railing{
 	dir = 4
@@ -8743,11 +8736,6 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/dark,
 /area/gateway/prep_room)
-"aDJ" = (
-/obj/machinery/vending/loadout/accessory,
-/obj/item/barrier_tape_segment/engineering,
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
 "aDK" = (
 /turf/simulated/floor/reinforced,
 /area/tether/exploration)
@@ -8973,8 +8961,19 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aED" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -9334,8 +9333,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aFY" = (
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
@@ -9503,17 +9502,13 @@
 	dir = 9
 	},
 /turf/simulated/wall,
-/area/quartermaster/foyer)
+/area/security/customs)
 "aGr" = (
 /obj/machinery/computer/shuttle_control/belter{
 	dir = 1
 	},
 /turf/simulated/shuttle/floor/yellow/airless,
 /area/shuttle/belter)
-"aGs" = (
-/obj/machinery/vending/assist,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
 "aGt" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9522,8 +9517,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aGu" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -9578,11 +9573,6 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/belterdock)
 "aGA" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -9593,7 +9583,7 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_grid,
-/area/quartermaster/foyer)
+/area/tether/station/visitorhallway/lounge)
 "aGB" = (
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
@@ -9630,16 +9620,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/chapel/chapel_morgue)
 "aGI" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Cargo Substation";
-	req_one_access = list(11,24,50)
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/maintenance/substation/cargo)
 "aGJ" = (
 /obj/machinery/power/apc{
@@ -9669,12 +9655,16 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/belterdock)
 "aGL" = (
-/obj/random/maintenance/clean,
-/obj/structure/table/rack{
-	dir = 1
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm3)
 "aGN" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -9722,11 +9712,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/photocopier,
 /obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/border{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -9755,9 +9741,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/window/reinforced/full,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "aGW" = (
@@ -9784,8 +9767,9 @@
 /area/shuttle/excursion/general)
 "aGZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/wall,
-/area/tether/exploration/hallway)
+/obj/machinery/door/airlock/glass_command,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/office)
 "aHa" = (
 /obj/structure/bed/chair/office/dark,
 /obj/machinery/light{
@@ -9823,12 +9807,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/porta_turret_construct,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/quartermaster/foyer)
+/area/tether/station/visitorhallway/lounge)
 "aHf" = (
 /obj/structure/table/woodentable,
 /obj/item/flame/candle/everburn,
@@ -10374,10 +10357,6 @@
 "aIq" = (
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"aIt" = (
-/obj/machinery/vending/loadout/overwear,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
 "aIu" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/blue{
@@ -10426,8 +10405,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "aIz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10628,12 +10608,6 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/refinery)
-"aIY" = (
-/obj/machinery/camera/network/cargo{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
 "aIZ" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -10840,9 +10814,11 @@
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
 "aJB" = (
-/obj/machinery/vending/loadout/loadout_misc,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/table/rack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aJE" = (
 /obj/machinery/light{
 	dir = 4
@@ -10897,8 +10873,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aJM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -10924,8 +10900,10 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aJQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -10942,8 +10920,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aJT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -10957,22 +10940,18 @@
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
 "aJU" = (
-/obj/structure/table/rack{
-	dir = 1
+/obj/structure/flora/pottedplant{
+	icon_state = "plant-21"
 	},
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aJV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/wall/r_wall,
 /area/quartermaster/belterdock)
 "aJW" = (
 /obj/structure/railing,
-/obj/structure/closet/crate,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/clean,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "aJX" = (
@@ -10991,29 +10970,14 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "aJZ" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/flora/pottedplant{
+	icon_state = "plant-21"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
-"aKb" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/northright{
-	dir = 8;
-	name = "Cargo desk";
-	req_access = list(50)
-	},
-/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/tether/station/visitorhallway/lounge)
 "aKc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -11324,7 +11288,7 @@
 "aKN" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
-/area/quartermaster/foyer)
+/area/security/customs)
 "aKO" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -11408,16 +11372,20 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/structure/table/standard,
-/obj/item/retail_scanner/civilian{
-	dir = 1
-	},
-/obj/machinery/recharger,
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown/border{
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "dock_cshutt";
+	name = "interior access button";
+	pixel_x = 28;
+	pixel_y = 26;
+	req_one_access = list(13)
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -11554,11 +11522,6 @@
 	},
 /obj/structure/cable/green{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
@@ -11578,7 +11541,20 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/tether/station/visitorhallway/lounge)
+"aLw" = (
+/obj/structure/table/bench/standard,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
 "aLy" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet/crate,
@@ -11587,15 +11563,9 @@
 /area/maintenance/station/eng_upper)
 "aLz" = (
 /obj/structure/cable{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
@@ -11926,17 +11896,14 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/belterdock/refinery)
 "aMD" = (
-/obj/random/maintenance/research,
-/obj/structure/table/rack{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/closet/secure_closet/personal,
+/obj/item/clothing/shoes/black,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm3)
 "aME" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "aMF" = (
@@ -12065,14 +12032,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/excursion/cargo)
 "aMX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aMY" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/cyan{
@@ -12146,9 +12111,9 @@
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
 "aNi" = (
-/obj/machinery/door/window/northright,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aNj" = (
 /turf/simulated/wall/r_wall,
 /area/quartermaster/belterdock/surface_mining_outpost_shuttle_hangar)
@@ -12300,10 +12265,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/surface_mining_outpost_shuttle_hangar)
-"aNF" = (
-/obj/machinery/light/small,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
 "aNG" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -12472,8 +12433,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aOe" = (
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/shuttle/floor,
@@ -12496,13 +12457,17 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
 "aOg" = (
-/obj/structure/closet,
-/obj/random/junk,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/clean,
-/obj/random/tech_supply,
+/obj/machinery/door/airlock/engineering{
+	name = "Cargo Substation";
+	req_one_access = list(11,24,50)
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/area/maintenance/substation/cargo)
 "aOi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/firealarm{
@@ -12533,16 +12498,20 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/cargo)
 "aOm" = (
-/obj/random/maintenance/cargo,
-/obj/structure/table/rack{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm3)
 "aOn" = (
-/obj/machinery/door/airlock/maintenance/common,
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/tiled,
+/area/security/customs)
 "aOp" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled,
@@ -12612,14 +12581,14 @@
 "aOB" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
@@ -12838,11 +12807,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/cargo)
 "aPb" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -12857,7 +12821,7 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/tether/station/visitorhallway/lounge)
 "aPc" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -13016,7 +12980,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall,
-/area/quartermaster/foyer)
+/area/security/customs)
 "aPy" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -13123,19 +13087,15 @@
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/general)
 "aPI" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aPN" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/lightgrey/bordercorner,
@@ -13711,13 +13671,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/surface_mining_outpost_shuttle_hangar)
-"aRe" = (
-/obj/structure/railing,
-/obj/structure/closet/crate,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
 "aRf" = (
 /obj/structure/closet/crate,
 /obj/random/junk,
@@ -13745,17 +13698,16 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
 	},
-/obj/machinery/door/airlock/glass_science{
-	name = "Exploration";
-	req_one_access = list(19,43,67)
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/glass{
+	name = "Visitor Office"
+	},
 /turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/area/tether/station/visitorhallway/office)
 "aRn" = (
 /obj/machinery/door/blast/regular,
 /turf/simulated/wall,
@@ -13889,14 +13841,14 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aRL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aRN" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8
@@ -13963,7 +13915,7 @@
 /area/tether/exploration)
 "aRX" = (
 /turf/simulated/open,
-/area/tether/exploration/hallway)
+/area/tether/station/visitorhallway/office)
 "aRY" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -14038,8 +13990,9 @@
 /area/quartermaster/belterdock/surface_mining_outpost_shuttle_hangar)
 "aSf" = (
 /obj/structure/table/reinforced,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aSg" = (
 /obj/structure/table/steel,
 /obj/random/maintenance/clean,
@@ -14063,8 +14016,11 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/table/rack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aSk" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14148,11 +14104,7 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/surface_mining_outpost_shuttle_hangar)
 "aSu" = (
-/obj/machinery/autolathe,
 /obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/border{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -14243,8 +14195,8 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 6
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aSF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14415,9 +14367,8 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
-/obj/item/barrier_tape_segment/engineering,
 /turf/simulated/wall,
-/area/maintenance/station/cargo)
+/area/security/customs)
 "aTa" = (
 /obj/structure/flora/pottedplant/flower,
 /turf/simulated/floor/wood,
@@ -14669,11 +14620,8 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
-/obj/structure/table/rack{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aTC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14682,8 +14630,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aTD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -14728,6 +14681,14 @@
 "aTI" = (
 /turf/simulated/floor/wood,
 /area/tether/station/burial)
+"aTJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/int_door,
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
 "aTL" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -14932,12 +14893,6 @@
 	},
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/mining_outpost/shuttle)
-"aUo" = (
-/obj/machinery/camera/network/cargo{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
 "aUp" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -14971,16 +14926,17 @@
 "aUv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/table/bench/standard,
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/obj/structure/table/woodentable,
+/obj/item/paper_bin,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "aUx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aUy" = (
 /obj/machinery/door/airlock{
 	name = "Coffin Storage";
@@ -15025,9 +14981,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "aUG" = (
-/obj/machinery/door/airlock/maintenance/common,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/wall,
+/area/crew_quarters/sleep/spacedorm3)
 "aUH" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -15331,8 +15286,13 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aVq" = (
 /obj/machinery/light{
 	dir = 8
@@ -15428,23 +15388,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/public_meeting_room)
-"aVB" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/cargo{
-	req_access = list(50);
-	req_one_access = list(48)
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/barrier_tape_segment/engineering,
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
 "aVC" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -15474,8 +15417,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 8
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aVH" = (
 /obj/structure/table/steel,
 /obj/item/radio{
@@ -15556,11 +15500,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/excursion/general)
-"aVN" = (
-/obj/structure/girder,
-/obj/item/barrier_tape_segment/engineering,
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
 "aVO" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -15592,11 +15531,22 @@
 /turf/simulated/floor/bluegrid,
 /area/ai_core_foyer)
 "aVV" = (
-/obj/structure/table/rack{
-	dir = 1
+/obj/structure/bed/double/padded,
+/obj/item/bedsheet/browndouble,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm4)
 "aVW" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -15607,10 +15557,6 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "aVY" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -15620,8 +15566,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/obj/structure/table/woodentable,
+/obj/item/folder/red,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "aWa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -15704,7 +15652,7 @@
 	req_one_access = list(38,63)
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/security/customs)
 "aWi" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -15725,10 +15673,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood,
 /area/tether/exploration/pathfinder_office)
-"aWm" = (
-/obj/machinery/vending/loadout/gadget,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
 "aWn" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15749,7 +15693,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/tether/station/visitorhallway/lounge)
 "aWo" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -15894,9 +15838,6 @@
 	sortType = "Cargo Bay"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/window/reinforced/full,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "aWK" = (
@@ -15940,8 +15881,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aWQ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -16110,9 +16051,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = -24
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "aXq" = (
@@ -16127,17 +16065,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/foyer)
-"aXs" = (
-/obj/structure/railing,
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
 "aXt" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/hatch{
@@ -16167,8 +16094,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "aXw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -16399,17 +16332,12 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/exploration)
 "aXY" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Cargo Substation";
-	req_one_access = list(11,24,50)
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/maintenance/substation/cargo)
+/area/tether/station/visitorhallway/lounge)
 "aXZ" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
@@ -16478,10 +16406,13 @@
 /turf/simulated/floor/airless,
 /area/maintenance/station/eng_upper)
 "aYi" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "aYj" = (
@@ -16670,10 +16601,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/eng_upper)
-"aYF" = (
-/obj/item/barrier_tape_segment/engineering,
-/turf/simulated/wall,
-/area/tether/exploration/hallway)
 "aYH" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -17183,22 +17110,8 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
-"aZW" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/table/rack{
-	dir = 1
-	},
-/obj/random/maintenance/clean,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
 "aZX" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -17235,6 +17148,20 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
+"bhU" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "dock_d2l";
+	name = "exterior access button";
+	pixel_x = 28;
+	pixel_y = -6;
+	req_access = list(13)
+	},
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
 "bjw" = (
 /mob/living/simple_mob/animal/sif/fluffy/silky,
 /obj/item/toy/plushie/squid/pink,
@@ -17243,6 +17170,18 @@
 	},
 /turf/simulated/floor/outdoors/grass/forest,
 /area/tether/exploration/pathfinder_office)
+"blx" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/customs)
+"bmB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "bpS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17262,6 +17201,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
+"brL" = (
+/obj/structure/flora/tree/jungle_small,
+/turf/simulated/floor/outdoors/grass/heavy/interior,
+/area/tether/station/visitorhallway/lounge)
 "bsY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -17298,6 +17241,12 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/wood,
 /area/tether/exploration/pathfinder_office)
+"bwK" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "bxa" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 10
@@ -17309,6 +17258,15 @@
 /obj/item/flame/candle/candelabra/everburn,
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"byT" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether/station/dock_one)
 "bHs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17326,6 +17284,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"bKy" = (
+/obj/machinery/washing_machine,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
+"bLa" = (
+/turf/simulated/wall,
+/area/tether/station/visitorhallway/laundry)
 "bLD" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -17384,6 +17352,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"bPS" = (
+/obj/machinery/door/firedoor/glass/hidden/steel,
+/obj/machinery/camera/network/tether{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "bQB" = (
 /obj/structure/grille,
 /obj/structure/sign/securearea,
@@ -17432,6 +17407,16 @@
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/general)
+"bSQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "bUg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -17439,14 +17424,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
-"bXZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/hallway/station/starboard)
 "cdk" = (
 /obj/structure/flora/pottedplant/orientaltree,
 /obj/effect/floor_decal/corner/lightgrey{
@@ -17471,6 +17455,35 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"cjl" = (
+/obj/structure/table/woodentable,
+/obj/item/folder/yellow,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
+"cjr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/railing,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/office)
+"cqy" = (
+/obj/effect/floor_decal/sign/dock/two,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "ctY" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -17581,6 +17594,9 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
 	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "cIj" = (
@@ -17600,10 +17616,27 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
-"cPg" = (
-/obj/structure/table/reinforced,
+"cKS" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/tether/station/visitorhallway/laundry)
+"cMw" = (
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
+"cPg" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/turf/simulated/floor/tiled,
+/area/security/customs)
 "cRn" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 10
@@ -17625,6 +17658,25 @@
 /obj/structure/plasticflaps,
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
+"cSZ" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "dock_d2b";
+	name = "interior access button";
+	pixel_x = -28;
+	pixel_y = 26;
+	req_one_access = list(13)
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/floor_decal/sign/b,
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "cUf" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
@@ -17659,11 +17711,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/exploration/pilot_office)
-"cUz" = (
-/obj/structure/girder,
-/obj/item/barrier_tape_segment/engineering,
-/turf/simulated/floor/tiled,
-/area/maintenance/station/cargo)
 "cVb" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -17677,12 +17724,6 @@
 "cZR" = (
 /turf/simulated/wall/rshull,
 /area/shuttle/excursion/cargo)
-"dbp" = (
-/obj/machinery/vending/snack{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
 "dbR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -17712,7 +17753,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/area/tether/station/visitorhallway/office)
 "diC" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -17727,8 +17768,11 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
@@ -17752,6 +17796,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
+"drE" = (
+/obj/structure/bed/double/padded,
+/obj/item/bedsheet/iandouble,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm3)
 "dvk" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
@@ -17809,6 +17867,16 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/large_escape_pod1)
+"dzg" = (
+/obj/effect/shuttle_landmark{
+	base_area = /area/space;
+	base_turf = /turf/space;
+	docking_controller = "dock_cshutt";
+	landmark_tag = "tether_customs_shuttle";
+	name = "Tether Customs To Surface Dock"
+	},
+/turf/space,
+/area/space)
 "dzD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17926,6 +17994,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/cargo)
+"dSM" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "dUy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17959,8 +18033,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "ebl" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -18094,8 +18169,8 @@
 "emB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "emT" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
@@ -18176,6 +18251,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
+"esF" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "dock_d2r";
+	name = "exterior access button";
+	pixel_x = -5;
+	pixel_y = -26;
+	req_one_access = list(13)
+	},
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
+"ewX" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "eyk" = (
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18297,6 +18391,15 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"ePn" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/tether/station/dock_one)
 "ePp" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -18313,6 +18416,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"eSz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "eSL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -18322,12 +18435,38 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"eTM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/landmark{
+	name = "morphspawn"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
+"eUD" = (
+/obj/machinery/door/airlock/glass{
+	name = "Visitor Laundry"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
 "eUF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "eUH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18355,6 +18494,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"fdl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "fdm" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18368,8 +18522,16 @@
 	name = "Trader Security";
 	req_one_access = list(44,38,63)
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/maintenance/station/cargo)
+/area/security/customs)
+"ffh" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled,
+/area/security/customs)
 "fgy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18400,6 +18562,18 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
+"fpH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
+"fpV" = (
+/obj/machinery/camera/network/tether{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "fsq" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate,
@@ -18408,6 +18582,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
+"fsC" = (
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/int_door,
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
+"ftC" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/tether/station/dock_one)
 "ftT" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -18426,7 +18611,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/area/tether/station/visitorhallway/office)
 "fvs" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 8
@@ -18436,6 +18621,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/exploration)
+"fxM" = (
+/obj/effect/floor_decal/spline/fancy{
+	dir = 6
+	},
+/obj/structure/flora/ausbushes/lavendergrass{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/turf/simulated/floor/outdoors/grass/heavy/interior,
+/area/tether/station/visitorhallway/lounge)
 "fyD" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -18487,6 +18682,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"fHm" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
 "fIo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -18503,10 +18707,10 @@
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/mining_outpost/shuttle)
 "fLT" = (
-/obj/structure/table/reinforced,
-/obj/structure/table/reinforced,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/table/woodentable,
+/obj/item/storage/box/glasses/meta,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/office)
 "fMG" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -18594,6 +18798,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
+"fXp" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "fYr" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 1
@@ -18641,21 +18850,48 @@
 /turf/simulated/floor,
 /area/hallway/station/port)
 "gew" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/newscaster{
+	pixel_x = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance/common,
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/obj/structure/table/standard,
+/obj/item/multitool,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/glass,
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "ggt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/turf/simulated/wall,
-/area/maintenance/station/cargo)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/vending/giftvendor,
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
+"ggX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm4)
 "ghE" = (
 /obj/structure/bed/chair/shuttle,
 /obj/effect/floor_decal/borderfloorblack,
@@ -18680,20 +18916,36 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/outdoors/grass/forest,
 /area/quartermaster/qm)
-"gpa" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
+"glE" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether/station/dock_one)
+"gns" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
+"gpa" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/area/tether/station/visitorhallway/office)
 "gpL" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -18723,9 +18975,17 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/exploration)
 "gra" = (
-/obj/machinery/vending/coffee,
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
+"gtq" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "gxS" = (
 /obj/structure/table/gamblingtable,
 /turf/simulated/floor/wood,
@@ -18762,11 +19022,18 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/exploration)
-"gEB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+"gEi" = (
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
 	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
+"gEB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -18829,6 +19096,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
+"gQZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "gSf" = (
 /obj/machinery/door/blast/shutters{
 	id = "qm_warehouse";
@@ -18893,6 +19164,27 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"gZe" = (
+/obj/effect/shuttle_landmark{
+	base_area = /area/space;
+	base_turf = /turf/space;
+	docking_controller = "dock_d2a";
+	landmark_tag = "tether_dockarm_d2a";
+	name = "Tether Dock D2A"
+	},
+/turf/space,
+/area/space)
+"hav" = (
+/obj/structure/table/woodentable,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm4)
 "hcQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -18945,6 +19237,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
+"hhw" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/security/customs)
 "hjW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northright{
@@ -18967,17 +19273,77 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"hmm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "hmV" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
-"htR" = (
-/obj/structure/disposalpipe/segment{
+"hsx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/lattice,
-/turf/space,
-/area/mine/explored/upper_level)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
+"htA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
+"htD" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1380;
+	id_tag = "dock_d2b_pump"
+	},
+/obj/machinery/light/small,
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "dock_d2b_sensor";
+	pixel_y = -25
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1380;
+	id_tag = "dock_d2b";
+	pixel_y = 28
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
+"htR" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/office)
 "hvk" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -19022,6 +19388,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"hBP" = (
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm4)
 "hFT" = (
 /obj/structure/table/standard,
 /obj/item/hand_labeler,
@@ -19064,10 +19433,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/outdoors/grass/forest,
 /area/quartermaster/qm)
-"hNw" = (
-/obj/machinery/vending/loadout/clothing,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
 "hOl" = (
 /obj/machinery/light,
 /obj/machinery/power/smes/buildable/point_of_interest,
@@ -19213,6 +19578,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/excursion/general)
+"hYE" = (
+/obj/machinery/vending/loadout/accessory,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "iaU" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -19246,6 +19615,12 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
+"ikC" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "ikI" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -19347,7 +19722,7 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/tether/station/visitorhallway/lounge)
 "iAO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -19370,6 +19745,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
+"iDc" = (
+/obj/structure/closet/wardrobe/black,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
+"iGu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
 "iIu" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -19388,6 +19775,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
+"iIF" = (
+/obj/effect/shuttle_landmark{
+	base_area = /area/space;
+	base_turf = /turf/space;
+	landmark_tag = "tether_space_SW";
+	name = "Near Tether (SW)"
+	},
+/turf/space,
+/area/space)
 "iIJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -19403,6 +19799,42 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
+"iLM" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
+"iMs" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
+"iMR" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/security/customs)
 "iOs" = (
 /obj/effect/floor_decal/industrial/outline,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -19422,10 +19854,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
-"iTr" = (
-/obj/structure/table/bench/standard,
-/turf/simulated/floor/tiled/steel_grid,
-/area/tether/exploration/hallway)
 "iVv" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/borderfloor{
@@ -19442,6 +19870,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
+"jaq" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/tether/station/dock_one)
 "jaL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -19485,6 +19920,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"jmD" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "dock_cshutt";
+	name = "exterior access button";
+	pixel_x = -5;
+	pixel_y = -26;
+	req_one_access = list(13)
+	},
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/office)
 "jmU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -19500,9 +19949,7 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/chapel/main)
 "jog" = (
-/obj/effect/landmark/start{
-	name = "Cargo Technician"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "jpv" = (
@@ -19558,6 +20005,12 @@
 /obj/structure/noticeboard,
 /turf/simulated/wall,
 /area/quartermaster/office)
+"juU" = (
+/obj/effect/floor_decal/spline/fancy{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/grass/heavy/interior,
+/area/tether/station/visitorhallway/lounge)
 "jwm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor,
@@ -19565,6 +20018,12 @@
 "jwA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
+"jxq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
@@ -19577,6 +20036,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/gear)
+"jzo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "jzB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
@@ -19609,14 +20079,12 @@
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
 "jCo" = (
-/obj/structure/closet/crate,
-/obj/random/drinkbottle,
-/obj/random/contraband,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/effect/floor_decal/rust,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/area/quartermaster/office)
 "jGz" = (
 /obj/structure/flora/pottedplant/stoutbush,
 /obj/machinery/light{
@@ -19652,6 +20120,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"jLE" = (
+/obj/effect/shuttle_landmark{
+	base_area = /area/space;
+	base_turf = /turf/space;
+	docking_controller = "dock_d2l";
+	landmark_tag = "tether_dockarm_d2l";
+	name = "Tether Dock D2L"
+	},
+/turf/space,
+/area/space)
 "jMR" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 5
@@ -19694,6 +20172,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
+"jWe" = (
+/turf/simulated/wall,
+/area/tether/station/dock_one)
 "jWp" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -19716,6 +20197,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"jXX" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
+"jYm" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether/station/dock_one)
 "jZa" = (
 /turf/simulated/wall/r_wall,
 /area/quartermaster/qm)
@@ -19765,6 +20261,10 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/exploration/pilot_office)
+"kiM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "kkh" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -19779,7 +20279,7 @@
 	dir = 4
 	},
 /turf/simulated/wall,
-/area/tether/exploration/hallway)
+/area/tether/station/visitorhallway/office)
 "kkI" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -19866,6 +20366,10 @@
 	dir = 4
 	},
 /area/tether/exploration)
+"krc" = (
+/obj/machinery/vending/loadout/costume,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "krd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19888,6 +20392,13 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"krB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
 "ksi" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -19897,14 +20408,14 @@
 "ktB" = (
 /turf/space,
 /area/mine/explored/upper_level)
-"kuX" = (
-/obj/machinery/light/small{
-	dir = 1
+"kus" = (
+/obj/machinery/door/airlock/glass_external,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/obj/structure/railing,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/obj/effect/map_helper/airlock/door/int_door,
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
 "kvM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -19915,14 +20426,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/exploration)
+"kwu" = (
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
 "kwy" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/obj/item/radio/intercom{
+	pixel_y = -24
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "kCk" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -19987,6 +20504,33 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/exploration)
+"kLX" = (
+/obj/effect/floor_decal/spline/fancy{
+	dir = 5
+	},
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = -5
+	},
+/turf/simulated/floor/outdoors/grass/heavy/interior,
+/area/tether/station/visitorhallway/lounge)
+"kTr" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/security/customs)
 "kUx" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -20017,6 +20561,23 @@
 /obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/wood,
 /area/tether/station/burial)
+"lku" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "dock_d2l";
+	name = "interior access button";
+	pixel_x = -28;
+	pixel_y = -26;
+	req_access = list(13)
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "lla" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -20050,15 +20611,11 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/brown/border{
-	dir = 8
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "lpR" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -20068,8 +20625,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "lrN" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -20094,6 +20652,37 @@
 /obj/structure/closet/crate/internals,
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
+"lyF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
+"lAU" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
+"lBN" = (
+/obj/machinery/vending/loadout/loadout_misc,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
+"lOd" = (
+/obj/effect/floor_decal/spline/fancy{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/outdoors/grass/heavy/interior,
+/area/tether/station/visitorhallway/lounge)
 "lOw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -20141,6 +20730,12 @@
 /obj/effect/floor_decal/corner/brown/border,
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/gear)
+"lTw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
 "lUJ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -20155,12 +20750,39 @@
 	dir = 5
 	},
 /obj/machinery/computer/timeclock/premade/west,
+/obj/machinery/vending/cola{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "lYb" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/outdoors/grass/heavy/interior,
 /area/tether/exploration/pilot_office)
+"lYZ" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "dock_d2b";
+	name = "exterior access button";
+	pixel_x = -5;
+	pixel_y = -26;
+	req_one_access = list(13)
+	},
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
+"lZf" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether/station/dock_one)
 "maf" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -20185,16 +20807,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
 "mcY" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/office)
 "mdh" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -20215,7 +20830,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/area/tether/station/visitorhallway/office)
 "met" = (
 /obj/structure/bed/chair,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -20246,6 +20861,21 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
+"miw" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/item/clothing/shoes/black,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm4)
+"mjk" = (
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm4)
 "mlc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
@@ -20268,9 +20898,55 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
+"mvF" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock{
+	id_tag = "spacedorm3";
+	name = "Room 3"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/sleep/spacedorm3)
 "mwj" = (
 /turf/simulated/floor/carpet/oracarpet,
 /area/chapel/main)
+"mwI" = (
+/obj/machinery/camera/network/civilian,
+/obj/machinery/gear_painter,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
+"mxk" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1;
+	frequency = 1380;
+	id_tag = "dock_d2l_pump"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "dock_d2l_sensor";
+	pixel_x = 30;
+	pixel_y = 8
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
 "mxK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -20302,9 +20978,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/brown/border{
 	dir = 10
 	},
 /obj/item/radio/intercom{
@@ -20356,10 +21029,21 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/tiled/techfloor,
 /area/hallway/station/port)
-"mPL" = (
-/obj/structure/table/bench/standard,
+"mPs" = (
+/obj/structure/closet/wardrobe/xenos,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/area/tether/station/visitorhallway/laundry)
+"mPL" = (
+/obj/structure/table/woodentable,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "mPN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -20368,12 +21052,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "mQF" = (
-/obj/structure/table/rack{
-	dir = 1
-	},
-/obj/random/maintenance/clean,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/wall,
+/area/crew_quarters/sleep/spacedorm4)
 "mTs" = (
 /obj/machinery/light{
 	dir = 8
@@ -20414,12 +21094,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
-"ndH" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
 "neJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -20453,9 +21127,6 @@
 /area/quartermaster/delivery)
 "niu" = (
 /obj/effect/floor_decal/borderfloor/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -20496,9 +21167,6 @@
 "npD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/structure/window/reinforced/full,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "npO" = (
@@ -20509,30 +21177,65 @@
 /obj/item/storage/bible,
 /turf/simulated/floor/carpet/bcarpet,
 /area/chapel/main)
+"nqk" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
+"nqH" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1380;
+	id_tag = "dock_d1a3_pump"
+	},
+/obj/machinery/light/small,
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "dock_cshutt_sensor";
+	pixel_y = -25
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1380;
+	id_tag = "dock_cshutt";
+	pixel_y = 28
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/office)
+"nsJ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "nvK" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/window/northright{
-	name = "Cargo desk";
-	req_access = list(50)
-	},
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Trader Security";
-	req_one_access = list(44,38,63)
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/glass_security{
+	name = "Trading Security Station";
+	req_one_access = list(38,63)
+	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/security/customs)
 "nvX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -20565,22 +21268,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
-"nzs" = (
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
 "nzz" = (
-/obj/structure/table/reinforced,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/security/customs)
 "nAu" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 1
@@ -20602,20 +21306,13 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "nBU" = (
-/obj/effect/shuttle_landmark{
-	base_area = /area/space;
-	base_turf = /turf/space;
-	landmark_tag = "tether_space_SE";
-	name = "Near Tether (SE)"
+/obj/effect/floor_decal/spline/fancy{
+	dir = 9
 	},
-/turf/space,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/outdoors/grass/heavy/interior,
+/area/tether/station/visitorhallway/lounge)
 "nCl" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -20624,8 +21321,8 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/wall,
+/area/tether/station/visitorhallway/lounge)
 "nCp" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -20708,6 +21405,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"nLF" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "dock_d2a";
+	name = "interior access button";
+	pixel_x = -28;
+	pixel_y = 26;
+	req_one_access = list(13)
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/floor_decal/sign/a,
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "nMM" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -20717,6 +21433,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/burial)
+"nNK" = (
+/obj/effect/floor_decal/spline/fancy,
+/obj/structure/flora/ausbushes/lavendergrass{
+	pixel_y = 10
+	},
+/turf/simulated/floor/outdoors/grass/heavy/interior,
+/area/tether/station/visitorhallway/lounge)
 "nQA" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -20741,8 +21464,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "nSo" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -20825,16 +21559,15 @@
 	},
 /turf/simulated/wall/rshull,
 /area/shuttle/excursion/cargo)
-"nWq" = (
-/obj/machinery/vending/fitness,
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
 "nWw" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "nYg" = (
 /obj/random/junk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -20902,6 +21635,32 @@
 /obj/random/trash_pile,
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
+"ohM" = (
+/obj/effect/floor_decal/spline/fancy{
+	dir = 10
+	},
+/obj/structure/flora/ausbushes/lavendergrass{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/outdoors/grass/heavy/interior,
+/area/tether/station/visitorhallway/lounge)
+"ohX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/sec{
+	req_one_access = list(38,63)
+	},
+/turf/simulated/floor/plating,
+/area/tether/station/visitorhallway/lounge)
 "ois" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -20940,6 +21699,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
+"ojV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "okS" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -20958,6 +21727,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"okY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "olK" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -20999,7 +21778,7 @@
 	dir = 6
 	},
 /turf/simulated/wall,
-/area/hallway/station/starboard)
+/area/tether/station/visitorhallway/office)
 "osM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21039,13 +21818,20 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "oxY" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/security/customs)
 "ozR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -21056,9 +21842,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "oBM" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -21066,6 +21852,7 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
+/obj/machinery/autolathe,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "oDv" = (
@@ -21091,9 +21878,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 5
 	},
-/obj/machinery/camera/network/cargo{
-	dir = 4
-	},
+/obj/machinery/vending/fitness,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "oIh" = (
@@ -21112,10 +21897,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
-"oLa" = (
-/obj/item/barrier_tape_segment/engineering,
-/turf/simulated/wall,
-/area/maintenance/station/cargo)
+"oII" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether/station/dock_one)
 "oLo" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 1
@@ -21125,6 +21915,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/exploration)
+"oLS" = (
+/obj/effect/shuttle_landmark{
+	base_area = /area/space;
+	base_turf = /turf/space;
+	docking_controller = "dock_d2b";
+	landmark_tag = "tether_dockarm_d2b";
+	name = "Tether Dock D2B"
+	},
+/turf/space,
+/area/space)
+"oMK" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether/station/dock_one)
 "oNw" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate{
@@ -21162,15 +21968,32 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
+"oRK" = (
+/obj/effect/floor_decal/spline/fancy{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass/heavy/interior,
+/area/tether/station/visitorhallway/lounge)
+"oSb" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "oSf" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -21268,11 +22091,6 @@
 "pcr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/glass_mining{
-	name = "Cargo Bay";
-	req_access = list(31);
-	req_one_access = list()
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "pdQ" = (
@@ -21331,6 +22149,9 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
+/obj/machinery/camera/network/cargo{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "pfV" = (
@@ -21381,8 +22202,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "puc" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 5
@@ -21392,6 +22213,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/exploration)
+"pwf" = (
+/obj/machinery/vending/assist,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "pxf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -21426,12 +22251,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
-"pzJ" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
 "pAx" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -21448,6 +22267,12 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/exploration)
+"pDq" = (
+/obj/machinery/vending/snack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "pEJ" = (
 /obj/effect/shuttle_landmark{
 	base_area = /area/space;
@@ -21465,9 +22290,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/glass,
+/obj/machinery/door/airlock/glass{
+	id_tag = "customs"
+	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/tether/station/visitorhallway/lounge)
 "pGy" = (
 /obj/machinery/mineral/equipment_vendor/survey,
 /obj/effect/floor_decal/borderfloorblack,
@@ -21534,6 +22361,23 @@
 /mob/living/simple_mob/animal/passive/snake/noodle,
 /turf/simulated/floor/outdoors/grass/heavy/interior,
 /area/tether/exploration/pilot_office)
+"pQw" = (
+/obj/machinery/button/remote/airlock{
+	id = "spacedorm3";
+	name = "Room 3 Lock";
+	pixel_x = -28;
+	pixel_y = -26;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm3)
 "pSj" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 8
@@ -21557,13 +22401,44 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"pWv" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/tether/station/dock_one)
+"pXg" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1380;
+	id_tag = "dock_d2r_pump"
+	},
+/obj/machinery/light/small,
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "dock_d2r_sensor";
+	pixel_y = -25
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1380;
+	id_tag = "dock_d2r";
+	pixel_y = 28
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
 "qaE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/area/tether/station/visitorhallway/lounge)
 "qbe" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -21679,6 +22554,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
+"qnm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "qoC" = (
 /obj/structure/disposalpipe/sortjunction/untagged/flipped{
 	dir = 1
@@ -21720,17 +22601,24 @@
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor,
 /area/hallway/station/starboard)
-"qsR" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+"qqO" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
+"qsR" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "qsV" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth{
 	frequency = 1380;
@@ -21788,15 +22676,14 @@
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/excursion/general)
 "qxU" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "qyD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -21882,8 +22769,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/start{
-	name = "Cargo Technician"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -21910,6 +22797,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"qWJ" = (
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
 "qXI" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -21928,20 +22821,27 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
-"qZT" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+"qZe" = (
+/obj/structure/table/woodentable,
+/obj/machinery/chemical_dispenser/bar_coffee/full,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/office)
+"qZi" = (
+/obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
+"qZT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/obj/structure/table/woodentable,
+/obj/machinery/button/windowtint{
+	id = "visitor_meeting"
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "rbW" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -21957,6 +22857,31 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
+"reE" = (
+/obj/machinery/button/remote/airlock{
+	id = "spacedorm4";
+	name = "Room 4 Lock";
+	pixel_x = 28;
+	pixel_y = -26;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm4)
+"rfW" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "rgp" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -21989,7 +22914,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/area/tether/station/visitorhallway/office)
 "rii" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -22016,6 +22941,15 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"riD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "riL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -22050,6 +22984,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"rnj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
+"rod" = (
+/obj/machinery/washing_machine,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
 "rrE" = (
 /obj/structure/lattice,
 /obj/machinery/door/firedoor/glass,
@@ -22058,6 +23010,38 @@
 	},
 /turf/simulated/open,
 /area/maintenance/station/eng_upper)
+"rtN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
+"rua" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK"
+	},
+/turf/simulated/floor/plating,
+/area/tether/station/dock_one)
 "rwX" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -22079,6 +23063,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
+"ryl" = (
+/obj/machinery/door/window/northright{
+	dir = 2
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "rAd" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -22092,6 +23082,15 @@
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/exploration)
+"rAE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "rAY" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -22106,18 +23105,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"rCL" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/mineral/floor/vacuum,
+/area/mine/explored/upper_level)
 "rCQ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
+"rDx" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "rDX" = (
 /obj/effect/overmap/visitable/sector/virgo3b,
 /turf/space,
 /area/space)
-"rEP" = (
-/obj/random/trash_pile,
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
 "rGT" = (
 /obj/machinery/photocopier,
 /obj/structure/cable/green{
@@ -22201,7 +23206,7 @@
 	dir = 4
 	},
 /turf/simulated/wall,
-/area/tether/exploration/hallway)
+/area/tether/station/visitorhallway/office)
 "rLt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -22223,13 +23228,22 @@
 /turf/simulated/wall,
 /area/quartermaster/warehouse)
 "rPb" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/tether/station/visitorhallway/lounge)
+"rPu" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
 "rPF" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
@@ -22315,6 +23329,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"sdw" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK"
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether/station/dock_one)
+"seJ" = (
+/obj/structure/closet/wardrobe/suit,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
 "seM" = (
 /obj/machinery/holoposter{
 	pixel_y = -30
@@ -22331,10 +23365,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
 "sgO" = (
-/obj/machinery/door/airlock/maintenance/cargo{
-	req_access = list(50);
-	req_one_access = list(48)
-	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "shy" = (
@@ -22346,14 +23379,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/gear)
-"siv" = (
-/obj/machinery/vending/loadout/uniform,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
 "sjK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
@@ -22374,9 +23408,31 @@
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
 "sro" = (
-/obj/machinery/vending/loadout/costume,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock{
+	id_tag = "spacedorm4";
+	name = "Room 4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/sleep/spacedorm4)
+"ssu" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "sta" = (
 /turf/simulated/wall/r_wall,
 /area/tether/exploration/pathfinder_office)
@@ -22387,6 +23443,30 @@
 	},
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/mining_outpost/shuttle)
+"svx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
+"swD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm3)
 "swQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -22461,6 +23541,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
+"sFw" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "sHL" = (
 /obj/effect/floor_decal/asteroid,
 /turf/simulated/floor/outdoors/grass/heavy/interior,
@@ -22478,15 +23564,18 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "sOB" = (
-/obj/random/junk,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "sPw" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"sRH" = (
+/obj/machinery/washing_machine,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
 "sSA" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22508,6 +23597,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
+"sTI" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "sTL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22556,6 +23652,24 @@
 	},
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
+"sZN" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
 "tao" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -22580,13 +23694,29 @@
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"tcf" = (
+/obj/effect/shuttle_landmark{
+	base_area = /area/space;
+	base_turf = /turf/space;
+	docking_controller = "dock_d2r";
+	landmark_tag = "tether_dockarm_d2R";
+	name = "Tether Dock D2R"
+	},
+/turf/space,
+/area/space)
 "tcX" = (
-/obj/machinery/porta_turret_construct,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/tether/station/visitorhallway/lounge)
+"tes" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -28
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm3)
 "thG" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -22600,6 +23730,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 5
 	},
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "thQ" = (
@@ -22624,7 +23755,7 @@
 	dir = 4
 	},
 /turf/simulated/wall,
-/area/tether/exploration/hallway)
+/area/tether/station/visitorhallway/office)
 "tjf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -22632,6 +23763,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
+"tjt" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "tjJ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -22646,12 +23788,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"tkv" = (
+/obj/machinery/vending/loadout/clothing,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "tmb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
+"tnK" = (
+/obj/structure/table/rack{
+	dir = 1
+	},
+/obj/random/maintenance/clean,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "tpi" = (
 /obj/structure/table/standard,
 /obj/item/hand_labeler,
@@ -22682,6 +23835,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
+"tql" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 8;
+	frequency = 1380;
+	id_tag = "dock_d2l";
+	pixel_x = 28
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
 "tqo" = (
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
@@ -22835,6 +24003,30 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/wood,
 /area/tether/exploration/pilot_office)
+"tGP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/railing,
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
+"tIc" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
+"tIA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
 "tIP" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/floor_decal/industrial/warning,
@@ -22901,6 +24093,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
+"tLk" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether/station/dock_one)
 "tMr" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/border_only,
@@ -22909,6 +24111,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/exploration/pilot_office)
+"tNC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "tNU" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -22922,6 +24130,20 @@
 /obj/structure/flora/pottedplant/drooping,
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/exploration)
+"tNY" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "dock_d2a";
+	name = "exterior access button";
+	pixel_x = -5;
+	pixel_y = -26;
+	req_one_access = list(13)
+	},
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
 "tTq" = (
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
@@ -22946,7 +24168,7 @@
 /area/tether/station/stairs_two)
 "uam" = (
 /turf/simulated/wall,
-/area/quartermaster/foyer)
+/area/security/customs)
 "uan" = (
 /obj/structure/table/woodentable,
 /obj/item/paper{
@@ -22983,6 +24205,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
+"uct" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "udH" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -23023,6 +24254,27 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
+"ufX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "dock_d2r";
+	name = "interior access button";
+	pixel_x = 28;
+	pixel_y = 26;
+	req_one_access = list(13)
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "ugX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23087,8 +24339,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/obj/structure/table/woodentable,
+/obj/item/paicard,
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "ukj" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
@@ -23100,6 +24354,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
+"uoA" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/tether/station/dock_one)
 "uqD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -23132,15 +24396,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
-"usx" = (
-/obj/random/junk,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
 "utJ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -23174,6 +24429,27 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"uGQ" = (
+/obj/machinery/light/small,
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1380;
+	id_tag = "dock_d2a";
+	pixel_y = 28
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "dock_d2a_sensor";
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1380;
+	id_tag = "dock_d2a_pump"
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
 "uGU" = (
 /obj/machinery/status_display/supply_display,
 /turf/simulated/wall,
@@ -23216,6 +24492,11 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 9
 	},
+/obj/structure/table/standard,
+/obj/item/retail_scanner/civilian{
+	dir = 1
+	},
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "uNm" = (
@@ -23248,21 +24529,13 @@
 /turf/simulated/wall,
 /area/quartermaster/office)
 "uQo" = (
-/obj/structure/railing,
-/obj/structure/closet/crate,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/door/airlock/glass_external,
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
+/obj/effect/map_helper/airlock/door/int_door,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/office)
 "uTM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -23284,13 +24557,49 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
+"uUP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
+"uVs" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/button/remote/airlock{
+	id = "customs";
+	name = "shop access lock";
+	pixel_x = 28;
+	pixel_y = -26;
+	specialfunctions = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/customs)
+"uWB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm4)
 "uYn" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -23349,9 +24658,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
-"vgI" = (
-/turf/simulated/wall,
-/area/tether/exploration/hallway)
 "viC" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23403,6 +24709,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
+"voG" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "vqq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/rshull,
@@ -23415,9 +24730,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"vsL" = (
+/turf/simulated/wall,
+/area/tether/station/visitorhallway/lounge)
 "vtH" = (
 /turf/space,
 /area/quartermaster/storage)
+"vuP" = (
+/obj/machinery/light_switch{
+	name = "light switch ";
+	pixel_x = -6;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
 "vvg" = (
 /obj/item/radio/beacon,
 /turf/simulated/floor/tiled/techmaint,
@@ -23445,6 +24771,16 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/hallway/station/port)
+"vCl" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/quartermaster/office)
 "vFc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -23470,8 +24806,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "vGz" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -23576,8 +24915,11 @@
 	dir = 4
 	},
 /obj/structure/railing,
+/obj/machinery/camera/network/cargo{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/area/tether/station/visitorhallway/office)
 "vQV" = (
 /obj/structure/sign/directions/evac,
 /turf/simulated/wall,
@@ -23644,6 +24986,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/excursion/cargo)
+"vWn" = (
+/obj/machinery/camera/network/tether{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "vWE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
@@ -23691,13 +25039,16 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/tether/station/visitorhallway/lounge)
 "wdQ" = (
 /obj/machinery/camera/network/cargo{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/obj/structure/table/rack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "wdV" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23759,6 +25110,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
+"woX" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether/station/visitorhallway/laundry)
+"woY" = (
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
 "wpU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23766,12 +25132,17 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
-"wrn" = (
-/obj/machinery/vending/giftvendor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/tether/station/visitorhallway/lounge)
+"wrn" = (
+/obj/structure/window/reinforced/polarized/full{
+	id = "visitor_meeting"
+	},
+/obj/structure/grille,
+/turf/simulated/floor,
+/area/tether/station/visitorhallway/office)
 "wtB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23784,24 +25155,8 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "wtF" = (
-/obj/effect/floor_decal/corner/lightgrey{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lightgrey{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/area/tether/station/visitorhallway/office)
 "wyG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -23845,9 +25200,54 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/outdoors/grass/forest,
 /area/tether/exploration/pathfinder_office)
+"wAr" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/door/window/brigdoor/eastleft{
+	req_access = null;
+	req_one_access = list(38,63)
+	},
+/turf/simulated/floor/tiled,
+/area/security/customs)
 "wDN" = (
 /turf/simulated/wall/rshull,
 /area/shuttle/excursion/cockpit)
+"wEJ" = (
+/turf/simulated/wall,
+/area/tether/station/visitorhallway/office)
+"wGQ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether/station/dock_one)
+"wKh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "wKr" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/signaler,
@@ -23943,8 +25343,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "wSQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -24004,6 +25404,11 @@
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
+"wZj" = (
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
 "xae" = (
 /obj/machinery/light_switch{
 	name = "light switch ";
@@ -24057,6 +25462,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/tether/exploration/pathfinder_office)
+"xkr" = (
+/obj/machinery/vending/loadout/overwear,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "xlr" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -24073,8 +25487,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/excursion/cargo)
 "xlI" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/structure/railing,
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "xnf" = (
@@ -24105,7 +25519,7 @@
 	dir = 4
 	},
 /turf/space,
-/area/mine/explored/upper_level)
+/area/space)
 "xtQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -24151,6 +25565,7 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 5
 	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "xvI" = (
@@ -24161,14 +25576,8 @@
 	dir = 9
 	},
 /turf/simulated/wall,
-/area/hallway/station/starboard)
+/area/tether/station/visitorhallway/office)
 "xya" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -24177,8 +25586,18 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
+"xyD" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/spacedorm4)
 "xBA" = (
 /obj/structure/closet/coffin,
 /obj/machinery/alarm{
@@ -24187,6 +25606,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/burial)
+"xDN" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
+"xFu" = (
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "xIj" = (
 /obj/machinery/camera/network/tether{
 	dir = 4
@@ -24225,6 +25656,18 @@
 	dir = 4
 	},
 /area/tether/exploration)
+"xPB" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "xPD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -24273,6 +25716,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
+"xUm" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1;
+	frequency = 1380;
+	id_tag = "dock_d2l_pump"
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
 "xVj" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -24315,6 +25770,21 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/tether/exploration)
+"xWL" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "xYr" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
@@ -24331,12 +25801,26 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
+"xZn" = (
+/obj/machinery/vending/loadout/gadget,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "yat" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
+"yeY" = (
+/obj/machinery/door/window/northright{
+	dir = 4
+	},
+/obj/machinery/camera/network/cargo{
+	dir = 1;
+	name = "security camera"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "yfO" = (
 /obj/effect/landmark/start{
 	name = "Pilot"
@@ -24366,7 +25850,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/area/tether/station/visitorhallway/office)
 "yhh" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -24379,6 +25863,23 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
+"yln" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "ylp" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -26915,8 +28416,8 @@ aaa
 aaa
 aaa
 aaa
-nBU
 aaa
+iIF
 aaa
 aaa
 aaa
@@ -35822,7 +37323,7 @@ aHC
 aac
 aaP
 aaP
-aac
+aaP
 aac
 aac
 aTr
@@ -35963,9 +37464,9 @@ xnf
 aHC
 aac
 aaP
-aac
 aaP
-aac
+aaP
+aaP
 aac
 aTr
 auW
@@ -36107,7 +37608,7 @@ aac
 aaP
 aaP
 aaP
-aac
+aaP
 aac
 aTr
 auW
@@ -36246,8 +37747,8 @@ aMP
 xnf
 aHC
 aac
-aac
-aac
+aaP
+aaP
 aaP
 aaP
 aac
@@ -36388,8 +37889,8 @@ aMP
 xnf
 aHC
 aac
-aac
-aac
+aaP
+aaP
 aaP
 aac
 aac
@@ -36530,9 +38031,9 @@ aMP
 xnf
 aHC
 aac
-aac
-aac
 aaP
+aaP
+aac
 aac
 aac
 aTr
@@ -36816,8 +38317,8 @@ aHC
 aac
 aaP
 aaP
-aac
-aac
+aaP
+aaP
 aac
 aTr
 auW
@@ -37834,7 +39335,7 @@ aac
 aac
 aac
 aac
-aac
+aaP
 aaP
 aaP
 aaP
@@ -37937,7 +39438,7 @@ apm
 rPF
 pfu
 oHH
-kCk
+ggt
 amE
 lUJ
 kCk
@@ -37975,8 +39476,8 @@ aac
 aac
 aac
 aac
-aac
-aac
+aaP
+aaP
 aac
 aaP
 aaP
@@ -38116,10 +39617,10 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
+aaP
+aaP
+aaP
+aaP
 aaP
 aaP
 aaa
@@ -38257,10 +39758,10 @@ aoY
 aac
 aac
 aac
-aac
-aac
-aac
-aac
+aaP
+aaP
+aaP
+aaP
 aaP
 aaP
 aaa
@@ -38366,12 +39867,12 @@ aTU
 aTU
 aTU
 aTU
-aIL
+aTU
 gra
 orW
 xvI
-bXZ
-aDL
+kkq
+wEJ
 aHC
 mdh
 aMP
@@ -38380,7 +39881,7 @@ aMP
 aQf
 uUq
 jwA
-aQf
+aLz
 aQf
 aQf
 fWC
@@ -38396,11 +39897,11 @@ aaP
 aaP
 aaP
 aaP
-aac
-aac
-aac
-aac
-aac
+aaP
+aaP
+aaP
+aaP
+aaP
 aaP
 aaP
 aaP
@@ -38506,23 +40007,23 @@ rPF
 krd
 aTU
 aTU
-aTU
-aIL
-aqG
-vgI
+wrn
+wrn
+wrn
+wrn
 rKN
 aRX
 aDw
 deM
-vgI
-aHC
-aHC
 aUG
-aHC
-ndH
+aUG
+aUG
+aUG
+aUG
+vsL
 aqk
 aJe
-aJe
+aOg
 aSY
 aJe
 aHC
@@ -38531,21 +40032,21 @@ aHC
 aHC
 aac
 aac
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aac
-aac
-aac
-aaP
-aaP
-aaP
-aaP
+rCL
+rCL
+rCL
+rCL
+rCL
+rCL
+rCL
+rCL
+rCL
+rCL
+rCL
+rCL
+rCL
+rCL
+rCL
 aaP
 aaa
 aaa
@@ -38648,22 +40149,22 @@ aTo
 krd
 aTU
 aTU
-aIL
-nWq
-vgI
-vgI
+wrn
+aBN
+qZe
+aBN
 vPY
 aRX
 gpa
 wtF
-vgI
+aUG
 aGL
 aCc
-aMP
-aHC
+tes
+aUG
 aJZ
-aLz
-aXY
+eUF
+aJe
 aOB
 asq
 aJe
@@ -38672,23 +40173,23 @@ foT
 aQf
 aHC
 aHC
-aac
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aac
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -38791,19 +40292,19 @@ iIu
 aTU
 aIL
 wrn
-vgI
-vgI
-aUo
-vPY
+fLT
+wtF
+wtF
+cjr
 aRX
 gpa
 wtF
-vgI
-aMP
-aMP
-aMP
-aHC
-aJU
+aUG
+drE
+swD
+pQw
+mvF
+okY
 nRW
 aJe
 aWz
@@ -38814,23 +40315,23 @@ iwd
 nYg
 eqW
 aHC
-aac
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -38932,20 +40433,20 @@ aJI
 aSF
 wYR
 wYR
-vgI
-vgI
+wrn
+wtF
 ahl
-iTr
+qsR
 anl
-nzs
+qsR
 qsR
 alU
-vgI
+aUG
 aOm
 axQ
 aMD
-aHC
-aOg
+aUG
+sOB
 aph
 aGI
 arB
@@ -38953,25 +40454,25 @@ aGU
 aJe
 aHC
 aHC
-mcY
+aHC
 aYi
 aHC
-aac
-aac
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -39074,46 +40575,46 @@ cIj
 kDq
 aTU
 aXm
-vgI
-vgI
+wrn
+wtF
 oBg
 mPL
 aVY
 aIw
 qZT
-nzs
-vgI
-aHC
-aHC
-aHC
-aHC
-aHC
-aVB
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
+qZi
+aUG
+aUG
+aUG
+aUG
+aUG
+sOB
+aXv
+vsL
+vsL
+vsL
+vsL
+vsL
+htA
 aJW
-jNP
+krB
 aHC
-aac
-aac
-aac
-aac
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -39217,46 +40718,46 @@ eqP
 aTU
 aSd
 aGZ
-aGZ
+mcY
 adA
 aUv
 lpR
 ujt
-nzs
-nzs
-aVN
-aMP
-aVV
+cjl
+qZi
 mQF
-aVV
-aMP
+hBP
+xyD
+miw
+mQF
+sOB
 aXv
-aMP
-azh
+sOB
+aJB
 wdQ
 aSj
-aMP
-aHC
+vsL
+qWJ
 ays
 jNP
 aHC
-aac
-aac
-aac
-aac
-aac
-aac
-aaP
-aaP
-aac
-aac
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -39358,48 +40859,48 @@ aJI
 arE
 aTU
 aTU
-pzJ
-vgI
-vgI
+wrn
+wtF
+ahl
 nWw
 qxU
 vGb
 xya
 kwy
-aDJ
-aMP
-aMP
-aMP
+mQF
+ggX
+uWB
+reE
 sro
-aMP
+okY
 aEC
 wpU
 aJP
-aMP
+rAE
 aJB
-aMP
+vsL
+jxq
+gEi
+jNP
 aHC
-aHC
-gew
-aHC
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -39500,49 +41001,49 @@ aJI
 aTx
 aIL
 aTU
-aTU
-pzJ
-vgI
-vgI
+wrn
+wtF
+wtF
+wtF
 fvh
 mdX
 rhx
 ygD
-aYF
+mQF
 aVV
-aMP
+hav
+mjk
+mQF
 sOB
-aMP
-aMP
-aMP
-rmj
+sOB
+gQZ
 aJK
 aMX
 apM
-aNF
-aHC
+vsL
+cMw
 xlI
 gEB
 aHC
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -39642,50 +41143,50 @@ aJI
 azN
 aTD
 aTU
-aTU
-aTU
-pzJ
-vgI
+wrn
+wrn
+wrn
+wrn
 kkq
 tjc
 aRk
-vgI
-aYF
+wEJ
 mQF
-aMP
-aMP
-aMP
-aVV
-aVV
-aVV
+mQF
+mQF
+mQF
+mQF
+aJB
+tnK
+aJB
 aFX
 eai
-aMP
-ayT
-aHC
-kuX
+aNi
+vsL
+cMw
+xlI
 doI
 aHC
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aaP
-aaP
-aaP
-aaP
-aac
-aaP
-aaP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -39790,41 +41291,41 @@ aTU
 aHB
 owJ
 iAG
-rPb
+rfW
 tcX
 qaE
-aVV
-aMP
-dbp
-aMP
-aMP
-aMP
-aMP
+aJB
+sOB
+sOB
+sOB
+sOB
+sOB
+sOB
 ayq
 aoT
-sOB
-aMP
+nqk
+vsL
+cMw
+xlI
+gEB
 aHC
-aRe
-aQf
-aHC
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aaP
-aaP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -39932,41 +41433,41 @@ wWC
 aXa
 aFw
 wcE
-rPb
-aTU
+rfW
+sOB
 qaE
-aVV
-aMP
-aMP
-aMP
-aMP
-siv
-aMP
-aXv
+aJB
+sOB
+sOB
+sOB
+sOB
+sOB
+sOB
+oSb
 aDz
-aMP
-aMP
+sOB
+vsL
+cMw
+xlI
+gEB
 aHC
-aXs
-aQf
-aHC
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aaP
-aaP
-aaP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -40074,10 +41575,10 @@ aWq
 aHp
 aSh
 pES
-usx
-aTU
+rfW
+sOB
 apY
-aMP
+sOB
 aSE
 aWP
 aWP
@@ -40086,29 +41587,29 @@ aWP
 aWP
 avW
 aVE
-aIt
-aBN
+sOB
+vsL
+aQf
+abY
+tIA
 aHC
-aHC
-aOn
-aHC
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aaP
-aaP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -40216,41 +41717,41 @@ aWq
 aTU
 wLl
 aPb
-rPb
-aTU
+rfW
+sOB
 qaE
-aMP
-ijh
-qsX
-aMP
-aVV
-mQF
-fDg
-aoL
+sOB
+rfW
+gtq
+aJB
+aJB
+tnK
+gns
+aFX
 aPI
-aGt
+emB
 nCl
+iGu
+tGP
+jXX
 aHC
-aQf
-aQf
-aHC
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aaP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -40358,41 +41859,41 @@ vdL
 aTU
 jpG
 aGA
-rPb
-aTU
+rfW
+sOB
 qaE
-aMP
-ijh
+sOB
+rfW
 wQK
-aGs
-aMP
-aMP
-wgb
-eUF
+sOB
+sOB
+sOB
+lyF
+aFX
 eai
-aMP
-poe
-aHC
-aQf
-aQf
-aHC
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aaP
-aaP
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aaP
+yeY
+vsL
+vsL
+vsL
+ohX
+vsL
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -40513,34 +42014,34 @@ aUx
 aTC
 aOd
 aTA
-aHC
-aHC
-aQf
-aQf
-aHC
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aaP
-aaP
-aac
-aac
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
+vsL
+pDq
+pwf
+svx
+aXY
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
+aaa
+gZe
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+oLS
 aaa
 aaa
 aaa
@@ -40638,44 +42139,44 @@ aVs
 aGV
 npD
 aWI
-aKb
+pcr
 pcr
 avL
 aGq
 aWg
 aKN
 aSZ
-aEB
+rPb
 aVp
-aEB
-aEB
-aEB
-aEB
-aEB
+rDx
+rDx
+rDx
+rDx
+rDx
 apZ
-aMP
-aZW
-aHC
-rEP
-aQf
-aQf
-aHC
-aac
-aac
-aac
-aac
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
+sOB
+sOB
+sOB
+sOB
+sOB
+svx
+aXY
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -40771,12 +42272,12 @@ aZc
 aZc
 aHl
 rmO
-niu
+gew
 xVC
 aYb
 eOz
 lno
-lno
+aoL
 aXV
 hvA
 aJY
@@ -40784,36 +42285,33 @@ aME
 hvA
 mIc
 aPx
-aTU
+iMR
 aum
-oLa
+uam
 sOB
-tmb
-aMP
-hNw
-aMP
+sFw
 sOB
-aMP
-mpF
-aWm
-mQF
-aHC
-ndH
-aQf
-aQf
-aHC
-aac
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
+sOB
+sOB
+sOB
+sOB
+tjt
+sOB
+sOB
+sOB
+sOB
+sOB
+svx
+aXY
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+glE
+tNY
+lZf
 aaa
 aaa
 aaa
@@ -40826,6 +42324,9 @@ aaa
 aaa
 aaa
 aaa
+aBz
+lYZ
+pWv
 aaa
 aaa
 aaa
@@ -40922,40 +42423,37 @@ niu
 hvA
 hvA
 qOP
-hvA
-hvA
+jog
+jog
 jog
 nvK
 oxY
-aTU
+uVs
 fdm
-aMP
+bmB
 aSf
 aSf
 aSf
 aSf
 aSf
-fLT
-aMP
-aMP
-aVV
-aHC
-aQf
-aQf
-aQf
-aHC
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
+aSf
+riD
+bmB
+nBU
+lOd
+ohM
+bmB
+bSQ
+aXY
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+byT
+uGQ
+jYm
 aaa
 aaa
 aaa
@@ -40968,6 +42466,9 @@ aaa
 aaa
 aaa
 aaa
+ePn
+htD
+jaq
 aaa
 aaa
 aaa
@@ -41070,55 +42571,55 @@ avV
 uam
 nzz
 cPg
-cUz
-aMP
+uam
+aJU
 aNi
-aMP
-aMP
+sOB
+sOB
 poe
-aMP
-aSf
-aIY
-aMP
-aHC
-aHC
-rEP
-aQf
-aQf
-aHC
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sOB
+ryl
+rfW
+sOB
+juU
+brL
+nNK
+sOB
+svx
+vsL
+wGQ
+wGQ
+wGQ
+jWe
+wGQ
+wGQ
+oMK
+aTJ
+oMK
+wGQ
+wGQ
+wGQ
+jWe
+wGQ
+wGQ
+wGQ
+wGQ
+jWe
+wGQ
+wGQ
+wGQ
+ftC
+kus
+ftC
+jWe
+wGQ
+wGQ
+wGQ
+jWe
+jWe
+wGQ
+wGQ
+sdw
 aaa
 aaa
 aaa
@@ -41205,64 +42706,64 @@ xeW
 aHl
 aHl
 sgO
-aHl
-aHl
+uQo
+sgO
 aHl
 aHl
 uam
+wAr
+blx
 uam
-uam
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-rEP
-aQf
-aQf
-aQf
-aHC
-aaP
-aaP
-aaP
-aaP
-aaP
+bLa
+bLa
+bLa
+bLa
+bLa
+bLa
+bLa
+xkr
+hYE
+kLX
+oRK
+fxM
+sOB
+hmm
+vWn
+xFu
+xFu
+xFu
+iLM
+xFu
+xFu
+tIc
+nLF
+xDN
+xFu
+bwK
+xFu
+fpV
+xFu
+xFu
+bwK
+xFu
+xFu
+xFu
+xFu
+bwK
+tIc
+cSZ
+ikC
+bPS
+xFu
+xFu
+xFu
+lku
+fsC
+qqO
+xUm
+wZj
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jLE
 aaa
 aaa
 aaa
@@ -41343,66 +42844,66 @@ aQf
 rLt
 vAv
 aHC
-uQo
-aQf
-rEP
-aQf
-aQf
+dzD
+aeM
+aeM
+sgO
+nqH
 jCo
-aQf
-aQf
-aQf
-aQf
-aHC
-ndH
-aQf
-aQf
-rEP
-aQf
-aOn
-aQf
-aQf
-aQf
-aQf
-aQf
-aQf
-aQf
-aQf
-rEP
-aHC
-aaP
-aaP
-aaP
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aeM
+aeM
+uam
+hhw
+ffh
+uam
+bLa
+sRH
+rod
+rPu
+iDc
+sZN
+eUD
+wKh
+okY
+okY
+okY
+okY
+okY
+yln
+jzo
+rnj
+rnj
+uUP
+xWL
+uUP
+uUP
+fdl
+iMs
+ojV
+qnm
+hsx
+qnm
+qnm
+qnm
+fpH
+nsJ
+fpH
+qnm
+qnm
+qnm
+eSz
+fpH
+cqy
+qnm
+sTI
+kiM
+kiM
+kiM
+fXp
+woY
+tql
+mxk
+bhU
 aaa
 aaa
 aaa
@@ -41484,67 +42985,67 @@ aHC
 aQf
 jNP
 nDO
+aHC
+dzD
+aeM
+aeM
+htR
+jmD
+vCl
+aeM
+aeM
+uam
+kTr
 aOn
-nRW
-aQf
-aQf
-aQf
-aQf
-aQf
-aQf
-aQf
-rEP
-aQf
-aOn
-aQf
-aQf
-aQf
-aQf
-aQf
-aHC
-ndH
-aQf
-rEP
-aQf
-aQf
-aQf
-aQf
-rEP
-aHC
-aHC
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+uam
+bLa
+fHm
+kwu
+kwu
+eTM
+rtN
+bLa
+krc
+tkv
+lBN
+xZn
+sOB
+sOB
+sOB
+poe
+xFu
+xFu
+xFu
+voG
+xFu
+xFu
+tNC
+xPB
+xFu
+xFu
+dSM
+xFu
+tNC
+xFu
+ssu
+ufX
+xFu
+tNC
+xFu
+xFu
+dSM
+xFu
+xFu
+xFu
+uct
+xFu
+xFu
+xFu
+lAU
+oMK
+oII
+oII
+tLk
 aaa
 aaa
 aaa
@@ -41627,32 +43128,7 @@ aQf
 qgB
 qbe
 aHC
-ggt
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
+dzD
 aaa
 aaa
 aaa
@@ -41660,30 +43136,55 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+uam
+uam
+uam
+uam
+bLa
+vuP
+kwu
+kwu
+lTw
+cKS
+bLa
+vsL
+vsL
+vsL
+vsL
+vsL
+vsL
+vsL
+vsL
+oII
+oII
+oII
+jWe
+oII
+oII
+oII
+jWe
+oII
+oII
+oII
+oII
+jWe
+oII
+ftC
+kus
+ftC
+jWe
+oII
+oII
+oII
+jWe
+oII
+oII
+jWe
+oII
+oII
+oII
+jWe
+jWe
 aaa
 aaa
 aaa
@@ -41770,28 +43271,28 @@ drb
 aHC
 aHC
 xtp
-aaP
-aac
-aac
-aac
-aac
-aaP
-aaP
-aaP
-aaP
-aaP
-aac
-aac
-aac
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
+aaa
+aaa
+aaa
+dzg
+aaa
+aaa
+aaa
+aeM
+aeM
+aeM
+aeM
+bLa
+mwI
+bKy
+seJ
+mPs
+aLw
+bLa
 aaP
 aaP
+aaP
+aaP
 aaa
 aaa
 aaa
@@ -41810,9 +43311,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+ftC
+pXg
+jaq
 aaa
 aaa
 aaa
@@ -41912,28 +43413,28 @@ xee
 rex
 aHC
 xtp
-aac
-aac
-aac
-aac
 aaa
 aaa
 aaa
 aaa
 aaa
-aac
-aac
-aac
+aaa
+aaa
+aeM
+aeM
+aeM
+aeM
+bLa
+woX
+woX
+woX
+woX
+bLa
+bLa
 aaP
 aaP
 aaP
 aaP
-aaP
-aaP
-aaP
-aaP
-aaP
-aaP
 aaa
 aaa
 aaa
@@ -41952,9 +43453,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+rua
+esF
+uoA
 aaa
 aaa
 aaa
@@ -42054,9 +43555,7 @@ nwo
 bqA
 aHC
 xtp
-aac
-aac
-aac
+aaa
 aaa
 aaa
 aaa
@@ -42064,8 +43563,10 @@ aaa
 aaa
 aaa
 aeM
-aac
-aac
+aeM
+aeM
+aeM
+aeM
 aaa
 aaa
 aaa
@@ -42195,8 +43696,7 @@ uYn
 vFZ
 nAu
 aHC
-htR
-aac
+dzD
 aaa
 aaa
 aaa
@@ -42204,7 +43704,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aeM
+ewX
+aeM
 aeM
 aaa
 aaa
@@ -42236,8 +43738,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+tcf
 aaa
 aaa
 aaa
@@ -42339,16 +43840,16 @@ soU
 aHC
 dzD
 aeM
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aeM
+aeM
+aeM
+aeM
+aeM
+aeM
+aeM
+aeM
+aeM
+aeM
 aaa
 aaa
 aaa
@@ -42478,18 +43979,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aeM
 dzD
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aeM
+aeM
+aeM
+aeM
+aeM
+aeM
+aeM
+aeM
+aeM
+aeM
 aaa
 aaa
 aaa

--- a/_maps/map_files/tether/tether-06-station2.dmm
+++ b/_maps/map_files/tether/tether-06-station2.dmm
@@ -7141,10 +7141,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "awa" = (
@@ -7650,9 +7646,6 @@
 /turf/simulated/floor/wood,
 /area/tether/exploration/pathfinder_office)
 "ayq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals6,
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 4
@@ -17111,6 +17104,9 @@
 	pixel_x = 5;
 	pixel_y = -32
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "bgE" = (
@@ -19156,6 +19152,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -21646,6 +21645,18 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
+"nWW" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
 "nYg" = (
 /obj/random/junk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -25458,12 +25469,15 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
@@ -26116,6 +26130,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
@@ -41811,8 +41828,8 @@ sOB
 sOB
 sOB
 rfW
-sOB
 eUF
+sOB
 aDz
 sOB
 vsL
@@ -41953,7 +41970,7 @@ aWP
 aWP
 aWP
 yaB
-aWP
+nWW
 avW
 aVE
 sOB

--- a/_maps/map_files/tether/tether-06-station2.dmm
+++ b/_maps/map_files/tether/tether-06-station2.dmm
@@ -21009,7 +21009,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1380;
-	id_tag = "dock_d2l_pump"
+	id_tag = "dock_d1l_pump"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
@@ -26064,7 +26064,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1380;
-	id_tag = "dock_d2l_pump"
+	id_tag = "dock_d1l_pump"
 	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/dark,

--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -232,13 +232,11 @@
 	icon_state = "globe"
 	color = "#d35b5b"
 	initial_generic_waypoints = list(
-		"tether_dockarm_d1a1", //Bottom left,
-		"tether_dockarm_d1a2", //Top left,
-		"tether_dockarm_d1a3", //Left on inside,
-		"tether_dockarm_d2a1", //Bottom right,
-		"tether_dockarm_d2a2", //Top right,
-		"tether_dockarm_d1l", //End of left arm,
-		"tether_dockarm_d2l", //End of right arm,
+		"tether_dockarm_d2a", //Top left
+        "tether_dockarm_d2b", //Bottom left,
+        "tether_dockarm_d2r", //Right,
+        "tether_dockarm_d2l", //End of arm,
+        "tether_space_SE", //station1, bottom right of space,
 		"tether_space_SE", //station1, bottom right of space,
 		"tether_space_NE", //station1, top right of space,
 		"tether_space_SW", //station2, bottom left of space,

--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -233,10 +233,10 @@
 	color = "#d35b5b"
 	initial_generic_waypoints = list(
 		"tether_dockarm_d2a", //Top left
-        "tether_dockarm_d2b", //Bottom left,
-        "tether_dockarm_d2r", //Right,
-        "tether_dockarm_d2l", //End of arm,
-        "tether_space_SE", //station1, bottom right of space,
+		"tether_dockarm_d2b", //Bottom left,
+		"tether_dockarm_d2r", //Right,
+		"tether_dockarm_d2l", //End of arm,
+		"tether_space_SE", //station1, bottom right of space,
 		"tether_space_SE", //station1, bottom right of space,
 		"tether_space_NE", //station1, top right of space,
 		"tether_space_SW", //station2, bottom left of space,

--- a/maps/tether/tether_shuttle_defs.dm
+++ b/maps/tether/tether_shuttle_defs.dm
@@ -64,7 +64,7 @@
 	warmup_time = 5
 	move_time = 45
 	landmark_offsite = "tether_backup_low"
-	landmark_station = "tether_dockarm_d1a3"
+	landmark_station = "tether_customs_shuttle"
 	landmark_transition = "tether_backup_transit"
 	shuttle_area = /area/shuttle/tether
 	//crash_areas = list(/area/shuttle/tether/crash1, /area/shuttle/tether/crash2)


### PR DESCRIPTION



<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A large shop area, the docking arm, a visitor room. Most importantly, all somewhat secure. It's now possible for security to watch a single chokepoint that people coming to the docking arm can access without hacking. There's still a side-door to encourage sneaking gameplay if traders wish to break in without taking out a wall, but overall, more secure. At the very least, customs is now more between the docking arm and the rest of the station, instead of on the far side of the docking arm. Note: old customs is still in place, as it has a shuttle attached I don't feel like needs to be moved. Old laundry is gone, but haven't decided what to do with old visit office.


Once I get this done, i'll be using the old docking arms for my planned Hardspace Shipbreaker content, to give engineering something to be doing
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Finally finishes the meat of the original project that was adjusted in creative direction. Visiting traders now have a large space they can set up shop in, and Customs actually has a chance to function as it's name suggests.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->



<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
