### PR TITLE
Makes the trash bin wrenchable, adds a portable secure briefcase to loadout, 

### DIFF
--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -178,6 +178,16 @@
 		src.add_fingerprint(usr)
 		M.put_in_active_hand(src)
 
+//LOADOUT ITEM
+/obj/item/storage/secure/briefcase/portable
+	name = "Portable Secure Briefcase"
+	desc = "A not-so large briefcase with a digital locking system. Holds less, but fits into more."
+	w_class = ITEMSIZE_NORMAL
+
+	starts_with = list(
+		/obj/item/paper,
+		/obj/item/pen
+	)
 //DONATOR ITEM
 
 /obj/item/storage/secure/briefcase/vicase

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -405,6 +405,18 @@
 	icon_opened = "largebinopen"
 	icon_closed = "largebin"
 
+/obj/structure/closet/crate/bin/attackby(obj/item/W as obj, mob/user as mob)
+	if(W.is_wrench() && !src.opened)
+		if(anchored)
+			user.show_message(text("<span class='notice'>[src] can now be moved.</span>"))
+			playsound(src, O.usesound, 50, 1)
+			anchored = FALSE
+
+		else if(!anchored)
+			user.show_message(text("<span class='notice'>[src] is now secured.</span>"))
+			playsound(src, O.usesound, 50, 1)
+			anchored = TRUE
+
 /obj/structure/closet/crate/radiation
 	name = "radioactive gear crate"
 	desc = "A crate with a radiation sign on it."

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -416,6 +416,8 @@
 			user.show_message(text("<span class='notice'>[src] is now secured.</span>"))
 			playsound(src, W.usesound, 50, 1)
 			anchored = TRUE
+	else
+		..()
 
 /obj/structure/closet/crate/radiation
 	name = "radioactive gear crate"

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -409,12 +409,12 @@
 	if(W.is_wrench() && !src.opened)
 		if(anchored)
 			user.show_message(text("<span class='notice'>[src] can now be moved.</span>"))
-			playsound(src, O.usesound, 50, 1)
+			playsound(src, W.usesound, 50, 1)
 			anchored = FALSE
 
 		else if(!anchored)
 			user.show_message(text("<span class='notice'>[src] is now secured.</span>"))
-			playsound(src, O.usesound, 50, 1)
+			playsound(src, W.usesound, 50, 1)
 			anchored = TRUE
 
 /obj/structure/closet/crate/radiation

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -65,8 +65,8 @@
 	path = /obj/item/paicard
 
 /datum/gear/utility/securecase
-	name = "Secure Briefcase"
-	path =/obj/item/storage/secure/briefcase
+	name = "Secure, Portable Briefcase"
+	path =/obj/item/storage/secure/briefcase/portable
 	cost = 2
 
 /datum/gear/utility/laserpointer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Adds wrench interactions to the large bin, Triumph people rejoice.
- Adds a portable secure briefcase to loadout. It fits into satchels now! Very specific number of people who were bothered by this rejoice! (It's just me.)

## Why It's Good For The Game

- You can move the bins that are everywhere on a certain map.
- You can have a keycode-secure personal container in your loadout that fits into your satchel.
## Changelog
:cl:
fix: Large bins can now be wrenched
add: a portable version of the secure briefcase, replacing the current one in loadout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
