### PR TITLE
Add alert status to MOTD

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -8,6 +8,35 @@
 		to_chat(src, "<div class=\"motd\">[motd]</div>", handle_whitespace=FALSE)
 	else
 		to_chat(src, "<span class='notice'>The Message of the Day has not been set.</span>")
+	to_chat(src, getAlertDesc())
+
+/client/proc/getAlertDesc()
+	var/color
+	var/desc
+	//borrow the same colors from the fire alarms
+	switch(get_security_level())
+		if("green")	 
+			color = "#00ff00"
+			desc = "" //no special description if nothing special is going on
+		if("yellow") 
+			color = "#ffff00"
+			desc = CONFIG_GET(string/alert_desc_yellow_upto)
+		if("violet") 
+			color = "#9933ff"
+			desc = CONFIG_GET(string/alert_desc_violet_upto)
+		if("orange") 
+			color = "#ff9900"
+			desc = CONFIG_GET(string/alert_desc_orange_upto)
+		if("blue")	 
+			color = "#1024A9"
+			desc = CONFIG_GET(string/alert_desc_blue_upto)
+		if("red")	 
+			color = "#ff0000"
+			desc = CONFIG_GET(string/alert_desc_red_upto)
+		if("delta")	 
+			color = "#FF6633"
+			desc = CONFIG_GET(string/alert_desc_delta)
+	. = SPAN_NOTICE("<br>The alert level on \the [station_name()] is currently: <font color=[color]>Code [capitalize(get_security_level())]</font>. [desc]")
 
 /client/proc/ooc_wrapper()
 	var/message = input("","ooc (text)") as text|null

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -30,7 +30,9 @@ var/obj/effect/lobby_image = new /obj/effect/lobby_image
 	var/motd = config.motd
 	if(motd)
 		to_chat(src, "<div class=\"motd\">[motd]</div>", handle_whitespace=FALSE)
-
+	if(client)
+		to_chat(src, client.getAlertDesc())
+		
 	if(!mind)
 		mind = new /datum/mind(key)
 		mind.active = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the ship's current alert status to the MOTD, shown either when someone logs in or if they use the MOTD verb. Since there is no pending emergency for code green and its description is a "down to" text, there is no description shown for it. All others use the "up to" text for the relevant alert level.

Pictures of each alert level as shown:
![image](https://user-images.githubusercontent.com/25853190/162550537-0df5837d-11f1-4a03-be90-aae9a4bfc0ea.png)
![image](https://user-images.githubusercontent.com/25853190/162550544-387ed767-e2bd-4ae2-a402-227858b0cee5.png)
![image](https://user-images.githubusercontent.com/25853190/162550548-86aca227-b77d-453f-912d-f7126c0afb46.png)
![image](https://user-images.githubusercontent.com/25853190/162550556-df1a6938-2e82-41c4-a61d-760bf2e19481.png)
![image](https://user-images.githubusercontent.com/25853190/162550568-ec1a7946-6195-47c5-a794-f86b4010ce14.png)
![image](https://user-images.githubusercontent.com/25853190/162550576-32cdf97d-a805-4b2f-85fe-90fa63e5778f.png)
![image](https://user-images.githubusercontent.com/25853190/162550588-5ec420a9-c852-40f9-aa13-4dc2c5d1cbd5.png)

## Why It's Good For The Game

Provides a useful glance of the current alert level. Since it is shown on the hub and (as I am told) on the join screen I don't think it provides any ick ock or anything of that sort.

## Changelog
:cl:
add: The alert status is now shown when logging in and when displaying the MOTD.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
