### PR TITLE
Adds range as an argument to visible message

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -664,7 +664,7 @@
 // Use for objects performing visible actions
 // message is output to anyone who can see, e.g. "The [src] does something!"
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
-/atom/proc/visible_message(var/message, var/self_message, var/blind_message)
+/atom/proc/visible_message(message, self_message, blind_message, range = world.view)
 
 	//VOREStation Edit
 	var/list/see
@@ -672,7 +672,7 @@
 		var/obj/belly/B = loc
 		see = B.get_mobs_and_objs_in_belly()
 	else
-		see = get_mobs_and_objs_in_view_fast(get_turf(src),world.view,remote_ghosts = FALSE)
+		see = get_mobs_and_objs_in_view_fast(get_turf(src),range,remote_ghosts = FALSE)
 	//VOREStation Edit End
 
 	var/list/seeing_mobs = see["mobs"]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Previously, visible messages would always show to everyone in the viewport (and they still do). But now there's an argument that you can specify if you want that range to be shorter/longer.

Obviously, this needs implementation in places that need it which is outside the scope of this PR.

## Why It's Good For The Game

Self-explanatory

## Changelog

N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
