### PR TITLE
[BOUNTY] Teshari can now use some two-handed weapons

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -115,6 +115,9 @@
 	var/drop_sound = 'sound/items/drop/device.ogg'
 
 	var/deploytype = null	//Deploytype for switchtools. Only really used on switchtool subtype items, but this is on a general item level in case admins want to do some wierd fucky shit with custom switchtools.
+
+	var/heavy = FALSE //Whether or not we are heavy. Used for some species to determine if they can two-hand it.
+
 /obj/item/Initialize(mapload)
 	. = ..()
 	if(islist(origin_tech))

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -108,10 +108,11 @@
 	can_cleave = TRUE
 	drop_sound = 'sound/items/drop/axe.ogg'
 	pickup_sound = 'sound/items/pickup/axe.ogg'
+	heavy = TRUE
 
 /obj/item/material/twohanded/fireaxe/update_held_icon()
 	var/mob/living/M = loc
-	if(istype(M) && !issmall(M) && M.item_is_in_hands(src) && !M.hands_are_full())
+	if(istype(M) && M.can_wield_item(src) && M.item_is_in_hands(src) && !M.hands_are_full())
 		wielded = 1
 		pry = 1
 		force = force_wielded
@@ -294,10 +295,11 @@
 	force_wielded = 23 //A fair bit less than the fireaxe.
 	attack_verb = list("attacked", "smashed", "crushed", "wacked", "pounded")
 	armor_penetration = 50
+	heavy = TRUE
 
 /obj/item/material/twohanded/sledgehammer/update_held_icon()
 	var/mob/living/M = loc
-	if(istype(M) && !issmall(M) && M.item_is_in_hands(src) && !M.hands_are_full())
+	if(istype(M) && M.can_wield_item(src) && M.item_is_in_hands(src) && !M.hands_are_full())
 		wielded = 1
 		pry = 1
 		force = force_wielded

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1643,3 +1643,10 @@
 
 /mob/living/carbon/human/get_mob_riding_slots()
 	return list(back, head, wear_suit)
+
+/mob/living/carbon/human/can_wield_item(obj/item/W)
+	//Since teshari are small by default, they have different logic to allow them to use certain guns despite that.
+	//If any other species need to adapt for this, you can modify this proc with a list instead
+	if(istype(species, /datum/species/teshari))
+		return !W.heavy //return true if it is not heavy, false if it is heavy
+	else return ..()

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -12,6 +12,7 @@
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/beam/midlaser
+	heavy = TRUE
 	one_handed_penalty = 30
 
 	firemodes = list(
@@ -135,6 +136,7 @@
 	battery_lock = 1
 	fire_delay = 20
 	w_class = ITEMSIZE_LARGE
+	heavy = TRUE
 	one_handed_penalty = 90 // The thing's heavy and huge.
 	accuracy = 75
 	charge_cost = 600
@@ -155,6 +157,7 @@
 	desc = "A high-power laser gun capable of expelling concentrated xray blasts, which are able to penetrate matter easier than \
 	standard photonic beams, resulting in an effective 'anti-armor' energy weapon."
 	icon_state = "xray"
+	heavy = TRUE
 	item_state = "xray"
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 3, TECH_MAGNET = 2)
 	projectile_type = /obj/item/projectile/beam/xray
@@ -174,6 +177,7 @@
 	charge_cost = 600
 	fire_delay = 35
 	force = 10
+	heavy = TRUE
 	w_class = ITEMSIZE_HUGE // So it can't fit in a backpack.
 	accuracy = 25 //shooting at the hip
 	scoped_accuracy = 80
@@ -208,6 +212,7 @@
 	charge_cost = 1300
 	fire_delay = 20
 	force = 8
+	heavy = TRUE
 	w_class = ITEMSIZE_LARGE
 	accuracy = 70
 	scoped_accuracy = 95
@@ -266,7 +271,7 @@
 	icon_state = "scatter"
 	desc = "A strange Almachi weapon, utilizing a refracting prism to turn a single laser blast into a diverging cluster."
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 1, TECH_MATERIAL = 4)
-
+	heavy = TRUE
 	projectile_type = /obj/item/projectile/scatter/laser
 
 // Other laser guns.
@@ -277,6 +282,7 @@
 	icon_state = "tommylas"
 	item_state = "tommylas"
 	w_class = ITEMSIZE_LARGE
+	heavy = TRUE
 	slot_flags = SLOT_BACK
 	charge_cost = 60 // 40 shots, lay down the firepower
 	projectile_type = /obj/item/projectile/beam/weaklaser

--- a/code/modules/projectiles/guns/energy/modular/gunframes.dm
+++ b/code/modules/projectiles/guns/energy/modular/gunframes.dm
@@ -62,6 +62,7 @@
 	cell_type = /obj/item/cell/device/weapon/modcannon
 	icon_state = "mod_cannon"
 	w_class = ITEMSIZE_HUGE
+	heavy = TRUE
 
 /obj/item/gun/energy/modular/cannon/Initialize(mapload)
 	. = ..()
@@ -80,7 +81,7 @@
 	cell_type = /obj/item/cell/device/weapon/recharge/captain
 	icon_state = "modnuc"
 	w_class = ITEMSIZE_HUGE
-
+	heavy = TRUE
 
 /obj/item/gun/energy/modular/nuke/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -29,7 +29,7 @@
 	force = 8
 	w_class = ITEMSIZE_LARGE	//Probably gonna make it a rifle sooner or later
 	fire_delay = 6
-
+	heavy = TRUE
 	projectile_type = /obj/item/projectile/beam/stun/weak
 	origin_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 2, TECH_ILLEGAL = 3)
 	modifystate = "fm-2tstun"
@@ -53,6 +53,7 @@
 	slot_flags = SLOT_BELT
 	force = 8 //looks heavier than a pistol
 	w_class = ITEMSIZE_LARGE	//Looks bigger than a pistol, too.
+	heavy = TRUE
 	fire_delay = 6	//This one's not a handgun, it should have the same fire delay as everything else
 	cell_type = /obj/item/cell/device/weapon/recharge
 	battery_lock = 1

--- a/code/modules/projectiles/guns/energy/particle.dm
+++ b/code/modules/projectiles/guns/energy/particle.dm
@@ -32,6 +32,7 @@
 	slot_flags = SLOT_BELT
 	force = 8 //looks heavier than a pistol
 	w_class = ITEMSIZE_LARGE	//bigger than a pistol, too.
+	heavy = TRUE
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 5, TECH_POWER = 3, TECH_MAGNET = 3)
 	fire_delay = 6	//This one's not a handgun, it should have the same fire delay as everything else
 	self_recharge = 1
@@ -58,6 +59,7 @@
 	accuracy = 70
 	charge_cost = 400 // 6 shots
 	self_recharge = 1
+	heavy = TRUE
 	charge_delay = 15 //won't start charging until it's ready to fire again
 	recharge_time = 8 //40 ticks after that to refill the whole thing.
 

--- a/code/modules/projectiles/guns/energy/phase.dm
+++ b/code/modules/projectiles/guns/energy/phase.dm
@@ -52,6 +52,7 @@ obj/item/gun/energy/phasegun/rifle
 	wielded_item_state = "phasecannon-wielded"	//TODO: New Sprites
 	w_class = ITEMSIZE_HUGE		// This thing is big.
 	slot_flags = SLOT_BACK
+	heavy = TRUE
 	charge_cost = 100
 	projectile_type = /obj/item/projectile/energy/phase/heavy/cannon
 	accuracy = 70

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -10,7 +10,8 @@
 	sel_mode = 2
 	accuracy = 90
 	one_handed_penalty = 10
-
+	heavy = TRUE
+	
 	firemodes = list(
 		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun, fire_delay=null, charge_cost = 120),
 		list(mode_name="lethal", projectile_type=/obj/item/projectile/beam, fire_delay=null, charge_cost = 120),

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -8,6 +8,7 @@
 	w_class = ITEMSIZE_LARGE
 	force = 10
 	slot_flags = SLOT_BACK
+	heavy = TRUE
 	projectile_type = /obj/item/projectile/ion
 	one_handed_penalty = 15
 
@@ -22,6 +23,7 @@
 	w_class = ITEMSIZE_NORMAL
 	force = 5
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
+	heavy = FALSE
 	charge_cost = 480
 	projectile_type = /obj/item/projectile/ion/pistol
 
@@ -89,6 +91,7 @@
 	item_state = "c20r"
 	slot_flags = SLOT_BELT|SLOT_BACK
 	w_class = ITEMSIZE_LARGE
+	heavy = TRUE
 	projectile_type = /obj/item/projectile/meteor
 	cell_type = /obj/item/cell/potato
 	charge_cost = 100
@@ -104,6 +107,7 @@
 	icon_state = "pen"
 	item_state = "pen"
 	w_class = ITEMSIZE_TINY
+	heavy = FALSE
 	slot_flags = SLOT_BELT
 	one_handed_penalty = 0
 
@@ -186,6 +190,7 @@ obj/item/gun/energy/staff/focus
 	item_state = "dakkalaser"
 	wielded_item_state = "dakkalaser-wielded"
 	w_class = ITEMSIZE_HUGE
+	heavy = TRUE
 	charge_cost = 24 // 100 shots, it's a spray and pray (to RNGesus) weapon.
 	projectile_type = /obj/item/projectile/energy/blue_pellet
 	cell_type = /obj/item/cell/device/weapon/recharge
@@ -210,6 +215,7 @@ obj/item/gun/energy/staff/focus
 	item_state = "mhdhowitzer"
 	wielded_item_state = "mhdhowitzer-wielded"
 	w_class = ITEMSIZE_HUGE
+	heavy = TRUE
 
 	charge_cost = 10000 // Uses large cells, can at max have 3 shots.
 	projectile_type = /obj/item/projectile/beam/tungsten
@@ -422,6 +428,7 @@ obj/item/gun/energy/staff/focus
 	cell_type = /obj/item/cell
 	slot_flags = SLOT_BELT|SLOT_BACK
 	w_class = ITEMSIZE_LARGE
+	heavy = TRUE
 	force = 10
 	origin_tech = list(TECH_COMBAT = 3, TECH_ENGINEERING = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000)
@@ -446,5 +453,6 @@ obj/item/gun/energy/staff/focus
 	battery_lock = 1
 	slot_flags = SLOT_BACK
 	w_class = ITEMSIZE_LARGE
+	heavy = TRUE
 	force = 10
 	one_handed_penalty = 60

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -4,6 +4,7 @@
 	icon_state = "riotgun"
 	item_state = "riotgun"
 	w_class = ITEMSIZE_LARGE
+	heavy = TRUE
 	force = 10
 	one_handed_penalty = 5
 

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -5,6 +5,7 @@
 	item_state = "pneumatic"
 	slot_flags = SLOT_BELT
 	w_class = ITEMSIZE_HUGE
+	heavy = TRUE
 	fire_sound_text = "a loud whoosh of moving air"
 	fire_delay = 50
 	fire_sound = 'sound/weapons/grenade_launcher.ogg' // Formerly tablehit1.ogg but I like this better -Ace

--- a/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
@@ -9,6 +9,7 @@
 	projectile_type = /obj/item/projectile/bullet/magnetic/slug
 	power_cost = 300
 	w_class = ITEMSIZE_HUGE
+	heavy = TRUE
 	slot_flags = SLOT_BELT
 	loaded = /obj/item/rcd_ammo/large
 	slowdown = 1	// Slowdown equals slowdown_worn, until we decide to import the system to differentiate between held and worn items

--- a/code/modules/projectiles/guns/modular_guns.dm
+++ b/code/modules/projectiles/guns/modular_guns.dm
@@ -168,6 +168,7 @@
 	icon_state = "mod_cannon"
 	max_components = 14
 	desc = "Say hello, to my little friend!"
+	heavy = TRUE
 	one_handed_penalty = 4 //dual wielding = no.
 	cell_type = /obj/item/cell //We're bigger. We can use much larger power cells.
 	origin_tech = list(TECH_COMBAT = 6, TECH_MAGNET = 6, TECH_MATERIAL = 5, TECH_BLUESPACE = 4) //its a damn cannon capable of holding a huge amount of parts.

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -24,7 +24,7 @@
 	slot_flags = SLOT_BELT
 	magazine_type = null // R&D builds this. Starts unloaded.
 	allowed_magazines = list(/obj/item/ammo_magazine/m9mmAdvanced, /obj/item/ammo_magazine/m9mm)
-
+	
 	firemodes = list(
 		list(mode_name="semiauto",       burst=1, fire_delay=0,    move_delay=null, burst_accuracy=null, dispersion=null),
 		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=4,    burst_accuracy=list(60,30,20), dispersion=list(0.0, 0.3, 0.6))
@@ -81,7 +81,7 @@
 	magazine_type = /obj/item/ammo_magazine/m545
 	allowed_magazines = list(/obj/item/ammo_magazine/m545)
 	projectile_type = /obj/item/projectile/bullet/rifle/a545
-
+	heavy = TRUE
 	one_handed_penalty = 30
 
 	firemodes = list(
@@ -141,7 +141,7 @@
 	projectile_type = /obj/item/projectile/bullet/rifle/a762
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
-
+	heavy = TRUE
 	one_handed_penalty = 60
 
 	burst_delay = 4
@@ -211,6 +211,7 @@
 	allowed_magazines = list(/obj/item/ammo_magazine/m545saw, /obj/item/ammo_magazine/m545)
 	projectile_type = /obj/item/projectile/bullet/rifle/a545
 	can_special_reload = FALSE
+	heavy = TRUE
 	one_handed_penalty = 90
 
 	var/cover_open = 0
@@ -289,7 +290,7 @@
 	magazine_type = /obj/item/ammo_magazine/m12gdrum
 	allowed_magazines = list(/obj/item/ammo_magazine/m12gdrum)
 	projectile_type = /obj/item/projectile/bullet/shotgun
-
+	heavy = TRUE
 	one_handed_penalty = 30 //The AA12 can be fired one-handed fairly easily.
 
 	firemodes = list(
@@ -426,7 +427,7 @@
 	magazine_type = /obj/item/ammo_magazine/m762
 	allowed_magazines = list(/obj/item/ammo_magazine/m762, /obj/item/ammo_magazine/m762m)
 	projectile_type = /obj/item/projectile/bullet/rifle/a762
-
+	heavy = TRUE
 	one_handed_penalty = 45
 
 	firemodes = list(
@@ -458,6 +459,7 @@ obj/item/gun/projectile/automatic/fal
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/m762m
 	allowed_magazines = list(/obj/item/ammo_magazine/m762, /obj/item/ammo_magazine/m762m)
+	heavy = TRUE
 	projectile_type = /obj/item/projectile/bullet/rifle/a762
 
 	firemodes = list(
@@ -481,6 +483,7 @@ obj/item/gun/projectile/automatic/automat
 	w_class = ITEMSIZE_LARGE
 	force = 10
 	caliber = "7.62mm"
+	heavy = TRUE
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3) //A real work around to a automatic rifle.
 	slot_flags = SLOT_BACK
 	load_method = SPEEDLOADER
@@ -511,6 +514,7 @@ obj/item/gun/projectile/automatic/automat/taj
 	icon_state = "holyshotgun"
 	item_state = null
 	w_class = ITEMSIZE_LARGE
+	heavy = TRUE
 	force = 10
 	caliber = "12g"
 	origin_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 1, TECH_ILLEGAL = 4)
@@ -543,6 +547,7 @@ obj/item/gun/projectile/automatic/automat/taj
 	item_state = "clownrifle"
 	wielded_item_state = "clownrifle_wielded"
 	w_class = ITEMSIZE_LARGE
+	heavy = TRUE
 	force = 10
 	caliber = "organic"
 	origin_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 1, TECH_ILLEGAL = 4)

--- a/code/modules/projectiles/guns/projectile/boltaction.dm
+++ b/code/modules/projectiles/guns/projectile/boltaction.dm
@@ -8,6 +8,7 @@
 	fire_sound = 'sound/weapons/Gunshot_generic_rifle.ogg'
 	max_shells = 5
 	caliber = "7.62mm"
+	heavy = TRUE
 	origin_tech = list(TECH_COMBAT = 1)// Old as shit rifle doesn't have very good tech.
 	ammo_type = /obj/item/ammo_casing/a762
 	load_method = SINGLE_CASING|SPEEDLOADER
@@ -201,6 +202,7 @@
 	fire_sound = 'sound/weapons/Gunshot_generic_rifle.ogg'
 	max_shells = 5
 	caliber = "7.62mm"
+	heavy = TRUE
 	origin_tech = list(TECH_COMBAT = 1)
 	load_method = SINGLE_CASING|SPEEDLOADER
 	action_sound = 'sound/weapons/riflebolt.ogg'

--- a/code/modules/projectiles/guns/projectile/contender.dm
+++ b/code/modules/projectiles/guns/projectile/contender.dm
@@ -11,6 +11,7 @@
 	projectile_type = /obj/item/projectile/bullet/pistol/strong
 	var/retracted_bolt = 0
 	load_method = SINGLE_CASING
+	heavy = TRUE
 
 /obj/item/gun/projectile/contender/attack_self(mob/user as mob)
 	if(chambered)

--- a/code/modules/projectiles/guns/projectile/rocket.dm
+++ b/code/modules/projectiles/guns/projectile/rocket.dm
@@ -7,6 +7,7 @@
 	max_shells = 1
 	load_method = SINGLE_CASING
 	w_class = ITEMSIZE_LARGE
+	heavy = TRUE
 	throw_speed = 2
 	throw_range = 10
 	force = 5.0

--- a/code/modules/projectiles/guns/projectile/semiauto.dm
+++ b/code/modules/projectiles/guns/projectile/semiauto.dm
@@ -4,6 +4,7 @@
 	icon_state = "garand"
 	item_state = "boltaction"
 	w_class = ITEMSIZE_LARGE
+	heavy = TRUE
 	caliber = "7.62mm"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	slot_flags = SLOT_BACK
@@ -44,6 +45,7 @@
 	icon_state = "apigun"
 	item_state = "speargun"
 	w_class = ITEMSIZE_LARGE
+	heavy = TRUE
 	caliber = "apidean"
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 3, TECH_BIO = 7)
 	slot_flags = SLOT_BACK

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -5,6 +5,7 @@
 	item_state = "shotgun"
 	max_shells = 4
 	w_class = ITEMSIZE_LARGE
+	heavy = TRUE
 	force = 10
 	slot_flags = SLOT_BACK
 	caliber = "12g"
@@ -125,6 +126,7 @@ obj/item/gun/projectile/shotgun/pump/combat/warden/verb/rename_gun()
 	handle_casings = CYCLE_CASINGS
 	max_shells = 2
 	w_class = ITEMSIZE_LARGE
+	heavy = TRUE
 	force = 10
 	slot_flags = SLOT_BACK
 	caliber = "12g"

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -7,6 +7,7 @@
 	item_state_slots = list(slot_r_hand_str = "l6closed-empty", slot_l_hand_str = "l6closed-empty") // placeholder
 	w_class = ITEMSIZE_HUGE // So it can't fit in a backpack.
 	force = 10
+	heavy = TRUE
 	slot_flags = SLOT_BACK
 	origin_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 2, TECH_ILLEGAL = 8)
 	caliber = "14.5mm"
@@ -82,6 +83,7 @@
 	load_method = MAGAZINE
 	accuracy = -45 //shooting at the hip
 	scoped_accuracy = 95
+	heavy = TRUE
 //	requires_two_hands = 1
 	one_handed_penalty = 60 // The weapon itself is heavy, and the long barrel makes it hard to hold steady with just one hand.
 	fire_sound = 'sound/weapons/Gunshot_SVD.ogg' // Has a very unique sound.

--- a/code/modules/projectiles/guns/vox.dm
+++ b/code/modules/projectiles/guns/vox.dm
@@ -57,6 +57,7 @@
 	icon_state = "darkcannon"
 	item_state = "darkcannon"
 	w_class = ITEMSIZE_HUGE
+	heavy = TRUE
 	charge_cost = 300
 	projectile_type = /obj/item/projectile/beam/stun/darkmatter
 	cell_type = /obj/item/cell/device/weapon/recharge
@@ -120,6 +121,7 @@
 	icon_state = "noise"
 	item_state = "noise"
 	w_class = ITEMSIZE_HUGE
+	heavy = TRUE
 	cell_type = /obj/item/cell/device/weapon/recharge
 	battery_lock = 1
 	charge_cost = 400


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Teshari are now able to use some two-handed, large-sized weapons despite being small. Since their entire species is built around being small it isn't that fair to exclude them from wielding most non-pistol weapons, so they have an exception built in to the usual "if small and gun large can't two-hand it".

**This PR is for a code bounty from @VailTheWolf.**

<details>
<summary>A full list of BLACKLISTED melee weapons</summary>
Anything not in this list is two-handable by teshari.

- Sledgehammer
- Fire axe
</details>

<details>
<summary>A full list of BLACKLISTED ranged weapons</summary>
Anything not in this list is two-handable by teshari. Categorized (mostly) by file.

#### Modular weapons

- Modular cannon
- Modular energy cannon
- Advanced modular energy gun

#### Vox weapons

- Dark matter gun
- Sound cannon

#### Laser weapons

- Laser rifle
- Laser cannon
- Xray laser gun
- Marksman energy rifle
- Antique mono-rifle
- Laser scattergun
- Tommy laser

#### Nuclear weapons

- Burst laser
- Advanced energy gun

#### Particle weapons

- Advanced anti-particle rifle
- Anti-particle cannon

#### Phase weapons

- Phase cannon

#### Pulse weapons

- Pulse rifle

#### Special weapons

- Ion rifle (NOT the ion pistol)
- Meteor gun (NOT the meteor pen)
- Suppression gun
- Portable MHD howitzer
- Ermitter rifle
- Microfission jezail

#### Grenade launchers

- Grenade launcher

#### Pneumatic weapons

- Pneumatic cannon

#### Magnetic weapons

- Railgun

#### Automatic ballistic weapons

- Assault rifle
- Designated marksman rifle
- Light machine gun
- Automatic shotgun
- Bullpup rifle
- FN-FAL
- Avtomat Rifle
- Holy automatic shotgun
- Clown assault rifle

#### Bolt-action ballistic weapons

- Bolt action rifle (and its variants)
- Lever-action rifle (and its variants)

#### Contender weapons

- Contender

#### Rocket launchers

- Rocket launcher

#### Semi-automatic ballistic weapons

- M1 Garand
- Apinae Stinger Rifle

#### Shotguns

- Pump shotgun (and its variants)
- Double barrel shotgun (and its variants, such as other multi-barrel shotguns)

#### Sniper rifles

- Anti-materiel rifle
- Dragunov

</details>

## Why It's Good For The Game

Makes teshari gunplay a bit more bearable.

## Changelog
:cl:
tweak: Teshari can now two-hand some weapons without suffering recoil. Please see PR #3884 on the Github for a full list.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
