### PR TITLE
Makes pumps and pressure regs renamable with a pen

### DIFF
--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -243,6 +243,11 @@
 	return
 
 /obj/machinery/atmospherics/binary/passive_gate/attackby(var/obj/item/W as obj, var/mob/user as mob)
+	if(istype(W, /obj/item/pen))
+		var/new_name = input(user, "Please enter the new name for this device:", "New Name")  as text|null
+		new_name = trim(new_name)
+		name = (new_name? new_name : name)
+		return
 	if (!W.is_wrench())
 		return ..()
 	if (unlocked)

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -271,6 +271,11 @@ Thus, the two variables affect pump operation are set in New():
 		update_icon()
 
 /obj/machinery/atmospherics/binary/pump/attackby(var/obj/item/W as obj, var/mob/user as mob)
+	if(istype(W, /obj/item/pen))
+		var/new_name = input(user, "Please enter the new name for this device:", "New Name")  as text|null
+		new_name = trim(new_name)
+		name = (new_name? new_name : name)
+		return
 	if (!W.is_wrench())
 		return ..()
 	if (!(stat & NOPOWER) && use_power)


### PR DESCRIPTION
## Changelog
:cl:
tweak: Allows for pumps and pressure regs to be renamed with a pen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
