### PR TITLE
Removes Gravitons from R&D Protolathe

### DIFF
--- a/code/modules/research/designs/HUDs.dm
+++ b/code/modules/research/designs/HUDs.dm
@@ -38,6 +38,7 @@
 	build_path = /obj/item/clothing/glasses/material
 	sort_string = "EAAAD"
 
+/* Graviton't
 /datum/design/item/hud/graviton_visor
 	name = "graviton visor"
 	id = "graviton_goggles"
@@ -45,6 +46,7 @@
 	materials = list(MAT_PLASTEEL = 2000, "glass" = 3000, MAT_PHORON = 1500)
 	build_path = /obj/item/clothing/glasses/graviton
 	sort_string = "EAAAE"
+*/
 
 /datum/design/item/hud/omni
 	name = "AR glasses"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. *Removes Gravitons from R&D Protolathe list.*

## Why It's Good For The Game

1. _Gravitons are just kinda ridiculous. They disrupt events. They disrupt Overmap flight. They're essentially wallhack goggles that trivialize encounters and daily functions. Their primary justification - ore detection, will be refactored shortly._

## Changelog
:cl:
del: Removes graviton goggles from R&D printer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
