### PR TITLE
Fixes: MultiZ Wire Bug, Exploration Airlock Docking (Including Initial Longstanding Docking Error), Robotics QOL Adjustments, Restores Nebula Gas Roles & Fixes Trade Port

### DIFF
--- a/_maps/map_files/triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/triumph/triumph-02-deck2.dmm
@@ -3787,8 +3787,6 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	d1 = 32;
-	d2 = 8;
 	icon_state = "32-8"
 	},
 /turf/simulated/open,

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -2365,11 +2365,11 @@
 /area/medical/medbay3)
 "bWI" = (
 /obj/machinery/door/firedoor/glass,
+/obj/effect/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/voidcraft/vertical{
 	frequency = 1380;
-	id_tag = "emt_shuttle_interior"
+	id_tag = null
 	},
-/obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
 "bWQ" = (
@@ -6496,7 +6496,7 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/voidcraft/vertical{
 	frequency = 1380;
-	id_tag = "emt_shuttle_exterior"
+	id_tag = null
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11757,16 +11757,11 @@
 /area/medical/recoveryrestroom)
 "jNn" = (
 /obj/machinery/door/firedoor/glass,
+/obj/effect/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/voidcraft/vertical{
 	frequency = 1380;
-	id_tag = "emt_shuttle_exterior"
+	id_tag = null
 	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	pixel_x = 24
-	},
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
 "jNC" = (
@@ -13576,13 +13571,13 @@
 	},
 /area/rnd/research)
 "lhX" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
-	id_tag = "emt_vent"
+	id_tag = "emt_shuttle_docker_pump"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
 "lid" = (
@@ -14639,6 +14634,10 @@
 "mfr" = (
 /obj/machinery/atmospherics/binary/pump{
 	name = "main fuel pump"
+	},
+/obj/structure/fuel_port{
+	dir = 4;
+	pixel_x = 29
 	},
 /turf/simulated/floor,
 /area/shuttle/emt/general)
@@ -16838,17 +16837,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "nRz" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	frequency = 1380;
-	id_tag = "emt_vent"
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
+	id_tag = "emt_shuttle_docker";
 	pixel_x = 24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1380;
+	id_tag = "emt_shuttle_docker_pump"
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
@@ -20733,7 +20733,7 @@
 	},
 /obj/machinery/door/airlock/voidcraft/vertical{
 	frequency = 1380;
-	id_tag = "emt_shuttle_interior"
+	id_tag = null
 	},
 /obj/machinery/access_button{
 	dir = 1;
@@ -30604,11 +30604,6 @@
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 1
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	pixel_y = 24
-	},
-/obj/effect/map_helper/airlock/sensor/int_sensor,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
 "xOy" = (

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -15088,11 +15088,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/medbreak/surgery)
 "mrJ" = (
-/obj/machinery/recharge_station,
 /obj/machinery/camera/network/research{
 	dir = 8;
 	network = list("Research","Toxins Test Area")
 	},
+/obj/structure/closet/secure_closet/guncabinet/robotics,
 /turf/simulated/floor/tiled/techfloor,
 /area/assembly/chargebay)
 "mth" = (
@@ -21142,6 +21142,15 @@
 /obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
+"qOn" = (
+/obj/machinery/computer/cryopod/robot{
+	pixel_y = -30
+	},
+/obj/structure/closet/crate/bin{
+	anchored = 1
+	},
+/turf/simulated/floor/tiled/old_cargo/purple,
+/area/assembly/robotics)
 "qOA" = (
 /obj/structure/sink{
 	dir = 8;
@@ -30266,11 +30275,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medbay/fore)
 "xDR" = (
-/obj/structure/closet/crate/bin{
-	anchored = 1
-	},
-/obj/machinery/computer/cryopod/robot{
-	pixel_y = -30
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/old_cargo/purple,
 /area/assembly/robotics)
@@ -35956,7 +35965,7 @@ vGq
 rxU
 eus
 vGq
-wgM
+qOn
 wor
 vrf
 wfK
@@ -37515,7 +37524,7 @@ jgu
 wQJ
 dXc
 jEz
-rKa
+rLt
 sGT
 oYT
 oNN

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -6504,6 +6504,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/access_button{
+	frequency = 1380;
 	master_tag = "emt_shuttle_docker";
 	name = "exterior access button";
 	pixel_x = -30;
@@ -11762,6 +11763,7 @@
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
 /obj/machinery/airlock_sensor{
+	frequency = 1380;
 	pixel_x = 24
 	},
 /obj/effect/map_helper/airlock/sensor/ext_sensor,
@@ -16845,6 +16847,7 @@
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/airlock_sensor{
+	frequency = 1380;
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/white,
@@ -19479,6 +19482,7 @@
 	dir = 1
 	},
 /obj/machinery/airlock_sensor{
+	frequency = 1380;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
@@ -20733,6 +20737,7 @@
 	},
 /obj/machinery/access_button{
 	dir = 1;
+	frequency = 1380;
 	master_tag = "emt_shuttle_docker";
 	name = "interior access button";
 	pixel_x = -20;
@@ -30600,6 +30605,7 @@
 	dir = 1
 	},
 /obj/machinery/airlock_sensor{
+	frequency = 1380;
 	pixel_y = 24
 	},
 /obj/effect/map_helper/airlock/sensor/int_sensor,

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -15068,8 +15068,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_medical{
-	name = "Patient Psychiatric Ward A";
-	req_one_access = list(5)
+	name = "Patient Psychiatric Ward A"
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -23663,8 +23662,6 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	d1 = 32;
-	d2 = 8;
 	icon_state = "32-8"
 	},
 /turf/simulated/open,

--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -1176,6 +1176,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/aft)
+"aXJ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/exploration/explorer_prep)
 "aYd" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 5
@@ -3095,7 +3101,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "cqx" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+/obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
 /turf/simulated/shuttle/wall/voidcraft/blue,
@@ -3318,6 +3324,19 @@
 /obj/structure/sign/deck/fourth,
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/clownoffice)
+"cyS" = (
+/obj/machinery/airlock_sensor{
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1380;
+	id_tag = null
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/turf/simulated/floor/tiled,
+/area/exploration/explorer_prep)
 "czs" = (
 /obj/structure/railing,
 /turf/simulated/open,
@@ -4475,6 +4494,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/airlock_sensor{
+	pixel_x = 26;
+	pixel_y = 38
+	},
+/obj/effect/map_helper/airlock/sensor/int_sensor,
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
 "dwx" = (
@@ -4701,11 +4725,10 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/security_lockerroom)
 "dFA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 8
-	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
-/area/shuttle/excursion/general)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/exploration/explorer_prep)
 "dFG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5101,7 +5124,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/hallway)
 "dSS" = (
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/monofloor{
+	dir = 8
+	},
 /area/exploration/explorer_prep)
 "dSV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -5209,7 +5234,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "dXI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
 /turf/simulated/shuttle/wall/voidcraft/blue,
@@ -5582,6 +5607,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
+"eis" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/exploration/excursion_dock)
 "eix" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -6089,6 +6126,7 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(19,43,67)
 	},
+/obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "eEq" = (
@@ -6409,9 +6447,8 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/triumph/surfacebase/tram)
 "eLS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 10
-	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/wall_mounted,
+/obj/effect/map_helper/airlock/atmos/pump_out_external,
 /turf/simulated/shuttle/wall/voidcraft/blue,
 /area/shuttle/excursion/general)
 "eMf" = (
@@ -7265,6 +7302,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/interrogation)
+"foe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monofloor{
+	dir = 4
+	},
+/area/exploration/explorer_prep)
 "fow" = (
 /obj/structure/sign/warning/lethal_turrets{
 	pixel_y = -32
@@ -8062,13 +8112,8 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/captain)
 "fUd" = (
-/obj/machinery/door/airlock/voidcraft/vertical{
-	frequency = null;
-	id_tag = null
-	},
 /obj/effect/map_helper/airlock/door/ext_door,
 /obj/effect/map_helper/airlock/sensor/ext_sensor,
-/obj/structure/fans/tiny,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -8082,8 +8127,9 @@
 	pixel_x = 24
 	},
 /obj/machinery/airlock_sensor{
-	pixel_x = -24
+	pixel_x = -56
 	},
+/obj/machinery/door/airlock/voidcraft/vertical,
 /turf/simulated/shuttle/plating,
 /area/shuttle/excursion/general)
 "fVF" = (
@@ -8953,6 +8999,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/triumph/surfacebase/tram)
+"gBL" = (
+/obj/machinery/camera/network/exploration,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/exploration/excursion_dock)
 "gBY" = (
 /obj/machinery/suit_cycler/medical,
 /turf/simulated/floor/tiled,
@@ -9834,6 +9890,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/lawoffice)
+"hjs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/exploration/excursion_dock)
 "hjI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/structure/shuttle/engine/heater{
@@ -10369,20 +10434,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
 "hCv" = (
-/obj/structure/cable/green,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/super;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -30
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/exploration/excursion_dock)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(19,43,67)
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled,
+/area/exploration/explorer_prep)
 "hCx" = (
 /obj/structure/table/rack,
 /turf/simulated/floor/plating,
@@ -10710,6 +10773,9 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "hOa" = (
@@ -11280,6 +11346,12 @@
 	pixel_y = 22
 	},
 /obj/machinery/camera/network/exploration,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/excursion_dock)
 "ifn" = (
@@ -11908,6 +11980,21 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
+"iDF" = (
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1380;
+	id_tag = "expshuttle_dock";
+	pixel_y = 32;
+	req_one_access = list(19,43,67)
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1380;
+	id_tag = null
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/turf/simulated/floor/tiled,
+/area/exploration/explorer_prep)
 "iEd" = (
 /obj/machinery/camera/network/command,
 /obj/structure/closet/crate/bin{
@@ -12926,6 +13013,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
+"jtp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/exploration/explorer_prep)
 "jtv" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32
@@ -13768,10 +13861,6 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "kdF" = (
-/obj/machinery/atmospherics/unary/vent_pump/siphon{
-	dir = 8;
-	id_tag = "expshuttle_pump_out_internal"
-	},
 /obj/effect/map_helper/airlock/atmos/pump_out_internal,
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
@@ -13779,6 +13868,11 @@
 	frequency = 1380;
 	id_tag = "expshuttle_docker";
 	pixel_x = -22
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1380;
+	id_tag = null
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
@@ -13888,12 +13982,13 @@
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/captain)
 "kln" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	id_tag = null
-	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1380;
+	id_tag = null
+	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
 "klp" = (
@@ -14134,6 +14229,11 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
+"kvv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/exploration/explorer_prep)
 "kvF" = (
 /obj/machinery/photocopier,
 /obj/machinery/camera/network/exploration,
@@ -14879,6 +14979,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/lounge)
+"lac" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/exploration/explorer_prep)
 "lak" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -16918,6 +17026,13 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled,
 /area/teleporter)
+"mtg" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/plating,
+/area/exploration/explorer_prep)
 "mtB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -17016,13 +17131,6 @@
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "mxQ" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/wall_mounted{
-	dir = 4;
-	frequency = 1380;
-	id_tag = "expshuttle_pump_out_external";
-	power_rating = 20000
-	},
-/obj/effect/map_helper/airlock/atmos/pump_out_external,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
@@ -17621,6 +17729,8 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(19,43,67)
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "mTK" = (
@@ -17800,6 +17910,12 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
+"nai" = (
+/obj/structure/table/rack,
+/obj/item/tank/air,
+/obj/item/tank/air,
+/turf/simulated/floor/plating,
+/area/exploration/explorer_prep)
 "naG" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/machinery/button/windowtint{
@@ -18120,9 +18236,10 @@
 "nnI" = (
 /obj/effect/map_helper/airlock/atmos/pump_out_internal,
 /obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/atmospherics/unary/vent_pump/siphon{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
-	id_tag = "expshuttle_pump_out_internal"
+	frequency = 1380;
+	id_tag = null
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
@@ -18211,6 +18328,9 @@
 	},
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
@@ -18424,6 +18544,12 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/excursion_dock)
@@ -21236,11 +21362,11 @@
 /area/library/study)
 "pwy" = (
 /obj/machinery/camera/network/exploration,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/excursion_dock)
@@ -21584,6 +21710,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/central)
+"pMg" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/exploration/explorer_prep)
 "pMj" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/floor_decal/grass_edge{
@@ -21788,15 +21920,19 @@
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "pSB" = (
-/obj/machinery/door/airlock/voidcraft/vertical{
-	frequency = null;
-	id_tag = null
-	},
 /obj/effect/map_helper/airlock/door/int_door,
 /obj/machinery/access_button/airlock_interior{
 	master_tag = "expshuttle_docker";
 	pixel_x = -24
 	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "shuttle_lockdown";
+	name = "Shuttle Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/voidcraft/vertical,
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
 "pTM" = (
@@ -22541,6 +22677,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
+"qmR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/exploration/excursion_dock)
 "qnw" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -24436,6 +24578,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/triumph/surfacebase/sauna)
+"rzm" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/exploration/explorer_prep)
 "rzp" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -24961,6 +25109,18 @@
 "rSb" = (
 /turf/simulated/floor/plating,
 /area/maintenance/central)
+"rSu" = (
+/obj/structure/closet/hydrant{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/exploration/excursion_dock)
 "rSv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -25113,7 +25273,10 @@
 /obj/machinery/vending/wallmed_airlock{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/monofloor,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/monofloor{
+	dir = 4
+	},
 /area/exploration/explorer_prep)
 "rXl" = (
 /obj/machinery/door/airlock/command{
@@ -25408,14 +25571,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/central)
 "skC" = (
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1380;
-	id_tag = "expshuttle_dock";
-	pixel_x = 32;
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_external{
 	req_one_access = list(19,43,67)
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/exploration/excursion_dock)
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled,
+/area/exploration/explorer_prep)
 "skS" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/crayons,
@@ -26367,6 +26529,12 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/excursion_dock)
 "sNZ" = (
@@ -26629,6 +26797,11 @@
 /obj/machinery/chemical_dispenser/bar_soft/full,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
+"sVA" = (
+/obj/structure/table/rack,
+/obj/item/tool/wrench,
+/turf/simulated/floor/plating,
+/area/exploration/explorer_prep)
 "sWo" = (
 /obj/machinery/light,
 /obj/machinery/alarm/alarms_hidden{
@@ -27168,6 +27341,21 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/excursion_dock)
 "tsY" = (
@@ -27508,11 +27696,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "tFr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/shuttle/wall/voidcraft/blue,
-/area/shuttle/excursion/general)
+/turf/simulated/floor/plating,
+/area/exploration/explorer_prep)
 "tFK" = (
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hop)
@@ -28047,7 +28241,7 @@
 /turf/simulated/floor/wood,
 /area/library)
 "ufP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/shuttle/wall/voidcraft/blue,
 /area/shuttle/excursion/general)
 "ugl" = (
@@ -28476,6 +28670,12 @@
 	layer = 3.3;
 	pixel_x = 4;
 	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/excursion_dock)
@@ -29572,6 +29772,12 @@
 	},
 /turf/simulated/floor/carpet/tealcarpet,
 /area/crew_quarters/sleep/CMO_quarters)
+"vhV" = (
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/exploration/explorer_prep)
 "vii" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -32158,6 +32364,9 @@
 /obj/item/radio/intercom{
 	pixel_y = -24
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "wPi" = (
@@ -32467,8 +32676,11 @@
 	dir = 4;
 	pixel_x = -23
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monofloor{
-	dir = 1
+	dir = 4
 	},
 /area/exploration/explorer_prep)
 "xcc" = (
@@ -36514,9 +36726,9 @@ xfo
 uNx
 heR
 uxK
-nIK
-nIK
-mAF
+sJC
+sJC
+sJC
 mAF
 xsI
 xsI
@@ -36656,11 +36868,11 @@ wMf
 uiG
 uxZ
 uxK
-nIK
-nIK
-mAF
-mAF
-xsI
+tFr
+kvv
+kvv
+qmR
+hjs
 xsI
 bYS
 bYS
@@ -36798,11 +37010,11 @@ qmb
 bQE
 idJ
 uxK
-nIK
-nIK
+jtp
+nai
+sJC
 mAF
-mAF
-xsI
+wlr
 vcd
 uDH
 nmi
@@ -36940,11 +37152,11 @@ wMf
 uiG
 oeN
 uxK
-nIK
-nIK
+vhV
+sVA
+sJC
 mAF
-mAF
-bPa
+rSu
 qbj
 uDH
 nmi
@@ -37082,11 +37294,11 @@ mLN
 rSv
 pxT
 uxK
-nIK
-nIK
+aXJ
+rzm
+sJC
 mAF
-mAF
-alS
+gBL
 mxQ
 uDH
 nmi
@@ -37224,12 +37436,12 @@ bFL
 wJG
 ofC
 uxK
-nIK
-nIK
+aXJ
+mtg
+sJC
 mAF
-mAF
-ouB
-dFA
+eis
+bYS
 hYe
 hYe
 reI
@@ -37365,10 +37577,10 @@ nfG
 pWx
 fdy
 nrn
+dFA
+pMg
+lac
 sJC
-nIK
-nIK
-mAF
 mAF
 sNX
 uDH
@@ -37513,7 +37725,7 @@ sJC
 sJC
 mAF
 tsJ
-tFr
+hYe
 eCV
 xLZ
 vhw
@@ -37652,7 +37864,7 @@ hNE
 mTh
 xbo
 rXj
-mTh
+foe
 hCv
 nxR
 eLS
@@ -37792,11 +38004,11 @@ yeU
 cVO
 baW
 sJC
+iDF
 cVO
-cVO
+cyS
 sJC
-xsI
-xsI
+wlr
 fUd
 pTM
 kdF
@@ -37934,11 +38146,11 @@ gHc
 cVO
 pYB
 eEl
-mmj
 dSS
-eEl
+dSS
+dSS
 skC
-xsI
+wlr
 hYe
 iRC
 kln
@@ -38080,7 +38292,7 @@ eee
 qJu
 sJC
 mAF
-xsI
+wlr
 hYe
 oZY
 obo
@@ -38364,7 +38576,7 @@ hqy
 hqy
 mjJ
 mAF
-ouB
+eis
 dzk
 qXa
 sfl
@@ -38506,7 +38718,7 @@ pCc
 hqy
 gxG
 mAF
-xsI
+wlr
 dzk
 gQk
 xnp
@@ -38790,7 +39002,7 @@ pLf
 gaT
 rsy
 mAF
-xsI
+wlr
 dzk
 lTt
 lTt
@@ -38932,7 +39144,7 @@ pLf
 hqy
 mHf
 mAF
-xsI
+wlr
 rWY
 mmQ
 mmQ
@@ -39074,7 +39286,7 @@ rNz
 hqy
 xQn
 mAF
-ouB
+eis
 bwh
 bwh
 bwh
@@ -39216,7 +39428,7 @@ hqy
 hqy
 eXs
 mXx
-xsI
+wlr
 xsI
 rkC
 xsI

--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -3101,11 +3101,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "cqx" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
+/obj/machinery/access_button/airlock_interior{
+	frequency = 1380;
+	master_tag = "expshuttle_dock";
+	pixel_y = 10
 	},
-/turf/simulated/shuttle/wall/voidcraft/blue,
-/area/shuttle/excursion/general)
+/turf/simulated/wall/r_wall,
+/area/exploration/explorer_prep)
 "cqJ" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/porta_turret/stationary{
@@ -4494,11 +4496,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/airlock_sensor{
-	pixel_x = 26;
-	pixel_y = 38
-	},
-/obj/effect/map_helper/airlock/sensor/int_sensor,
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
 "dwx" = (
@@ -5234,11 +5231,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "dXI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
 	},
-/turf/simulated/shuttle/wall/voidcraft/blue,
-/area/shuttle/excursion/general)
+/obj/machinery/meter{
+	frequency = 1443;
+	id = "dist_aux_meter";
+	name = "Distribution Loop"
+	},
+/turf/simulated/floor/plating,
+/area/exploration/explorer_prep)
 "dXT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5612,9 +5614,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -6447,10 +6446,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/triumph/surfacebase/tram)
 "eLS" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/wall_mounted,
-/obj/effect/map_helper/airlock/atmos/pump_out_external,
-/turf/simulated/shuttle/wall/voidcraft/blue,
-/area/shuttle/excursion/general)
+/obj/machinery/access_button/airlock_exterior{
+	frequency = 1380;
+	master_tag = "expshuttle_dock"
+	},
+/turf/simulated/wall/r_wall,
+/area/exploration/explorer_prep)
 "eMf" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -8113,7 +8114,6 @@
 /area/crew_quarters/captain)
 "fUd" = (
 /obj/effect/map_helper/airlock/door/ext_door,
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -8121,15 +8121,14 @@
 	name = "Shuttle Lockdown";
 	opacity = 0
 	},
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1380;
-	master_tag = "expshuttle_docker";
-	pixel_x = 24
+/obj/machinery/door/airlock/voidcraft/vertical{
+	id_tag = null
 	},
-/obj/machinery/airlock_sensor{
-	pixel_x = -56
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/obj/machinery/airlock_sensor/airlock_exterior{
+	id_tag = "expshuttle_docker";
+	pixel_x = 26
 	},
-/obj/machinery/door/airlock/voidcraft/vertical,
 /turf/simulated/shuttle/plating,
 /area/shuttle/excursion/general)
 "fVF" = (
@@ -9002,9 +9001,6 @@
 "gBL" = (
 /obj/machinery/camera/network/exploration,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -9891,9 +9887,6 @@
 /turf/simulated/floor/wood,
 /area/lawoffice)
 "hjs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -11349,9 +11342,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/excursion_dock)
 "ifn" = (
@@ -12322,6 +12312,7 @@
 	},
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
+	id_tag = "expshuttle_docker";
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled,
@@ -13861,18 +13852,16 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "kdF" = (
-/obj/effect/map_helper/airlock/atmos/pump_out_internal,
-/obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
-	cycle_to_external_air = 1;
 	frequency = 1380;
 	id_tag = "expshuttle_docker";
-	pixel_x = -22
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	frequency = 1380;
-	id_tag = null
+	pixel_x = -22;
+	tag_airpump = null;
+	tag_chamber_sensor = null;
+	tag_exterior_door = null;
+	tag_exterior_sensor = null;
+	tag_interior_door = null;
+	tag_interior_sensor = null
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
@@ -13987,7 +13976,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1380;
-	id_tag = null
+	id_tag = "expshuttle_docker_pump"
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
@@ -14230,7 +14219,6 @@
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
 "kvv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/exploration/explorer_prep)
@@ -18234,15 +18222,11 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/hop)
 "nnI" = (
-/obj/effect/map_helper/airlock/atmos/pump_out_internal,
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	frequency = 1380;
-	id_tag = null
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/shuttle/excursion/general)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/exploration/excursion_dock)
 "nnL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
@@ -18546,9 +18530,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -21365,8 +21346,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/excursion_dock)
@@ -21921,10 +21902,6 @@
 /area/hydroponics/garden)
 "pSB" = (
 /obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/access_button/airlock_interior{
-	master_tag = "expshuttle_docker";
-	pixel_x = -24
-	},
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -21932,7 +21909,14 @@
 	name = "Shuttle Lockdown";
 	opacity = 0
 	},
-/obj/machinery/door/airlock/voidcraft/vertical,
+/obj/machinery/door/airlock/voidcraft/vertical{
+	id_tag = null
+	},
+/obj/machinery/airlock_sensor/airlock_interior{
+	id_tag = "expshuttle_docker";
+	pixel_x = -26
+	},
+/obj/effect/map_helper/airlock/sensor/int_sensor,
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
 "pTM" = (
@@ -22678,7 +22662,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
 "qmR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
@@ -25116,9 +25099,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/excursion_dock)
 "rSv" = (
@@ -26532,9 +26512,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/excursion_dock)
 "sNZ" = (
@@ -27344,9 +27321,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
@@ -27696,9 +27670,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "tFr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -28240,10 +28211,6 @@
 /obj/machinery/librarycomp,
 /turf/simulated/floor/wood,
 /area/library)
-"ufP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/shuttle/wall/voidcraft/blue,
-/area/shuttle/excursion/general)
 "ugl" = (
 /obj/structure/catwalk,
 /obj/machinery/alarm{
@@ -28672,9 +28639,6 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -37014,7 +36978,7 @@ jtp
 nai
 sJC
 mAF
-wlr
+nnI
 vcd
 uDH
 nmi
@@ -37294,7 +37258,7 @@ mLN
 rSv
 pxT
 uxK
-aXJ
+dXI
 rzm
 sJC
 mAF
@@ -37867,10 +37831,10 @@ rXj
 foe
 hCv
 nxR
-eLS
-ufP
-cqx
-dXI
+hYe
+hYe
+hYe
+hYe
 bYS
 hdl
 ieD
@@ -38003,16 +37967,16 @@ xOb
 yeU
 cVO
 baW
-sJC
+cqx
 iDF
 cVO
 cyS
-sJC
-wlr
+eLS
+nnI
 fUd
 pTM
 kdF
-nnI
+ieD
 pSB
 dvW
 mpE
@@ -38150,7 +38114,7 @@ dSS
 dSS
 dSS
 skC
-wlr
+nnI
 hYe
 iRC
 kln
@@ -38292,7 +38256,7 @@ eee
 qJu
 sJC
 mAF
-wlr
+nnI
 hYe
 oZY
 obo
@@ -38718,7 +38682,7 @@ pCc
 hqy
 gxG
 mAF
-wlr
+nnI
 dzk
 gQk
 xnp
@@ -39002,7 +38966,7 @@ pLf
 gaT
 rsy
 mAF
-wlr
+nnI
 dzk
 lTt
 lTt
@@ -39144,7 +39108,7 @@ pLf
 hqy
 mHf
 mAF
-wlr
+nnI
 rWY
 mmQ
 mmQ
@@ -39428,7 +39392,7 @@ hqy
 hqy
 eXs
 mXx
-wlr
+nnI
 xsI
 rkC
 xsI

--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -2557,7 +2557,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
-/obj/machinery/door/airlock/voidcraft/vertical,
+/obj/machinery/door/airlock/voidcraft/vertical{
+	frequency = null
+	},
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
 "bWc" = (
@@ -2847,11 +2849,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/airlock_sensor{
-	pixel_x = -24;
-	pixel_y = -24
-	},
-/obj/effect/map_helper/airlock/sensor/int_sensor,
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
 "chc" = (
@@ -3328,15 +3325,16 @@
 /area/crew_quarters/clownoffice)
 "cyS" = (
 /obj/machinery/airlock_sensor{
+	id_tag = "expshuttle_dock";
 	pixel_y = -24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	frequency = 1380;
-	id_tag = null
 	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1380;
+	id_tag = "expshuttle_dock_pump"
+	},
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "czs" = (
@@ -3459,6 +3457,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/cyan,
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
+	id_tag = "civvie_docker";
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/old_tile/green,
@@ -5142,7 +5141,9 @@
 	pixel_y = 25
 	},
 /obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/door/airlock/voidcraft/vertical,
+/obj/machinery/door/airlock/voidcraft/vertical{
+	frequency = null
+	},
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
 "dTy" = (
@@ -6086,6 +6087,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/airlock_sensor{
+	id_tag = "civvie_dock";
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark,
@@ -8121,13 +8123,13 @@
 	name = "Shuttle Lockdown";
 	opacity = 0
 	},
+/obj/machinery/access_button/airlock_exterior{
+	frequency = 1380;
+	master_tag = "expshuttle_docker";
+	pixel_x = 24
+	},
 /obj/machinery/door/airlock/voidcraft/vertical{
 	id_tag = null
-	},
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
-/obj/machinery/airlock_sensor/airlock_exterior{
-	id_tag = "expshuttle_docker";
-	pixel_x = 26
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/excursion/general)
@@ -11841,12 +11843,12 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
-	id_tag = "civvie_vent"
+	id_tag = "civvie_docker_pump"
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
 "ixx" = (
@@ -11980,7 +11982,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
-	id_tag = null
+	id_tag = "expshuttle_dock_pump"
 	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
@@ -12315,6 +12317,13 @@
 	id_tag = "expshuttle_docker";
 	pixel_x = 24
 	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1380;
+	id_tag = "expshuttle_docker_pump";
+	power_rating = 20000
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
 "iRH" = (
@@ -13253,7 +13262,9 @@
 "jCa" = (
 /obj/machinery/door/firedoor,
 /obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/door/airlock/voidcraft/vertical,
+/obj/machinery/door/airlock/voidcraft/vertical{
+	frequency = null
+	},
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
 "jCj" = (
@@ -13971,12 +13982,8 @@
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/captain)
 "kln" = (
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1380;
-	id_tag = "expshuttle_docker_pump"
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
@@ -14212,7 +14219,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1380;
-	id_tag = "civvie_vent"
+	id_tag = "civvie_docker_pump"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
@@ -14234,6 +14241,10 @@
 /turf/simulated/floor/tiled,
 /area/exploration/pathfinder_office)
 "kvR" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 32;
+	pixel_y = -10
+	},
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 32;
 	pixel_y = 3
@@ -18753,7 +18764,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
-	id_tag = null
+	id_tag = "civvie_dock_pump"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
@@ -19221,7 +19232,7 @@
 /area/hallway/secondary/civilian_hallway_mid)
 "obo" = (
 /obj/effect/wingrille_spawn/reinforced_phoron,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/cyan,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/shuttle/floor/voidcraft,
 /area/shuttle/excursion/general)
 "obs" = (
@@ -21500,11 +21511,9 @@
 /area/triumph/surfacebase/tram)
 "pFz" = (
 /obj/effect/map_helper/airlock/door/ext_door,
-/obj/machinery/door/airlock/voidcraft/vertical,
-/obj/machinery/airlock_sensor{
-	pixel_y = 24
+/obj/machinery/door/airlock/voidcraft/vertical{
+	frequency = null
 	},
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
 "pFE" = (
@@ -21902,6 +21911,11 @@
 /area/hydroponics/garden)
 "pSB" = (
 /obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/access_button/airlock_interior{
+	frequency = 1380;
+	master_tag = "expshuttle_docker";
+	pixel_x = -24
+	},
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -21912,16 +21926,14 @@
 /obj/machinery/door/airlock/voidcraft/vertical{
 	id_tag = null
 	},
-/obj/machinery/airlock_sensor/airlock_interior{
-	id_tag = "expshuttle_docker";
-	pixel_x = -26
-	},
-/obj/effect/map_helper/airlock/sensor/int_sensor,
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
 "pTM" = (
 /obj/effect/overmap/visitable/ship/landable/excursion,
 /obj/effect/shuttle_landmark/triumph/deck4/excursion,
+/obj/structure/handrail{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
 "pUS" = (
@@ -24454,7 +24466,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
-	id_tag = "civvie_vent"
+	id_tag = "civvie_docker_pump"
 	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/old_tile/green,
@@ -25870,9 +25882,9 @@
 /area/exploration/excursion_dock)
 "sxb" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 32;
-	pixel_y = 2
+/obj/structure/fuel_port{
+	dir = 4;
+	pixel_x = 29
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/cargo)
@@ -25931,13 +25943,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1380;
-	id_tag = "civvie_vent"
+	id_tag = "civvie_docker_pump"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
 "szg" = (
@@ -28211,6 +28223,17 @@
 /obj/machinery/librarycomp,
 /turf/simulated/floor/wood,
 /area/library)
+"ufP" = (
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1;
+	frequency = 1380;
+	id_tag = "expshuttle_docker_pump";
+	power_rating = 20000
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/excursion/general)
 "ugl" = (
 /obj/structure/catwalk,
 /obj/machinery/alarm{
@@ -28405,12 +28428,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/chapel/main)
-"ula" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9
-	},
-/turf/simulated/shuttle/wall/voidcraft/blue,
-/area/shuttle/excursion/general)
 "uln" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -30643,6 +30660,10 @@
 "vKo" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/structure/fuel_port{
+	dir = 4;
+	pixel_y = -29
+	},
 /turf/simulated/floor,
 /area/shuttle/civvie/general)
 "vKA" = (
@@ -37976,7 +37997,7 @@ nnI
 fUd
 pTM
 kdF
-ieD
+dOp
 pSB
 dvW
 mpE
@@ -38118,7 +38139,7 @@ nnI
 hYe
 iRC
 kln
-kln
+ufP
 hYe
 jxu
 eau
@@ -38260,7 +38281,7 @@ nnI
 hYe
 oZY
 obo
-ula
+hYe
 hYe
 nri
 hYe

--- a/_maps/map_levels/140x140/tradeport.dmm
+++ b/_maps/map_levels/140x140/tradeport.dmm
@@ -53,12 +53,12 @@
 	frequency = 8018;
 	id_tag = "trade_space_lock";
 	pixel_x = -25;
-	tag_airpump = "trade_pump";
-	tag_chamber_sensor = "trade_sensor";
-	tag_exterior_door = "trade_ext_lock";
-	tag_exterior_sensor = "trade_ext_sensor";
-	tag_interior_door = "trade_int_lock";
-	tag_interior_sensor = "trade_int_sensor"
+	tag_airpump = null;
+	tag_chamber_sensor = null;
+	tag_exterior_door = null;
+	tag_exterior_sensor = null;
+	tag_interior_door = null;
+	tag_interior_sensor = null
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
@@ -526,17 +526,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
-"cQ" = (
-/obj/machinery/airlock_sensor/airlock_exterior/shuttle{
-	frequency = 8018;
-	id_tag = "beru_ex_sensor";
-	master_tag = "tradeport_hangar_docker";
-	pixel_x = -8;
-	pixel_y = -10
-	},
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
-/turf/simulated/shuttle/wall/voidcraft,
-/area/shuttle/trade_ship/general)
 "cR" = (
 /obj/machinery/light,
 /obj/structure/flora/pottedplant/drooping,
@@ -626,13 +615,6 @@
 /area/tradeport)
 "dd" = (
 /obj/machinery/suit_cycler/syndicate,
-/obj/machinery/airlock_sensor/airlock_interior{
-	frequency = 8018;
-	id_tag = "beru_int_sensor";
-	master_tag = "tradeport_hangar_docker";
-	pixel_x = 25;
-	pixel_y = 5
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -641,7 +623,6 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "de" = (
@@ -690,14 +671,6 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/tradeport/commons)
 "dA" = (
-/obj/machinery/door/airlock/glass_external{
-	frequency = 8018;
-	icon_state = "door_locked";
-	id_tag = "trade_int_lock";
-	locked = 1;
-	name = "Shuttle Hatch";
-	req_one_access = null
-	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 8018;
@@ -705,6 +678,11 @@
 	pixel_x = -25;
 	pixel_y = -5
 	},
+/obj/machinery/door/airlock/glass_external{
+	frequency = null;
+	name = "Ship Hatch"
+	},
+/obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "dB" = (
@@ -1979,14 +1957,16 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 8018;
-	id_tag = "trade_pump"
+	id_tag = "trade_space_lock_pump"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 8018;
-	id_tag = "trade_sensor";
-	master_tag = "trade_space_lock";
+	id_tag = "trade_space_lock";
+	master_tag = null;
 	pixel_x = 25
 	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "iX" = (
@@ -2007,6 +1987,10 @@
 /area/tradeport/engineering)
 "iY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/structure/fuel_port{
+	dir = 4;
+	pixel_x = 29
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "iZ" = (
@@ -2481,12 +2465,12 @@
 	frequency = 8018;
 	id_tag = "tradeport_hangar_docker";
 	pixel_x = -25;
-	tag_airpump = "beru_pump";
-	tag_chamber_sensor = "beru_sensor";
-	tag_exterior_door = "beru_outer";
-	tag_exterior_sensor = "beru_ex_sensor";
-	tag_interior_door = "beru_inner";
-	tag_interior_sensor = "beru_int_sensor"
+	tag_airpump = null;
+	tag_chamber_sensor = null;
+	tag_exterior_door = null;
+	tag_exterior_sensor = null;
+	tag_interior_door = null;
+	tag_interior_sensor = null
 	},
 /obj/effect/shuttle_landmark/triumph/trade/hangar,
 /obj/effect/overmap/visitable/ship/landable/trade,
@@ -2564,22 +2548,22 @@
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 8018;
-	id_tag = "beru_sensor";
-	master_tag = "tradeport_hangar_docker";
+	id_tag = "tradeport_hangar_docker";
+	master_tag = null;
 	pixel_x = 25
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 8018;
-	id_tag = "beru_pump"
+	id_tag = "tradeport_hangar_docker_pump"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "lC" = (
@@ -3839,14 +3823,6 @@
 /turf/simulated/floor/plating,
 /area/tradeport/engineering)
 "sg" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/door/airlock/glass_external{
-	frequency = 8018;
-	icon_state = "door_locked";
-	id_tag = "beru_inner";
-	locked = 1;
-	name = "Ship Hatch"
-	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 8018;
@@ -3855,6 +3831,10 @@
 	pixel_y = 5
 	},
 /obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/door/airlock/glass_external{
+	frequency = null;
+	name = "Ship Hatch"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "si" = (
@@ -4458,13 +4438,6 @@
 /turf/simulated/floor/wood,
 /area/tradeport/cyndi)
 "uR" = (
-/obj/machinery/door/airlock/glass_external{
-	frequency = 8018;
-	icon_state = "door_locked";
-	id_tag = "beru_inner";
-	locked = 1;
-	name = "Ship Hatch"
-	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -4472,17 +4445,10 @@
 	icon_state = "1-2"
 	},
 /obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/trade_ship/general)
-"uT" = (
 /obj/machinery/door/airlock/glass_external{
-	frequency = 8018;
-	icon_state = "door_locked";
-	id_tag = "beru_outer";
-	locked = 1;
+	frequency = null;
 	name = "Ship Hatch"
 	},
-/obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "uU" = (
@@ -5622,13 +5588,10 @@
 	pixel_y = 5
 	},
 /obj/machinery/door/airlock/glass_external{
-	frequency = 8018;
-	icon_state = "door_locked";
-	id_tag = "trade_ext_lock";
-	locked = 1;
-	name = "Shuttle Hatch";
-	req_one_access = null
+	frequency = null;
+	name = "Ship Hatch"
 	},
+/obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "zU" = (
@@ -8359,19 +8322,16 @@
 	pixel_x = 25;
 	pixel_y = -5
 	},
-/obj/machinery/door/airlock/glass_external{
-	frequency = 8018;
-	icon_state = "door_locked";
-	id_tag = "beru_outer";
-	locked = 1;
-	name = "Ship Hatch"
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/door/airlock/glass_external{
+	frequency = null;
+	name = "Ship Hatch"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "Ms" = (
@@ -8709,20 +8669,10 @@
 /area/shuttle/trade_ship/general)
 "NN" = (
 /obj/machinery/door/airlock/glass_external{
-	frequency = 8018;
-	icon_state = "door_locked";
-	id_tag = "trade_ext_lock";
-	locked = 1;
-	name = "Shuttle Hatch";
-	req_one_access = null
+	frequency = null;
+	name = "Ship Hatch"
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 8018;
-	id_tag = "trade_ext_sensor";
-	master_tag = "trade_space_lock";
-	pixel_x = -25;
-	pixel_y = 10
-	},
+/obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "NP" = (
@@ -10664,20 +10614,10 @@
 "WF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/glass_external{
-	frequency = 8018;
-	icon_state = "door_locked";
-	id_tag = "trade_int_lock";
-	locked = 1;
-	name = "Shuttle Hatch";
-	req_one_access = null
+	frequency = null;
+	name = "Ship Hatch"
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 8018;
-	id_tag = "trade_int_sensor";
-	master_tag = "trade_space_lock";
-	pixel_x = 25;
-	pixel_y = -10
-	},
+/obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "WG" = (
@@ -26608,7 +26548,7 @@ ZP
 GY
 rd
 tm
-cQ
+tm
 nG
 wR
 jQ
@@ -27036,7 +26976,7 @@ Rm
 Wc
 sg
 lq
-uT
+NN
 jn
 bB
 Yo

--- a/_maps/map_levels/140x140/tradeport.dmm
+++ b/_maps/map_levels/140x140/tradeport.dmm
@@ -805,18 +805,11 @@
 /turf/simulated/floor/grass,
 /area/tradeport/safarizoo)
 "dW" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/sign/atmos_plasma{
+	desc = "WARNING! Plasma flow tube nearby.";
+	name = "Pump Five"
 	},
-/obj/machinery/atmospherics/binary/pump/high_power/on{
-	dir = 8;
-	frequency = 8018;
-	id = "pumpfive";
-	name = "Pump Five";
-	target_pressure = 15000
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor,
+/turf/simulated/wall/r_wall,
 /area/tradeport/pads)
 "ea" = (
 /obj/structure/cable/yellow{
@@ -945,8 +938,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/tradeport/pads)
@@ -1614,12 +1610,11 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/tradeport/cyndi)
 "ht" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/computer/shuttle_control/explore/trade{
+	dir = 4
 	},
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/reinforced,
-/area/tradeport/pads)
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/trade_ship/cockpit)
 "hv" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/blast/shutters{
@@ -2968,6 +2963,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/tradeport/engineering)
+"ny" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -22;
+	req_one_access = list(160)
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/tradeport/pads)
 "nz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3792,16 +3796,17 @@
 /turf/simulated/floor/tiled/asteroid_steel/airless,
 /area/tradeport/pads)
 "rY" = (
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	frequency = 1380;
-	id_tag = "nebula_pump5";
-	name = "Nebula Pump Controller";
-	pixel_x = 25
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/effect/shuttle_landmark/triumph/trade/mining,
 /turf/simulated/floor/reinforced,
+/area/tradeport/pads)
+"rZ" = (
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
 /area/tradeport/pads)
 "sb" = (
 /obj/structure/table/steel_reinforced,
@@ -4548,13 +4553,8 @@
 /turf/simulated/floor/wood,
 /area/tradeport/commons)
 "vk" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/apc/alarms_hidden{
-	pixel_y = -28;
-	req_access = list(160)
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor,
+/obj/effect/shuttle_landmark/triumph/trade/pirate,
+/turf/simulated/floor/reinforced,
 /area/tradeport/pads)
 "vl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5287,6 +5287,18 @@
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
+/area/tradeport/pads)
+"ye" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "nebula_pump6";
+	name = "Nebula Pump Controller";
+	pixel_x = -25
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
 /area/tradeport/pads)
 "yg" = (
 /obj/machinery/door/airlock/command{
@@ -6711,6 +6723,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/tradeport/safarizoo)
+"EF" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc/alarms_hidden{
+	pixel_y = -28;
+	req_access = list(160)
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/tradeport/pads)
 "EH" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
@@ -7338,15 +7359,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/camera{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/cap/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/tradeport/pads)
@@ -7369,11 +7383,8 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tradeport/dock)
 "HD" = (
-/obj/structure/sign/atmos_plasma{
-	desc = "WARNING! Plasma flow tube nearby.";
-	name = "Pump Five"
-	},
-/turf/simulated/wall/r_wall,
+/obj/effect/shuttle_landmark/triumph/trade/excursion,
+/turf/simulated/floor/reinforced,
 /area/tradeport/pads)
 "HE" = (
 /obj/machinery/door/window/westleft{
@@ -7469,13 +7480,8 @@
 /turf/simulated/floor/wood,
 /area/tradeport/commons)
 "Ih" = (
-/obj/machinery/alarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -22;
-	req_one_access = list(160)
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor,
+/obj/effect/shuttle_landmark/triumph/trade/emt,
+/turf/simulated/floor/reinforced,
 /area/tradeport/pads)
 "Ij" = (
 /obj/structure/flora/pumpkin/carved/owo,
@@ -8409,6 +8415,24 @@
 	},
 /turf/simulated/floor/wood,
 /area/tradeport/commons)
+"ME" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/cap/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/tradeport/pads)
 "MF" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4
@@ -9684,18 +9708,11 @@
 /turf/simulated/floor/tiled/old_tile/blue,
 /area/tradeport)
 "Sb" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/sign/atmos_plasma{
+	desc = "WARNING! Plasma flow tube nearby.";
+	name = "Pump Six"
 	},
-/obj/machinery/atmospherics/binary/pump/high_power/on{
-	dir = 4;
-	frequency = 8018;
-	id = "pumpsix";
-	name = "Pump Six";
-	target_pressure = 15000
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor,
+/turf/simulated/wall/r_wall,
 /area/tradeport/pads)
 "Sc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10236,13 +10253,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "UC" = (
-/obj/machinery/door/firedoor{
-	req_one_access = list(160)
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced/full,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/reinforced,
 /area/tradeport/pads)
 "UF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -10272,16 +10287,18 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/tradeport/cyndishow)
 "UN" = (
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	frequency = 1380;
-	id_tag = "nebula_pump6";
-	name = "Nebula Pump Controller";
-	pixel_x = -25
-	},
 /obj/machinery/light{
-	dir = 8
+	dir = 1
 	},
-/turf/simulated/floor/reinforced,
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	dir = 8;
+	frequency = 8018;
+	id = "pumpfive";
+	name = "Pump Five";
+	target_pressure = 15000
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
 /area/tradeport/pads)
 "UP" = (
 /obj/structure/closet/crate/bin{
@@ -10335,15 +10352,15 @@
 /turf/simulated/floor/tiled/old_tile/blue,
 /area/tradeport)
 "Vg" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	dir = 4;
+	frequency = 8018;
+	id = "pumpsix";
+	name = "Pump Six";
+	target_pressure = 15000
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor,
@@ -10820,6 +10837,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/tradeport/cyndishow)
+"Xo" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "nebula_pump5";
+	name = "Nebula Pump Controller";
+	pixel_x = 25
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/tradeport/pads)
 "Xp" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -11060,7 +11089,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /turf/simulated/floor,
@@ -11174,11 +11203,8 @@
 /turf/simulated/shuttle/floor/white,
 /area/tradeport/commons)
 "YQ" = (
-/obj/structure/sign/atmos_plasma{
-	desc = "WARNING! Plasma flow tube nearby.";
-	name = "Pump Six"
-	},
-/turf/simulated/wall/r_wall,
+/obj/effect/shuttle_landmark/triumph/trade/civvie,
+/turf/simulated/floor/reinforced,
 /area/tradeport/pads)
 "YV" = (
 /obj/machinery/door/firedoor{
@@ -23727,7 +23753,7 @@ nG
 tm
 Hl
 pr
-IA
+ht
 Hl
 tm
 nG
@@ -24249,9 +24275,9 @@ FL
 FL
 FL
 FL
+FL
 gV
 gV
-wN
 wN
 wN
 wN
@@ -24391,9 +24417,9 @@ Ft
 Ft
 Ft
 Ft
+Ft
 fa
 gV
-wN
 wN
 wN
 wN
@@ -24534,8 +24560,8 @@ Ft
 Ft
 Ft
 Ft
+Ft
 gV
-wN
 wN
 wN
 wN
@@ -24676,8 +24702,8 @@ Ft
 Ft
 Ft
 Ft
+Ft
 gV
-wN
 wN
 wN
 wN
@@ -24818,8 +24844,8 @@ Ft
 Ft
 Ft
 Ft
+Ft
 gV
-wN
 wN
 wN
 wN
@@ -24960,8 +24986,8 @@ Ft
 Ft
 Ft
 Ft
+Ft
 gV
-wN
 wN
 wN
 wN
@@ -25101,9 +25127,9 @@ Ft
 Ft
 Ft
 Ft
+Ft
 mR
 gV
-wN
 wN
 wN
 wN
@@ -25220,7 +25246,7 @@ Ft
 Ft
 Ft
 Ft
-Ft
+HD
 Ft
 Ft
 Ft
@@ -25237,6 +25263,7 @@ Ft
 Ft
 Ft
 Ft
+Ih
 Ft
 Ft
 Ft
@@ -25244,8 +25271,7 @@ Ft
 Ft
 Ft
 Ft
-UC
-wN
+rZ
 wN
 wN
 wN
@@ -25352,6 +25378,22 @@ wN
 XO
 Ft
 Ft
+rY
+Ft
+Ft
+Ft
+Ft
+yW
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
 Ft
 Ft
 Ft
@@ -25371,23 +25413,7 @@ Ft
 Ft
 Ft
 Ft
-Ft
-Ft
-yW
-Ft
-Ft
-Ft
-Ft
-Ft
-Ft
-Ft
-Ft
-Ft
-Ft
-Ft
-Ft
-UC
-wN
+rZ
 wN
 wN
 wN
@@ -25528,8 +25554,8 @@ Ft
 Ft
 Ft
 Ft
-UC
-wN
+Ft
+rZ
 wN
 wN
 wN
@@ -25670,8 +25696,8 @@ Ft
 Ft
 Ft
 Ft
-UC
-wN
+Ft
+rZ
 wN
 wN
 wN
@@ -25812,8 +25838,8 @@ Ft
 Ft
 Ft
 Ft
-UC
-wN
+Ft
+rZ
 wN
 wN
 wN
@@ -25954,8 +25980,8 @@ Ft
 Ft
 Ft
 Ft
-UC
-wN
+Ft
+rZ
 wN
 wN
 wN
@@ -26096,8 +26122,8 @@ Ft
 Ft
 Ft
 Ft
-UC
-wN
+Ft
+rZ
 wN
 wN
 wN
@@ -26238,8 +26264,8 @@ Ft
 Ft
 Ft
 Ft
-UC
-wN
+Ft
+rZ
 wN
 wN
 wN
@@ -26379,9 +26405,9 @@ Ft
 Ft
 Ft
 Ft
+Ft
 mR
 gV
-wN
 wN
 wN
 wN
@@ -26522,8 +26548,8 @@ Ft
 Ft
 Ft
 Ft
+Ft
 gV
-wN
 wN
 wN
 wN
@@ -26664,8 +26690,8 @@ Ft
 Ft
 Ft
 Ft
+Ft
 gV
-wN
 wN
 wN
 wN
@@ -26798,16 +26824,16 @@ Ft
 Ft
 Ft
 Ft
+Ft
 Ua
 CW
 tu
-rY
+Xo
 Ft
 Ft
 Ft
 Ft
 gV
-wN
 wN
 wN
 wN
@@ -26940,8 +26966,9 @@ UH
 UH
 UH
 UH
-HD
+UH
 dW
+UN
 vE
 gV
 UH
@@ -26951,7 +26978,6 @@ UH
 gV
 gV
 gV
-wN
 wN
 wN
 wN
@@ -27082,18 +27108,18 @@ ZL
 ZL
 ZL
 ZL
-Vg
+ZL
 eA
 Yw
 Hu
+ME
 JO
 JO
 JO
 JO
 JO
-vk
+EF
 gV
-wN
 wN
 wN
 wN
@@ -27224,6 +27250,7 @@ tu
 tu
 tu
 tu
+tu
 VP
 ng
 tu
@@ -27233,9 +27260,8 @@ tu
 tu
 tu
 tu
-Ih
+ny
 gV
-wN
 wN
 wN
 wN
@@ -27366,8 +27392,9 @@ iZ
 iZ
 iZ
 iZ
-YQ
+iZ
 Sb
+Vg
 vE
 gV
 iZ
@@ -27377,7 +27404,6 @@ iZ
 gV
 gV
 gV
-wN
 wN
 wN
 wN
@@ -27508,16 +27534,16 @@ Ft
 Ft
 Ft
 Ft
-ht
+Ft
+UC
 Xl
 tu
-UN
+ye
 Ft
 Ft
 Ft
 Ft
 gV
-wN
 wN
 wN
 wN
@@ -27658,8 +27684,8 @@ Ft
 Ft
 Ft
 Ft
+Ft
 gV
-wN
 wN
 wN
 wN
@@ -27800,8 +27826,8 @@ Ft
 Ft
 Ft
 Ft
+Ft
 gV
-wN
 wN
 wN
 wN
@@ -27941,9 +27967,9 @@ Ft
 Ft
 Ft
 Ft
+Ft
 mR
 gV
-wN
 wN
 wN
 wN
@@ -28078,14 +28104,14 @@ Ft
 Ft
 Ft
 Ft
+YQ
 Ft
 Ft
 Ft
 Ft
 Ft
 Ft
-UC
-wN
+rZ
 wN
 wN
 wN
@@ -28226,8 +28252,8 @@ Ft
 Ft
 Ft
 Ft
-UC
-wN
+Ft
+rZ
 wN
 wN
 wN
@@ -28368,8 +28394,8 @@ Ft
 Ft
 Ft
 Ft
-UC
-wN
+Ft
+rZ
 wN
 wN
 wN
@@ -28510,8 +28536,8 @@ Ft
 Ft
 Ft
 Ft
-UC
-wN
+Ft
+rZ
 wN
 wN
 wN
@@ -28652,8 +28678,8 @@ Ft
 Ft
 Ft
 Ft
-UC
-wN
+Ft
+rZ
 wN
 wN
 wN
@@ -28794,8 +28820,8 @@ Ft
 Ft
 Ft
 Ft
-UC
-wN
+Ft
+rZ
 wN
 wN
 wN
@@ -28936,8 +28962,8 @@ Ft
 Ft
 Ft
 Ft
-UC
-wN
+Ft
+rZ
 wN
 wN
 wN
@@ -29078,8 +29104,8 @@ Ft
 Ft
 Ft
 Ft
-UC
-wN
+Ft
+rZ
 wN
 wN
 wN
@@ -29220,8 +29246,8 @@ Ft
 Ft
 Ft
 Ft
-UC
-wN
+Ft
+rZ
 wN
 wN
 wN
@@ -29361,9 +29387,9 @@ Ft
 Ft
 Ft
 Ft
+Ft
 mR
 gV
-wN
 wN
 wN
 wN
@@ -29478,6 +29504,20 @@ Ft
 gV
 Ft
 Ft
+vk
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+Ft
+gV
 Ft
 Ft
 Ft
@@ -29492,20 +29532,6 @@ Ft
 Ft
 Ft
 gV
-Ft
-Ft
-Ft
-Ft
-Ft
-Ft
-Ft
-Ft
-Ft
-Ft
-Ft
-Ft
-gV
-wN
 wN
 wN
 wN
@@ -29646,8 +29672,8 @@ Ft
 Ft
 Ft
 Ft
+Ft
 gV
-wN
 wN
 wN
 wN
@@ -29788,8 +29814,8 @@ Ft
 Ft
 Ft
 Ft
+Ft
 gV
-wN
 wN
 wN
 wN
@@ -29929,9 +29955,9 @@ Ft
 Ft
 Ft
 Ft
+Ft
 CN
 gV
-wN
 wN
 wN
 wN
@@ -30071,9 +30097,9 @@ FL
 FL
 FL
 FL
+FL
 gV
 gV
-wN
 wN
 wN
 wN

--- a/_maps/map_levels/140x140/tradeport.dmm
+++ b/_maps/map_levels/140x140/tradeport.dmm
@@ -534,6 +534,7 @@
 	pixel_x = -8;
 	pixel_y = -10
 	},
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/shuttle/wall/voidcraft,
 /area/shuttle/trade_ship/general)
 "cR" = (
@@ -640,6 +641,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "de" = (
@@ -2576,6 +2578,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "lC" = (
@@ -3850,6 +3854,7 @@
 	pixel_x = -25;
 	pixel_y = 5
 	},
+/obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "si" = (
@@ -4466,6 +4471,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "uT" = (
@@ -4476,6 +4482,7 @@
 	locked = 1;
 	name = "Ship Hatch"
 	},
+/obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "uU" = (
@@ -8364,6 +8371,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "Ms" = (

--- a/code/game/trader_visit.dm
+++ b/code/game/trader_visit.dm
@@ -3,9 +3,6 @@
 var/global/hire_nebula = 0
 var/can_call_traders = 1
 
-//I'm disabling this for now, until Overmaps/Nebula Gas is reinstated.
-
-/*
 /client/proc/trader_ship()
 	set name = "Hire Nebula Gas Employees"
 	set category = "Special Verbs"
@@ -63,4 +60,3 @@ proc/trigger_trader_visit()
 	hire_nebula = 1
 
 	sleep(600 * 5)
-*/


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. _Wipes the varedits in two multi-z cables._
2. _Rearranges Exploration's dock to allow for actual docking._
3. _Adds a secure locker and two chargers to Robotics._
4. _Nebula Gas Beruang Shuttle Jump Console restored._
5. _Landing points for Nebula Gas station restored._
6. _Nebula Gas ghost role selection system restored._

## Why It's Good For The Game

1. These two multi-z cables are identified as disrupting power flow to other areas on the map. I believe the issue is just a faulty varedit, so I've wiped those edits to see if the wires assert correctly now.
2. Exploration's shuttle has been perpetually stuck in docking limbo for over a year. After finally returning to the Triumph, I have painstakingly disassembled the dock, isolated the core issue, and fixed it. The Exploration shuttle now docks properly and its airlock functions. Due to this, I have removed its tinyfan.
3. I'm tired of leaving Mech weapons on the floor. I added this on Tether, and I'm bringing it back in here. Also, one cell charger in a Robotics bay this big is unforgivable.
4. The Beruang's jump console was gutted. It has been restored, allowing the ship to launch once more.
5. All shuttles can now land at the Nebula Gas station for commerce and refueling.
6. The Nebula Gas ghost role has been enabled.

## Changelog
:cl:
fix: Fixes power cables.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
