### PR TITLE
Add back autohiss verbs, add type discrimination

### DIFF
--- a/code/modules/client/preference_setup/vore/04_autohiss.dm
+++ b/code/modules/client/preference_setup/vore/04_autohiss.dm
@@ -1,12 +1,17 @@
 #define AUTOHISS_OFF 0
 #define AUTOHISS_BASIC 1
 #define AUTOHISS_FULL 2
+#define AUTOHISS_NUM 3 //The number of autohiss types that we have. Used for sanitization
 
-#define AUTOHISS_NUM 3
+#define AUTOHISS_TYPE_NONE  0//Equivalent to being off
+#define AUTOHISS_TYPE_UNATHI 1
+#define AUTOHISS_TYPE_TAJARAN 2
+#define AUTOHISS_TYPE_NUM 3 //The number of autohiss types that we have. Used for sanitization
 
 // Define a place to save in character setup
 /datum/preferences
 	var/autohiss = AUTOHISS_OFF
+	var/autohiss_type = AUTOHISS_TYPE_NONE
 
 // Definition of the stuff for autohiss
 /datum/category_item/player_setup_item/vore/autohiss
@@ -15,23 +20,42 @@
 
 /datum/category_item/player_setup_item/vore/autohiss/load_character(var/savefile/S)
 	S["autohiss"] >> pref.autohiss
+	S["autohiss_type"] >> pref.autohiss_type
 
 
 /datum/category_item/player_setup_item/vore/autohiss/save_character(var/savefile/S)
 	S["autohiss"] << pref.autohiss
+	S["autohiss_type"] << pref.autohiss_type
 
 /datum/category_item/player_setup_item/vore/autohiss/sanitize_character()
 	pref.autohiss = sanitize_integer(pref.autohiss, AUTOHISS_OFF, AUTOHISS_NUM, AUTOHISS_OFF)
+	pref.autohiss_type = sanitize_integer(pref.autohiss_type, AUTOHISS_TYPE_NONE, AUTOHISS_TYPE_NUM, AUTOHISS_TYPE_NONE)
 
 /datum/category_item/player_setup_item/vore/autohiss/copy_to_mob(var/mob/living/carbon/human/character)
 	character.autohiss_mode = pref.autohiss
+	character.autohiss_type = pref.autohiss_type
 
 /datum/category_item/player_setup_item/vore/autohiss/content(var/mob/user)
 	. += "<br>"
+	. += "<b>Autohiss Type:</b> "
+
+	//These switches looks scary but we're essentially determining which button to highlight based on the current state of the prefs.
+	//Thank you UI code.
+
+	//If we get more species we'll probably have to convert this to a dropdown.
+	switch(pref.autohiss_type)
+		if(AUTOHISS_TYPE_NONE,null)
+			. += "<span class='linkOn'><b>None</b></span> <a href='?src=\ref[src];toggle_type_unathi=1'>Unathi</a> <a href='?src=\ref[src];toggle_type_tajaran=1'>Tajaran</a>"
+		if(AUTOHISS_TYPE_UNATHI)
+			. += "<a href='?src=\ref[src];toggle_type_none=1'>None</a> <span class='linkOn'><b>Unathi</b></span> <a href='?src=\ref[src];toggle_type_tajaran=1'>Tajaran</a>"
+		if(AUTOHISS_TYPE_TAJARAN)
+			. += "<a href='?src=\ref[src];toggle_type_none=1'>None</a> <a href='?src=\ref[src];toggle_type_unathi=1'>Unathi</a> <span class='linkOn'><b>Tajaran</b></span>"
+		else 
+			CRASH("Invalid autohiss type preference! '[pref.autohiss]'")
+
+	. += "<br>"
 	. += "<b>Autohiss Mode:</b> "
 
-	//This switch looks scary but we're essentially determining which button to highlight based on the current state of the prefs.
-	//Thank you UI code.
 	switch(pref.autohiss)
 		if(AUTOHISS_OFF,null)
 			. += "<span class='linkOn'><b>Off</b></span> <a href='?src=\ref[src];toggle_basic=1'>Basic</a> <a href='?src=\ref[src];toggle_full=1'>Full</a>"
@@ -52,4 +76,15 @@
 	if(href_list["toggle_full"])
 		pref.autohiss = AUTOHISS_FULL
 		return TOPIC_REFRESH
+
+	if(href_list["toggle_type_none"])
+		pref.autohiss_type = AUTOHISS_TYPE_NONE
+		return TOPIC_REFRESH
+	if(href_list["toggle_type_unathi"])
+		pref.autohiss_type = AUTOHISS_TYPE_UNATHI
+		return TOPIC_REFRESH
+	if(href_list["toggle_type_tajaran"])
+		pref.autohiss_type = AUTOHISS_TYPE_TAJARAN
+		return TOPIC_REFRESH
+
 	return ..();

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -2,45 +2,21 @@
 	return message // no autohiss at this level
 
 /mob/living/carbon/human/handle_autohiss(message, datum/language/L)
-	if(!client || autohiss_mode == AUTOHISS_OFF) // no need to process if there's no client or they have autohiss off
-		return message
-	return species.handle_autohiss(message, L, autohiss_mode)
-
-/mob/living
-	var/autohiss_mode = AUTOHISS_OFF
-
-/datum/species
-	var/list/autohiss_basic_map = null
-	var/list/autohiss_extra_map = null
-	var/list/autohiss_exempt = null
-
-/datum/species/unathi
-	autohiss_basic_map = list(
-			"s" = list("ss", "sss", "ssss")
-		)
-	autohiss_extra_map = list(
-			"x" = list("ks", "kss", "ksss")
-		)
-	autohiss_exempt = list(LANGUAGE_UNATHI)
-
-/datum/species/tajaran
-	autohiss_basic_map = list(
-			"r" = list("rr", "rrr", "rrrr")
-		)
-	autohiss_exempt = list(LANGUAGE_SIIK,LANGUAGE_AKHANI)
-
-
-/datum/species/proc/handle_autohiss(message, datum/language/lang, mode)
-	if(!autohiss_basic_map)
-		return message
-	if(lang.flags & NO_STUTTER)		// Currently prevents EAL, Sign language, and emotes from autohissing
-		return message
-	if(autohiss_exempt && (lang.name in autohiss_exempt))
+	if(!client || autohiss_mode == AUTOHISS_OFF || autohiss_type == AUTOHISS_TYPE_NONE) // no need to process if there's no client or they have autohiss off
 		return message
 
-	var/map = autohiss_basic_map.Copy()
-	if(mode == AUTOHISS_FULL && autohiss_extra_map)
-		map |= autohiss_extra_map
+	var/datum/autohiss_maps/maps = autohiss_type_to_datum(autohiss_type)
+	
+	if(!maps.basic)
+		return message
+	if(L.flags & NO_STUTTER)		// Currently prevents EAL, Sign language, and emotes from autohissing
+		return message
+	if(maps.exempt && (L.name in maps.exempt))
+		return message
+
+	var/map = maps.basic.Copy()
+	if(autohiss_mode == AUTOHISS_FULL && maps.extra)
+		map |= maps.extra
 
 	. = list()
 
@@ -69,3 +45,75 @@
 		message = copytext(message, min_index + 1)
 
 	return jointext(., null)
+
+/mob/living
+	var/autohiss_mode = AUTOHISS_OFF
+	var/autohiss_type = AUTOHISS_TYPE_NONE
+
+//If you are planning on adding autohiss for a new species, please change autohiss_type_to_datum, toggle_autohiss_type,
+//as well as code/modules/client/preference_setup/vore/04_autohiss.dm to add in the new species as well.
+
+/datum/autohiss_maps
+	var/list/basic //The things we will replace on basic settings.
+	var/list/extra //The things we will replace on full settings, on top of basic.
+	var/list/exempt //If we are speaking this language, we will not apply autohiss. (Usually for native languages to a species.)
+
+/datum/autohiss_maps/unathi
+	basic = list(
+			"s" = list("ss", "sss", "ssss")
+		)
+	extra = list(
+			"x" = list("ks", "kss", "ksss")
+		)
+	exempt = list(LANGUAGE_UNATHI)
+
+/datum/autohiss_maps/tajaran
+	basic = list(
+			"r" = list("rr", "rrr", "rrrr")
+		)
+	exempt = list(LANGUAGE_SIIK,LANGUAGE_AKHANI)
+
+/proc/autohiss_type_to_datum(type)
+	RETURN_TYPE(/datum/autohiss_maps)
+	switch(type)
+		if(AUTOHISS_TYPE_UNATHI)
+			return new /datum/autohiss_maps/unathi()
+		if(AUTOHISS_TYPE_TAJARAN)
+			return new /datum/autohiss_maps/tajaran()
+		else 
+			CRASH("Autohiss could not convert '[type]' to maps!")
+
+/mob/living/carbon/human/verb/toggle_autohiss()
+	set name = "Toggle Autohiss"
+	set category = "OOC"
+	set desc = "Toggle your autohiss configuration between disabled, basic, and full."
+
+	switch(autohiss_mode)
+		if(AUTOHISS_OFF)
+			autohiss_mode = AUTOHISS_BASIC
+			to_chat(src, SPAN_NOTICE("Autohiss changed to basic."))
+		if(AUTOHISS_BASIC)
+			autohiss_mode = AUTOHISS_FULL
+			to_chat(src, SPAN_NOTICE("Autohiss changed to full."))
+		if(AUTOHISS_FULL)
+			autohiss_mode = AUTOHISS_OFF
+			to_chat(src, SPAN_NOTICE("Autohiss disabled."))
+
+
+/mob/living/carbon/human/verb/toggle_autohiss_type()
+	set name = "Toggle Autohiss Type"
+	set category = "OOC"
+	set desc = "Set the type of autohissing you will do."
+
+	var/new_autohiss_type = input(usr, "Select your new autohiss type.", "Autohiss Type") in list("None", "Unathi", "Tajaran")
+
+	switch(new_autohiss_type)
+		if("None")
+			autohiss_type = AUTOHISS_TYPE_NONE
+			to_chat(src, SPAN_NOTICE("Autohiss disabled."))
+		if("Unathi")
+			autohiss_type = AUTOHISS_TYPE_UNATHI
+			to_chat(src, SPAN_NOTICE("Autohiss type changed to unathi."))
+		if("Tajaran")
+			autohiss_type = AUTOHISS_TYPE_TAJARAN
+			to_chat(src, SPAN_NOTICE("Autohiss type changed to tajaran."))

--- a/code/modules/mob/living/carbon/human/species/station/station_special.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special.dm
@@ -43,7 +43,6 @@
 		/mob/living/carbon/human/proc/resp_biomorph,
 		/mob/living/carbon/human/proc/biothermic_adapt,
 		/mob/living/carbon/human/proc/atmos_biomorph,
-		/mob/living/carbon/human/proc/vocal_biomorph,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
 		/mob/living/carbon/human/proc/shapeshifter_select_colour,
@@ -678,28 +677,6 @@
 				infect_virus2(target, virus2)
 				log_and_message_admins("Infected [target] with a virus. (Xenochimera)", src)
 		target.visible_message("<span class = 'danger'>[src] pulls the tendrils out!</span>", "<span class = 'warning'>The sensation fades. You feel made anew.</span>")
-
-
-/mob/living/carbon/human/proc/vocal_biomorph()
-	set name = "Vocalization Biomorph"
-	set desc = "Changes our speech pattern."
-	set category = "Chimera"
-
-	var/vocal_biomorph = input(src, "How should we adjust our speech?") as null|anything in list("common", "unathi", "tajaran")
-	if(!vocal_biomorph)
-		return
-	to_chat(src, "You begin modifying your internal structure!")
-	if(do_after(src,15 SECONDS))
-		switch(vocal_biomorph)
-			if("common")
-				return
-			if("unathi")
-				species.autohiss_basic_map = list("s" = list("ss", "sss", "ssss"))
-				species.autohiss_extra_map = list("x" = list("ks", "kss", "ksss"))
-				species.autohiss_exempt = "Sinta'unathi"
-			if("tajaran")
-				species.autohiss_basic_map = list("r" = list("rr", "rrr", "rrrr"))
-				species.autohiss_exempt = "Siik"
 
 /////////////////////
 /////SPIDER RACE/////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Refactors the autohiss file, now the maps are stored in their own datums and not on the species. This is done because now the species you're playing as and the species you autohiss as might not be the same anymore!

You can once again change your autohiss type with the new "Toggle Autohiss" verb in the OOC tab, but you can now use "Toggle Autohiss Type" to change what species you autohiss ass. Playing as a custom lizard but want to autohiss as an unathi? There you go. Catgirl human that wants to speak like a tajaran? Bam.

This also comes with its own preferences selection. **Just like with the old autohiss, changes made mid-round will not be saved for future rounds.**

![image](https://user-images.githubusercontent.com/25853190/163670126-01243ae6-e3b3-43ab-94a0-8ad48cfead89.png)


## Why It's Good For The Game

Custom species ahoy, and it can't hurt to be able to change your autohissing midround if something happens.

## Changelog
:cl:
add: Re-added a verb to toggle your autohissing mode, named "Toggle Autohiss" in the OOC tab.
add: You can now change what kind of species you autohiss as (such as hissssing of unathi or rrrrrolling of tajarans) with the new "Toggle Autohiss Type" verb in the OOC tab.
del: Removed the chimera's ability to change its vocal biomorph since the above verbs accomplish the same thing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
