### PR TITLE
Moves Xenochimera to /shapeshifter/, gives them passive regen akin to prommies, reworks commune verb, gives proteans 2 more languages

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -521,7 +521,7 @@
 
 		if("danger level")
 			var/mob/living/carbon/human/H = usr
-			if(istype(H) && istype(H.species, /datum/species/xenochimera))
+			if(istype(H) && istype(H.species, /datum/species/shapeshifter/xenochimera))
 				if(H.feral > 50)
 					to_chat(usr, "<span class='warning'>You are currently <b>completely feral.</b></span>")
 				else if(H.feral > 10)

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -202,8 +202,8 @@ var/global/list/datum/dna/gene/dna_genes[0]
 		src.base_species = CS.base_species
 		src.blood_color = CS.blood_color
 
-	if(istype(character.species,/datum/species/xenochimera))
-		var/datum/species/xenochimera/CS = character.species
+	if(istype(character.species,/datum/species/shapeshifter/xenochimera))
+		var/datum/species/shapeshifter/xenochimera/CS = character.species
 		//src.species_traits = CS.traits.Copy() //No traits
 		src.base_species = CS.base_species
 		src.blood_color = CS.blood_color
@@ -213,7 +213,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 		//src.species_traits = CS.traits.Copy() //No traits
 		src.base_species = CS.base_species
 		src.blood_color = CS.blood_color
-		
+
 	src.custom_say = character.custom_say
 	src.custom_ask = character.custom_ask
 	src.custom_whisper = character.custom_whisper

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -233,17 +233,17 @@
 			var/datum/species/custom/new_CS = CS.produceCopy(dna.base_species,dna.species_traits,src)
 			new_CS.blood_color = dna.blood_color
 
-		if(istype(H.species,/datum/species/xenochimera))
-			var/datum/species/xenochimera/CS = H.species
-			var/datum/species/xenochimera/new_CS = CS.produceCopy(dna.base_species,dna.species_traits,src)
+		if(istype(H.species,/datum/species/shapeshifter/xenochimera))
+			var/datum/species/shapeshifter/xenochimera/CS = H.species
+			var/datum/species/shapeshifter/xenochimera/new_CS = CS.produceCopy(dna.base_species,dna.species_traits,src)
 			new_CS.blood_color = dna.blood_color
+			H.regenerate_icons()
 
 		if(istype(H.species,/datum/species/alraune))
 			var/datum/species/alraune/CS = H.species
 			var/datum/species/alraune/new_CS = CS.produceCopy(dna.base_species,dna.species_traits,src)
 			new_CS.blood_color = dna.blood_color
 		// VOREStation Edit End
-
 		H.force_update_organs() //VOREStation Add - Gotta do this too
 		H.force_update_limbs()
 		//H.update_body(0) //VOREStation Edit - Done in force_update_limbs already

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -119,14 +119,13 @@
 	var/distance = get_dist(M.loc,loc)
 	var/distance_modifier
 	var/turf/target_location = get_turf(M.loc)
-	var/delay
 	if(target_location)
 		if(target_location.z in GLOB.using_map.station_levels)
 			distance_modifier = 0	//No additional values if they're on-station
 	else
-		distance_modifier = distance_mod	//No quick snapchatting with someone off-station
+		distance_modifier = default_distance_mod	//No quick snapchatting with someone off-station
 
-	var/delay_mod = clamp((distance / 2), 1, 8) SECONDS + default_distance_modifier	//Half of distance worth of seconds, up to 8, plus 30 if they're off-station. Max: 38, min: 1.
+	var/delay = clamp((distance / 2), 1, 8) SECONDS + distance_modifier	//Half of distance worth of seconds, up to 8, plus 30 if they're off-station. Max: 38, min: 1.
 	src.visible_message("<span class = 'warning'>[src] seems to focus for a few seconds.</span>","You begin to seek [target] out. This may take a while.")
 
 	if(do_after(src, delay))

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -88,7 +88,7 @@
 	var/list/targets = list()
 	var/target = null
 	var/text = null
-	var/default_distance_mod = #0 SECONDS
+	var/default_distance_mod = 0 SECONDS
 
 	if(nutrition < 50)
 		to_chat(src, "<span class = 'notice'>You don't have enough energy! Try eating. </span>")

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -88,8 +88,7 @@
 	var/list/targets = list()
 	var/target = null
 	var/text = null
-	var/default_delay = 5 SECONDS
-	var/distance_mod = 60 SECONDS
+	var/default_distance_mod = #0 SECONDS
 
 	if(nutrition < 50)
 		to_chat(src, "<span class = 'notice'>You don't have enough energy! Try eating. </span>")
@@ -127,15 +126,11 @@
 	else
 		distance_modifier = distance_mod	//No quick snapchatting with someone off-station
 
-	var/delay_mod = clamp((distance / 2), 1, 30) SECONDS + distance_modifier	//Half of distance worth of seconds, up to thirty, plus 60 if they're off-station. Max: 90, min: 1.
-	if(delay_mod > default_delay)
-		delay = delay_mod
-	else
-		delay = default_delay
+	var/delay_mod = clamp((distance / 2), 1, 8) SECONDS + default_distance_modifier	//Half of distance worth of seconds, up to 8, plus 30 if they're off-station. Max: 38, min: 1.
 	src.visible_message("<span class = 'warning'>[src] seems to focus for a few seconds.</span>","You begin to seek [target] out. This may take a while.")
 
 	if(do_after(src, delay))
-		log_and_message_admins("([key_name(src)] COMMUNED to [key_name(M)]) [text]", src)
+		log_and_message_admins("COMMUNED to [key_name(M)]) [text]", src)
 
 		to_chat(M, "<font color=#4F49AF>Like lead slabs crashing into the ocean, alien thoughts drop into your mind: <b>[text]</b></font>")
 		nutrition -= 50

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -135,7 +135,7 @@
 	src.visible_message("<span class = 'warning'>[src] seems to focus for a few seconds.</span>","You begin to seek [target] out. This may take a while.")
 
 	if(do_after(src, delay))
-		log_and_message_admins("([key_name(src)] COMMUNED to [key_name(M)]) [text]")
+		log_and_message_admins("([key_name(src)] COMMUNED to [key_name(M)]) [text]", src)
 
 		to_chat(M, "<font color=#4F49AF>Like lead slabs crashing into the ocean, alien thoughts drop into your mind: <b>[text]</b></font>")
 		nutrition -= 50

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -119,12 +119,12 @@
 	//The further the target is, the longer it takes.
 	var/distance = get_dist(M.loc,loc)
 	var/distance_modifier
-	var/target_location = get_turf(M.loc)
+	var/turf/target_location = get_turf(M.loc)
 	var/delay
 	if(target_location && target_location.z in GLOB.using_map.station_levels)
 		distance_modifier = 0	//No additional values if they're on-station
 	else
-		distance_modifier = 60 SECONDS	//No quick snapchatting with someone off-station
+		distance_modifier = distance_mod	//No quick snapchatting with someone off-station
 
 	var/delay_mod = clamp((distance / 2), 1, 30) SECONDS + distance_modifier	//Half of distance worth of seconds, up to thirty, plus 60 if they're off-station. Max: 90, min: 1.
 	if(delay_mod > default_delay)

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -121,8 +121,9 @@
 	var/distance_modifier
 	var/turf/target_location = get_turf(M.loc)
 	var/delay
-	if(target_location && target_location.z in GLOB.using_map.station_levels)
-		distance_modifier = 0	//No additional values if they're on-station
+	if(target_location)
+		if(target_location.z in GLOB.using_map.station_levels)
+			distance_modifier = 0	//No additional values if they're on-station
 	else
 		distance_modifier = distance_mod	//No quick snapchatting with someone off-station
 

--- a/code/modules/mob/living/carbon/human/species/outsider/replicant.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/replicant.dm
@@ -36,6 +36,7 @@
 	flash_mod = 0.9
 	sound_mod = 0.9
 	siemens_coefficient = 0.9
+	heal_rate = 0
 
 	spawn_flags = SPECIES_IS_RESTRICTED
 	appearance_flags = HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_HAIR_COLOR | HAS_UNDERWEAR

--- a/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
+++ b/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
@@ -12,8 +12,9 @@ var/list/wrapped_species_by_ref = list()
 		)
 
 	var/list/valid_transform_species = list()
-	var/monochromatic
+	var/monochromatic = FALSE
 	var/default_form = SPECIES_HUMAN
+	var/heal_rate = 0
 
 /datum/species/shapeshifter/get_valid_shapeshifter_forms(var/mob/living/carbon/human/H)
 	return valid_transform_species
@@ -493,3 +494,41 @@ var/list/wrapped_species_by_ref = list()
 	visible_message("<span class='notice'>\The [src]'s interal composition seems to change.</span>")
 	update_icons_body()
 
+/datum/species/shapeshifter/handle_environment_special(var/mob/living/carbon/human/H)
+/* VOREStation Removal - Too crazy with our uncapped hunger and slowdown stuff.
+	var/turf/T = H.loc
+	if(istype(T))
+		var/obj/effect/decal/cleanable/C = locate() in T
+		if(C && !(H.shoes || (H.wear_suit && (H.wear_suit.body_parts_covered & FEET))))
+			qdel(C)
+			if (istype(T, /turf/simulated))
+				var/turf/simulated/S = T
+				S.dirt = 0
+
+			H.nutrition = min(500, max(0, H.nutrition + rand(15, 30)))
+VOREStation Removal End */
+	// Heal remaining damage.
+	if(H.fire_stacks >= 0 && heal_rate > 0)
+		if(H.getBruteLoss() || H.getFireLoss() || H.getOxyLoss() || H.getToxLoss())
+			var/nutrition_cost = 0
+			var/nutrition_debt = H.getBruteLoss()
+			var/starve_mod = 1
+			if(H.nutrition <= 25)
+				starve_mod = 0.75
+			H.adjustBruteLoss(-heal_rate * starve_mod)
+			nutrition_cost += nutrition_debt - H.getBruteLoss()
+
+			nutrition_debt = H.getFireLoss()
+			H.adjustFireLoss(-heal_rate * starve_mod)
+			nutrition_cost += nutrition_debt - H.getFireLoss()
+
+			nutrition_debt = H.getOxyLoss()
+			H.adjustOxyLoss(-heal_rate * starve_mod)
+			nutrition_cost += nutrition_debt - H.getOxyLoss()
+
+			nutrition_debt = H.getToxLoss()
+			H.adjustToxLoss(-heal_rate * starve_mod)
+			nutrition_cost += nutrition_debt - H.getToxLoss()
+			H.nutrition -= (2 * nutrition_cost) //Costs Nutrition when damage is being repaired, corresponding to the amount of damage being repaired.
+			H.nutrition = max(0, H.nutrition) //Ensure it's not below 0.
+	..()

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -128,9 +128,8 @@ var/datum/species/shapeshifter/promethean/prometheans
 		"Rapala", "Neaera", "Stok", "Farwa", "Sobaka",
 		"Wolpin", "Saru", "Sparra")
 
-	var/heal_rate = 0.35 //As of writing, original was 0.2 - speeds up regen
 	active_regen_mult = 0.66 //As of writing, original was 1 (good)
-
+	heal_rate = 0.35
 	color_mult = 1
 	trashcan = 1 //They have goopy bodies. They can just dissolve things within them.
 
@@ -182,46 +181,6 @@ var/datum/species/shapeshifter/promethean/prometheans
 	spawn(1)
 		if(H)
 			H.gib()
-
-/datum/species/shapeshifter/promethean/handle_environment_special(var/mob/living/carbon/human/H)
-/* VOREStation Removal - Too crazy with our uncapped hunger and slowdown stuff.
-	var/turf/T = H.loc
-	if(istype(T))
-		var/obj/effect/decal/cleanable/C = locate() in T
-		if(C && !(H.shoes || (H.wear_suit && (H.wear_suit.body_parts_covered & FEET))))
-			qdel(C)
-			if (istype(T, /turf/simulated))
-				var/turf/simulated/S = T
-				S.dirt = 0
-
-			H.nutrition = min(500, max(0, H.nutrition + rand(15, 30)))
-VOREStation Removal End */
-	// Heal remaining damage.
-	if(H.fire_stacks >= 0)
-		if(H.getBruteLoss() || H.getFireLoss() || H.getOxyLoss() || H.getToxLoss())
-			var/nutrition_cost = 0
-			var/nutrition_debt = H.getBruteLoss()
-			var/starve_mod = 1
-			if(H.nutrition <= 25)
-				starve_mod = 0.75
-			H.adjustBruteLoss(-heal_rate * starve_mod)
-			nutrition_cost += nutrition_debt - H.getBruteLoss()
-
-			nutrition_debt = H.getFireLoss()
-			H.adjustFireLoss(-heal_rate * starve_mod)
-			nutrition_cost += nutrition_debt - H.getFireLoss()
-
-			nutrition_debt = H.getOxyLoss()
-			H.adjustOxyLoss(-heal_rate * starve_mod)
-			nutrition_cost += nutrition_debt - H.getOxyLoss()
-
-			nutrition_debt = H.getToxLoss()
-			H.adjustToxLoss(-heal_rate * starve_mod)
-			nutrition_cost += nutrition_debt - H.getToxLoss()
-			H.nutrition -= (2 * nutrition_cost) //Costs Nutrition when damage is being repaired, corresponding to the amount of damage being repaired.
-			H.nutrition = max(0, H.nutrition) //Ensure it's not below 0.
-	//else//VOREStation Removal
-		//H.adjustToxLoss(2*heal_rate)	// Doubled because 0.5 is miniscule, and fire_stacks are capped in both directions
 
 /datum/species/shapeshifter/promethean/get_blood_colour(var/mob/living/carbon/human/H)
 	return (H ? rgb(H.r_skin, H.g_skin, H.b_skin) : ..())

--- a/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
@@ -22,7 +22,7 @@
 	appearance_flags = HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_HAIR_COLOR | HAS_UNDERWEAR | HAS_LIPS
 	spawn_flags		 = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED | SPECIES_WHITELIST_SELECTABLE
 	health_hud_intensity = 2
-	num_alternate_languages = 3  // Let's not make them know every language, past me.
+	num_alternate_languages = 5  // Let's not make them know every language, past me.
 	assisted_langs = list(LANGUAGE_ROOTLOCAL, LANGUAGE_ROOTGLOBAL, LANGUAGE_VOX)
 	color_mult = TRUE
 

--- a/code/modules/mob/living/carbon/human/species/station/station_special.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special.dm
@@ -4,7 +4,7 @@
 
 
 
-/datum/species/xenochimera //Scree's race.
+/datum/species/shapeshifter/xenochimera //Scree's race.
 	name = SPECIES_XENOCHIMERA
 	name_plural = "Xenochimeras"
 	icobase = 'icons/mob/human_races/r_xenochimera.dmi'
@@ -96,6 +96,14 @@
 		"Your skin prickles in the heat."
 		)
 
+	valid_transform_species = list(
+		"Human", "Unathi", "Tajara", "Skrell",
+		"Diona", "Teshari", "Monkey","Sergal",
+		"Akula","Nevrean","Highlander Zorren",
+		"Flatland Zorren", "Vulpkanin", "Vasilissan",
+		"Rapala", "Neaera", "Stok", "Farwa", "Sobaka",
+		"Wolpin", "Saru", "Sparra")
+
 	//primitive_form = "Farwa"
 
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED | SPECIES_WHITELIST_SELECTABLE//Whitelisted as restricted is broken.
@@ -114,13 +122,14 @@
 		O_INTESTINE =	/obj/item/organ/internal/intestine/xenochimera
 		)
 
+	heal_rate = 0.5
 	flesh_color = "#AFA59E"
 	base_color 	= "#333333"
 	blood_color = "#14AD8B"
 
 	reagent_tag = IS_CHIMERA
 
-/datum/species/xenochimera/handle_environment_special(var/mob/living/carbon/human/H)
+/datum/species/shapeshifter/xenochimera/handle_environment_special(var/mob/living/carbon/human/H)
 	//If they're KO'd/dead, they're probably not thinking a lot about much of anything.
 	if(!H.stat)
 		handle_feralness(H)
@@ -147,9 +156,10 @@
 		if(temp_diff >= 50)
 			H.shock_stage = min(H.shock_stage + (temp_diff/20), 160) // Divided by 20 is the same as previous numbers, but a full scale
 			H.eye_blurry = max(5,H.eye_blurry)
+	..()
 
 
-/datum/species/xenochimera/proc/handle_feralness(var/mob/living/carbon/human/H)
+/datum/species/shapeshifter/xenochimera/proc/handle_feralness(var/mob/living/carbon/human/H)
 
 	//Low-ish nutrition has messages and eventually feral
 	var/hungry = H.nutrition <= 200
@@ -339,7 +349,7 @@
 	// HUD update time
 	update_xenochimera_hud(H, danger, feral_state)
 
-/datum/species/xenochimera/proc/produceCopy(var/datum/species/to_copy,var/list/traits,var/mob/living/carbon/human/H)
+/datum/species/shapeshifter/xenochimera/proc/produceCopy(var/datum/species/to_copy,var/list/traits,var/mob/living/carbon/human/H)
 	ASSERT(to_copy)
 	ASSERT(istype(H))
 
@@ -348,7 +358,7 @@
 	if(istext(to_copy))
 		to_copy = GLOB.all_species[to_copy]
 
-	var/datum/species/xenochimera/new_copy = new()
+	var/datum/species/shapeshifter/xenochimera/new_copy = new()
 
 	//Initials so it works with a simple path passed, or an instance
 	new_copy.base_species = to_copy.name
@@ -378,14 +388,14 @@
 
 	return new_copy
 
-/datum/species/xenochimera/get_bodytype()
+/datum/species/shapeshifter/xenochimera/get_bodytype()
 	return base_species
 
-/datum/species/xenochimera/get_race_key()
+/datum/species/shapeshifter/xenochimera/get_race_key()
 	var/datum/species/real = GLOB.all_species[base_species]
 	return real.race_key
 
-/datum/species/xenochimera/proc/update_xenochimera_hud(var/mob/living/carbon/human/H, var/danger, var/feral)
+/datum/species/shapeshifter/xenochimera/proc/update_xenochimera_hud(var/mob/living/carbon/human/H, var/danger, var/feral)
 	if(H.xenochimera_danger_display)
 		H.xenochimera_danger_display.invisibility = 0
 		if(danger && feral)
@@ -459,7 +469,8 @@
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)
-				target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel made anew.</span>")
+				log_and_message_admins("[src]Infected [target] with a virus. (Xenochimera)")
+		target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel made anew.</span>")
 
 
 /mob/living/carbon/human/proc/biothermic_adapt(mob/living/carbon/human/target in view(1))
@@ -553,7 +564,8 @@
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)
-				target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel made anew.</span>")
+				log_and_message_admins("[src]Infected [target] with a virus. (Xenochimera)")
+		target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel made anew.</span>")
 
 /mob/living/carbon/human/proc/atmos_biomorph(mob/living/carbon/human/target in view(1))
 	set name = "Atmospheric Biomorph"
@@ -601,7 +613,8 @@
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)
-				target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel made anew.</span>")
+				log_and_message_admins("[src]Infected [target] with a virus. (Xenochimera)")
+		target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel made anew.</span>")
 
 
 /mob/living/carbon/human/proc/vocal_biomorph()

--- a/code/modules/mob/living/carbon/human/species/station/station_special.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special.dm
@@ -465,7 +465,7 @@
 		if(target == src)
 			to_chat("<span class = 'Notice'>It is done.</span>")
 		else
-			if(prob(80) && !get_virus_immune(target))
+			if(prob(80))
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)
@@ -560,7 +560,7 @@
 		if(target == src)
 			to_chat(src, "<span class = 'Notice'>It is done.</span>")
 		else
-			if(prob(80) && !get_virus_immune(target))
+			if(prob(80))
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)
@@ -609,7 +609,7 @@
 		if(target == src)
 			to_chat(src, "<span class = 'notice'>It is done.</span>")
 		else
-			if(prob(80) && !get_virus_immune(target))
+			if(prob(80))
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)

--- a/code/modules/mob/living/carbon/human/species/station/station_special.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special.dm
@@ -469,7 +469,7 @@
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)
-				log_and_message_admins("[src]Infected [target] with a virus. (Xenochimera)")
+				log_and_message_admins("Infected [target] with a virus. (Xenochimera)", src)
 		target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel made anew.</span>")
 
 
@@ -564,7 +564,7 @@
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)
-				log_and_message_admins("[src]Infected [target] with a virus. (Xenochimera)")
+				log_and_message_admins("Infected [target] with a virus. (Xenochimera)", src)
 		target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel made anew.</span>")
 
 /mob/living/carbon/human/proc/atmos_biomorph(mob/living/carbon/human/target in view(1))
@@ -613,7 +613,7 @@
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)
-				log_and_message_admins("[src]Infected [target] with a virus. (Xenochimera)")
+				log_and_message_admins("Infected [target] with a virus. (Xenochimera)", src)
 		target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel made anew.</span>")
 
 

--- a/code/modules/mob/living/carbon/human/species/station/station_special.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special.dm
@@ -465,7 +465,7 @@
 		if(target == src)
 			to_chat("<span class = 'Notice'>It is done.</span>")
 		else
-			if(prob(80))
+			if(prob(80) && !get_virus_immune(target))
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)
@@ -560,7 +560,7 @@
 		if(target == src)
 			to_chat(src, "<span class = 'Notice'>It is done.</span>")
 		else
-			if(prob(80))
+			if(prob(80) && !get_virus_immune(target))
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)
@@ -609,7 +609,7 @@
 		if(target == src)
 			to_chat(src, "<span class = 'notice'>It is done.</span>")
 		else
-			if(prob(80))
+			if(prob(80) && !get_virus_immune(target))
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities.dm
@@ -92,18 +92,10 @@
 
 		//Dead when hatching
 		if(stat == DEAD)
-			//Check again for nutriment (necessary?)
-			if(hasnutriment())
-				chimera_hatch()
-				adjustBrainLoss(10) // if they're reviving from dead, they come back with 10 brainloss on top of whatever's unhealed.
-				visible_message("<span class='danger'><p><font size=4>The lifeless husk of [src] bursts open, revealing a new, intact copy in the pool of viscera.</font></p></span>") //Bloody hell...
-				return
-
-			//Don't have nutriment to hatch! Or you somehow died in between completing your revive and hitting hatch.
-			else
-				to_chat(src, "Your body was unable to regenerate, what few living cells remain require additional nutrients to complete the process.")
-				verbs -= /mob/living/carbon/human/proc/hatch
-				revive_ready = REVIVING_READY //reset their cooldown they can try again when they're given a kickstart
+			chimera_hatch()
+			adjustBrainLoss(10) // if they're reviving from dead, they come back with 10 brainloss on top of whatever's unhealed.
+			visible_message("<span class='danger'><p><font size=4>The lifeless husk of [src] bursts open, revealing a new, intact copy in the pool of viscera.</font></p></span>") //Bloody hell...
+			return
 
 		//Alive when hatching
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A biit of a blender here. If requested, I can remove, or split, any parts.

## Why It's Good For The Game

- Makes commune a bit less concerning, though the delay may be too harsh if genetics comes back (depends on distance, up to 90 seconds if they're off somewhere, 30 if they're far away on-station. Make that message count, I suppose)
- Standardizes xenochimeras, however I couldn't add 'change body shape', it kept needing forced icon updates.
- The species that goes schizo from damage now heals passively faster. I think that's a natural expectation.
- Proteans got their languages back, as you'd expect them to.
## Changelog
:cl:
tweak: Xenochimeras now heal passively
add: 2 more extra languages to Proteans
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
