### PR TITLE
Anti-Drone Map Edit, Also Adds Community Theater

### DIFF
--- a/_maps/map_files/triumph/triumph-01-deck1.dmm
+++ b/_maps/map_files/triumph/triumph-01-deck1.dmm
@@ -3196,10 +3196,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "ln" = (
-/obj/random/trash,
-/mob/living/simple_mob/mechanical/corrupt_maint_drone/weak_no_poison,
-/turf/simulated/floor/wood,
-/area/maintenance/dormitory)
+/obj/structure/railing,
+/obj/structure/closet/crate/mimic/closet/cointoss,
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "lp" = (
 /obj/machinery/camera/network/engineering{
 	dir = 8
@@ -12988,9 +12988,9 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
 "Su" = (
-/mob/living/simple_mob/mechanical/corrupt_maint_drone/weak_no_poison,
-/turf/simulated/floor/plating,
-/area/maintenance/engineering)
+/obj/structure/closet/crate/mimic/cointoss,
+/turf/simulated/floor/carpet,
+/area/maintenance/dormitory)
 "Sw" = (
 /obj/effect/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -22212,7 +22212,7 @@ ID
 ib
 Tt
 Uy
-ht
+Su
 jd
 Px
 fN
@@ -22781,7 +22781,7 @@ ib
 RM
 wT
 lV
-ln
+YP
 ib
 fN
 fN
@@ -26567,7 +26567,7 @@ fN
 LO
 ID
 dv
-iu
+ln
 qb
 Se
 jV
@@ -30850,7 +30850,7 @@ ID
 We
 dv
 vK
-Su
+Yb
 NL
 bh
 Yq

--- a/_maps/map_files/triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/triumph/triumph-02-deck2.dmm
@@ -503,7 +503,7 @@
 "by" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "bC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -842,7 +842,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/structure/table/gamblingtable,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "cB" = (
 /obj/machinery/camera/network/outside{
@@ -935,10 +936,13 @@
 /turf/simulated/wall,
 /area/janitor)
 "cN" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "cP" = (
 /obj/machinery/conveyor{
@@ -1385,10 +1389,10 @@
 	pixel_y = -28
 	},
 /obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "ep" = (
 /obj/effect/landmark{
@@ -1558,12 +1562,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
 "eM" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled,
+/obj/item/stool/padded,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "eO" = (
 /obj/machinery/door/firedoor,
@@ -1762,6 +1762,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
+/obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/coffee_shop)
 "fi" = (
@@ -2828,6 +2829,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
+"hX" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_shop)
 "hY" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -4343,24 +4352,15 @@
 /turf/simulated/wall/r_wall,
 /area/station/stairs_two)
 "mr" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
+/obj/structure/flora/pottedplant/fern,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_shop)
 "ms" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5077,6 +5077,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
+"nW" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Community Theater"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_shop)
 "nX" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor,
@@ -5906,6 +5918,10 @@
 "qu" = (
 /turf/simulated/floor/airless/ceiling,
 /area/space)
+"qv" = (
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_shop)
 "qw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5932,6 +5948,17 @@
 /obj/item/suit_cooling_unit,
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
+"qB" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
 "qE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -7289,9 +7316,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
 "uf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "ug" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7467,10 +7495,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/dormitory)
 "uC" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "uE" = (
 /obj/structure/cable/green{
@@ -7628,16 +7654,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "vb" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/structure/table/gamblingtable,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_shop)
 "vc" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8024,12 +8052,6 @@
 	},
 /turf/simulated/floor,
 /area/quartermaster/warehouse)
-"wn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/vacant/vacant_shop)
 "wo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
@@ -8162,13 +8184,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/showers)
-"wH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Vacant Shop"
-	},
-/turf/simulated/floor/tiled,
-/area/vacant/vacant_shop)
 "wJ" = (
 /obj/item/stool/padded,
 /turf/simulated/floor/wood,
@@ -9895,6 +9910,14 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
+"BP" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/table/woodentable,
+/obj/item/paper_bin,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_shop)
 "BQ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/structure/cable{
@@ -10084,7 +10107,7 @@
 /area/triumph/surfacebase/mining_main/storage)
 "Cq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "Cr" = (
 /obj/structure/cable/green{
@@ -10211,12 +10234,10 @@
 /area/crew_quarters/lounge/kitchen_freezer)
 "CJ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/curtain/black,
+/turf/simulated/floor/plating,
 /area/vacant/vacant_shop)
 "CK" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central6{
@@ -10586,10 +10607,13 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "DT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "DX" = (
 /obj/machinery/computer/ship/navigation/telescreen{
@@ -10812,6 +10836,9 @@
 	},
 /obj/item/reagent_containers/food/condiment/small/saltshaker{
 	pixel_x = -9
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
@@ -11276,7 +11303,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
 "FQ" = (
-/turf/simulated/floor/plating,
+/obj/structure/table/gamblingtable,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "FR" = (
 /obj/structure/cable/yellow{
@@ -11427,6 +11455,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "Gn" = (
@@ -11472,7 +11505,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "Gx" = (
 /obj/machinery/firealarm{
@@ -11529,7 +11562,14 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/plating,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/structure/table/gamblingtable,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "GD" = (
 /obj/structure/table/woodentable,
@@ -11561,7 +11601,11 @@
 	layer = 3.3;
 	pixel_x = -27
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table/woodentable,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "GN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11640,7 +11684,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "Ha" = (
 /obj/structure/cable/green{
@@ -12061,7 +12108,7 @@
 /area/maintenance/dormitory)
 "In" = (
 /obj/machinery/camera/network/civilian,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "Io" = (
 /obj/structure/cable/green{
@@ -12835,6 +12882,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"KF" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_shop)
 "KH" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12873,7 +12926,8 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/table/fancyblack,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "KO" = (
 /obj/machinery/conveyor{
@@ -12946,7 +13000,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "Lb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13674,10 +13728,13 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "Nq" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "Nr" = (
 /obj/structure/bed/chair/comfy/teal{
@@ -14404,7 +14461,15 @@
 /turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "Pz" = (
-/turf/simulated/floor/tiled,
+/obj/machinery/door/window/eastright{
+	dir = 8;
+	name = "Stage"
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/structure/table/gamblingtable,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "PB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14635,7 +14700,8 @@
 /obj/machinery/light_switch{
 	pixel_y = 25
 	},
-/turf/simulated/floor/plating,
+/obj/structure/flora/pottedplant/minitree,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "Qg" = (
 /obj/structure/cable/green{
@@ -14959,12 +15025,14 @@
 /turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "Rn" = (
-/obj/machinery/camera/network/civilian{
-	dir = 8
+/obj/machinery/door/airlock/glass{
+	name = "Community Theater"
 	},
-/obj/structure/flora/pottedplant/minitree,
+/obj/structure/curtain/black{
+	icon_state = "open"
+	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/coffee_shop)
+/area/vacant/vacant_shop)
 "Ro" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -16872,6 +16940,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
+"Wi" = (
+/obj/structure/closet/crate/mimic/closet/cointoss,
+/turf/simulated/floor/plating,
+/area/maintenance/dormitory)
 "Wj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -17027,10 +17099,10 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_11)
 "Wz" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "WA" = (
 /obj/structure/shuttle/engine/heater{
@@ -17646,6 +17718,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/bar)
+"Yk" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/structure/table/gamblingtable,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_shop)
 "Ym" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -25760,7 +25845,7 @@ sl
 Pm
 ON
 ai
-oE
+Wi
 oE
 tA
 rC
@@ -30850,7 +30935,7 @@ qT
 NB
 NB
 ED
-Rn
+Tf
 iH
 GJ
 lf
@@ -30992,7 +31077,7 @@ lu
 VR
 NB
 mQ
-mQ
+Rn
 mQ
 mQ
 Qj
@@ -31133,7 +31218,7 @@ lP
 tN
 YM
 NB
-FQ
+mr
 uC
 GM
 mQ
@@ -31277,7 +31362,7 @@ YS
 NB
 Nq
 Wz
-FQ
+BP
 mQ
 oa
 Qg
@@ -31419,8 +31504,8 @@ XU
 NB
 KK
 La
-FQ
-wH
+eM
+CJ
 nM
 FC
 hT
@@ -31563,8 +31648,8 @@ GY
 La
 eM
 CJ
-vb
-mr
+nM
+FC
 hQ
 zk
 zy
@@ -31701,7 +31786,7 @@ NB
 NB
 NB
 NB
-GY
+uf
 La
 eo
 mQ
@@ -31843,11 +31928,11 @@ mx
 Dt
 mQ
 Qf
-GY
-wn
-Pz
-sD
-nM
+uf
+La
+hX
+nW
+qB
 Gl
 cH
 jB
@@ -31984,11 +32069,11 @@ VZ
 VZ
 SM
 aX
-uf
+vB
 by
 Cq
-FQ
-sD
+Py
+qv
 nM
 FC
 hT
@@ -32129,7 +32214,7 @@ mQ
 Gw
 cN
 DT
-FQ
+KF
 mQ
 Yp
 Qg
@@ -32269,9 +32354,9 @@ Rj
 aC
 mQ
 In
-FQ
-FQ
-Pz
+cN
+DT
+KF
 mQ
 nM
 FC
@@ -32411,8 +32496,8 @@ Rj
 tV
 mQ
 Pz
-FQ
-FQ
+vb
+Yk
 GC
 mQ
 Je
@@ -32553,7 +32638,7 @@ Rj
 aC
 mQ
 FQ
-Pz
+FQ
 cz
 FQ
 mQ

--- a/_maps/map_files/triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/triumph/triumph-02-deck2.dmm
@@ -842,8 +842,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/table/gamblingtable,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled,
 /area/vacant/vacant_shop)
 "cB" = (
 /obj/machinery/camera/network/outside{
@@ -4803,6 +4802,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"no" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_shop)
 "np" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1
@@ -6133,6 +6144,9 @@
 "ra" = (
 /turf/simulated/wall,
 /area/vacant/vacant_office)
+"rb" = (
+/turf/simulated/floor/tiled,
+/area/vacant/vacant_shop)
 "rd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -7657,14 +7671,10 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/floor_decal/corner/red{
+	dir = 9
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/obj/structure/table/gamblingtable,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled,
 /area/vacant/vacant_shop)
 "vc" = (
 /obj/structure/cable/green{
@@ -11085,6 +11095,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
+"Fj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_shop)
 "Fk" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
@@ -11303,8 +11325,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
 "FQ" = (
-/obj/structure/table/gamblingtable,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/corner/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
 /area/vacant/vacant_shop)
 "FR" = (
 /obj/structure/cable/yellow{
@@ -11562,14 +11586,12 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/floor_decal/corner/red,
+/obj/effect/floor_decal/corner/red{
+	dir = 1
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/obj/structure/table/gamblingtable,
-/turf/simulated/floor/wood,
+/obj/structure/musician/piano,
+/turf/simulated/floor/tiled,
 /area/vacant/vacant_shop)
 "GD" = (
 /obj/structure/table/woodentable,
@@ -11814,6 +11836,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/mining_ship/general)
+"Hu" = (
+/obj/effect/floor_decal/corner/red,
+/obj/structure/table/bench/padded,
+/turf/simulated/floor/tiled,
+/area/vacant/vacant_shop)
 "Hv" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -12108,6 +12135,9 @@
 /area/maintenance/dormitory)
 "In" = (
 /obj/machinery/camera/network/civilian,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "Io" = (
@@ -12927,6 +12957,7 @@
 	pixel_y = 22
 	},
 /obj/structure/table/fancyblack,
+/obj/structure/spirit_board/prop,
 /turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "KO" = (
@@ -14216,6 +14247,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
+"OL" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_shop)
 "OM" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
@@ -14461,15 +14501,13 @@
 /turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "Pz" = (
-/obj/machinery/door/window/eastright{
-	dir = 8;
-	name = "Stage"
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
+/obj/effect/floor_decal/corner/red{
 	dir = 8
 	},
-/obj/structure/table/gamblingtable,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/corner/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
 /area/vacant/vacant_shop)
 "PB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -17722,14 +17760,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/floor_decal/corner/red{
+	dir = 9
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/obj/structure/table/gamblingtable,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled,
 /area/vacant/vacant_shop)
 "Ym" = (
 /obj/machinery/firealarm{
@@ -32354,9 +32388,9 @@ Rj
 aC
 mQ
 In
-cN
-DT
-KF
+no
+Fj
+OL
 mQ
 nM
 FC
@@ -32638,9 +32672,9 @@ Rj
 aC
 mQ
 FQ
-FQ
+rb
 cz
-FQ
+Hu
 mQ
 lf
 FC

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -23847,7 +23847,6 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/mob/living/simple_mob/mechanical/corrupt_maint_drone/weak_no_poison,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay/aft)
@@ -25607,11 +25606,11 @@
 /area/medical/resleeving)
 "tUb" = (
 /obj/machinery/light/small{
-	dir = 8
+	dir = 4
 	},
-/mob/living/simple_mob/mechanical/corrupt_maint_drone/weak_no_poison,
+/obj/structure/closet/crate/mimic/cointoss,
 /turf/simulated/floor/plating,
-/area/maintenance/research)
+/area/maintenance/medbay/aft)
 "tUL" = (
 /turf/simulated/wall,
 /area/rnd/xenobiology)
@@ -27447,10 +27446,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/hallway/primary/aft)
-"vrz" = (
-/mob/living/simple_mob/mechanical/corrupt_maint_drone/weak_no_poison,
-/turf/simulated/floor/plating,
-/area/maintenance/research)
 "vsf" = (
 /obj/structure/table/reinforced,
 /obj/item/paicard,
@@ -33416,7 +33411,7 @@ pCH
 gpN
 sQl
 iCM
-tUb
+pCH
 pXl
 slN
 pYD
@@ -34279,7 +34274,7 @@ uiL
 pRL
 qKL
 uHP
-rhL
+tUb
 iQL
 hgV
 eAd
@@ -36951,7 +36946,7 @@ shT
 wpE
 boQ
 njF
-vrz
+sQl
 hnF
 czP
 ezT

--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -976,6 +976,10 @@
 	},
 /turf/simulated/floor,
 /area/security/brig)
+"aME" = (
+/obj/structure/closet/crate/mimic/cointoss,
+/turf/simulated/floor/plating,
+/area/maintenance/security/starboard)
 "aMF" = (
 /obj/structure/closet,
 /obj/random/maintenance/clean,
@@ -6053,7 +6057,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "ete" = (
-/mob/living/simple_mob/mechanical/corrupt_maint_drone/weak_no_poison,
 /obj/random/maintenance/security,
 /obj/random/trash,
 /turf/simulated/floor/tiled,
@@ -12918,7 +12921,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/lobby)
 "iUB" = (
-/mob/living/simple_mob/mechanical/corrupt_maint_drone/weak_no_poison,
+/obj/structure/closet/crate/mimic/cointoss,
 /turf/simulated/floor/plating,
 /area/maintenance/central)
 "iVA" = (
@@ -13756,9 +13759,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "jBs" = (
-/mob/living/simple_mob/mechanical/corrupt_maint_drone/weak_no_poison,
-/turf/simulated/floor/wood/broken,
-/area/maintenance/security/starboard)
+/obj/structure/closet/crate/mimic/cointoss,
+/turf/simulated/floor/plating,
+/area/maintenance/chapel)
 "jCa" = (
 /obj/machinery/door/firedoor,
 /obj/effect/map_helper/airlock/door/int_door,
@@ -14734,9 +14737,9 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "krE" = (
-/mob/living/simple_mob/mechanical/corrupt_maint_drone/weak_no_poison,
+/obj/structure/closet/crate/mimic/closet/cointoss,
 /turf/simulated/floor/plating,
-/area/maintenance/security/starboard)
+/area/maintenance/central)
 "krQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -43695,7 +43698,7 @@ sNf
 qPI
 wQz
 iEQ
-kKQ
+jBs
 amB
 rXs
 fgy
@@ -45993,7 +45996,7 @@ lJa
 lJa
 kqL
 gMN
-gMN
+aME
 kpY
 mkI
 ygn
@@ -46568,7 +46571,7 @@ wfb
 gvV
 fIg
 rYP
-jBs
+vbZ
 rYP
 qtH
 gMN
@@ -49238,7 +49241,7 @@ ruS
 lXy
 xMk
 bKz
-rSb
+krE
 tvx
 skw
 vrq
@@ -49511,7 +49514,7 @@ ini
 oxJ
 rnG
 lZG
-rSb
+iUB
 rSb
 rrW
 xMk
@@ -50272,7 +50275,7 @@ iWf
 lsu
 jYA
 myb
-krE
+gMN
 aSO
 nIK
 nIK
@@ -51371,7 +51374,7 @@ xMk
 uXq
 tyW
 bKd
-iUB
+rSb
 gUv
 cQt
 fWb


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. *Removes the corrupt drones from maint and returns some mimics.*
2. *Adds a Community Theater where the Vacant Store is.*

## Why It's Good For The Game

1. _This was a ridiculous substitution. I'm reversing it._
2. _This store is never used for what it's supposed to be used for. I've made it a small theater now._

## Changelog
:cl:
add: Adds mimics.
del: Removes all corrupt maint drone spawns.
add: Adds a Community Theater.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
