### PR TITLE
Mediborg NIF install

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -97,6 +97,7 @@
 		/obj/item/reagent_containers/pill,
 		/obj/item/reagent_containers/blood,
 		/obj/item/stack/material/phoron,
+		/obj/item/implant,
 		/obj/item/nif
 		)
 

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -118,8 +118,8 @@
 /datum/surgery_step/cavity/place_item/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		if(istype(user,/mob/living/silicon/robot))
-			return
+		//if(istype(user,/mob/living/silicon/robot))
+			//return
 		if(affected && affected.cavity)
 			var/total_volume = tool.w_class
 			for(var/obj/item/I in affected.implants)


### PR DESCRIPTION
## About The Pull Request

Allows Mediborgs (both dogborg and non-dogborg) to install NIFs and other implants.

## Why It's Good For The Game

Mediborgs already had the option to pick up NIFs, but were never able to install them. This lead to situations where Mediborgs, who were able to do other surgery just fine, were not able to install implants like the NIF, and lead to awkward moments. These days are now days of the past.

## Changelog
:cl:
add: Enables Borgs to install NIFs and Implants
add: Enables Borgs to pick up Implants with the Medical Gripper
/:cl:
![NIF Surgery 01](https://user-images.githubusercontent.com/47318585/150566581-bb849e7e-1419-4489-a8f3-240c64033c15.png)
![NIF Surgery 02](https://user-images.githubusercontent.com/47318585/150566598-31257531-d334-4036-aa41-d8e9dcc5adfc.png)
