### PR TITLE
Wall actions are based on intent

### DIFF
--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -104,8 +104,33 @@
 		else
 			fail_smash(user)
 			return 1
+	if(iscarbon(user))
+		var/mob/living/carbon/M = user
+		switch(M.a_intent)
+			if(INTENT_HELP)
+				return
+			if(INTENT_DISARM, INTENT_GRAB)
+				try_touch(M, rotting)
+			if(INTENT_HARM)
+				//since only humans have organs_by_name but carbons still have intents this check only applies to humans
+				//it's hacky but it works
+				if(ishuman(user))
+					var/mob/living/carbon/human/H = user
+					var/obj/item/organ/external/E = H.organs_by_name[M.hand ? BP_L_HAND : BP_R_HAND]
+					if (!(E.is_usable()))
+						to_chat(user, SPAN_WARNING("You can't use that hand."))
+						return
+				if(rotting && !reinf_material)
+					M.visible_message(SPAN_DANGER("[M.name] punches \the [src] and it crumbles!"), SPAN_DANGER("You punch \the [src] and it crumbles!"))
+					dismantle_wall()
+					playsound(src, get_sfx("punch"), 20)
+				else
+					M.visible_message(SPAN_DANGER("[M.name] punches \the [src]!"), SPAN_DANGER("You punch \the [src]!"))
+					M.apply_damage(3, BRUTE, M.hand ? BP_L_HAND : BP_R_HAND)
+					playsound(src, get_sfx("punch"), 20)
 
-	try_touch(user, rotting)
+	else
+		try_touch(user, rotting)
 
 /turf/simulated/wall/attack_generic(var/mob/user, var/damage, var/attack_message)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Wall actions are now based on intent. If you click a wall on help intent, nothing happens. On disarm and grab intents, you will push it. On harm intent you will punch it (which will hurt yourself if the wall isn't weakened).

## Why It's Good For The Game

Some people like yours truly like to rotate our character by clicking in the direction that we want to face. If we end up clicking on an adjacent wall we push it for no reason which just looks silly. This fixes that.

## Changelog
:cl:
tweak: You will no longer push a wall on help intent.
tweak: On harm intent, you will punch a wall instead of pushing it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
