### PR TITLE
Creates new item type, cleans up code, fixes unintentional buff

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_donator.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_donator.dm
@@ -229,7 +229,7 @@
 
 /datum/gear/donator/aura
 	name = "KNIGHT-brand Melodic headset"
-	path = /obj/item/clothing/ears/earmuffs/headphones/aura
+	path = /obj/item/radio/headset/speak_n_rock/aura
 	ckeywhitelist = list("theknightofaura")
 
 /datum/gear/donator/dancer_scarf

--- a/code/modules/clothing/ears/ears.dm
+++ b/code/modules/clothing/ears/ears.dm
@@ -193,4 +193,3 @@
 	name = "light blue headtail cloth"
 	icon_state = "skrell_cloth_lblue_male"
 	item_state_slots = list(slot_r_hand_str = "egg2", slot_l_hand_str = "egg2")
-	

--- a/code/modules/clothing/ears/ears.dm
+++ b/code/modules/clothing/ears/ears.dm
@@ -16,6 +16,7 @@
 	icon_state = "headphones_off"
 	item_state_slots = list(slot_r_hand_str = "headphones", slot_l_hand_str = "headphones")
 	slot_flags = SLOT_EARS
+	ear_protection = 0
 
 /obj/item/clothing/ears/earmuffs/headphones/verb/togglemusic()
 	set name = "Toggle Headphone Music"
@@ -192,12 +193,3 @@
 	name = "light blue headtail cloth"
 	icon_state = "skrell_cloth_lblue_male"
 	item_state_slots = list(slot_r_hand_str = "egg2", slot_l_hand_str = "egg2")
-
-//donator item
-/obj/item/clothing/ears/earmuffs/headphones/aura
-	name = "KNIGHT-brand Melodic headset"
-	desc = "Unce unce unce unce."
-	headphones_on = 0
-	icon_state = "auraphones_off"
-	item_state_slots = list(slot_r_hand_str = "headphones", slot_l_hand_str = "headphones")
-	slot_flags = SLOT_EARS

--- a/code/modules/clothing/ears/ears.dm
+++ b/code/modules/clothing/ears/ears.dm
@@ -193,3 +193,4 @@
 	name = "light blue headtail cloth"
 	icon_state = "skrell_cloth_lblue_male"
 	item_state_slots = list(slot_r_hand_str = "egg2", slot_l_hand_str = "egg2")
+	

--- a/code/modules/clothing/ears/speakrock.dm
+++ b/code/modules/clothing/ears/speakrock.dm
@@ -1,0 +1,43 @@
+/obj/item/radio/headset/speak_n_rock
+    name = "\improper 'NT'-brand headphones"
+    desc = "A set of open-backed headphones emblazened with a corporate logo. Connects to radio networks. Warranty void if used underwater."
+    icon = 'icons/obj/items.dmi'    // Radios set their own icons, so have to re-set this here.
+
+    icon_state = "headphones_off"
+    item_state_slots = list(slot_r_hand_str = "headphones", slot_l_hand_str = "headphones")
+    slot_flags = SLOT_EARS
+    ear_protection = 0    // set to 0 for now, can change later
+
+    var/headphones_on = FALSE
+
+// This is a clone of /obj/item/clothing/ears/earmuffs/headphones/verb/togglemusic()'s functionality.
+/obj/item/radio/headset/speak_n_rock/verb/togglemusic()
+    set name = "Toggle Headphone Music"
+    set category = "Object"
+    set src in usr
+    if(!istype(usr, /mob/living) || usr.stat) return
+
+    var/base_icon = copytext(icon_state,1,(length(icon_state) - 3 + headphones_on))
+
+    headphones_on = !headphones_on
+    icon_state = "[base_icon]_[headphones_on ? "on" : "off"]"
+    to_chat(usr, SPAN_NOTICE("You turn the music [headphones_on ? "on" : "off"]."))
+
+    if (ismob(loc))
+        var/mob/M = loc
+        M.update_inv_ears()
+
+/obj/item/radio/headset/speak_n_rock/AltClick(mob/user)
+    if(!Adjacent(user))
+        return
+    else if(!headphones_on)
+        togglemusic()
+    else
+        togglemusic()
+
+//donator item
+/obj/item/radio/headset/speak_n_rock/aura
+    name = "\improper KNIGHT-brand Melodic headset"
+    icon_state = "auraphones_off"
+    desc = "A hand-made series of headphones. Featuring a unique, bowman-inspired design, each is made with the individual in mind."
+    adhoc_fallback = TRUE

--- a/code/modules/clothing/ears/speakrock.dm
+++ b/code/modules/clothing/ears/speakrock.dm
@@ -41,4 +41,3 @@
     icon_state = "auraphones_off"
     desc = "A hand-made series of headphones. Featuring a unique, bowman-inspired design, each is made with the individual in mind."
     adhoc_fallback = TRUE
-    

--- a/code/modules/clothing/ears/speakrock.dm
+++ b/code/modules/clothing/ears/speakrock.dm
@@ -41,3 +41,4 @@
     icon_state = "auraphones_off"
     desc = "A hand-made series of headphones. Featuring a unique, bowman-inspired design, each is made with the individual in mind."
     adhoc_fallback = TRUE
+    

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1792,6 +1792,7 @@
 #include "code\modules\clothing\clothing_icons.dm"
 #include "code\modules\clothing\ears\earrings.dm"
 #include "code\modules\clothing\ears\ears.dm"
+#include "code\modules\clothing\ears\speakrock.dm"
 #include "code\modules\clothing\glasses\glasses.dm"
 #include "code\modules\clothing\glasses\hud.dm"
 #include "code\modules\clothing\gloves\arm_guards.dm"


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Speak 'n' Rock headsets are headphones and Radio Headsets in one. Currently, they're not accessable via loadout. I have re-made my donator item as a subtype of this, to powercreep it a little later. That code is a lot more difficult then this is.

Speaking of difficult coding, Sillycons accidentally didn't adjust a thing, and all of the single-eared musical note headphones he craved to have on without sacrificing the radio earpiece where giving top-tier flashbang protection. this makes it so that they give none, as a stop-gap until further in-depth discussion can happen on the subject. ((Earmuffs are unaffected, and still give good flashbang protection))
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better code, and a small bugfix in the affected areas while I'm at it. Technically some new content, but I haven't added it to the general loadout for everyone to use, due to balance discussion needing to happen
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: my new donator item, complete with better code
add: the code my donator item works off of, pending some balance discussion.
del: my old donator item
fix: sillycon's silly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
