### PR TITLE
Add sprinting and stamina

### DIFF
--- a/code/__DEFINES/_flags/movement.dm
+++ b/code/__DEFINES/_flags/movement.dm
@@ -11,3 +11,6 @@
 #define FLOATING				(1<<4)
 /// Ventcrawling
 #define VENTCRAWLING			(1<<5)
+
+#define MOVING_DELIBERATELY(X) (X.move_intent.flags & MOVE_INTENT_DELIBERATE)
+#define MOVING_QUICKLY(X) (X.move_intent.flags & MOVE_INTENT_QUICK)

--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -43,6 +43,7 @@
 #define CE_SPEEDBOOST "gofast" // Hyperzine
 #define CE_SLOWDOWN "goslow" // Slowdown
 #define CE_ANTACID "nopuke" // Don't puke.
+#define CE_ENERGETIC "energetic" // Speeds up stamina recovery.
 
 #define REAGENTS_PER_SHEET 20
 

--- a/code/__HELPERS/lists/misc.dm
+++ b/code/__HELPERS/lists/misc.dm
@@ -16,3 +16,9 @@
 	return r
 
 #define IS_VALID_INDEX(list, index) (list.len && index > 0 && index <= list.len)
+
+/proc/next_in_list(element, list/L)
+	for(var/i=1, i<L.len, i++)
+		if(L[i] == element)
+			return L[i+1]
+	return L[1]

--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -57,6 +57,7 @@
 #define ui_movi "EAST-3:24,SOUTH:5"
 #define ui_zonesel "EAST-1:28,SOUTH:5"
 #define ui_acti_alt "EAST-1:28,SOUTH:5" //alternative intent switcher for when the interface is hidden (F12)
+#define ui_stamina "EAST-3:24,SOUTH+1:5"
 
 #define ui_borg_pull "EAST-3:24,SOUTH+1:7"
 #define ui_borg_module "EAST-2:26,SOUTH+1:7"

--- a/code/_onclick/hud/alien_larva.dm
+++ b/code/_onclick/hud/alien_larva.dm
@@ -9,7 +9,7 @@
 	using.name = "mov_intent"
 	using.setDir(SOUTHWEST)
 	using.icon = 'icons/mob/screen1_alien.dmi'
-	using.icon_state = (mymob.m_intent == "run" ? "running" : "walking")
+	using.icon_state = mymob.move_intent.flags & 0x004 ? "running" : "walking" //We cannot use the macro because of the load order in the .dme
 	using.screen_loc = ui_acti
 	using.layer = HUD_LAYER
 	src.adding += using

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -178,7 +178,7 @@ GLOBAL_DATUM_INIT(global_hud, /datum/global_hud, new)
 	var/atom/movable/screen/l_hand_hud_object
 	var/atom/movable/screen/action_intent
 	var/atom/movable/screen/move_intent
-
+	var/atom/movable/screen/stamina/stamina_bar
 	var/list/static_inventory = list() //the screen objects which are static
 
 	var/list/adding
@@ -208,6 +208,7 @@ GLOBAL_DATUM_INIT(global_hud, /datum/global_hud, new)
 	hurt_intent = null
 	disarm_intent = null
 	help_intent = null
+	stamina_bar = null
 	lingchemdisplay = null
 	wiz_instability_display = null
 	wiz_energy_display = null
@@ -225,6 +226,22 @@ GLOBAL_DATUM_INIT(global_hud, /datum/global_hud, new)
 	minihuds = null
 
 	QDEL_LIST(static_inventory)
+
+/atom/movable/screen/stamina
+	name = "stamina"
+	icon = 'icons/effects/progressbar.dmi'
+	icon_state = "prog_bar_100"
+	invisibility = INVISIBILITY_MAXIMUM
+	screen_loc = ui_stamina
+
+/datum/hud/proc/update_stamina()
+	if(mymob && stamina_bar)
+		var/stamina = mymob.get_stamina()
+		if(stamina < 100)
+			stamina_bar.invisibility = 0
+			stamina_bar.icon_state = "prog_bar_[round(stamina/5)*5]"
+		else
+			stamina_bar.invisibility = INVISIBILITY_MAXIMUM
 
 /datum/hud/proc/hidden_inventory_update()
 	if(!mymob) return
@@ -461,3 +478,10 @@ GLOBAL_DATUM_INIT(global_hud, /datum/global_hud, new)
 
 /mob/new_player/add_click_catcher()
 	return
+
+/obj/screen/stamina
+	name = "stamina"
+	icon = 'icons/effects/progessbar.dmi'
+	icon_state = "prog_bar_100"
+	invisibility = INVISIBILITY_MAXIMUM
+	screen_loc = ui_stamina

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -20,6 +20,9 @@
 	var/atom/movable/screen/using
 	var/atom/movable/screen/inventory/inv_box
 
+	stamina_bar = new
+	adding += stamina_bar
+
 	// Draw the various inventory equipment slots.
 	var/has_hidden_gear
 	for(var/gear_slot in hud_data.gear)
@@ -123,11 +126,11 @@
 		hurt_intent = using
 		//end intent small hud objects
 
-	if(hud_data.has_m_intent)
+	if(hud_data.has_move_intent)
 		using = new /atom/movable/screen()
 		using.name = "mov_intent"
 		using.icon = ui_style
-		using.icon_state = (mymob.m_intent == "run" ? "running" : "walking")
+		using.icon_state = mymob.move_intent.flags & 0x004 ? "running" : "walking" //We cannot use the macro because of the load order in the .dme
 		using.screen_loc = ui_movi
 		using.color = ui_color
 		using.alpha = ui_alpha
@@ -513,3 +516,7 @@
 			to_chat(usr, SPAN_NOTICE("You are breathing easy."))
 		else
 			to_chat(usr, SPAN_DANGER("You cannot breathe!"))
+
+/obj/screen/movement/Click(var/location, var/control, var/params)
+	if(istype(usr))
+		usr.set_next_usable_move_intent()

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -208,38 +208,6 @@
 			if(isliving(usr))
 				var/mob/living/L = usr
 				L.resist()
-
-		if("mov_intent")
-			if(isliving(usr))
-				if(iscarbon(usr))
-					var/mob/living/carbon/C = usr
-					if(C.legcuffed)
-						to_chat(C, "<span class='notice'>You are legcuffed! You cannot run until you get [C.legcuffed] removed!</span>")
-						C.m_intent = "walk"	//Just incase
-						C.hud_used.move_intent.icon_state = "walking"
-						return 1
-				var/mob/living/L = usr
-				L.toggle_move_intent()
-		if("m_intent")
-			if(!usr.m_int)
-				switch(usr.m_intent)
-					if("run")
-						usr.m_int = "13,14"
-					if("walk")
-						usr.m_int = "14,14"
-					if("face")
-						usr.m_int = "15,14"
-			else
-				usr.m_int = null
-		if("walk")
-			usr.m_intent = "walk"
-			usr.m_int = "14,14"
-		if("face")
-			usr.m_intent = "face"
-			usr.m_int = "15,14"
-		if("run")
-			usr.m_intent = "run"
-			usr.m_int = "13,14"
 		if("Reset Machine")
 			usr.unset_machine()
 		if("internal")

--- a/code/controllers/configuration_old/configuration.dm
+++ b/code/controllers/configuration_old/configuration.dm
@@ -167,8 +167,11 @@
 
 	//Used for modifying movement speed for mobs.
 	//Unversal modifiers
-	var/run_speed = 0
-	var/walk_speed = 0
+	var/run_speed = 3
+	var/walk_speed = 8
+	var/sprint_cost = 0.8
+	var/minimum_stamina_recovery = 5
+	var/maximum_stamina_recovery = 5
 
 	//Mob specific modifiers. NOTE: These will affect different mob types in different ways
 	var/human_delay = 0
@@ -877,6 +880,12 @@
 					config_legacy.run_speed = value
 				if("walk_speed")
 					config_legacy.walk_speed = value
+				if("sprint_cost")
+					config_legacy.sprint_cost = value
+				if("minimum_stamina_recovery")
+					config_legacy.minimum_stamina_recovery = value
+				if("maximum_stamina_recovery")
+					config_legacy.maximum_stamina_recovery = value
 
 				if("human_delay")
 					config_legacy.human_delay = value

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -27,7 +27,7 @@
 		if(HAS_TRAIT(H, TRAIT_PIERCEIMMUNE))
 			return
 
-		if((flags & CALTROP_IGNORE_WALKERS) && H.m_intent == MOVE_INTENT_WALK)
+		if((flags & CALTROP_IGNORE_WALKERS) && MOVING_DELIBERATELY(H))
 			return
 
 		var/picked_def_zone = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)

--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -27,7 +27,7 @@
 		var/mob/living/carbon/C = LM
 		if(!C.get_bodypart(BODY_ZONE_L_LEG) && !C.get_bodypart(BODY_ZONE_R_LEG))
 			return
-		if(ishuman(C) && C.m_intent == MOVE_INTENT_WALK)
+		if(ishuman(C) && MOVING_DELIBERATELY(H))
 			return // stealth
 	steps++
 

--- a/code/datums/move_intent/move_intent.dm
+++ b/code/datums/move_intent/move_intent.dm
@@ -1,0 +1,33 @@
+// Quick and deliberate movements are not necessarily mutually exclusive
+#define MOVE_INTENT_DELIBERATE 0x0001
+#define MOVE_INTENT_EXERTIVE   0x0002
+#define MOVE_INTENT_QUICK      0x0004
+
+/decl/move_intent
+	var/name
+	var/flags = 0
+	var/move_delay = 1
+	var/hud_icon_state
+
+/decl/move_intent/proc/can_be_used_by(var/mob/user)
+	if(flags & MOVE_INTENT_QUICK)
+		return user.can_sprint()
+	return TRUE
+
+/decl/move_intent/walk
+	name = "Walk"
+	flags = MOVE_INTENT_DELIBERATE
+	hud_icon_state = "walking"
+
+/decl/move_intent/walk/New()
+	. = ..()
+	move_delay = config_legacy.walk_speed
+
+/decl/move_intent/run
+	name = "Run"
+	flags = MOVE_INTENT_EXERTIVE | MOVE_INTENT_QUICK
+	hud_icon_state = "running"
+
+/decl/move_intent/run/New()
+	. = ..()
+	move_delay = config_legacy.run_speed

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -522,7 +522,7 @@ GLOBAL_LIST_EMPTY(forced_ambiance_list)
 			return
 		if(H.flags & NO_SLIP)//diona and similar should not slip from moving onto space either.
 			return
-		if(H.m_intent == "run")
+		if(MOVING_QUICKLY(H))
 			H.AdjustStunned(6)
 			H.AdjustWeakened(6)
 		else

--- a/code/game/area/areas_movement.dm
+++ b/code/game/area/areas_movement.dm
@@ -20,7 +20,7 @@
 		L.lastarea = get_area(L.loc)
 	var/area/newarea = get_area(L.loc)
 	var/area/oldarea = L.lastarea
-	if((oldarea.has_gravity == 0) && (newarea.has_gravity == 1) && (L.m_intent == "run")) // Being ready when you change areas gives you a chance to avoid falling all together.
+	if((oldarea.has_gravity == 0) && (newarea.has_gravity == 1) && MOVING_DELIBERATELY(L)) // Being ready when you change areas gives you a chance to avoid falling all together.
 		thunk(L)
 		L.update_floating( L.Check_Dense_Object() )
 

--- a/code/game/gamemodes/changeling/powers/visible_camouflage.dm
+++ b/code/game/gamemodes/changeling/powers/visible_camouflage.dm
@@ -41,13 +41,13 @@
 			to_chat(src, "<span class='notice'>We may move at our normal speed while hidden.</span>")
 
 		if(must_walk)
-			H.set_m_intent("walk")
+			H.set_moving_slowly()
 
 		var/remain_cloaked = TRUE
 		while(remain_cloaked) //This loop will keep going until the player uncloaks.
 			sleep(1 SECOND) // Sleep at the start so that if something invalidates a cloak, it will drop immediately after the check and not in one second.
 
-			if(H.m_intent != "walk" && must_walk) // Moving too fast uncloaks you.
+			if(!MOVING_DELIBERATELY(H) && must_walk) // Moving too fast uncloaks you.
 				remain_cloaked = 0
 			if(!H.mind.changeling.cloaked)
 				remain_cloaked = 0
@@ -65,7 +65,7 @@
 		H.invisibility = initial(invisibility)
 		visible_message("<span class='warning'>[src] suddenly fades in, seemingly from nowhere!</span>",
 		"<span class='notice'>We revert our camouflage, revealing ourselves.</span>")
-		H.set_m_intent("run")
+		H.set_moving_quickly()
 		H.mind.changeling.cloaked = 0
 		H.mind.changeling.chem_recharge_rate = old_regen_rate
 

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -100,7 +100,7 @@
 
 	if(istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
-		if((M.m_intent != "walk") && (anchored))
+		if((!MOVING_DELIBERATELY(M) && (anchored)))
 			flash()
 
 /obj/machinery/flasher/portable/attackby(obj/item/W as obj, mob/user as mob)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -330,7 +330,7 @@
 		return
 	if((ishuman(H))) //i guess carp and shit shouldn't set them off
 		var/mob/living/carbon/M = H
-		if(M.m_intent == "run")
+		if(MOVING_QUICKLY(M))
 			to_chat(M, "<span class='warning'>You step on the snap pop!</span>")
 
 			var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -310,19 +310,13 @@ var/last_chew = 0
 	lcuffs.loc = target
 	target.legcuffed = lcuffs
 	target.update_inv_legcuffed()
-	if(target.m_intent != "walk")
-		target.m_intent = "walk"
-		if(target.hud_used && user.hud_used.move_intent)
-			target.hud_used.move_intent.icon_state = "walking"
+	target.set_moving_slowly()
 	return 1
 
 /obj/item/handcuffs/legcuffs/equipped(var/mob/living/user,var/slot)
 	. = ..()
 	if(slot == slot_legcuffed)
-		if(user.m_intent != "walk")
-			user.m_intent = "walk"
-			if(user.hud_used && user.hud_used.move_intent)
-				user.hud_used.move_intent.icon_state = "walking"
+		user.set_moving_slowly()
 
 /obj/item/handcuffs/legcuffs/fuzzy
 	name = "fuzzy legcuffs"
@@ -369,10 +363,7 @@ var/last_chew = 0
 	lcuffs.loc = target
 	target.legcuffed = lcuffs
 	target.update_inv_legcuffed()
-	if(target.m_intent != "walk")
-		target.m_intent = "walk"
-		if(target.hud_used && user.hud_used.move_intent)
-			target.hud_used.move_intent.icon_state = "walking"
+	target.set_moving_slowly()
 	return 1
 
 /obj/item/handcuffs/legcuffs/bola/tactical

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -133,7 +133,7 @@
 		return
 	if(deployed && isliving(AM))
 		var/mob/living/L = AM
-		if(L.m_intent == "run")
+		if(MOVING_QUICKLY(L))
 			L.visible_message(
 				"<span class='danger'>[L] steps on \the [src].</span>",
 				"<span class='danger'>You step on \the [src]!</span>",

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -50,7 +50,7 @@
 		add_fingerprint(M)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
-			if(H.m_intent == "walk")
+			if(MOVING_DELIBERATELY(H))
 				to_chat(H, "<span class='warning'>You stop at the edge of \the [src.name].</span>")
 				return FALSE
 			else

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -96,7 +96,7 @@
 			if(H.shoes)
 				var/obj/item/clothing/shoes/S = H.shoes
 				if(istype(S))
-					S.handle_movement(src,(H.m_intent == "run" ? 1 : 0))
+					S.handle_movement(src,(MOVING_QUICKLY(H) ? 1 : 0))
 					if(S.track_blood && S.blood_DNA)
 						bloodDNA = S.blood_DNA
 						bloodcolor=S.blood_color
@@ -117,7 +117,7 @@
 
 		if(src.wet)
 
-			if(M.buckled || (src.wet == 1 && M.m_intent == "walk"))
+			if(M.buckled || (src.wet == 1 && MOVING_DELIBERATELY(M)))
 				return
 
 			var/slip_dist = 1

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -88,7 +88,7 @@
 	if(armed)
 		if(ishuman(AM))
 			var/mob/living/carbon/H = AM
-			if(H.m_intent == "run")
+			if(MOVING_QUICKLY(H))
 				triggered(H)
 				H.visible_message("<span class='warning'>[H] accidentally steps on [src].</span>", \
 								  "<span class='warning'>You accidentally step on [src]</span>")

--- a/code/modules/keybindings/keybind/mob.dm
+++ b/code/modules/keybindings/keybind/mob.dm
@@ -194,17 +194,15 @@
 /datum/keybinding/mob/toggle_move_intent
 	hotkey_keys = list("Alt")
 	name = "toggle_move_intent"
-	full_name = "Hold to toggle move intent"
-	description = "Held down to cycle to the other move intent, release to cycle back"
+	full_name = "Move Quickly"
+	description = "Hold down to move quickly, release to move slowly."
 
 /datum/keybinding/mob/toggle_move_intent/down(client/user)
-	var/mob/M = user.mob
-	M.toggle_move_intent()
+	user.mob.set_moving_quickly()
 	return TRUE
 
 /datum/keybinding/mob/toggle_move_intent/up(client/user)
-	var/mob/M = user.mob
-	M.toggle_move_intent()
+	user.mob.set_moving_slowly()
 	return TRUE
 
 /datum/keybinding/mob/toggle_move_intent_alternative
@@ -214,8 +212,10 @@
 	description = "Pressing this cycle to the opposite move intent, does not cycle back"
 
 /datum/keybinding/mob/toggle_move_intent_alternative/down(client/user)
-	var/mob/M = user.mob
-	M.toggle_move_intent()
+	if(MOVING_QUICKLY(user.mob))
+		user.mob.set_moving_slowly()
+	else
+		user.mob.set_moving_quickly()
 	return TRUE
 
 /datum/keybinding/mob/target_head_cycle

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -77,7 +77,7 @@
 		src.visible_message("<b>\The [src.name]</b> [deathmessage]")
 
 	stat = DEAD
-
+	adjust_stamina(-100)
 	update_canmove()
 
 	dizziness = 0

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -7,13 +7,13 @@
 				var/mob/living/carbon/human/M = src
 				if(M.stat != 2 && M.nutrition > 0)
 					M.nutrition -= M.species.hunger_factor/10
-					if(M.m_intent == "run")
+					if(MOVING_QUICKLY(M))
 						M.nutrition -= M.species.hunger_factor/10
 					if(M.nutrition < 0)
 						M.nutrition = 0
 			else
 				src.nutrition -= DEFAULT_HUNGER_FACTOR/10
-				if(src.m_intent == "run")
+				if(MOVING_QUICKLY(src))
 					src.nutrition -= DEFAULT_HUNGER_FACTOR/10
 		// Moving around increases germ_level faster
 		if(germ_level < GERM_LEVEL_MOVE_CAP && prob(8))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -70,7 +70,7 @@
 	..()
 	if(statpanel("Status"))
 		stat("Intent:", "[a_intent]")
-		stat("Move Mode:", "[m_intent]")
+		stat("Move Mode:", "[move_intent]")
 		if(SSemergencyshuttle)
 			var/eta_status = SSemergencyshuttle.get_status_panel_eta()
 			if(eta_status)
@@ -1227,6 +1227,12 @@
 	//A slew of bits that may be affected by our species change
 	regenerate_icons()
 
+	default_walk_intent = null
+	default_run_intent = null
+	move_intent = null
+	move_intents = species.move_intents.Copy()
+	set_next_usable_move_intent()
+	
 	if(species)
 		//if(mind) //VOREStation Removal
 			//apply_traits() //VOREStation Removal

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -35,6 +35,7 @@
 	var/heartbeat = 0
 	var/last_synthcooling_message = 0 		// to whoever is looking at git blame in the future, i'm not the author, and this is shitcode, but what came before i changed it
 	// made me vomit
+	var/stamina = 100
 
 /mob/living/carbon/human/Life()
 
@@ -82,6 +83,8 @@
 
 		handle_pain()
 
+		handle_stamina()
+
 		handle_medical_side_effects()
 
 		handle_heartbeat()
@@ -96,6 +99,27 @@
 	name = get_visible_name()
 
 	pulse = handle_pulse()
+
+/mob/living/carbon/human/get_stamina()
+	return stamina
+
+/mob/living/carbon/human/adjust_stamina(var/amt)
+	var/last_stamina = stamina
+	if(stat == DEAD)
+		stamina = 0
+	else
+		stamina = clamp(stamina + amt, 0, 100)
+		if(stamina <= 0)
+			to_chat(src, SPAN_WARNING("You are exhausted!"))
+			if(MOVING_QUICKLY(src))
+				set_moving_slowly()
+	if(last_stamina != stamina && hud_used)
+		hud_used.update_stamina()
+
+/mob/living/carbon/human/proc/handle_stamina()
+	if((world.time - last_quick_move_time) > 5 SECONDS)
+		var/mod = (lying + (nutrition / initial(nutrition))) / 2
+		adjust_stamina(max(config_legacy.minimum_stamina_recovery, config_legacy.maximum_stamina_recovery * mod) * (1+chem_effects[CE_ENERGETIC]))
 
 /mob/living/carbon/human/proc/handle_some_updates()
 	if(life_tick > 5 && timeofdeath && (timeofdeath < 5 || world.time - timeofdeath > 6000))	//We are long dead, or we're junk mobs spawned like the clowns on the clown shuttle

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -161,6 +161,8 @@
 
 	var/metabolic_rate = 1
 
+	var/list/move_intents = list(/decl/move_intent/walk, /decl/move_intent/run)
+	
 	// HUD data vars.
 	var/datum/hud_data/hud
 	var/hud_type

--- a/code/modules/mob/living/carbon/human/species/species_hud.dm
+++ b/code/modules/mob/living/carbon/human/species/species_hud.dm
@@ -1,7 +1,7 @@
 /datum/hud_data
 	var/icon              // If set, overrides ui_style.
 	var/has_a_intent = 1  // Set to draw intent box.
-	var/has_m_intent = 1  // Set to draw move intent box.
+	var/has_move_intent = 1  // Set to draw move intent box.
 	var/has_warnings = 1  // Set to draw environment warnings.
 	var/has_pressure = 1  // Draw the pressure indicator.
 	var/has_nutrition = 1 // Draw the nutrition indicator.

--- a/code/modules/mob/living/carbon/human/species/station/traits/weaver_objs.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/weaver_objs.dm
@@ -103,7 +103,7 @@ var/global/list/weavable_items = list()
 			return
 	if(isliving(AM) && trap_active)
 		var/mob/living/L = AM
-		if(L.m_intent == "run")
+		if(MOVING_QUICKLY(L))
 			L.visible_message(
 				"<span class='danger'>[L] steps on \the [src].</span>",
 				"<span class='danger'>You step on \the [src]!</span>",

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -324,7 +324,7 @@
 
 	icon = 'icons/mob/screen1_alien.dmi'
 	has_a_intent =  1
-	has_m_intent =  1
+	has_move_intent =  1
 	has_warnings =  1
 	has_hands =     1
 	has_drop =      1

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -19,33 +19,22 @@
 /mob/CanZASPass(turf/T, is_zone)
 	return ATMOS_PASS_YES
 
-/**
-  * Toggle the move intent of the mob
-  *
-  * triggers an update the move intent hud as well
-  */
-/mob/proc/toggle_move_intent(mob/user)
-	if(m_intent == MOVE_INTENT_RUN)
-		m_intent = MOVE_INTENT_WALK
-	else
-		m_intent = MOVE_INTENT_RUN
 /*
 	if(hud_used && hud_used.static_inventory)
 		for(var/atom/movable/screen/mov_intent/selector in hud_used.static_inventory)
 			selector.update_icon()
 */
 	// nah, vorecode bad.
-	hud_used?.move_intent?.icon_state = (m_intent == MOVE_INTENT_RUN)? "running" : "walking"
+	//hud_used?.move_intent?.icon_state = (m_intent == MOVE_INTENT_RUN)? "running" : "walking"
 
 /mob/living/movement_delay()
 	. = ..()
-	switch(m_intent)
-		if(MOVE_INTENT_RUN)
-			if(drowsyness > 0)
-				. += 6
-			. += config_legacy.run_speed
-		if(MOVE_INTENT_WALK)
-			. += config_legacy.walk_speed
+	if(MOVING_QUICKLY(src))
+		if(drowsyness > 0)
+			. += 6
+		. += config_legacy.run_speed
+	else
+		. += config_legacy.walk_speed
 
 /mob/living/Move(NewLoc, Dir)
 	// what the hell does this do i don't know fine we'll keep it for now..
@@ -194,7 +183,7 @@
 	. = ..()
 	if (!istype(AM, /atom/movable) || AM.anchored)
 		//VOREStation Edit - object-specific proc for running into things
-		if(((confused || is_blind()) && stat == CONSCIOUS && prob(50) && m_intent=="run") || flying && !SPECIES_ADHERENT)
+		if(((confused || is_blind()) && stat == CONSCIOUS && prob(50) && MOVING_QUICKLY(src)) || flying && !SPECIES_ADHERENT)
 			AM.stumble_into(src)
 		//VOREStation Edit End
 		/* VOREStation Removal - See above

--- a/code/modules/mob/living/simple_mob/simple_hud.dm
+++ b/code/modules/mob/living/simple_mob/simple_hud.dm
@@ -125,7 +125,7 @@
 	using = new /atom/movable/screen()
 	using.name = "mov_intent"
 	using.icon = ui_style
-	using.icon_state = (m_intent == "run" ? "running" : "walking")
+	using.icon_state = (MOVING_QUICKLY(src) ? "running" : "walking")
 	using.screen_loc = ui_movi
 	using.color = ui_color
 	using.alpha = ui_alpha

--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -268,7 +268,7 @@
 			tally = 1
 		tally *= purge
 
-	if(m_intent == "walk")
+	if(MOVING_DELIBERATELY(src))
 		tally *= 1.5
 
 	return . + tally + config_legacy.animal_delay

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -49,6 +49,10 @@
 		living_mob_list += src
 	hook_vr("mob_new",list(src)) //VOREStation Code
 	update_transform() // Some mobs may start bigger or smaller than normal.
+	if(!move_intent)
+		move_intent = move_intents[1]
+	if(ispath(move_intent))
+		move_intent = decls_repository.get_decl(move_intent)
 	return ..()
 
 /mob/proc/show_message(msg, type, alt, alt_type)//Message, type of message (1 or 2), alternative message, alt message type (1 or 2)
@@ -1266,3 +1270,6 @@ mob/proc/yank_out_object()
  */
 /mob/proc/allow_examine(atom/A)
 	return client && (client.eye == src)
+
+/mob/proc/get_stamina_used_per_step()
+	return config_legacy.sprint_cost

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -5,9 +5,17 @@
 	animate_movement = 2
 	flags = PROXMOVE | HEAR
 
+	var/mob_flags
+	var/last_quick_move_time = 0
+	var/list/client_images = list() // List of images applied to/removed from the client on login/logout
+
 	// Intents
 	/// How are we intending to move? Walk/run/etc.
-	var/m_intent = MOVE_INTENT_RUN
+	var/decl/move_intent/move_intent = /decl/move_intent/walk
+	var/list/move_intents = list(/decl/move_intent/walk)
+
+	var/decl/move_intent/default_walk_intent
+	var/decl/move_intent/default_run_intent
 
 	var/datum/mind/mind
 
@@ -143,6 +151,8 @@
 	var/obj/buckled = null//Living
 
 	var/seer = 0 //for cult//Carbon, probably Human
+
+
 
 	var/datum/hud/hud_used = null
 

--- a/code/modules/organs/internal/intestine.dm
+++ b/code/modules/organs/internal/intestine.dm
@@ -16,7 +16,7 @@
 	if (. >= 2)
 		if(prob(1))
 			owner.custom_pain("Your abdomen feels like it's tearing itself apart!",1)
-			owner.m_intent = "walk"
+			owner.set_moving_slowly()
 			owner.hud_used.move_intent.icon_state = "walking"
 
 /obj/item/organ/internal/intestine/xeno

--- a/code/modules/organs/internal/kidneys.dm
+++ b/code/modules/organs/internal/kidneys.dm
@@ -40,7 +40,7 @@
 	if (. >= 2)
 		if(prob(1))
 			owner.custom_pain("You feel extremely tired, like you can't move!",1)
-			owner.m_intent = "walk"
+			owner.set_moving_slowly()
 			owner.hud_used.move_intent.icon_state = "walking"
 
 /obj/item/organ/internal/kidneys/grey

--- a/code/modules/projectiles/targeting/targeting_mob.dm
+++ b/code/modules/projectiles/targeting/targeting_mob.dm
@@ -56,11 +56,3 @@
 		aiming.update_aiming()
 	if(aimed.len)
 		trigger_aiming(TARGET_CAN_MOVE)
-
-/mob/living/proc/set_m_intent(var/intent)
-	if (intent != "walk" && intent != "run")
-		return 0
-	m_intent = intent
-	if(hud_used)
-		if (hud_used.move_intent)
-			hud_used.move_intent.icon_state = intent == "walk" ? "walking" : "running"

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -376,7 +376,7 @@
 		move_delay = max(0, (-car_limit * active_engines) + train_length - active_engines)	//limits base overweight so you cant overspeed trains
 		move_delay *= (1 / max(1, active_engines)) * 2 										//overweight penalty (scaled by the number of engines)
 		move_delay += config_legacy.run_speed 														//base reference speed
-		move_delay *= speed_mod																//makes cargo trains 10% slower than running when not overweight
+		move_delay *= speed_mod																	//makes cargo trains 10% slower than running when not overweight
 
 /obj/vehicle/train/trolley/update_car(var/train_length, var/active_engines)
 	src.train_length = train_length

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -251,7 +251,7 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 				forceMove(tmob.loc)
 
 				//Running on INTENT_DISARM
-				if(m_intent == "run")
+				if(MOVING_QUICKLY(src))
 					tmob.resting = 1 //Force them down to the ground.
 
 					//Log it for admins (as opposed to walk which logs damage)
@@ -310,7 +310,7 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 				var/calculated_damage = damage/2 //This will sting, but not kill. Does .5 to 2.625 damage, randomly, to each limb.
 
 				//Running on INTENT_HARM
-				if(m_intent == "run")
+				if(MOVING_QUICKLY(src))
 
 					//Not a human, or not a taur, generic message only
 					if(!H || !isTaurTail(H.tail_style))

--- a/config/legacy/game_options.txt
+++ b/config/legacy/game_options.txt
@@ -46,9 +46,11 @@ REVIVAL_BRAIN_LIFE -1
 
 
 ## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied. 
-RUN_SPEED 2
-WALK_SPEED 5
-
+RUN_SPEED 3
+WALK_SPEED 8
+SPRINT_COST 0.8
+MINIMUM_STAMINA_RECOVERY 5
+MAXIMUM_STAMINA_RECOVERY 5
 
 ## The variables below affect the movement of specific mob types.
 HUMAN_DELAY 0

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -387,6 +387,7 @@
 #include "code\datums\looping_sounds\machinery_sounds.dm"
 #include "code\datums\looping_sounds\sequence.dm"
 #include "code\datums\looping_sounds\weather_sounds.dm"
+#include "code\datums\move_intent\move_intent.dm"
 #include "code\datums\observation\_debug.dm"
 #include "code\datums\observation\_defines.dm"
 #include "code\datums\observation\observation.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds sprinting and stamina as mechanics from https://github.com/Baystation12/Baystation12/pull/25773. Or, more specifically, changes running to be stamina-based so you can no longer do it all the time.

The way this works is that mobs now default to walking. When using the move intent key (default alt), you start running, and a stamina bar appears above your move intent, which goes down with each tile you run across. If it reaches zero, you become exhausted and are no longer able to run for a few seconds, until you recover some stamina.

Stamina replenishes over time when not running, and is (typically) faster if you are lying down or otherwise relaxing.

A couple new verbs were added to the IC tab, default runs and default walks. Basically changing what move intent you go to when holding down the sprint button and when you release it, respectively, and is used for species who have ways to move beyond just walking and running. Currently it's just those two though, so the verbs don't have much use.

-------


Of course, new config options are needed for this.
`SPRINT_COST` is the stamina cost for each tile, defaulting to `0.8`. (Stamina caps out at 100.)
`MINIMUM_STAMINA_RECOVERY` is the least you can recover every time you start replenishing some stamina, defaulting to `5`.
`MAXIMUM_STAMINA_RECOVERY` is the most you can recover every time you start replenishing some stamina, defaulting to `5`.

(The minimums and maximums are the same because...well that's how they were ported. So unless changed, you'll recover stamina at a static rate no matter what.)

### Because of this change, I recommend changing walk speeds to be a lot faster since most people will be using that a lot more now.


## Why It's Good For The Game

No more zooming around everywhere, people can walk at more reasonable speeds and run to places if they need to.

## Changelog
:cl:
tweak: Running is now stamina-based. When running, a bar will appear above your move intent icon that shows your remaining stamina. If it reaches zero, you become exhausted and are forced to walk. Stamina replenishes over time when not running. (Ported from BS12)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
