### PR TITLE
adds species specific spell compatibility

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1150,6 +1150,7 @@
 			remove_language(L)
 		// Clear out their species abilities.
 		species.remove_inherent_verbs(src)
+		species.remove_inherent_spells(src)
 		holder_type = null
 
 	species = GLOB.all_species[new_species]

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -162,6 +162,7 @@
 
 	// Body/form vars.
 	var/list/inherent_verbs = list()									// Species-specific verbs.
+	var/list/inherent_spells = list()									// Species-specific spells.
 	var/has_fine_manipulation = 1							// Can use small items.
 	var/siemens_coefficient = 1								// The lower, the thicker the skin and better the insulation.
 	var/darksight = 2										// Native darksight distance.
@@ -413,8 +414,20 @@ GLOBAL_LIST_INIT(species_oxygen_tank_by_gas, list(
 			H.verbs |= verb_path
 	return
 
+/datum/species/proc/add_inherent_spells(var/mob/living/carbon/human/H)
+	if(inherent_spells)
+		for(var/spell_to_add in inherent_spells)
+			var/spell/S = new spell_to_add(H)
+			H.add_spell(S)
+	return
+
+/datum/species/proc/remove_inherent_spells(var/mob/living/carbon/human/H)
+	H.spellremove()
+	return
+
 /datum/species/proc/handle_post_spawn(var/mob/living/carbon/human/H) //Handles anything not already covered by basic species assignment.
 	add_inherent_verbs(H)
+	add_inherent_spells(H)
 	H.mob_bump_flag = bump_flag
 	H.mob_swap_flags = swap_flags
 	H.mob_push_flags = push_flags


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
that's it, after this PR you can now give Tajarans Jaunt or some shit, or make your own / convert other abilities to spells.

## Why It's Good For The Game
WAY WAY WAY better technical and mechanical foundation for any species ability that you'd like to be active / cooldown based

## Changelog
:cl:
tweak:species spells can now be a thing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
