### PR TITLE
Dogborg, tell me the weather.

### DIFF
--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -219,6 +219,47 @@
 			playsound(src.loc, 'sound/machines/synth_no.ogg', 50, 0)
 			m_type = 1
 
+		if("scary")
+			var/M = null
+			if(param)
+				for (var/mob/A in view(null, null))
+					if(param == A.name)
+						M = A
+						break
+			if(!M)
+				param = null
+
+			if (param)
+				message = "emits a disconcerting tone at [param]."
+			else
+				message = "emits a disconcerting tone."
+			playsound(src.loc, 'sound/machines/synth_scary.ogg', 50, 0)
+			m_type = 1
+
+		if("dwoop")
+			var/M = null
+			if(param)
+				for (var/mob/A in view(null, null))
+					if(param == A.name)
+						M = A
+						break
+			if(!M)
+				param = null
+
+			if (param)
+				message = "chirps happily at [param]."
+			else
+				message = "chirps happily."
+			playsound(src.loc, 'sound/machines/dwoop.ogg', 50, 0)
+			m_type = 1
+
+		if("flip")
+			if(src.sleeping || src.resting || src.buckled || src.weakened || src.restrained())
+				to_chat(src, "<span class='warning'>You can't *flip in your current state!</span>")
+			else
+				src.SpinAnimation(7,1)
+				m_type = 1
+
 		if("law")
 			if (istype(module,/obj/item/robot_module/robot/security) || istype(module,/obj/item/robot_module/robot/knine)) //VOREStation Add - K9
 				message = "shows its legal authorization barcode."
@@ -270,6 +311,7 @@
 				message = "gonks."
 			playsound(src.loc, 'sound/machines/gonk.ogg', 50, 0)
 			m_type = 1
+
 
 		if ("help")
 			to_chat(src, "salute, bow-(none)/mob, clap, flap, aflap, twitch, twitch_s, nod, deathgasp, glare-(none)/mob, stare-(none)/mob, look, beep, ping, \nbuzz, law, halt, yes, no")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds *flip, *dwoop, and *scary to the emotes for cyborgs/robots/drones, with focusing (like *glare-name).

Has all been tested on a local server, no issues.

## Why It's Good For The Game

The borgs get the new synth noises, and dogs can now roll over.

## Changelog
:cl:
add: *flip emote
add: *dwoop emote
add: *flip emote
add: A random space in the dm that literally does nothing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
