### PR TITLE
Xenochimera Update

### DIFF
--- a/code/_onclick/hud/spell_screen_objects.dm
+++ b/code/_onclick/hud/spell_screen_objects.dm
@@ -218,3 +218,12 @@
 
 	spell.perform(usr)
 	update_charge(1)
+
+
+
+//Xenochimera, literally just different icons
+/obj/screen/movable/spell_master/chimera
+	name = "Chimera Abilities"
+	icon_state = "cult_spell_ready"
+	open_state = "genetics_open"
+	closed_state = "genetics_closed"

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -155,19 +155,6 @@
 	return 1
 
 /mob/living/carbon/brain/handle_regular_hud_updates()
-	if (stat == 2 || (XRAY in src.mutations))
-		sight |= SEE_TURFS
-		sight |= SEE_MOBS
-		sight |= SEE_OBJS
-		see_in_dark = 8
-		see_invisible = SEE_INVISIBLE_LEVEL_TWO
-	else if (stat != 2)
-		sight &= ~SEE_TURFS
-		sight &= ~SEE_MOBS
-		sight &= ~SEE_OBJS
-		see_in_dark = 2
-		see_invisible = SEE_INVISIBLE_LIVING
-
 	if (healths)
 		if (stat != 2)
 			switch(health)
@@ -187,19 +174,6 @@
 					healths.icon_state = "health6"
 		else
 			healths.icon_state = "health7"
-
-		if (stat == 2 || (XRAY in src.mutations))
-			sight |= SEE_TURFS
-			sight |= SEE_MOBS
-			sight |= SEE_OBJS
-			see_in_dark = 8
-			see_invisible = SEE_INVISIBLE_LEVEL_TWO
-		else if (stat != 2)
-			sight &= ~SEE_TURFS
-			sight &= ~SEE_MOBS
-			sight &= ~SEE_OBJS
-			see_in_dark = 2
-			see_invisible = SEE_INVISIBLE_LIVING
 	if (client)
 		client.screen.Remove(GLOB.global_hud.blurry,GLOB.global_hud.druggy,GLOB.global_hud.vimpaired)
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1390,8 +1390,6 @@
 
 /mob/living/carbon/human/handle_vision()
 	if(stat == DEAD)
-		sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS|SEE_SELF
-		see_in_dark = 8
 		if(client)
 			if(client.view != world.view) // If mob dies while zoomed in with device, unzoom them.
 				for(var/obj/item/item in contents)
@@ -1400,7 +1398,6 @@
 						break
 
 	else //We aren't dead
-		sight &= ~(SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		see_invisible = see_in_dark>2 ? SEE_INVISIBLE_LEVEL_ONE : see_invisible_default
 
 		if(XRAY in mutations)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -177,6 +177,7 @@
 	var/has_glowing_eyes = 0								// Whether the eyes are shown above all lighting
 	var/water_movement = 0									// How much faster or slower the species is in water
 	var/snow_movement = 0									// How much faster or slower the species is on snow
+	var/infect_wounds = 0									// Whether the species can infect wounds, only works with claws / bites
 
 
 	var/item_slowdown_mod = 1								// How affected by item slowdown the species is.
@@ -419,7 +420,6 @@ GLOBAL_LIST_INIT(species_oxygen_tank_by_gas, list(
 		for(var/spell_to_add in inherent_spells)
 			var/spell/S = new spell_to_add(H)
 			H.add_spell(S)
-	return
 
 /datum/species/proc/remove_inherent_spells(var/mob/living/carbon/human/H)
 	H.spellremove()

--- a/code/modules/mob/living/carbon/human/species/station/station_special.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special.dm
@@ -528,7 +528,7 @@
 		if(target == src)
 			to_chat("<span class = 'Notice'>It is done.</span>")
 		else
-			if(prob(80))
+			if(prob(10))
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)
@@ -623,7 +623,7 @@
 		if(target == src)
 			to_chat(src, "<span class = 'Notice'>It is done.</span>")
 		else
-			if(prob(80))
+			if(prob(10))
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)
@@ -672,7 +672,7 @@
 		if(target == src)
 			to_chat(src, "<span class = 'notice'>It is done.</span>")
 		else
-			if(prob(80))
+			if(prob(10))
 				var/datum/disease2/disease/virus2 = new /datum/disease2/disease
 				virus2.makerandom()
 				infect_virus2(target, virus2)

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -340,3 +340,6 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 		if(!user || (!(spell_flags & (STATALLOWED|GHOSTCAST)) && user.stat != originalstat)  || !(user.loc == Location))
 			return 0
 	return 1
+
+/spell/proc/remove_self(mob/user = usr)
+	user.remove_spell(src)

--- a/code/modules/spells/spells.dm
+++ b/code/modules/spells/spells.dm
@@ -36,7 +36,6 @@
 /mob/proc/add_spell(var/spell/spell_to_add, var/spell_base = "wiz_spell_ready", var/master_type = /obj/screen/movable/spell_master)
 	if(!spell_masters)
 		spell_masters = list()
-
 	if(spell_masters.len)
 		for(var/obj/screen/movable/spell_master/spell_master in spell_masters)
 			if(spell_master.type == master_type)

--- a/code/modules/spells/targeted/chimera_spells.dm
+++ b/code/modules/spells/targeted/chimera_spells.dm
@@ -1,0 +1,170 @@
+///////////////////////////////////////////////////////////////////////////////////////////////////
+//			These are species-aimed spells meant to be used by the Xenochimera species			 //
+///////////////////////////////////////////////////////////////////////////////////////////////////
+/spell/targeted/chimera
+	name = "A Chimera Spell"
+	desc = "You shouldn't be seeing this."
+
+	charge_max = 50
+	spell_flags = INCLUDEUSER
+	invocation = "none"
+	invocation_type = SpI_NONE
+	range = 1
+	max_targets = 1
+	cooldown_min = 0
+	duration = 0
+
+	hud_state = "wiz_jaunt"
+	var/nutrition_cost_minimum = 50
+	var/nutrition_cost_proportional = 20 //percentage of nutriment it should cost if it's higher than the minimum
+
+/spell/targeted/chimera/cast(list/targets, mob/user)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/nut = H.nutrition / nutrition_cost_proportional
+		var/final_cost
+		if(nut > nutrition_cost_minimum)
+			final_cost = nut
+		else
+			final_cost = nutrition_cost_minimum
+		H.nutrition -= final_cost
+	else
+		return
+
+////////////////////////
+//Timed thermal sight.//
+////////////////////////
+
+/spell/targeted/chimera/thermal_sight
+	name = "Thermal Sight"
+	desc = "We focus ourselves, able to sense prey and threat through walls or mist. We cannot sustain this for long."
+
+	spell_flags = INCLUDEUSER
+	hud_state = "ling_augmented_eyesight"
+	invocation = "none"
+	invocation_type = SpI_NONE
+	charge_max = 35 SECONDS
+	duration = 30 SECONDS
+	nutrition_cost_minimum = 100
+	nutrition_cost_proportional = 10
+	var/active = FALSE
+
+
+/spell/targeted/chimera/thermal_sight/cast(list/targets, mob/user = usr)
+	if(user.stat != DEAD)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			toggle_sight(user)
+			addtimer(CALLBACK(src, .proc/toggle_sight,H), duration, TIMER_UNIQUE)
+	..()
+
+/spell/targeted/chimera/thermal_sight/proc/toggle_sight(mob/living/carbon/human/H)
+	if(!active)
+		to_chat(H, "<span class='notice'>We focus outward, gaining a keen sense of all those around us.</span>")
+		H.species.vision_flags |= SEE_MOBS
+		active = TRUE
+	else
+		to_chat(H, "<span class='notice'>Our senses dull.</span>")
+		H.species.vision_flags &= ~SEE_MOBS
+		active = FALSE
+
+///////////////
+//Voice Mimic//
+///////////////
+
+/spell/targeted/chimera/voice_mimic
+	name = "Voice Mimicry"
+	desc = "We shape our throat and tongue to imitate a person, or a sound. This ability is a toggle."
+
+	spell_flags = INCLUDEUSER
+	hud_state = "ling_mimic_voice"
+	invocation = "none"
+	invocation_type = SpI_NONE
+	charge_max = 10 SECONDS
+	duration = 0
+	nutrition_cost_minimum = 100
+	nutrition_cost_proportional = 15
+	var/active = FALSE
+
+/spell/targeted/chimera/voice_mimic/cast(list/targets, mob/user = usr)
+	if(user.stat != DEAD)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			if(!active)
+				var/mimic_voice = sanitize(input(usr, "Enter a name to mimic. Leave blank to cancel.", "Mimic Voice", null), MAX_NAME_LEN)
+				if(!mimic_voice)
+					return
+
+				to_chat(user, "<span class='notice'>We shift and morph our tongues, ready to reverberate as: <b>[mimic_voice]</b>.</span>")
+				H.SetSpecialVoice(mimic_voice)
+				active = TRUE
+				..()
+			else
+				to_chat(user, "<span class='notice'>We return our voice to our normal identity.</span>")
+				H.UnsetSpecialVoice()
+				active = FALSE
+		else
+			return
+
+
+///////////////
+//EMP Shriek //
+///////////////
+//Only to be used during feral state, has a very long cooldown. Mostly to get away.
+
+/spell/aoe_turf/dissonant_shriek
+	name = "Dissonant Shriek"
+	desc = "We shift our vocal cords to release a high-frequency sound that overloads nearby electronics."
+	invocation = "none"
+	invocation_type = SpI_NONE
+	hud_state = "ling_resonant_shriek"
+	spell_flags = INCLUDEUSER
+	range = 8
+	//Slightly more potent than an EMP grenade
+	var/emp_heavy = 3
+	var/emp_med = 6
+	var/emp_light = 9
+	var/emp_long = 12
+	charge_max = 5 MINUTES
+
+
+/spell/aoe_turf/dissonant_shriek/before_cast(list/targets, mob/user = usr)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.is_muzzled())
+			to_chat(src, "<span class='danger'>Mmmf mrrfff!</span>")
+			return
+
+		if(H.silent)
+			to_chat(src, "<span class='danger'>You can't speak!</span>")
+			return
+
+		if(!isturf(H.loc))
+			to_chat(src, "<span class='warning'>Shrieking here would be a bad idea.</span>")
+			return
+		..()
+	else
+		return
+
+/spell/aoe_turf/dissonant_shriek/cast(list/targets, mob/user = usr)
+
+	for(var/mob/living/T in targets)
+		if(iscarbon(T))
+			if(T.mind)
+				if(T.get_ear_protection() >= 2)
+					continue
+				to_chat(T, "<span class='danger'>You hear an extremely loud screeching sound!  It slightly \
+				[pick("confuses","confounds","perturbs","befuddles","dazes","unsettles","disorients")] you.</span>")
+				if(T != user)
+					T.Confuse(10)
+				SEND_SOUND(T, sound('sound/effects/screech.ogg'))
+
+	empulse(get_turf(user), emp_heavy, emp_med, emp_light, emp_long)
+
+	user.visible_message("<span class='danger'>[user] vibrates and bubbles, letting out an inhuman shriek, reverberating through your ears!</span>")
+
+	add_attack_logs(user,null,"Used dissonant shriek (Xenochimera) ")
+
+	for(var/obj/machinery/light/L in range(range, src))
+		L.on = 1
+		L.broken()

--- a/code/modules/spells/targeted/chimera_spells.dm
+++ b/code/modules/spells/targeted/chimera_spells.dm
@@ -15,19 +15,24 @@
 	duration = 0
 
 	hud_state = "wiz_jaunt"
+	override_base = "cult"
 	var/nutrition_cost_minimum = 50
 	var/nutrition_cost_proportional = 20 //percentage of nutriment it should cost if it's higher than the minimum
 
 /spell/targeted/chimera/cast(list/targets, mob/user)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		var/nut = H.nutrition / nutrition_cost_proportional
+		var/nut = (H.nutrition * nutrition_cost_proportional) / 100
 		var/final_cost
 		if(nut > nutrition_cost_minimum)
 			final_cost = nut
 		else
 			final_cost = nutrition_cost_minimum
-		H.nutrition -= final_cost
+
+		if((H.nutrition - final_cost) >= 0)
+			H.nutrition -= final_cost
+		else
+			H.nutrition = 0		//We're already super starved, and feral, so cast it for free, you're likely using it to get food at this point.
 	else
 		return
 
@@ -45,7 +50,7 @@
 	invocation_type = SpI_NONE
 	charge_max = 35 SECONDS
 	duration = 30 SECONDS
-	nutrition_cost_minimum = 100
+	nutrition_cost_minimum = 15		//The hungrier you get the less it will cost
 	nutrition_cost_proportional = 10
 	var/active = FALSE
 
@@ -71,7 +76,7 @@
 ///////////////
 //Voice Mimic//
 ///////////////
-
+//It's a toggle, but doesn't cost nutriment to be toggled off
 /spell/targeted/chimera/voice_mimic
 	name = "Voice Mimicry"
 	desc = "We shape our throat and tongue to imitate a person, or a sound. This ability is a toggle."
@@ -80,10 +85,10 @@
 	hud_state = "ling_mimic_voice"
 	invocation = "none"
 	invocation_type = SpI_NONE
-	charge_max = 10 SECONDS
+	charge_max = 5 SECONDS
 	duration = 0
-	nutrition_cost_minimum = 100
-	nutrition_cost_proportional = 15
+	nutrition_cost_minimum = 25
+	nutrition_cost_proportional = 5
 	var/active = FALSE
 
 /spell/targeted/chimera/voice_mimic/cast(list/targets, mob/user = usr)
@@ -98,13 +103,218 @@
 				to_chat(user, "<span class='notice'>We shift and morph our tongues, ready to reverberate as: <b>[mimic_voice]</b>.</span>")
 				H.SetSpecialVoice(mimic_voice)
 				active = TRUE
-				..()
+				..()	//Processes nutriment cost
 			else
 				to_chat(user, "<span class='notice'>We return our voice to our normal identity.</span>")
 				H.UnsetSpecialVoice()
 				active = FALSE
 		else
 			return
+
+
+////////////////
+//Regeneration//
+////////////////
+//Huge cooldown, huge cost, but will actually heal most of your issues.
+
+/spell/targeted/chimera/regenerate
+	name = "Regeneration"
+	desc = "We shed our skin, purging it of damage, regrowing limbs."
+
+	spell_flags = INCLUDEUSER
+	hud_state = "ling_fleshmend"
+	invocation = "none"
+	invocation_type = SpI_NONE
+	charge_max = 10 MINUTES
+	duration = 0
+	nutrition_cost_minimum = 500
+	nutrition_cost_proportional = 75
+	var/healing_amount = 30
+	var/delay = 2 MINUTES
+
+
+/spell/targeted/chimera/regenerate/cast_check(skipcharge = 0,mob/user = usr)
+	if(..())
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			if((nutrition_cost_minimum > H.nutrition) || nutrition_cost_minimum > ((H.nutrition * nutrition_cost_proportional) / 100) )
+				to_chat(H,"<span class = 'notice'>We don't have enough nutriment. This ability is costly...</span>")
+				return FALSE
+			else return TRUE
+
+/spell/targeted/chimera/regenerate/cast(list/targets, mob/user = usr)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(do_after(H, delay, null, FALSE, TRUE, INCAPACITATION_DISABLED))
+			H.restore_blood()
+			H.species.create_organs(H)
+			H.restore_all_organs()
+			H.adjustBruteLoss(-healing_amount)
+			H.adjustFireLoss(-healing_amount)
+			H.adjustOxyLoss(-healing_amount)
+			H.adjustCloneLoss(-healing_amount)
+			H.adjustBrainLoss(-healing_amount)
+			H.blinded = 0
+			H.SetBlinded(0)
+			H.eye_blurry = 0
+			H.ear_deaf = 0
+			H.ear_damage = 0
+
+			H.regenerate_icons()
+
+			playsound(H, 'sound/effects/blobattack.ogg', 30, 1)
+			var/T = get_turf(src)
+			new /obj/effect/gibspawner/human(T, H.dna,H.dna.blood_color,H.dna.blood_color)
+			H.visible_message("<span class='warning'>With a sickening squish, [src] reforms their whole body, casting their old parts on the floor!</span>",
+			"<span class='notice'>We reform our body.  We are whole once more.</span>",
+			"<span class='italics'>You hear organic matter ripping and tearing!</span>")
+			..()
+		else
+			to_chat(user,"<span class = 'warning'>We were interrupted!</span>")
+			charge_counter = 9.8 MINUTES
+
+
+////////////////
+//Revive spell//
+////////////////
+//Will incapacitate you for 10 minutes, and then you can revive.
+/spell/targeted/chimera/hatch
+	name = "Hatch Stasis"
+	desc = "We attempt to grow an entirely new body from scratch, or death."
+
+	spell_flags = INCLUDEUSER | GHOSTCAST
+	hud_state = "ling_regenerative_stasis"
+	invocation = "none"
+	invocation_type = SpI_NONE
+	charge_max = 60 MINUTES
+	duration = 0 SECONDS
+	nutrition_cost_minimum = 1
+	nutrition_cost_proportional = 1
+
+
+/spell/targeted/chimera/hatch/cast_check(skipcharge, mob/user = usr)
+	if(..())
+		if(!ishuman(user))
+			to_chat(user,"Non-humans can't use this!")
+			return FALSE
+
+		var/confirmation = alert("You will begin a lengthy process of around ten minutes you cannot cancel- Is this what you want?","Hatching Prompt","Yes", "No")
+		if(confirmation != "Yes")
+			to_chat(user, "<span class = 'notice'> Hatching cancelled. </span>")
+			return FALSE
+		else return TRUE
+
+/spell/targeted/chimera/hatch/cast(list/targets, mob/user = usr)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.stat == DEAD)
+			H.visible_message("<span class = 'warning'> [H] lays eerily still. Something about them seems off, even when dead.</span>","<span class = 'notice'>We begin to gather up whatever is left to begin regrowth.</span>")
+		else
+			H.visible_message("<span class = 'warning'> [H] suddenly collapses, seizing up and going eerily still. </span>", "<span class = 'notice'>We begin the regrowth process to start anew.</span>")
+			H.SetParalysis(8000) //admin style self-stun
+
+		//These are only messages to give the player and everyone around them an idea of which stage they're at
+		//visible_message doesn't seem to relay selfmessages if you're paralysed, so we use to_chat
+		addtimer(CALLBACK(H, /atom/.proc/visible_message,"<span class = 'warning'> [H]'s skin begins to ripple and move, as if something was crawling underneath.</span>"), 4 MINUTES)
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat,H,"<span class = 'notice'>We begin to recycle the dead tissue.</span>"),4 MINUTES)
+
+		addtimer(CALLBACK(H, /atom/.proc/visible_message,"<span class = 'warning'> <i>[H]'s body begins to lose its shape, skin sloughing off and melting, losing form and composure.</i></span>","<span class = 'notice'>There is little left. We will soon be ready.</span>"), 8 SECONDS)
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat,H,"<span class = 'notice'>There is little left. We will soon be ready.</span>"), 8 MINUTES)
+
+		addtimer(CALLBACK(src, .proc/add_pop,H,), 10 MINUTES)
+
+/spell/targeted/chimera/hatch/proc/add_pop(mob/user = usr)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.visible_message("<span class = 'warning'> <b>[H] looks ready to burst!</b></span>")
+		to_chat(H,"<span class = 'notice'><b>We are ready.</b></span>")
+		var/spell/targeted/chimera/hatch_pop/S = new /spell/targeted/chimera/hatch_pop(H)
+		var/master_type = /obj/screen/movable/spell_master/chimera
+		H.add_spell(S, "cult", master_type)
+
+
+///////////////////////
+//Actual Revive Spell//
+///////////////////////
+//Not to be used normally. Given by the 'hatch' spell
+/spell/targeted/chimera/hatch_pop
+	name = "Emerge"
+	desc = "We emerge in our new form."
+
+	spell_flags = INCLUDEUSER | GHOSTCAST
+	hud_state = "ling_revive"
+	invocation = "none"
+	invocation_type = SpI_NONE
+	charge_max = 10 SECONDS	//It gets removed after_cast anyway
+	duration = 0
+	nutrition_cost_minimum = 1
+	nutrition_cost_proportional = 1
+
+/spell/targeted/chimera/hatch_pop/cast(list/targets, mob/user = usr)
+	var/mob/living/carbon/human/H = user
+
+	var/braindamage = (H.brainloss * 0.6) //Can only heal half brain damage.
+
+	H.revive()
+	H.mutations.Remove(HUSK)
+	H.nutrition = 50		//Hungy, also guarantees ferality without any other tweaking
+	H.setBrainLoss(braindamage)
+
+	//Drop everything
+	for(var/obj/item/W in H)
+		H.drop_from_inventory(W)
+	H.visible_message("<span class = 'warning'>[H] emerges from a cloud of viscera!</b>")
+	H.SetParalysis(0)
+	//Unfreeze some things
+	H.does_not_breathe = FALSE
+	H.update_canmove()
+	H.weakened = 2
+	//Visual effects
+	var/T = get_turf(H)
+	new /obj/effect/gibspawner/human(T, H.dna,H.dna.blood_color,H.dna.blood_color)
+	playsound(T, 'sound/effects/splat.ogg')
+
+/spell/targeted/chimera/hatch_pop/after_cast(list/targets, mob/user = usr)
+	var/mob/living/carbon/human/H = user
+	H.remove_spell(src)
+	qdel(src)
+
+
+////////////////////
+//Timed No Breathe//
+////////////////////
+//Same principle as thermal sight. Could be status effects?
+/spell/targeted/chimera/no_breathe
+	name = "Stop Respiration"
+	desc = "We change our form to no longer need to breathe at all. We cannot sustain this for long."
+
+	spell_flags = INCLUDEUSER
+	hud_state = "ling_toggle_breath"
+	invocation = "none"
+	invocation_type = SpI_NONE
+	charge_max = 125 SECONDS	//5 seconds inbetween uses
+	duration = 120 SECONDS
+	nutrition_cost_minimum = 100
+	nutrition_cost_proportional = 20	//Costly.
+	var/active = FALSE
+
+
+/spell/targeted/chimera/no_breathe/cast(list/targets, mob/user = usr)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		toggle_breath(user)
+		addtimer(CALLBACK(src, .proc/toggle_breath,H), duration, TIMER_UNIQUE)
+	..()
+
+/spell/targeted/chimera/no_breathe/proc/toggle_breath(mob/living/carbon/human/H)
+	if(!active)
+		to_chat(H, "<span class='notice'>We preserve the air we have, no longer needing to breathe.</span>")
+		H.does_not_breathe = TRUE
+		active = TRUE
+	else
+		to_chat(H, "<span class='notice'>Our reserves are drained.</span>")
+		H.does_not_breathe = FALSE
+		active = FALSE
 
 
 ///////////////
@@ -125,7 +335,10 @@
 	var/emp_med = 6
 	var/emp_light = 9
 	var/emp_long = 12
-	charge_max = 5 MINUTES
+	smoke_spread = 1
+	smoke_amt = 1
+	override_base = "cult"
+	charge_max = 5 MINUTES	//Let's not be able to spam this
 
 
 /spell/aoe_turf/dissonant_shriek/before_cast(list/targets, mob/user = usr)
@@ -147,17 +360,15 @@
 		return
 
 /spell/aoe_turf/dissonant_shriek/cast(list/targets, mob/user = usr)
-
 	for(var/mob/living/T in targets)
 		if(iscarbon(T))
 			if(T.mind)
-				if(T.get_ear_protection() >= 2)
+				if(T.get_ear_protection() >= 2 || T == user)
 					continue
 				to_chat(T, "<span class='danger'>You hear an extremely loud screeching sound!  It slightly \
 				[pick("confuses","confounds","perturbs","befuddles","dazes","unsettles","disorients")] you.</span>")
-				if(T != user)
-					T.Confuse(10)
-				SEND_SOUND(T, sound('sound/effects/screech.ogg'))
+				T.Confuse(10)
+	playsound(get_turf(user),'sound/effects/screech.ogg', 75, TRUE)
 
 	empulse(get_turf(user), emp_heavy, emp_med, emp_light, emp_long)
 

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3374,6 +3374,7 @@
 #include "code\modules\spells\aoe_turf\conjure\forcewall.dm"
 #include "code\modules\spells\general\area_teleport.dm"
 #include "code\modules\spells\general\rune_write.dm"
+#include "code\modules\spells\targeted\chimera_spells.dm"
 #include "code\modules\spells\targeted\ethereal_jaunt.dm"
 #include "code\modules\spells\targeted\genetic.dm"
 #include "code\modules\spells\targeted\harvest.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds stuff! Tweaks stuff! Not everything, though.
- Reworks revival and regeneration (for them only, sorry prommies)
- Adds Voice Mimic spell (toggle)
- Adds a timed thermal vision
- Adds a timed nobreathe thing
- Adds a feral-only dissonant shriek (EMP one with smoke puff)
- All non-revival spells have a %-age and a flat cost, you get billed whichever's higher.
- Added a species-based bool that can cause wound infections. Xenochimeras have that by default. Default is 10%, but it immediately sets a new wound to infection level one and forces bleeding (even on bruises)
- Removes chimera reconstitute form (replaced with a spell)
- Removes regeneration from chimera, replaced with a much more powerful (and way more nutrient costing) version.

### New spell UI! Sorta. It's now the same as any other spell / power. Just looks nicer, don't it?
![dreamseeker_2022-01-17_09-18-35](https://user-images.githubusercontent.com/11361525/149725881-e0524684-201f-40d3-8f67-e17878472e66.gif)

### Thermal vision! Lasts 30 seconds
![dreamseeker_2022-01-17_09-20-03](https://user-images.githubusercontent.com/11361525/149725965-7a96e3cf-773b-48bf-9f00-a6e8f5b9a1b7.gif)

### Voice mimic!
![image](https://user-images.githubusercontent.com/11361525/149726074-717f3502-f68f-47cd-a8ae-6f084032f9a4.png)
![image](https://user-images.githubusercontent.com/11361525/149726085-7399d8d9-2e75-4a67-bfdd-15bd627924c5.png)

And others, as listed above.

## Why It's Good For The Game

This should help Xenochimeras feel a lot more like bio-adaptive creepy hunters rather than janky pseudo-prommies held up only by their lore. I can't deny, this loads them up with a lot not-so-soft benefits.

THINGS TO NOTE:
- The nutriment prices are RELATIVE. If you chonk yourself out with 2000 nutrient, you will get chonked in turn for 10% of it anyway, depending on the ability.
- Everything (except revival stuff and feral-only shriek) costs nutriment. It's far more relevant to them now, especially with my last update ( #3665 ) increasing their base nutriment drain (due to increased health regen). They'll be, on average, way more hungy now.
- Their ferality is unchanged. Meaning they are mechanically still encouraged to _flee_ and have many mechanics restricted from them during that state, which is now way easier to reach if you spam these abilities. **Proteans never had to deal with this.**

### WARNING
This modifies life()! Particularly many vision flag overrides! My testing showed no difference, but my testing isn't nearly as all-encompassing as a bunch of players doing just about everything. People may go blind, or may get ghost vision while alive, or anything of the sort. I'm ready to revert that commit whenever during a TM if it proves buggy.

## Changelog
:cl:FreeStylaLT
add: Voice mimicry, thermal vision, no breathe and some other spells to Xenochimera
add: Wound infection to Xenochimera (and ability to be added to other species)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
