### PR TITLE
Allows The Illegal Removal of Firing Pins From Guns Without Destroying Them (Not Clickbait)

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -287,23 +287,23 @@
 
 	if(A.is_multitool())
 		if(!scrambled)
-			to_chat(user, "<span class='notice'>You begin scrambling \the [src]'s electronic warfare systems.</span>")
+			to_chat(user, "<span class='notice'>You begin scrambling \the [src]'s electronic pins.</span>")
 			playsound(src, A.usesound, 50, 1)
-			switch(rand(1,100))
-				if(1 to 10)
-					do_after(user, 60 * A.toolspeed)
-					to_chat(user, "<span class='danger'>The electronic warfare suite detects the intrusion and explodes!</span>")
-					user.show_message("<span class='danger'>SELF-DESTRUCTING...</span><br>", 2)
-					explosion(get_turf(src), -1, 0, 2, 3)
-					qdel(src)
-				if(11 to 49)
-					do_after(user, 60 * A.toolspeed)
-					to_chat(user, "<span class='notice'>You fail to disrupt \the electronic warfare suite.</span>")
+			if(do_after(user, 60 * A.toolspeed))
+				if(!do_after())
 					return
-				if(50 to 100)
-					do_after(user, 60 * A.toolspeed)
-					to_chat(user, "<span class='notice'>You disrupt \the electronic warfare suite.</span>")
-					scrambled = 1
+				else switch(rand(1,100))
+					if(1 to 10)
+						to_chat(user, "<span class='danger'>The electronic pin suite detects the intrusion and explodes!</span>")
+						user.show_message("<span class='danger'>SELF-DESTRUCTING...</span><br>", 2)
+						explosion(get_turf(src), -1, 0, 2, 3)
+						qdel(src)
+					if(11 to 49)
+						to_chat(user, "<span class='notice'>You fail to disrupt \the electronic warfare suite.</span>")
+						return
+					if(50 to 100)
+						to_chat(user, "<span class='notice'>You disrupt \the electronic warfare suite.</span>")
+						scrambled = 1
 		else
 			to_chat(user, "<span class='warning'>\The [src] does not have an active electronic warfare suite!</span>")
 
@@ -311,20 +311,20 @@
 		if(pin && scrambled)
 			to_chat(user, "<span class='notice'>You attempt to remove \the firing pin from \the [src].</span>")
 			playsound(src, A.usesound, 50, 1)
-			switch(rand(1,100))
-				if(1 to 10)
-					do_after(user, 60 * A.toolspeed)
-					to_chat(user, "<span class='danger'>You twist \the firing pin as you tug, destroying the firing pin.</span>")
-					pin = null
-				if(11 to 74)
-					do_after(user, 60 * A.toolspeed)
-					to_chat(user, "<span class='notice'>You grasp the firing pin, but it slips free!</span>")
+			if(do_after(user, 60* A.toolspeed))
+				if(!do_after())
 					return
-				if(75 to 100)
-					do_after(user, 60 * A.toolspeed)
-					to_chat(user, "<span class='notice'>You remove \the firing pin from \the [src].</span>")
-					user.put_in_hands(src.pin)
-					pin = null
+				else switch(rand(1,100))
+					if(1 to 10)
+						to_chat(user, "<span class='danger'>You twist \the firing pin as you tug, destroying the firing pin.</span>")
+						pin = null
+					if(11 to 74)
+						to_chat(user, "<span class='notice'>You grasp the firing pin, but it slips free!</span>")
+						return
+					if(75 to 100)
+						to_chat(user, "<span class='notice'>You remove \the firing pin from \the [src].</span>")
+						user.put_in_hands(src.pin)
+						pin = null
 		else if(pin && !scrambled)
 			to_chat(user, "<span class='notice'>The \the firing pin is firmly locked into \the [src].</span>")
 		else

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -106,6 +106,7 @@
 
 	var/obj/item/firing_pin/pin = /obj/item/firing_pin
 	var/no_pin_required = 0
+	var/scrambled = 0
 
 /obj/item/gun/CtrlClick(mob/user)
 	if(can_flashlight && ishuman(user) && src.loc == usr && !user.incapacitated(INCAPACITATION_ALL))
@@ -283,6 +284,52 @@
 				verbs -= /obj/item/gun/verb/allow_dna
 		else
 			to_chat(user, "<span class='warning'>\The [src] is not accepting modifications at this time.</span>")
+
+	if(A.is_multitool())
+		if(!scrambled)
+			to_chat(user, "<span class='notice'>You begin scrambling \the [src]'s electronic warfare systems.</span>")
+			playsound(src, A.usesound, 50, 1)
+			switch(rand(1,100))
+				if(1 to 10)
+					do_after(user, 60 * A.toolspeed)
+					to_chat(user, "<span class='danger'>The electronic warfare suite detects the intrusion and explodes!</span>")
+					user.show_message("<span class='danger'>SELF-DESTRUCTING...</span><br>", 2)
+					explosion(get_turf(src), -1, 0, 2, 3)
+					qdel(src)
+				if(11 to 49)
+					do_after(user, 60 * A.toolspeed)
+					to_chat(user, "<span class='notice'>You fail to disrupt \the electronic warfare suite.</span>")
+					return
+				if(50 to 100)
+					do_after(user, 60 * A.toolspeed)
+					to_chat(user, "<span class='notice'>You disrupt \the electronic warfare suite.</span>")
+					scrambled = 1
+		else
+			to_chat(user, "<span class='warning'>\The [src] does not have an active electronic warfare suite!</span>")
+
+	if(A.is_wirecutter())
+		if(pin && scrambled)
+			to_chat(user, "<span class='notice'>You attempt to remove \the firing pin from \the [src].</span>")
+			playsound(src, A.usesound, 50, 1)
+			switch(rand(1,100))
+				if(1 to 10)
+					do_after(user, 60 * A.toolspeed)
+					to_chat(user, "<span class='danger'>You twist \the firing pin as you tug, destroying the firing pin.</span>")
+					pin = null
+				if(11 to 74)
+					do_after(user, 60 * A.toolspeed)
+					to_chat(user, "<span class='notice'>You grasp the firing pin, but it slips free!</span>")
+					return
+				if(75 to 100)
+					do_after(user, 60 * A.toolspeed)
+					to_chat(user, "<span class='notice'>You remove \the firing pin from \the [src].</span>")
+					user.put_in_hands(src.pin)
+					pin = null
+		else if(pin && !scrambled)
+			to_chat(user, "<span class='notice'>The \the firing pin is firmly locked into \the [src].</span>")
+		else
+			to_chat(user, "<span class='warning'>\The [src] does not have a firing pin installed!</span>")
+
 	..()
 
 /obj/item/gun/emag_act(var/remaining_charges, var/mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. _Enables the illegal extraction of firing pins._

## Why It's Good For The Game

1. Currently, firing pins can only be overwritten by other pins. There is no way to extract extant pins with bootleg modification. Although I can see this being rife with abuse potential, I also believe it frees up a lot of choice and experimentation potential for the players. I'm willing to revisit this to tweak the RNG weights on failure and success chances, after further testing.

## Changelog
:cl:
add: Adds the ability to extract firing pins from guns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
