### PR TITLE
Change alert descriptions to be config options

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -11,3 +11,39 @@
 
 /datum/config_entry/flag/nightshifts_enabled
 	config_entry_value = TRUE
+
+/datum/config_entry/string/alert_desc_green
+	config_entry_value = "All threats to the station have passed. Security may not have weapons visible, privacy laws are once again fully enforced."
+
+/datum/config_entry/string/alert_desc_blue_upto
+	config_entry_value = "The station has received reliable information about possible hostile activity in the local area. Security staff may have weapons visible. Privacy laws are still in effect."
+	
+/datum/config_entry/string/alert_desc_blue_downto
+	config_entry_value = "Code Blue procedures are now in effect: The immediate threat has passed. Security staff may not have weapons drawn, but may still have weapons visible. Privacy laws are once again fully enforced."
+
+/datum/config_entry/string/alert_desc_yellow_upto
+	config_entry_value = "The station has confirmed hostile activity in the local area. Security staff may have weapons visible. Random searches are permitted."
+
+/datum/config_entry/string/alert_desc_yellow_downto
+	config_entry_value = "Code Yellow procedures are now in effect: The immediate security threat has been downgraded. Security staff may not have weapons drawn, but may still have weapons visible. Random searches are still permitted."
+
+/datum/config_entry/string/alert_desc_violet_upto
+	config_entry_value = "A major medical emergency has been reported. Medical personnel are required to report to the Medbay immediately. Non-medical personnel are required to obey all relevant instructions from medical staff."
+
+/datum/config_entry/string/alert_desc_violet_downto
+	config_entry_value = "Code Violet procedures are now in effect: Medical personnel are required to report to the Medbay immediately. Non-medical personnel are required to obey all relevant instructions from medical staff."
+
+/datum/config_entry/string/alert_desc_orange_upto
+	config_entry_value = "A major engineering emergency has been reported. Engineering personnel are required to report to the affected area immediately. Non-engineering personnel are required to evacuate any affected areas and obey relevant instructions from engineering staff."
+
+/datum/config_entry/string/alert_desc_orange_downto
+	config_entry_value = "Code Orange procedures are now in effect: Engineering personnel are required to report to the affected area immediately. Non-engineering personnel are required to evacuate any affected areas and obey relevant instructions from engineering staff."
+
+/datum/config_entry/string/alert_desc_red_upto
+	config_entry_value = "There is an immediate serious threat to the station. Security may have weapons unholstered at all times. Random searches are allowed and advised."
+
+/datum/config_entry/string/alert_desc_red_downto
+	config_entry_value = "Code Red procedures are now in effect: The station is no longer under threat of imminent destruction, but there is still an immediate serious threat to the station. Security may have weapons unholstered at all times, random searches are allowed and advised."
+
+/datum/config_entry/string/alert_desc_delta
+	config_entry_value = "The station is under immediate threat of imminent destruction! All crew are instructed to obey all instructions given by heads of staff. Any violations of these orders can be punished by death. This is not a drill."

--- a/code/controllers/configuration_old/configuration.dm
+++ b/code/controllers/configuration_old/configuration.dm
@@ -134,20 +134,6 @@
 	var/rulesurl
 	var/mapurl
 
-	//Alert level description
-	var/alert_desc_green = "All threats to the station have passed. Security may not have weapons visible, privacy laws are once again fully enforced."
-	var/alert_desc_blue_upto = "The station has received reliable information about possible hostile activity in the local area. Security staff may have weapons visible. Privacy laws are still in effect."
-	var/alert_desc_blue_downto = "Code Blue procedures are now in effect: The immediate threat has passed. Security staff may not have weapons drawn, but may still have weapons visible. Privacy laws are once again fully enforced."
-	var/alert_desc_yellow_upto = "The station has confirmed hostile activity in the local area. Security staff may have weapons visible. Random searches are permitted."
-	var/alert_desc_yellow_downto = "Code Yellow procedures are now in effect: The immediate security threat has been downgraded. Security staff may not have weapons drawn, but may still have weapons visible. Random searches are still permitted."
-	var/alert_desc_violet_upto = "A major medical emergency has been reported. Medical personnel are required to report to the Medbay immediately. Non-medical personnel are required to obey all relevant instructions from medical staff."
-	var/alert_desc_violet_downto = "Code Violet procedures are now in effect: Medical personnel are required to report to the Medbay immediately. Non-medical personnel are required to obey all relevant instructions from medical staff."
-	var/alert_desc_orange_upto = "A major engineering emergency has been reported. Engineering personnel are required to report to the affected area immediately. Non-engineering personnel are required to evacuate any affected areas and obey relevant instructions from engineering staff."
-	var/alert_desc_orange_downto = "Code Orange procedures are now in effect: Engineering personnel are required to report to the affected area immediately. Non-engineering personnel are required to evacuate any affected areas and obey relevant instructions from engineering staff."
-	var/alert_desc_red_upto = "There is an immediate serious threat to the station. Security may have weapons unholstered at all times. Random searches are allowed and advised."
-	var/alert_desc_red_downto = "Code Red procedures are now in effect: The station is no longer under threat of imminent destruction, but there is still an immediate serious threat to the station. Security may have weapons unholstered at all times, random searches are allowed and advised."
-	var/alert_desc_delta = "The station is under immediate threat of imminent destruction! All crew are instructed to obey all instructions given by heads of staff. Any violations of these orders can be punished by death. This is not a drill."
-
 	var/forbid_singulo_possession = 0
 
 	//game_options.txt configs
@@ -620,24 +606,6 @@
 
 				if("load_jobs_from_txt")
 					load_jobs_from_txt = 1
-
-				if("alert_red_upto")
-					config_legacy.alert_desc_red_upto = value
-
-				if("alert_red_downto")
-					config_legacy.alert_desc_red_downto = value
-
-				if("alert_blue_downto")
-					config_legacy.alert_desc_blue_downto = value
-
-				if("alert_blue_upto")
-					config_legacy.alert_desc_blue_upto = value
-
-				if("alert_green")
-					config_legacy.alert_desc_green = value
-
-				if("alert_delta")
-					config_legacy.alert_desc_delta = value
 
 				if("forbid_singulo_possession")
 					forbid_singulo_possession = 1

--- a/code/modules/security levels/security levels.dm
+++ b/code/modules/security levels/security levels.dm
@@ -32,40 +32,40 @@
 	if(level >= SEC_LEVEL_GREEN && level <= SEC_LEVEL_DELTA && level != security_level)
 		switch(level)
 			if(SEC_LEVEL_GREEN)
-				security_announcement_down.Announce("[config_legacy.alert_desc_green]", "Attention! Alert level lowered to code green.")
+				security_announcement_down.Announce("[CONFIG_GET(string/alert_desc_green)]", "Attention! Alert level lowered to code green.")
 				security_level = SEC_LEVEL_GREEN
 			if(SEC_LEVEL_BLUE)
 				if(security_level < SEC_LEVEL_BLUE)
-					security_announcement_up.Announce("[config_legacy.alert_desc_blue_upto]", "Attention! Alert level elevated to blue", new_sound = 'sound/misc/voybluealert.ogg')
+					security_announcement_up.Announce("[CONFIG_GET(string/alert_desc_blue_upto)]", "Attention! Alert level elevated to blue", new_sound = 'sound/misc/voybluealert.ogg')
 				else
-					security_announcement_down.Announce("[config_legacy.alert_desc_blue_downto]", "Attention! Alert level lowered to blue", new_sound = 'sound/misc/voybluealert.ogg')
+					security_announcement_down.Announce("[CONFIG_GET(string/alert_desc_blue_downto)]", "Attention! Alert level lowered to blue", new_sound = 'sound/misc/voybluealert.ogg')
 				security_level = SEC_LEVEL_BLUE
 			if(SEC_LEVEL_YELLOW)
 				if(security_level < SEC_LEVEL_YELLOW)
-					security_announcement_up.Announce("[config_legacy.alert_desc_yellow_upto]", "Attention! Alert level elevated to yellow")
+					security_announcement_up.Announce("[CONFIG_GET(string/alert_desc_yellow_upto)]", "Attention! Alert level elevated to yellow")
 				else
-					security_announcement_down.Announce("[config_legacy.alert_desc_yellow_downto]", "Attention! Alert level lowered to yellow")
+					security_announcement_down.Announce("[CONFIG_GET(string/alert_desc_yellow_downto)]", "Attention! Alert level lowered to yellow")
 				security_level = SEC_LEVEL_YELLOW
 			if(SEC_LEVEL_VIOLET)
 				if(security_level < SEC_LEVEL_VIOLET)
-					security_announcement_up.Announce("[config_legacy.alert_desc_violet_upto]", "Attention! Alert level elevated to violet")
+					security_announcement_up.Announce("[CONFIG_GET(string/alert_desc_violet_upto)]", "Attention! Alert level elevated to violet")
 				else
-					security_announcement_down.Announce("[config_legacy.alert_desc_violet_downto]", "Attention! Alert level lowered to violet")
+					security_announcement_down.Announce("[CONFIG_GET(string/alert_desc_violet_downto)]", "Attention! Alert level lowered to violet")
 				security_level = SEC_LEVEL_VIOLET
 			if(SEC_LEVEL_ORANGE)
 				if(security_level < SEC_LEVEL_ORANGE)
-					security_announcement_up.Announce("[config_legacy.alert_desc_orange_upto]", "Attention! Alert level elevated to orange")
+					security_announcement_up.Announce("[CONFIG_GET(string/alert_desc_orange_upto)]", "Attention! Alert level elevated to orange")
 				else
-					security_announcement_down.Announce("[config_legacy.alert_desc_orange_downto]", "Attention! Alert level lowered to orange")
+					security_announcement_down.Announce("[CONFIG_GET(string/alert_desc_orange_downto)]", "Attention! Alert level lowered to orange")
 				security_level = SEC_LEVEL_ORANGE
 			if(SEC_LEVEL_RED)
 				if(security_level < SEC_LEVEL_RED)
-					security_announcement_up.Announce("[config_legacy.alert_desc_red_upto]", "Attention! Code red!", new_sound = 'sound/effects/alert_levels/red_alert.ogg')
+					security_announcement_up.Announce("[CONFIG_GET(string/alert_desc_red_upto)]", "Attention! Code red!", new_sound = 'sound/effects/alert_levels/red_alert.ogg')
 				else
-					security_announcement_down.Announce("[config_legacy.alert_desc_red_downto]", "Attention! Code red!", new_sound = 'sound/misc/voyalert.ogg')
+					security_announcement_down.Announce("[CONFIG_GET(string/alert_desc_red_downto)]", "Attention! Code red!", new_sound = 'sound/misc/voyalert.ogg')
 				security_level = SEC_LEVEL_RED
 			if(SEC_LEVEL_DELTA)
-				security_announcement_up.Announce("[config_legacy.alert_desc_delta]", "Attention! Delta alert level reached!", new_sound = 'sound/effects/alert_levels/deltaklaxon.ogg')
+				security_announcement_up.Announce("[CONFIG_GET(string/alert_desc_delta)]", "Attention! Delta alert level reached!", new_sound = 'sound/effects/alert_levels/deltaklaxon.ogg')
 				security_level = SEC_LEVEL_DELTA
 
 		var/newlevel = get_security_level()

--- a/config/entries/game_options.txt
+++ b/config/entries/game_options.txt
@@ -17,3 +17,23 @@ ENGINE_SUBMAP EngineSubmap_Singulo 20
 
 ## Comment this out if you don't want to use the 'nightshift lighting' subsystem to adjust lights based on ingame time.
 NIGHTSHIFTS_ENABLED
+
+## The descriptions of each alert status.
+ALERT_DESC_GREEN All threats to the station have passed. Security may not have weapons visible, privacy laws are once again fully enforced.
+
+ALERT_DESC_BLUE_UPTO The station has received reliable information about possible hostile activity in the local area. Security staff may have weapons visible. Privacy laws are still in effect.
+ALERT_DESC_BLUE_DOWNTO Code Blue procedures are now in effect: The immediate threat has passed. Security staff may not have weapons drawn, but may still have weapons visible. Privacy laws are once again fully enforced.
+
+ALERT_DESC_YELLOW_UPTO The station has confirmed hostile activity in the local area. Security staff may have weapons visible. Random searches are permitted.
+ALERT_DESC_YELLOW_DOWNTO Code Yellow procedures are now in effect: The immediate security threat has been downgraded. Security staff may not have weapons drawn, but may still have weapons visible. Random searches are still permitted.
+
+ALERT_DESC_VIOLET_UPTO A major medical emergency has been reported. Medical personnel are required to report to the Medbay immediately. Non-medical personnel are required to obey all relevant instructions from medical staff.
+ALERT_DESC_VIOLET_DOWNTO Code Violet procedures are now in effect: Medical personnel are required to report to the Medbay immediately. Non-medical personnel are required to obey all relevant instructions from medical staff.
+
+ALERT_DESC_ORANGE_UPTO A major engineering emergency has been reported. Engineering personnel are required to report to the affected area immediately. Non-engineering personnel are required to evacuate any affected areas and obey relevant instructions from engineering staff.
+ALERT_DESC_ORANGE_DOWNTO Code Orange procedures are now in effect: Engineering personnel are required to report to the affected area immediately. Non-engineering personnel are required to evacuate any affected areas and obey relevant instructions from engineering staff.
+
+ALERT_DESC_RED_UPTO There is an immediate serious threat to the station. Security may have weapons unholstered at all times. Random searches are allowed and advised.
+ALERT_DESC_RED_DOWNTO Code Red procedures are now in effect: The station is no longer under threat of imminent destruction, but there is still an immediate serious threat to the station. Security may have weapons unholstered at all times, random searches are allowed and advised.
+
+ALERT_DESC_DELTA The station is under immediate threat of imminent destruction! All crew are instructed to obey all instructions given by heads of staff. Any violations of these orders can be punished by death. This is not a drill.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The alert descriptions displayed whenever the alert level changes have been moved to `game_options.txt` instead of being hardcoded, allowing them to be modified much more easily.

_The current settings/defaults are the descriptions as-is, however, there are some discrepancies from the wiki so it'd probably be a good idea to change that before adding them in._

## Why It's Good For The Game

Easier administration.

## Changelog
:cl:
server: Alert descriptions have been moved to game_options.txt.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
