### PR TITLE
Nerfs the HoP

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -41,7 +41,6 @@
 		/obj/item/radio/headset/heads/hop,
 		/obj/item/radio/headset/heads/hop/alt,
 		/obj/item/storage/box/ids = 2,
-		/obj/item/gun/energy/gun,
 		/obj/item/gps/command,
 		/obj/item/gun/energy/gun/martin, //VOREStation Add,
 		/obj/item/storage/box/commandkeys, //VOREStation Add,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. *Removes the Energy Gun from the HoP Locker.*

## Why It's Good For The Game

1. _It was brought to my attention that the HoP locker has two guns, thanks to a VORE edit that was presumably not implemented properly. I've removed the baseline e-gun, and left the holdout in place, as that seems more suitable for the role._

## Changelog
:cl:
del: Removes the egun in the HoP locker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
