### PR TITLE
Changes RD console sync range from 3 to 5 tiles

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -84,7 +84,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	return return_name
 
 /obj/machinery/computer/rdconsole/proc/SyncRDevices() //Makes sure it is properly sync'ed up with the devices attached to it (if any).
-	for(var/obj/machinery/r_n_d/D in range(3, src))
+	for(var/obj/machinery/r_n_d/D in range(5, src)) //Originally 3, buffed to 5 - Werewolf
 		if(D.linked_console != null || D.panel_open)
 			continue
 		if(istype(D, /obj/machinery/r_n_d/destructive_analyzer))


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin.

## Why It's Good For The Game

This allows us to place research machines further apart, while still being short enough to not interfere with robotics or elsewhere.

## Changelog
:cl:
tweak: RD console sync range 3 --> 5
/:cl: