### PR TITLE
Changes Dremachir and Auril default languages to galcom

### DIFF
--- a/code/modules/mob/living/carbon/human/species/outsider/celestials.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/celestials.dm
@@ -1,8 +1,8 @@
 /datum/species/auril
 	name = SPECIES_AURIL
 	name_plural = "Auril"
-	default_language = LANGUAGE_ENOCHIAN
-	language = LANGUAGE_GALCOM
+	default_language = LANGUAGE_GALCOM
+	language = LANGUAGE_ENOCHIAN
 	num_alternate_languages = 3
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite)
 
@@ -48,8 +48,8 @@
 /datum/species/dremachir
 	name = SPECIES_DREMACHIR
 	name_plural = "Dremachir"
-	default_language = LANGUAGE_DAEMON
-	language = LANGUAGE_GALCOM
+	default_language = LANGUAGE_GALCOM
+	language = LANGUAGE_DAEMON
 	num_alternate_languages = 3
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
stops annoying thing 

## Why It's Good For The Game

that was annoying wasn't it

## Changelog
:cl:
tweak:Auril / Dremachir no longer have their species languages set as default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
