### PR TITLE
[testmerge first] pipes hiding now use 100 invisibility instead of 101

### DIFF
--- a/code/modules/atmospherics/pipes/pipe_base.dm
+++ b/code/modules/atmospherics/pipes/pipe_base.dm
@@ -131,7 +131,7 @@
 
 /obj/machinery/atmospherics/pipe/hide(var/i)
 	if(istype(loc, /turf/simulated))
-		invisibility = i ? 101 : 0
+		invisibility = i ? 100 : 0
 	update_icon()
 
 /obj/machinery/atmospherics/pipe/process(delta_time)


### PR DESCRIPTION
tl;dr

101 occludes from range() and view()
sane codebases like /tg/ use 100 because there's no reason to occlude from range() and view().
if someone doesn't check for hidden pipes in range(), that's their issue. not the goddamn pipes.

don't wanton throw invisibility 101 on things.