### PR TITLE
fixes locker welding race condition

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -314,6 +314,8 @@
 						to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 						return
 			if(do_after(user, 20 * S.toolspeed))
+				if(opened)
+					return
 				playsound(src, S.usesound, 50)
 				src.sealed = !src.sealed
 				src.update_icon()


### PR DESCRIPTION
fixes being able to start welding, open a locker, to have it welded such that closing it immediately welds whoever's on the tile inside.