### PR TITLE
Salt PR: Moves the R&D Sulphuric Acid Dispenser over one tile so it stops blocking thrown items. Also adds a door to the circuitry room so I don't have to walk all the way around into a garden to access it.

### DIFF
--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -1035,6 +1035,9 @@
 	dir = 1
 	},
 /obj/machinery/camera/network/research,
+/obj/structure/reagent_dispensers/acid{
+	pixel_y = 30
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/reception_desk)
 "aOn" = (
@@ -3023,6 +3026,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
+"czy" = (
+/obj/machinery/door/airlock/science{
+	name = "Circuitry Workshop";
+	req_access = list(7);
+	req_one_access = list(7)
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/hallway)
 "czP" = (
 /turf/simulated/wall,
 /area/maintenance/research)
@@ -3473,6 +3484,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor,
+/obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
 "cTH" = (
@@ -6568,11 +6580,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medbay/fore)
 "ftw" = (
-/obj/structure/flora/pottedplant/stoutbush,
 /obj/effect/floor_decal/techfloor{
 	dir = 6
 	},
 /obj/machinery/light/small,
+/obj/machinery/media/jukebox,
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
 "ful" = (
@@ -9666,6 +9678,9 @@
 /obj/item/integrated_circuit_printer,
 /obj/effect/floor_decal/techfloor{
 	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
@@ -21936,11 +21951,6 @@
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
 "rnQ" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/media/jukebox,
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
@@ -24720,9 +24730,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/structure/reagent_dispensers/acid{
-	pixel_y = 30
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -41209,7 +41216,7 @@ rqX
 rqX
 gCR
 gCR
-rqX
+czy
 rqX
 nDo
 nDo


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. *Moves the R&D Sulphuric Acid Dispenser over one tile.*
2. *Adds a door to the circuitry room.*

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

1 & 2: _QOL_

## Changelog
:cl:
tweak: Moves dispenser in R&D. Adds door to circuitry room.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
