### PR TITLE
Dogborg boop enabled

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -47,7 +47,7 @@
 			w_class = ITEMSIZE_NORMAL
 		update_icon()
 
-//Boop //New and improved, now a simple reagent sniffer.
+//Boop //Newer and better, can sniff reagents, tanks, and boop people!
 /obj/item/dogborg/boop_module
 	name = "boop module"
 	icon = 'icons/mob/dogborg_vr.dmi'

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -84,30 +84,36 @@
 			to_chat(user, "<span class='notice'>[GLOB.meta_gas_names[g]]: [round((environment.gas[g] / total_moles) * 100)]%</span>")
 		to_chat(user, "<span class='notice'>Temperature: [round(environment.temperature-T0C,0.1)]&deg;C ([round(environment.temperature,0.1)]K)</span>")
 
-/obj/item/dogborg/boop_module/afterattack(obj/O, mob/user as mob, proximity)
+/obj/item/dogborg/boop_module/afterattack(atom/target, mob/user, proximity)
 	if(!proximity)
 		return
 	if (user.stat)
 		return
-	if(!istype(O))
+	if(!istype(target) && !ismob(target))
 		return
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	user.visible_message("<span class='notice'>[user] sniffs at \the [O.name].</span>", "<span class='notice'>You sniff \the [O.name]...</span>")
 
-	if(!isnull(O.reagents))
-		var/dat = ""
-		if(O.reagents.reagent_list.len > 0)
-			for (var/datum/reagent/R in O.reagents.reagent_list)
-				dat += "\n \t <span class='notice'>[R]</span>"
 
-		if(dat)
-			to_chat(user, "<span class='notice'>Your BOOP module indicates: [dat]</span>")
-		else
-			to_chat(user, "<span class='notice'>No active chemical agents smelled in [O].</span>")
+	if(ismob(target))
+		user.visible_message("<span class='notice'>\the [user] boops \the [target.name]!</span>", "<span class='notice'>You boop \the [target.name]!</span>")
+		playsound(src.loc, 'sound/misc/slip.ogg', 50, 1)
 	else
-		to_chat(user, "<span class='notice'>No significant chemical agents smelled in [O].</span>")
-
+		user.visible_message("<span class='notice'>[user] sniffs at \the [target.name].</span>", "<span class='notice'>You sniff \the [target.name]...</span>")
+		if(!isnull(target.reagents))
+			var/dat = ""
+			if(target.reagents.reagent_list.len > 0)
+				for (var/datum/reagent/R in target.reagents.reagent_list)
+					dat += "\n \t <span class='notice'>[R]</span>"
+			if(dat)
+				to_chat(user, "<span class='notice'>Your BOOP module indicates: [dat]</span>")
+			else
+				to_chat(user, "<span class='notice'>No active chemical agents smelled in [target].</span>")
+		else
+			if(istype(target, /obj/item/tank)) // don't double post what atmosanalyzer_scan returns
+				analyze_gases(target, user)
+			else
+				to_chat(user, "<span class='notice'>No significant chemical agents smelled in [target].</span>")
 	return
 
 


### PR DESCRIPTION
## About The Pull Request

Allows dogborgs to boop mobs/people and to sniff contents of tanks.

## Why It's Good For The Game

Some people in the past claimed that the Boop module was bugged because it could not check pipes or tanks. This partially restores the Boop module's abilities by making it able to check tanks, but not making it able to check pipes as to not just make it a better analyzer, leaving the ability to check pipes to the Engiborg.
In addition, Borgs can now use their Boop module to, shockingly, boop people. Along with a cute sound.

## Changelog
:cl:
add: Boop module can now scan tanks
add: Boop module can now boop people and simplemobs
/:cl:

![Boop 01](https://user-images.githubusercontent.com/47318585/150635883-976d212a-62e3-4989-9da3-aaa56f781fda.png)
Boop module used on a human. Small text message (not in red, not an attack) and a little sound is played.

![Boop 02](https://user-images.githubusercontent.com/47318585/150635889-b965c5aa-0f53-415d-99f8-867f935896de.png)
Boop module used on a bottle with a chemical. No changes to prior function.

![Boop 03](https://user-images.githubusercontent.com/47318585/150635890-ebf23014-6177-47eb-b27b-14955a175504.png)
Boop module used on a tank.

![Boop 04](https://user-images.githubusercontent.com/47318585/150635893-d01f9d64-223c-407d-b14f-5796ee557ed5.png)
Boop module used on a pipe. No changes to prior function.

![Boop 05](https://user-images.githubusercontent.com/47318585/150635898-407fdc23-c73d-4602-9e4d-72a3616d3e63.png)
Boop module used (clicking module/activation key.) No changes to prior function.