### PR TITLE
Buffs Clear Sky Time on Surt

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -94,6 +94,7 @@
 		/obj/item/shovel,
 		/obj/item/pickaxe,
 		/obj/item/gps/mining,
+		/obj/item/survivalcapsule,
 		/obj/item/clothing/glasses/material,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/miner,
 		/obj/item/clothing/shoes/boots/winter/mining,

--- a/maps/nsv_triumph/lavaland.dm
+++ b/maps/nsv_triumph/lavaland.dm
@@ -113,8 +113,8 @@ var/datum/planet/lavaland/planet_lavaland = null
 
 /datum/weather/lavaland/clear
 	name = "clear"
-	timer_low_bound = 4			// How long this weather must run before it tries to change, in minutes
-	timer_high_bound = 4		// How long this weather can run before it tries to change, in minutes
+	timer_low_bound = 6			// How long this weather must run before it tries to change, in minutes
+	timer_high_bound = 15		// How long this weather can run before it tries to change, in minutes
 	transition_chances = list(
 		WEATHER_CLEAR = 75,
 		WEATHER_PRE_ASH_STORM = 25


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. *Increases the time between storms on Lava Land.*
2. *Gives each mining locker one free survival capsule.*

## Why It's Good For The Game

1. _The increase in storm lengths requires a touch of balancing._
2. _There should be one per miner, as was the old way._

## Changelog
:cl:
tweak: Adjusts clear sky time on Lavaland and gives miners a survival capsule by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
