### PR TITLE
Fix nutrition I think

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1271,8 +1271,8 @@
 
 		if(nutrition_icon)
 			switch(nutrition)
-				if(species.max_nutrition to INFINITY)				nutrition_icon.icon_state = "nutrition0"
-				if(350 to species.max_nutrition)					nutrition_icon.icon_state = "nutrition1"
+				if(450 to INFINITY)				nutrition_icon.icon_state = "nutrition0"
+				if(350 to 450)					nutrition_icon.icon_state = "nutrition1"
 				if(250 to 350)					nutrition_icon.icon_state = "nutrition2"
 				if(150 to 250)					nutrition_icon.icon_state = "nutrition3"
 				else							nutrition_icon.icon_state = "nutrition4"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There is a bug where despite spawning with normal nutrition amounts, you'll get the HUD icon for being overfed anyway. I think it was due to a problem with the max_nutrition value so the value was hardcoded instead. (It's the same 450 but when I tested it it didn't break the hud anymore.)

## Why It's Good For The Game

bugfix

## Changelog
:cl:
fix: Potentially fixed an error where you would spawn with the "overfed" nutrition icon despite having normal nutrition amounts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
