### PR TITLE
Removes 'Containment Specialist' as an exploration job title

### DIFF
--- a/code/game/jobs/job/exploration.dm
+++ b/code/game/jobs/job/exploration.dm
@@ -152,9 +152,6 @@
 /datum/alt_title/explorer/junior
 	title = "Jr. Explorer"
 
-/datum/alt_title/explorer/containment
-	title = "Containment Specialist"
-
 /datum/job/sar
 	title = "Field Medic"
 	flag = SAR

--- a/code/game/jobs/job/exploration.dm
+++ b/code/game/jobs/job/exploration.dm
@@ -133,8 +133,7 @@
 		"Offsite Scout" = /datum/alt_title/offsite_scout,
 		"Field Scout" = /datum/alt_title/explorer/field_scout,
 		"Pioneer" = /datum/alt_title/explorer/pioneer,
-		"Jr. Explorer" = /datum/alt_title/explorer/junior,
-		"Containment Specialist" = /datum/alt_title/explorer/containment
+		"Jr. Explorer" = /datum/alt_title/explorer/junior
 		)
 
 /datum/alt_title/surveyor


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reverts 'Containment Specialist' as an exploration job title

## Why It's Good For The Game

This is a good first test PR, but also 'containment specialist' is a weird-as-hell exploration title that no one uses, everyone and their mother finds weird, and several headmins wanted to revert but forgot to.

## Changelog
:cl:
del: Containment Specialist Exploration alt job title

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
