### PR TITLE
Fixes and improves Xenochimera morph abilities, makes them have 5 alt languages, additional minor tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -89,6 +89,9 @@
 	var/target = null
 	var/text = null
 
+	if(nutrition < 50)
+		to_chat(src, "<span class 'notice'>You don't have enough energy! Try eating. </span>")
+		return
 	targets += getmobs() //Fill list, prompt user with list
 	target = input("Select a creature!", "Speak to creature", null, null) as null|anything in targets
 
@@ -109,6 +112,7 @@
 	log_say("(COMMUNE to [key_name(M)]) [text]",src)
 
 	to_chat(M, "<font color=#4F49AF>Like lead slabs crashing into the ocean, alien thoughts drop into your mind: [text]</font>")
+	nutrition -= 50
 	if(istype(M,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 		if(H.species.name == src.species.name)

--- a/code/modules/mob/living/carbon/human/species/station/station_special.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special.dm
@@ -428,6 +428,9 @@
 		choice = input(src, "How should we adapt our respiration?") as null|anything in gas_choices
 	if(!choice || !target)
 		return
+	if(target.isSynthetic())
+		to_chat(src,"<span class = 'Notice'>We cannot change a being of metal!</span>")
+		return
 	var/resp_biomorph = gas_choices[choice]
 	if(target == src)
 		to_chat(src,"<span class = 'Notice'>We begin modifying our internal structure.</span>")
@@ -477,6 +480,9 @@
 		biothermic_adapt = input(src, "How should we modify our core temperature?") as null|anything in temperature_options
 
 	if(!biothermic_adapt || !target)
+		return
+	if(target.isSynthetic())
+		to_chat(src,"<span class = 'Notice'>We cannot change a being of metal!</span>")
 		return
 	if(target == src)
 		to_chat(src, "<span class = 'Notice'>We begin modifying our internal biothermic structure.</span>")
@@ -567,7 +573,9 @@
 		atmos_biomorph = input(src, "How should we modify our atmospheric sensitivity?") as null|anything in pressure_options
 	if(!atmos_biomorph || !target)
 		return
-
+	if(target.isSynthetic())
+		to_chat(src,"<span class = 'Notice'>We cannot change a being of metal!</span>")
+		return
 	if(target == src)
 		to_chat("<span class = 'Notice'>We begin modifying our skin...</span>")
 	else

--- a/code/modules/mob/living/carbon/human/species/station/station_special.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special.dm
@@ -19,7 +19,7 @@
 	base_species = "Xenochimera"
 	selects_bodytype = TRUE
 
-	num_alternate_languages = 2
+	num_alternate_languages = 5
 	secondary_langs = list("Sol Common")
 
 	//color_mult = 1 //It seemed to work fine in testing, but I've been informed it's unneeded.
@@ -57,7 +57,7 @@
 
 	virus_immune = 1 // They practically ARE one.
 	min_age = 18
-	max_age = 80
+	max_age = 200
 
 	blurb = "Some amalgamation of different species from across the universe,with extremely unstable DNA, making them unfit for regular cloners. \
 	Widely known for their voracious nature and violent tendencies when stressed or left unfed for long periods of time. \

--- a/code/modules/mob/living/carbon/human/species/station/station_special.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special.dm
@@ -409,7 +409,7 @@
 
 //Verbs Follow
 
-/mob/living/carbon/human/proc/resp_biomorph(mob/user)
+/mob/living/carbon/human/proc/resp_biomorph(mob/living/carbon/human/target in view(1))
 	set name = "Respiratory Biomorph"
 	set desc = "Changes the gases we need to breathe."
 	set category = "Abilities"
@@ -420,80 +420,188 @@
 		"nitrogen" = /datum/gas/nitrogen,
 		"carbon dioxide" = /datum/gas/carbon_dioxide
 	)
-	var/choice = input(user, "How should we adapt our respiration?") as null|anything in gas_choices
-	if(!choice)
+	var/choice
+	if(target && target != src)
+		choice= input(src, "How should we modify their respiration?") as null|anything in gas_choices
+	if(target == src)
+		choice = input(src, "How should we adapt our respiration?") as null|anything in gas_choices
+	if(!choice || !target)
 		return
 	var/resp_biomorph = gas_choices[choice]
-	to_chat(user,"You begin modifying your internal structure!")
-	if(do_after(user,15 SECONDS))
+	if(target == src)
+		to_chat(src,"<span class = 'Notice'>We begin modifying our internal structure.</span>")
+	else
+		target.visible_message("<span class = 'danger'>[src] begins to burrow their digits into [target], slithering down their throat!</span>", "<span class = 'warning'>You feel an extremely uncomfortable slithering sensation going through your throat and into your chest...</span>")
+	if(do_after(src,15 SECONDS))
 		switch(resp_biomorph)
 			if(/datum/gas/oxygen)
-				species.breath_type = /datum/gas/oxygen
-				species.poison_type = /datum/gas/phoron
-				species.exhale_type = /datum/gas/carbon_dioxide
+				target.species.breath_type = /datum/gas/oxygen
+				target.species.poison_type = /datum/gas/phoron
+				target.species.exhale_type = /datum/gas/carbon_dioxide
 			if(/datum/gas/phoron)
-				species.breath_type = /datum/gas/phoron
-				species.poison_type = /datum/gas/oxygen
-				species.exhale_type = /datum/gas/nitrogen
+				target.species.breath_type = /datum/gas/phoron
+				target.species.poison_type = null
+				target.species.exhale_type = /datum/gas/nitrogen
 			if(/datum/gas/nitrogen)
-				species.breath_type = /datum/gas/nitrogen
-				species.poison_type = /datum/gas/carbon_dioxide
+				target.species.breath_type = /datum/gas/nitrogen
+				target.species.poison_type = null
 			if(/datum/gas/carbon_dioxide)
-				species.breath_type = /datum/gas/carbon_dioxide
-				species.exhale_type = /datum/gas/oxygen
+				target.species.breath_type = /datum/gas/carbon_dioxide
+				target.species.exhale_type = /datum/gas/oxygen
+		if(target == src)
+			to_chat("<span class = 'Notice'>It is done.</span>")
+		else
+			var/datum/disease2/disease/virus2 = new /datum/disease2/disease
+			virus2.makerandom()
+			infect_virus2(target, virus2)
+			target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel maded anew.</span>")
 
-/mob/living/carbon/human/proc/biothermic_adapt(mob/user)
+
+/mob/living/carbon/human/proc/biothermic_adapt(mob/living/carbon/human/target in view(1))
 	set name = "Biothermic Adaptation"
 	set desc = "Changes our core body temperature."
 	set category = "Abilities"
 
-	var/biothermic_adapt = input(user, "How should we modify our core temperature?") as null|anything in list("warm-blooded", "cold-blooded", "hot-blooded")
-	if(!biothermic_adapt)
-		return
-	to_chat(user,"You begin modifying your internal structure!")
-	if(do_after(user,15 SECONDS))
-		switch(biothermic_adapt)
-			if("warm-blooded")
-				species.cold_discomfort_level = 285
-				species.heat_discomfort_level = 315
-			if("cold-blooded")
-				species.cold_discomfort_level = T0C+21
-			if("hot-blooded")
-				species.heat_discomfort_level = T0C+19
+	var/list/temperature_options = list(
+	"warm-blooded",
+	"cold-blooded",
+	"hot-blooded"
+	)
 
-/mob/living/carbon/human/proc/atmos_biomorph(mob/user)
+	var/biothermic_adapt
+	if(target && target != src)
+		biothermic_adapt = input(src, "How should we modify their core temperature?") as null|anything in temperature_options
+	if(target == src)
+		biothermic_adapt = input(src, "How should we modify our core temperature?") as null|anything in temperature_options
+
+	if(!biothermic_adapt || !target)
+		return
+	if(target == src)
+		to_chat(src, "<span class = 'Notice'>We begin modifying our internal biothermic structure.</span>")
+	else
+		target.visible_message("<span class = 'danger'>[src] has fleshy tendrils emerge and begin slither inside the veins of [target]!</span>", "<span class = 'warning'>You feel an extremely uncomfortable slithering sensation going through your skin, your veins suddenly feeling as if they have bugs crawling inside...</span>")
+	if(do_after(src,15 SECONDS))
+		switch(biothermic_adapt)
+			if("warm-blooded")	//reverts to default
+				target.species.cold_discomfort_level = 285
+				target.species.cold_level_1 = 260
+				target.species.cold_level_2 = 180
+				target.species.cold_level_3 = 100
+
+				target.species.breath_cold_level_1 = 240
+				target.species.breath_cold_level_2 = 160
+				target.species.breath_cold_level_3 = 80
+
+				target.species.heat_level_1 = 360
+				target.species.heat_level_2 = 400
+				target.species.heat_level_3 = 1000
+
+				target.species.breath_heat_level_1 = 380
+				target.species.breath_heat_level_2 = 450
+				target.species.breath_heat_level_3 = 1250
+
+				target.species.heat_discomfort_level = 315
+			if("cold-blooded")
+				target.species.cold_discomfort_level = T0C+21
+
+				target.species.cold_level_1 = T0C+19
+				target.species.cold_level_2 = T0C
+				target.species.cold_level_3 = T0C - 15
+
+				target.species.breath_cold_level_1 = T0C + 5
+				target.species.breath_cold_level_2 = T0C - 10
+				target.species.breath_cold_level_3 = T0C - 25
+
+				target.species.heat_level_1 = 1000
+				target.species.heat_level_2 = 1200
+				target.species.heat_level_3 = 1400
+
+				target.species.breath_heat_level_1 = 800
+				target.species.breath_heat_level_2 = 1000
+				target.species.breath_heat_level_3 = 1200
+
+			if("hot-blooded")
+				target.species.cold_level_1 = T0C - 75
+				target.species.cold_level_2 = T0C - 100
+				target.species.cold_level_3 = T0C - 125
+
+				target.species.breath_cold_level_1 = T0C - 75
+				target.species.breath_cold_level_2 = T0C - 100
+				target.species.breath_cold_level_3 = T0C - 125
+
+				target.species.heat_level_1 = T0C + 25
+				target.species.heat_level_2 = T0C + 50
+				target.species.heat_level_3 = T0C + 100
+
+				target.species.breath_heat_level_1 = T0C + 50
+				target.species.breath_heat_level_2 = T0C + 75
+				target.species.breath_heat_level_3 = T0C + 100
+
+				target.species.heat_discomfort_level = T0C+19
+		if(target == src)
+			to_chat(src, "<span class = 'Notice'>It is done.</span>")
+		else
+			var/datum/disease2/disease/virus2 = new /datum/disease2/disease
+			virus2.makerandom()
+			infect_virus2(target, virus2)
+			target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel maded anew.</span>")
+
+/mob/living/carbon/human/proc/atmos_biomorph(mob/living/carbon/human/target in view(1))
 	set name = "Atmospheric Biomorph"
 	set desc = "Changes our sensitivity to atmospheric pressure."
 	set category = "Abilities"
 
-	var/atmos_biomorph = input(user, "How should we adapt our rigidity?") as null|anything in list("flexible", "compact", "elastic")
-	if(!atmos_biomorph)
+
+	var/list/pressure_options = list(
+	"flexible",
+	"compact",
+	"elastic"
+	)
+	var/atmos_biomorph
+	if(target && target != src)
+		atmos_biomorph = input(src, "How should we modify their atmospheric sensitivity?") as null|anything in pressure_options
+	if(target == src)
+		atmos_biomorph = input(src, "How should we modify our atmospheric sensitivity?") as null|anything in pressure_options
+	if(!atmos_biomorph || !target)
 		return
-	to_chat(user,"You begin modifying your internal structure!")
-	if(do_after(user,15 SECONDS))
+
+	if(target == src)
+		to_chat("<span class = 'Notice'>We begin modifying our skin...</span>")
+	else
+		target.visible_message("<span class = 'danger'>[src] has fleshy tendrils emerge and begin to merge and mold with [target]!</span>", "<span class = 'warning'>You feel an extremely uncomfortable slithering sensation going through your skin, it begins to feel foreign and dead, emanating from them...</span>")
+	if(do_after(src,15 SECONDS))
 		switch(atmos_biomorph)
 			if("flexible")
-				species.warning_low_pressure = WARNING_LOW_PRESSURE
-				species.hazard_low_pressure = -1
-				species.warning_high_pressure = WARNING_HIGH_PRESSURE
-				species.hazard_high_pressure = HAZARD_HIGH_PRESSURE
-			if("rigid")
-				species.warning_low_pressure = 50
-				species.hazard_low_pressure = -1
+				target.species.warning_low_pressure = WARNING_LOW_PRESSURE
+				target.species.hazard_low_pressure = -1
+				target.species.warning_high_pressure = WARNING_HIGH_PRESSURE
+				target.species.hazard_high_pressure = HAZARD_HIGH_PRESSURE
+			if("compact")
+				target.species.warning_low_pressure = 50
+				target.species.hazard_low_pressure = -1
 			if("elastic")
-				species.warning_high_pressure = WARNING_HIGH_PRESSURE + 50
-				species.hazard_high_pressure = HAZARD_HIGH_PRESSURE + 100
+				target.species.warning_high_pressure = WARNING_HIGH_PRESSURE + 200
+				target.species.hazard_high_pressure = HAZARD_HIGH_PRESSURE + 400
 
-/mob/living/carbon/human/proc/vocal_biomorph(mob/user)
+		if(target == src)
+			to_chat(src, "<span class = 'notice'>It is done.</span>")
+		else
+			var/datum/disease2/disease/virus2 = new /datum/disease2/disease
+			virus2.makerandom()
+			infect_virus2(target, virus2)
+			target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel made anew.</span>")
+
+
+/mob/living/carbon/human/proc/vocal_biomorph()
 	set name = "Vocalization Biomorph"
 	set desc = "Changes our speech pattern."
 	set category = "Abilities"
 
-	var/vocal_biomorph = input(user, "How should we adjust our speech?") as null|anything in list("common", "unathi", "tajaran")
+	var/vocal_biomorph = input(src, "How should we adjust our speech?") as null|anything in list("common", "unathi", "tajaran")
 	if(!vocal_biomorph)
 		return
-	to_chat(user, "You begin modifying your internal structure!")
-	if(do_after(user,15 SECONDS))
+	to_chat(src, "You begin modifying your internal structure!")
+	if(do_after(src,15 SECONDS))
 		switch(vocal_biomorph)
 			if("common")
 				return

--- a/code/modules/mob/living/carbon/human/species/station/station_special.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special.dm
@@ -451,10 +451,11 @@
 		if(target == src)
 			to_chat("<span class = 'Notice'>It is done.</span>")
 		else
-			var/datum/disease2/disease/virus2 = new /datum/disease2/disease
-			virus2.makerandom()
-			infect_virus2(target, virus2)
-			target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel maded anew.</span>")
+			if(prob(80))
+				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
+				virus2.makerandom()
+				infect_virus2(target, virus2)
+				target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel maded anew.</span>")
 
 
 /mob/living/carbon/human/proc/biothermic_adapt(mob/living/carbon/human/target in view(1))
@@ -541,10 +542,11 @@
 		if(target == src)
 			to_chat(src, "<span class = 'Notice'>It is done.</span>")
 		else
-			var/datum/disease2/disease/virus2 = new /datum/disease2/disease
-			virus2.makerandom()
-			infect_virus2(target, virus2)
-			target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel maded anew.</span>")
+			if(prob(80))
+				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
+				virus2.makerandom()
+				infect_virus2(target, virus2)
+				target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel maded anew.</span>")
 
 /mob/living/carbon/human/proc/atmos_biomorph(mob/living/carbon/human/target in view(1))
 	set name = "Atmospheric Biomorph"
@@ -586,10 +588,11 @@
 		if(target == src)
 			to_chat(src, "<span class = 'notice'>It is done.</span>")
 		else
-			var/datum/disease2/disease/virus2 = new /datum/disease2/disease
-			virus2.makerandom()
-			infect_virus2(target, virus2)
-			target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel made anew.</span>")
+			if(prob(80))
+				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
+				virus2.makerandom()
+				infect_virus2(target, virus2)
+				target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel made anew.</span>")
 
 
 /mob/living/carbon/human/proc/vocal_biomorph()

--- a/code/modules/mob/living/carbon/human/species/station/station_special.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special.dm
@@ -456,7 +456,7 @@
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)
-				target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel maded anew.</span>")
+				target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel made anew.</span>")
 
 
 /mob/living/carbon/human/proc/biothermic_adapt(mob/living/carbon/human/target in view(1))
@@ -547,7 +547,7 @@
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)
-				target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel maded anew.</span>")
+				target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel made anew.</span>")
 
 /mob/living/carbon/human/proc/atmos_biomorph(mob/living/carbon/human/target in view(1))
 	set name = "Atmospheric Biomorph"

--- a/code/modules/mob/living/carbon/human/species/station/station_special.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special.dm
@@ -53,7 +53,8 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_wings,
 		/mob/living/carbon/human/proc/shapeshifter_select_tail,
 		/mob/living/carbon/human/proc/shapeshifter_select_ears,
-		/mob/living/carbon/human/proc/regenerate) //Xenochimera get all the special verbs since they can't select traits.
+		/mob/living/carbon/human/proc/regenerate,
+		/mob/living/carbon/human/proc/commune) //Xenochimera get all the special verbs since they can't select traits.
 
 	virus_immune = 1 // They practically ARE one.
 	min_age = 18


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes:
- Each morph ability (except for the one that changes your accent) can now be used on yourself OR a target.
- Breath morph removes poison gasses
- Temperature morph adds significantly higher (lower) high / low temp tolerances for cold / hot blooded
- Choosing to add one to someone else has a pretty high chance of giving them a random virus. They ARE a virus themselves, after all. Maybe don't let them shove themselves literally inside of your bloodstream.
- (Unrelated to PR, non-issue to revert) adds 5 languages to Xenochimeras. Seriously, the adaptive multi-species chimeroid only having two?  This makes them, I believe, on-par with Proteans in known language capacity.
- (Unrelated to PR, non-issue to revert) Changes their max age to 200. No lore iteration we have or do use has a concrete age limit on them.
- (Unrelated to PR, non-issue to revert) Gives them the 'commune' verb, which allows for a telepathic message to be sent.

## Why It's Good For The Game
- Makes the morph abilities usable
- Makes them have much more tangible effects
- Adds ~excitement~ and ~viruses~ if you're a pleb who asks the walking Thing:tm: monster for a sloppie toppie for a powergay boost
Code-wise this is adding on top of and using kind of shit systems that really need to be refactored entirely but that's outside of my code set at the moment.
## Changelog
:cl:
tweak: Xenochimera morph abilities can now be used on targets properly (with virus-related risk!)
tweak: Xenochimera morph abilities have been buffed overall.
add: Xenochimera gets 5 alternate languages now.
tweak: Xenochimera max age set to 200.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
