### PR TITLE
Makes the Stripper Gun a Pref, a la Size Guns - Defaults Both to Off

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -38,6 +38,8 @@
 	var/permit_size_trample = TRUE
 	/// pending refactor - allow being picked up when not a micro?
 	var/permit_size_pickup = TRUE
+	/// Following the above - allow stripper gun on us?
+	var/permit_stripped
 
 //
 // Hook for generic creation of stuff on new creatures
@@ -238,6 +240,7 @@
 	P.permit_sizegun = src.permit_sizegun
 	P.permit_size_trample = src.permit_size_trample
 	P.permit_size_pickup = src.permit_size_pickup
+	P.permit_stripped = src.permit_stripped
 
 	var/list/serialized = list()
 	for(var/belly in src.vore_organs)
@@ -271,6 +274,7 @@
 	permit_sizegun = P.permit_sizegun
 	permit_size_trample = P.permit_size_trample
 	permit_size_pickup = P.permit_size_pickup
+	permit_stripped = P.permit_stripped
 
 	release_vore_contents(silent = TRUE)
 	vore_organs.Cut()

--- a/code/modules/vore/eating/vore_vr.dm
+++ b/code/modules/vore/eating/vore_vr.dm
@@ -33,9 +33,10 @@
 	var/permit_healbelly = FALSE
 	var/can_be_drop_prey = FALSE
 	var/can_be_drop_pred = FALSE
-	var/permit_sizegun = TRUE
+	var/permit_sizegun = FALSE
 	var/permit_size_trample = TRUE
 	var/permit_size_pickup = TRUE
+	var/permit_stripped = FALSE
 
 	//Mechanically required
 	var/path
@@ -110,6 +111,7 @@
 	permit_sizegun = json_from_file["permit_sizegun"]
 	permit_size_trample = json_from_file["permit_size_trample"]
 	permit_size_pickup = json_from_file["permit_size_pickup"]
+	permit_stripped = json_from_file["permit_stripped"]
 
 	//Quick sanitize
 	if(isnull(digestable))
@@ -129,11 +131,13 @@
 	if(isnull(can_be_drop_pred))
 		can_be_drop_pred = FALSE
 	if(isnull(permit_sizegun))
-		permit_sizegun = TRUE
+		permit_sizegun = FALSE
 	if(isnull(permit_size_trample))
 		permit_size_trample = TRUE
 	if(isnull(permit_size_pickup))
 		permit_size_pickup = TRUE
+	if(isnull(permit_stripped))
+		permit_stripped = FALSE
 	if(isnull(belly_prefs))
 		belly_prefs = list()
 
@@ -158,7 +162,8 @@
 			"belly_prefs"			= belly_prefs,
 			"permit_size_trample"	= permit_size_trample,
 			"permit_size_pickup"	= permit_size_pickup,
-			"permit_sizegun"		= permit_sizegun
+			"permit_sizegun"		= permit_sizegun,
+			"permit_stripped"		= permit_stripped
 		)
 
 	//List to JSON

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -353,6 +353,11 @@
 			dat += "<a style='background:#173d15;' href='?src=\ref[src];toggle_permit_pickup=1'>Permit Instant Pickup (Size >75%) (Currently: ON)</a>"
 		if(FALSE)
 			dat += "<a style='background:#990000;' href='?src=\ref[src];toggle_permit_pickup=1'>Permit Instant Pickup (Size >75%) (Currently: OFF)</a>"
+	switch(user.permit_stripped)
+		if(TRUE)
+			dat += "<a style='background:#173d15;' href='?src=\ref[src];toggle_permit_stripped=1'>Allow Stripper Gun (Currently: ON)</a>"
+		if(FALSE)
+			dat += "<a style='background:#990000;' href='?src=\ref[src];toggle_permit_stripped=1'>Allow Stripper Gun (Currently: OFF)</a>"
 	switch(user.can_be_drop_prey)
 		if(TRUE)
 			dat += "<br><a style='background:#173d15;' href='?src=\ref[src];toggle_dropnom_prey=1'>Toggle Prey Spontaneous Vore (Currently: ON)</a>"
@@ -971,6 +976,10 @@
 	if(href_list["toggle_permit_pickup"])
 		user.permit_size_pickup = !user.permit_size_pickup
 		user.client.prefs_vr?.permit_size_pickup = user.permit_size_pickup
+
+	if(href_list["toggle_permit_stripped"])
+		user.permit_stripped = !user.permit_stripped
+		user.client.prefs_vr?.permit_stripped = user.permit_stripped
 
 	if(href_list["toggledfeed"])
 		var/choice = alert(user, "This button is to toggle your ability to be fed to or by others vorishly. Force Feeding is currently: [user.feeding ? "Allowed" : "Prevented"]", "", "Allow Feeding", "Cancel", "Prevent Feeding")

--- a/code/modules/vore/fluffstuff/guns/nsfw.dm
+++ b/code/modules/vore/fluffstuff/guns/nsfw.dm
@@ -280,6 +280,9 @@
 	check_armour = "melee"
 
 /obj/item/projectile/bullet/stripper/on_hit(var/atom/stripped)
+	if(!M.permit_stripped)
+		M.visible_message("<span class='warning'>[src] has no effect on [M].</span>")
+		return
 	if(ishuman(stripped))
 		var/mob/living/carbon/human/H = stripped
 		if(H.wear_suit)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Makes the Stripper Gun a Pref Toggle.**
2. **Changes Size Gun and Stripper Gun Toggles to Off by Default.**

## Why It's Good For The Game

1. _Players are being made uncomfortable by the function and presence of stripper guns. There are further meta implications for this kind of tech being readily available. I am making Stripper beams a pref, just like size beams have become._
2. _I am making both of these functions Off by default due to the revelation that the majority of the playerbase does not know the Vore panel held options to toggle these. The players that want these functions are more likely to toggle them on, and enabling it is trivial to do._

## Changelog
:cl:
tweak: Stripper beams are now a pref.
tweak: Stripper and Size Mechanics are now toggled to off by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
