### PR TITLE
Cleans up vey-med skrell prosthetics

### DIFF
--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -326,18 +326,10 @@ var/const/cyberbeast_monitor_styles = "blank=cyber_blank;\
 	//robo_brute_mod = 1.1 //VOREStation Edit
 	//robo_burn_mod = 1.1 //VOREStation Edit
 
-/datum/robolimb/veymed_skrell
+/datum/robolimb/veymed/skrell
 	company = "Vey-Med - Skrell"
-	desc = "This high quality limb is nearly indistinguishable from an organic one."
-	icon = 'icons/mob/human_races/cyberlimbs/veymed/veymed_skrell.dmi'
-	unavailable_to_build = 1
-	lifelike = 1
-	skin_color = TRUE
 	species_cannot_use = list(SPECIES_TESHARI, SPECIES_PROMETHEAN, SPECIES_TAJ, SPECIES_HUMAN, SPECIES_VOX, SPECIES_HUMAN_VATBORN, SPECIES_UNATHI, SPECIES_DIONA, SPECIES_ZADDAT)
 	blood_color = "#4451cf"
-	speech_bubble_appearance = "normal"
-	robo_brute_mod = 1.05
-	robo_burn_mod = 1.05
 
 // thanks kraso
 /datum/robolimb/moth


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just makes them be a subtype and share the same spriteset. You can make the spooky eyes using markings, anyway. Black-faced sprites aren't colorable /at all/, which is kinda lame, given Skrells aren't supposed to be tar-black, thus why would the vey-med version of them be?

## Why It's Good For The Game
Just some sprite cleanup. That's all.

## Changelog
:cl:
tweak: Skrell Vey-med prosthetics are now colorable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
