### PR TITLE
Adds a closed curtain to the lavaland bar to save jerry

### DIFF
--- a/_maps/map_levels/140x140/lavaland.dmm
+++ b/_maps/map_levels/140x140/lavaland.dmm
@@ -2014,6 +2014,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/lavaland/base/common)
+"UN" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor{
+	req_one_access = list(48)
+	},
+/obj/structure/curtain/open/privacy{
+	icon_state = "closed";
+	opacity = 1
+	},
+/turf/simulated/floor/plating,
+/area/lavaland/base/common)
 "UU" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled,
@@ -7239,7 +7254,7 @@ AO
 AO
 AO
 AO
-TA
+UN
 AO
 AO
 Hr


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Miners always have to burry jerry if they dont safe him the moment the round begins, this prevents that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a curtain to the lavaland base bar, to protect jerry.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
