### PR TITLE
The gamemode announcement at round start now tells what engine is used, additional to the gamemode

### DIFF
--- a/code/controllers/subsystems/mapping/_mapping.dm
+++ b/code/controllers/subsystems/mapping/_mapping.dm
@@ -1,5 +1,6 @@
 #define INIT_ANNOUNCE(X) to_chat(world, "<span class='boldannounce'>[X]</span>"); log_world(X)
 
+GLOBAL_VAR_INIT(used_engine, "None")
 // Handles map-related tasks, mostly here to ensure it does so after the MC initializes.
 SUBSYSTEM_DEF(mapping)
 	name = "Mapping"
@@ -355,6 +356,7 @@ SUBSYSTEM_DEF(mapping)
 	subsystem_log("Chose Engine Map: [chosen_type.name]")
 	admin_notice("<span class='danger'>Chose Engine Map: [chosen_type.name]</span>", R_DEBUG)
 	to_chat(world, "<span class='danger'>Engine loaded: [chosen_type.display_name]</span>")
+	GLOB.used_engine = chosen_type.display_name
 
 	// Annihilate movable atoms
 	engine_loader.annihilate_bounds()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -114,7 +114,8 @@ var/global/list/additional_antag_types = list()
 				return
 
 /datum/game_mode/proc/announce() //to be called when round starts
-	to_chat(world, "<B>The current game mode is [capitalize(name)]!</B>")
+	//to_chat(world, "<B>The current game mode is [capitalize(name)]!</B>") //Overwritten to show the engine used rather than the gamemode
+	to_chat(world, "<B>The current game mode is [GLOB.used_engine]!</B>")
 	if(round_description) to_chat(world, "[round_description]")
 	if(round_autoantag) to_chat(world, "Antagonists will be added to the round automagically as needed.")
 	if(antag_templates && antag_templates.len)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -521,6 +521,7 @@ proc/get_nt_opposed()
 
 	if(master_mode != "secret")
 		to_chat(usr, "<b>The roundtype is [capitalize(SSticker.mode.name)]</b>")
+		to_chat(usr, "<b>The engine is [GLOB.used_engine]</b>")
 		if(SSticker.mode.round_description)
 			to_chat(usr, "<i>[SSticker.mode.round_description]</i>")
 		if(SSticker.mode.extended_round_description)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -114,8 +114,8 @@ var/global/list/additional_antag_types = list()
 				return
 
 /datum/game_mode/proc/announce() //to be called when round starts
-	//to_chat(world, "<B>The current game mode is [capitalize(name)]!</B>") //Overwritten to show the engine used rather than the gamemode
-	to_chat(world, "<B>The current game mode is [GLOB.used_engine]!</B>")
+	to_chat(world, "<B>The current game mode is [capitalize(name)]!</B>") 
+	to_chat(world, "<B>The current engine is [GLOB.used_engine]!</B>")//Actually, why not expand this....
 	if(round_description) to_chat(world, "[round_description]")
 	if(round_autoantag) to_chat(world, "Antagonists will be added to the round automagically as needed.")
 	if(antag_templates && antag_templates.len)


### PR DESCRIPTION
to allow people to see what engine loaded instead of having to observe and go back to the lobby because its again one of the usuall 4, smh why cant we have cool engines

:cl:
Add: Adds engine type info to round info
/:cl: