### PR TITLE
Tasers Should Not be More Effective Than Guns at Killing

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/_giant_spider.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/_giant_spider.dm
@@ -77,6 +77,7 @@
 	movement_cooldown = 10
 	movement_sound = 'sound/effects/spider_loop.ogg'
 	poison_resist = 0.5
+	taser_kill = 0 //These seem like they won't be bothered by a taser
 
 	see_in_dark = 10
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/alien.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/alien.dm
@@ -62,6 +62,7 @@
 	melee_damage_upper = 25
 	attack_sharp = TRUE
 	attack_edge = TRUE
+	taser_kill = 0
 
 	attacktext = list("slashed")
 	attack_sound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/mob/living/simple_mob/subtypes/horror/horror .dm
+++ b/code/modules/mob/living/simple_mob/subtypes/horror/horror .dm
@@ -30,6 +30,7 @@
 	faction = "horror"
 	icon = 'icons/mob/horror_show/GHPS.dmi'
 	icon_gib = "generic_gib"
+	taser_kill = 0
 
 /datum/ai_holder/simple_mob/horror
 	hostile = TRUE // The majority of simplemobs are hostile, gaslamps are nice.

--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/humanoid.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/humanoid.dm
@@ -11,6 +11,7 @@
 	min_n2 = 0
 	max_n2 = 0
 	unsuitable_atoms_damage = 15
+	taser_kill = 0 //Humanoid Enemies Are generally not for Taser Kill
 
 	health = 150			// Point of human crit, as of commenting
 	maxHealth = 150

--- a/code/modules/mob/living/simple_mob/subtypes/occult/creature.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/creature.dm
@@ -30,6 +30,7 @@
 	attack_armor_pen = 5	//It's a horror from beyond, I ain't gotta explain 5 AP
 	attack_sharp = 1
 	attack_edge = 1
+	taser_kill = 0 //See the Above on why you can't tase it.
 
 	attacktext = list("chomped")
 	attack_sound = 'sound/weapons/bite.ogg'

--- a/code/modules/mob/living/simple_mob/subtypes/occult/faithless.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/faithless.dm
@@ -28,6 +28,7 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 18
 	attack_armor_pen = 5	//It's a horror from beyond, I ain't gotta explain 5 AP
+	taser_kill = 0 //See Above
 
 	attacktext = list("gripped")
 	attack_sound = 'sound/hallucinations/growl1.ogg'

--- a/code/modules/mob/living/simple_mob/subtypes/vore/corrupt_hounds.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/corrupt_hounds.dm
@@ -31,6 +31,7 @@
 	melee_damage_lower = 5
 	melee_damage_upper = 10 //makes it so 4 max dmg hits don't instakill you.
 	grab_resist = 100
+	taser_kill = 0 //This Mechanical Dog should probably not be harmed by tasers
 
 	response_help = "pets the"
 	response_disarm = "bops the"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Virgo Virgo Virgo
Apparently some months ago, changes from Virgo were ported that meant that the Taser_Kill var was be default enabled. This meant that tasers became incredibly effective at killing a ton of different mobs that they probably shouldn't be. This PR makes sure Taser Kill is disabled for mobs it should have never been enabled with to begin with, since it frankly stupid that a taser more effective than lethal weapons uinder certain circumstances.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Tasers no longer damage the following mobs: 
1. All Humanoids including Mercs, Pirates, and Cultists.
2. Corrupt Hounds because they are Machines
3. Giant Spiders: since they seem like it wouldn't effect them
4. Xenomorph Simple Mobs: Because its a Xenomorph
5. Horror Mobs: Flesh Monstrosities Should not be Tased to Death
6. Horror Adjacent Mobs: 'Creatures' and Faithless since they are supernatural enough.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
