### PR TITLE
cataloguers now have unlimited sharing range if someone is on the same zlevel as sharers

### DIFF
--- a/code/modules/catalogue/cataloguer.dm
+++ b/code/modules/catalogue/cataloguer.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_EMPTY(all_cataloguers)
 	force = 0
 	var/points_stored = 0 // Amount of 'exploration points' this device holds.
 	var/scan_range = 3 // How many tiles away it can scan. Changing this also changes the box size.
-	var/credit_sharing_range = 14 // If another person is within this radius, they will also be credited with a successful scan.
+	var/credit_sharing_range = INFINITY // If another person is within this radius, they will also be credited with a successful scan.
 	var/datum/category_item/catalogue/displayed_data = null // Used for viewing a piece of data in the UI.
 	var/busy = FALSE // Set to true when scanning, to stop multiple scans.
 	var/debug = FALSE // If true, can view all catalogue data defined, regardless of unlock status.
@@ -148,11 +148,16 @@ GLOBAL_LIST_EMPTY(all_cataloguers)
 	// Figure out who may have helped out.
 	var/list/contributers = list()
 	var/list/contributer_names = list()
+	var/turf/T = get_turf(user) || get_turf(target)
+	var/list/contributing_z = GetConnectedZlevels(T.z)
 	for(var/thing in player_list)
 		var/mob/living/L = thing
 		if(L == user)
 			continue
 		if(!istype(L))
+			continue
+		var/turf/other = get_turf(L)
+		if(!(other.z in contributing_z))
 			continue
 		if(get_dist(L, user) <= credit_sharing_range)
 			contributers += L


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

makes explo not suffer from splitting up as much (they already do enough)
makes it so you don't magically get points from scans on other zlevels too
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: cataloguers now consider everyone on their zlevels for sharing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
