### PR TITLE
Maint drones now die if you ghost from them, no more pseudo alive drones!

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -72,8 +72,9 @@ var/list/mob_hat_cache = list()
 	..()
 
 /mob/living/silicon/robot/drone/ghost()
-	if(..())
-		shut_down()
+	. = ..()
+	if (!ckey)
+		death()
 
 /mob/living/silicon/robot/drone/is_sentient()
 	return FALSE

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -47,8 +47,8 @@ var/list/mob_hat_cache = list()
 	mob_push_flags = SIMPLE_ANIMAL
 	mob_always_swap = 1
 
-	mob_size = MOB_LARGE // Small mobs can't open doors, it's a huge pain for drones.
-
+	mob_size = MOB_SMALL // pulled here from a _vr file
+	
 	//Used for self-mailing.
 	var/mail_destination = ""
 	var/obj/machinery/drone_fabricator/master_fabricator
@@ -70,6 +70,10 @@ var/list/mob_hat_cache = list()
 	if(hat)
 		hat.loc = get_turf(src)
 	..()
+
+/mob/living/silicon/robot/drone/ghost()
+	if(..())
+		shut_down()
 
 /mob/living/silicon/robot/drone/is_sentient()
 	return FALSE

--- a/code/modules/mob/living/silicon/robot/drone/drone_vr.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_vr.dm
@@ -1,2 +1,0 @@
-/mob/living/silicon/robot/drone
-	mob_size = MOB_SMALL

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2663,7 +2663,6 @@
 #include "code\modules\mob\living\silicon\robot\drone\drone_items.dm"
 #include "code\modules\mob\living\silicon\robot\drone\drone_manufacturer.dm"
 #include "code\modules\mob\living\silicon\robot\drone\drone_say.dm"
-#include "code\modules\mob\living\silicon\robot\drone\drone_vr.dm"
 #include "code\modules\mob\living\silicon\robot\drone\swarm.dm"
 #include "code\modules\mob\living\silicon\robot\drone\swarm_abilities.dm"
 #include "code\modules\mob\living\silicon\robot\drone\swarm_items.dm"


### PR DESCRIPTION
## Why It's Good For The Game
You feel kinda silly talking to a drone that turns out to have ghosted even before you found it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed Maintdrones not indicating that they have been abandond when the player inside ghosts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
