### PR TITLE
Demotes xenobotanist/xenobiologist to alt titles of scientist

### DIFF
--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -61,14 +61,14 @@
 	departments = list(DEPARTMENT_RESEARCH)
 	department_flag = MEDSCI
 	faction = "Station"
-	total_positions = 5
-	spawn_positions = 3
+	total_positions = 7
+	spawn_positions = 5
 	supervisors = "the Research Director"
 	selection_color = "#633D63"
 	idtype = /obj/item/card/id/science/scientist
 	economic_modifier = 7
-	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch)
-	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenoarch)
+	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch, access_xenobotany)
+	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenoarch, access_xenobiology, access_xenobotany)
 
 	minimal_player_age = 14
 
@@ -85,7 +85,9 @@
 		"Anomalist" = /datum/alt_title/anomalist, \
 		"Phoron Researcher" = /datum/alt_title/phoron_research,
 		"Circuit Designer" = /datum/alt_title/scientist/circuit,
-		"Research Field Technician" = /datum/alt_title/scientist/fieldtech
+		"Research Field Technician" = /datum/alt_title/scientist/fieldtech,
+		"Xenobotanist" = /datum/alt_title/scientist/xenobotanist,
+		"Xenobiologist" = /datum/alt_title/scientist/xenobiologist
 		)
 
 // Scientist Alt Titles
@@ -126,6 +128,19 @@
 /datum/alt_title/scientist/fieldtech
 	title = "Research Field Technician"
 
+/datum/alt_title/scientist/xenobiologist
+	title = "Xenobiologist"
+	title_blurb = "A Xenobiologist studies esoteric lifeforms, usually in the relative safety of their lab. They attempt to find ways to benefit \
+						from the byproducts of these lifeforms, and their main subject at present is the Giant Slime."
+	title_outfit = /decl/hierarchy/outfit/job/science/xenobiologist
+						
+/datum/alt_title/scientist/xenobotanist
+	title = "Xenobotanist"
+	title_blurb = "A Xenobotanist grows and cares for a variety of abnormal, custom made, and frequently dangerous plant life. When the products of these plants \
+					are both safe and beneficial to the station, they may choose to introduce it to the rest of the crew."
+	title_outfit = /decl/hierarchy/outfit/job/science/xenobiologist
+					
+/* Demoted to alt title for now
 //////////////////////////////////
 //			Xenobiologist
 //////////////////////////////////
@@ -198,6 +213,7 @@
 
 /datum/alt_title/xenohydroponicist
 	title = "Xenohydroponicist"
+*/
 
 //////////////////////////////////
 //			Roboticist

--- a/code/game/objects/items/weapons/id cards/station_ids.dm
+++ b/code/game/objects/items/weapons/id cards/station_ids.dm
@@ -338,7 +338,7 @@
 	name = "xenobiologist ID"
 	assignment = "Xenobiologist"
 	rank = "Xenobiologist"
-	job_access_type = /datum/job/xenobiologist
+	job_access_type = /datum/job/scientist // /datum/job/xenobiologist
 
 /obj/item/card/id/science/roboticist
 	name = "roboticist ID"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Yes, they keep the spiffy gear
Also removes hydroponics access from them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We don't nearly have the playercount or map design (I hate triumph) to justify separating two subdepartments of science into subroles.
They're literally the same thing because god knows we're too much of cowards to turn on minimal access.

Furthermore the alt title bloat is insane, why do we need 3 alt titles each of the two subdepartment roles?? Bruh.

Science max pop bumped to 7 to compensate, with 5 spawn positions. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Xenobotanist and Xenobiologist have been demoted to Scientist alt titles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
