### PR TITLE
new vampire trait + why could literally anyone with hands drain IV packs and get nutrients from it

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -76,7 +76,7 @@
 	var_changes = list(
 		"is_vampire" = TRUE,
 		"darksight" = 7,
-		"flash_mod" = 3.0,
+		"flash_mod" = 2,
 		"flash_burn" = 5,
 		"burn_mod" = 1.25,
 		"unarmed_types" = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp, /datum/unarmed_attack/bite/sharp/numbing))

--- a/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -69,6 +69,23 @@
 	..(S,H)
 	H.verbs |= /mob/living/carbon/human/proc/bloodsuck
 
+/datum/trait/vampire
+	name = "Vetalan / Vampiric"
+	desc = "Vampires, officially known as the Vetalan, are weaker to burns, bright lights, and must consume blood to survive. To this end, they can see near-perfectly in the darkness, possess sharp, numbing fangs, and anti-septic saliva."
+	cost = 0
+	var_changes = list(
+		"is_vampire" = TRUE,
+		"darksight" = 7,
+		"flash_mod" = 3.0,
+		"flash_burn" = 5,
+		"burn_mod" = 1.25,
+		"unarmed_types" = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp, /datum/unarmed_attack/bite/sharp/numbing))
+
+/datum/trait/vampire/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/carbon/human/proc/bloodsuck
+	H.verbs |= /mob/living/carbon/human/proc/lick_wounds
+
 /datum/trait/succubus_drain
 	name = "Succubus Drain"
 	desc = "Makes you able to gain nutrition from draining prey in your grasp."

--- a/code/modules/reagents/reagent_containers/blood_pack_vr.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack_vr.dm
@@ -1,27 +1,30 @@
 /obj/item/reagent_containers/blood/attack_self(mob/living/user as mob)
-	if(user.a_intent == INTENT_HARM)
-		if(reagents.total_volume && volume)
-			var/remove_volume = volume* 0.1 //10% of what the bloodpack can hold.
-			var/reagent_to_remove = reagents.get_master_reagent_id()
-			switch(reagents.get_master_reagent_id())
-				if("blood")
-					user.show_message("<span class='warning'>You sink your fangs into \the [src] and suck the blood out of it!</span>")
-					user.visible_message("<font color='red'>[user] sinks their fangs into \the [src] and drains it!</font>")
-					user.nutrition += remove_volume*4
-					reagents.remove_reagent(reagent_to_remove, remove_volume)
-					update_icon()
-					if(!bitten_state)
-						desc += "<font color='red'> It has two circular puncture marks in it.</font>"
-						bitten_state = TRUE
-					return
+	if(istype(user, /mob/living/carbon/human))
+		var/mob/living/carbon/human/human_user = user
+		if(human_user.species.is_vampire)
+			if(user.a_intent == INTENT_HARM)
+				if(reagents.total_volume && volume)
+					var/remove_volume = volume* 0.1 //10% of what the bloodpack can hold.
+					var/reagent_to_remove = reagents.get_master_reagent_id()
+					switch(reagents.get_master_reagent_id())
+						if("blood")
+							user.show_message("<span class='warning'>You sink your fangs into \the [src] and suck the blood out of it!</span>")
+							user.visible_message("<font color='red'>[user] sinks their fangs into \the [src] and drains it!</font>")
+							user.nutrition += remove_volume*4
+							reagents.remove_reagent(reagent_to_remove, remove_volume)
+							update_icon()
+							if(!bitten_state)
+								desc += "<font color='red'> It has two circular puncture marks in it.</font>"
+								bitten_state = TRUE
+							return
+						else
+							user.show_message("<span class='warning'>You take a look at \the [src] and notice that it is not filled with blood!</span>")
+							return
 				else
-					user.show_message("<span class='warning'>You take a look at \the [src] and notice that it is not filled with blood!</span>")
+					user.show_message("<span class='warning'>You take a look at \the [src] and notice it has nothing in it!</span>")
 					return
-		else
-			user.show_message("<span class='warning'>You take a look at \the [src] and notice it has nothing in it!</span>")
-			return
-	else
-		return
+			else
+				return
 
 /obj/item/reagent_containers/blood/prelabeled
 	name = "IV Pack"


### PR DESCRIPTION
## About The Pull Request

Introduces the all-new Vampire/Vetalan trait. This is a merger of... Bloodsucker, major darksight, numbing bites, antiseptic saliva, major burn weakness, and photosensitivity.
Patches bloodpacks to not allow literally anyone with hands to apply it to their face to gain nutrients. Ex3-378 does not have a mouth and runs on electricity. Ex3-378 would've been able to bite the bloodpack and drain its blood to gain electricity.

## Why It's Good For The Game

New trait is stage one in reworking the Vetalan species.
That bloodpack was one hell of a drug.

## Changelog
:cl:
add: Introduces the all-new Vampire/Vetalan trait. This is a merger of bloodsucker, major darksight, numbing bites, antiseptic saliva, major burn weakness, and photosensitivity.
fix: Patches bloodpacks to not allow literally anyone with hands to apply it to their face to gain nutrients. Ex3-378 does not have a mouth and runs on electricity. Ex3-378 would've been able to bite the bloodpack and drain its blood to gain electricity.
/:cl:
