### PR TITLE
Gives QM a mining radio

### DIFF
--- a/code/datums/outfits/jobs/cargo.dm
+++ b/code/datums/outfits/jobs/cargo.dm
@@ -5,6 +5,7 @@
 /decl/hierarchy/outfit/job/cargo/qm
 	name = OUTFIT_JOB_NAME("Cargo")
 	uniform = /obj/item/clothing/under/rank/cargo
+	l_ear = /obj/item/radio/headset/headset_mine
 	shoes = /obj/item/clothing/shoes/brown
 	glasses = /obj/item/clothing/glasses/sunglasses
 	l_hand = /obj/item/clipboard

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -52,6 +52,7 @@
 		/obj/item/clothing/shoes/brown,
 		/obj/item/radio/headset/headset_cargo,
 		/obj/item/radio/headset/headset_cargo/alt,
+		/obj/item/radio/headset/headset_mine,
 		/obj/item/clothing/gloves/black,
 		/obj/item/clothing/gloves/fingerless,
 		/obj/item/clothing/suit/fire/firefighter,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Literally what it says on the tin (also adds one to the QM locker in case)

## Why It's Good For The Game

This is honestly a QOL thing for QM, since the mining radio has shortwave, and is the only way to communicate on mining zones such as the belt or the Magmatic Rift. Since the QM prior could just steal one of these radios out of the lockers, it's not really even a balance change.

## Changelog
:cl:
add: Mining headset to QM locker
tweak: Replaced QM cargo headset with a mining headset
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
