### PR TITLE
Reduces sizeshift trait cost to 2

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -219,3 +219,12 @@
 /datum/trait/antiseptic_saliva/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
 	H.verbs |= /mob/living/carbon/human/proc/lick_wounds
+	
+/datum/trait/size_change
+	name = "Sizeshift"
+	desc = "Lets you shift sizes by yourself. Remember that abusing size mechanics is against the rules!"
+	cost = 0
+
+/datum/trait/size_change/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/proc/set_size

--- a/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -184,7 +184,7 @@
 /datum/trait/size_change
 	name = "Sizeshift"
 	desc = "Lets you shift sizes by yourself. Remember that abusing size mechanics is against the rules!"
-	cost = 4
+	cost = 2
 
 /datum/trait/size_change/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)

--- a/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -181,15 +181,6 @@
 	cost = 1
 	var_changes = list("bloodloss_rate" = 0.75)
 
-/datum/trait/size_change
-	name = "Sizeshift"
-	desc = "Lets you shift sizes by yourself. Remember that abusing size mechanics is against the rules!"
-	cost = 2
-
-/datum/trait/size_change/apply(var/datum/species/S,var/mob/living/carbon/human/H)
-	..(S,H)
-	H.verbs |= /mob/living/proc/set_size
-
 /datum/trait/positive/weaver
 	name = "Weaver"
 	desc = "You can produce silk and create various articles of clothing and objects."


### PR DESCRIPTION
## About The Pull Request

Reduces the trait cost for sizeshift to 2.

## Why It's Good For The Game

Since using size mechanics for combat and such is against the rules anyway, I don't think this trait should cost the equivalent of haste. I wanted to reduce it down to 1 point, but 2 seems much more agreeable.

## Changelog
:cl:
balance: reduced sizeshift trait cost to 2
/:cl: