### PR TITLE
fixes resin nests being not buckleable

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/xenomorph_hybrids/hybrid_resin.dm
+++ b/code/modules/mob/living/carbon/human/species/station/xenomorph_hybrids/hybrid_resin.dm
@@ -117,7 +117,7 @@
 
 	var/mob/living/carbon/xenos = user
 
-	if(istype(xenos) && xenos.species == SPECIES_XENOHYBRID)//if a non xenomorph tries to buckle someone in, fail, because they cant secrete resin
+	if(istype(xenos) && xenos.species.name == SPECIES_XENOHYBRID)//if a non xenomorph tries to buckle someone in, fail, because they cant secrete resin
 		return
 
 	if(M == usr)

--- a/code/modules/mob/living/carbon/human/species/station/xenomorph_hybrids/hybrid_resin.dm
+++ b/code/modules/mob/living/carbon/human/species/station/xenomorph_hybrids/hybrid_resin.dm
@@ -117,7 +117,7 @@
 
 	var/mob/living/carbon/xenos = user
 
-	if(istype(xenos) && xenos.species.name == SPECIES_XENOHYBRID)//if a non xenomorph tries to buckle someone in, fail, because they cant secrete resin
+	if(istype(xenos) && !istype(xenos.species, /datum/species/xenohybrid))//if a non xenomorph tries to buckle someone in, fail, because they cant secrete resin
 		return
 
 	if(M == usr)


### PR DESCRIPTION

## Changelog
:cl:
fix: Fixes xenohybrids being unable to buckle anyone into their nests
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
