### PR TITLE
loads the ugly voidsuits into suit storage insteadof space suits

### DIFF
--- a/code/game/machinery/suit_storage/suit_storage_prepared.dm
+++ b/code/game/machinery/suit_storage/suit_storage_prepared.dm
@@ -1,8 +1,8 @@
 //Here you find suit storage units prefilled to make mapping in easier
 
 /obj/machinery/suit_storage_unit/standard_unit
-	suit_stored_TYPE = /obj/item/clothing/suit/space
-	helmet_stored_TYPE = /obj/item/clothing/head/helmet/space
+	suit_stored_TYPE = /obj/item/clothing/suit/space/void
+	helmet_stored_TYPE = /obj/item/clothing/head/helmet/space/void
 	mask_stored_TYPE = /obj/item/clothing/mask/breath
 
 /obj/machinery/suit_storage_unit/atmos


### PR DESCRIPTION
## Changelog
:cl:
fix: Fixed solar space suits not being able to be refitted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
