### PR TITLE
[testmerge first] adjusts say emphasis regex .*? --> .+?

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -117,11 +117,11 @@
 
 // Converts specific characters, like +, |, and _ to formatted output.
 /mob/proc/say_emphasis(input)
-	var/static/regex/italics = regex("\\|(?=\\S)(.*?)(?=\\S)\\|", "g")
+	var/static/regex/italics = regex("\\|(?=\\S)(.+?)(?=\\S)\\|", "g")
 	input = replacetext_char(input, italics, "<i>$1</i>")
-	var/static/regex/bold = regex("\\+(?=\\S)(.*?)(?=\\S)\\+", "g")
+	var/static/regex/bold = regex("\\+(?=\\S)(.+?)(?=\\S)\\+", "g")
 	input = replacetext_char(input, bold, "<b>$1</b>")
-	var/static/regex/underline = regex("_(?=\\S)(.*?)(?=\\S)_", "g")
+	var/static/regex/underline = regex("_(?=\\S)(.+?)(?=\\S)_", "g")
 	input = replacetext_char(input, underline, "<u>$1</u>")
 	return input
 


### PR DESCRIPTION
tl;dr

you can now do

`thing++` without the regex triggering

useful if you're shitposting code huh

