### PR TITLE
The Biggest Engineering Buff in the History of Engineering

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -276,7 +276,7 @@
 				<br><br>
 				<ol>
 				<li>Enable and max output and input on the SMES in the engine room. This is to power the gyrotrons and pumps.</li>
-				<li>Go into the control room, interact with the fusion core control console. Raise the field size to 700 and turn it on. Any smaller will cause the gyrotrons to blast out the walls. Bigger than this will cause the field to immediately fail.</li>
+				<li>Go into the control room, interact with the fusion core control console. Raise the field size to 400 and turn it on. Any smaller will cause the gyrotrons to blast out the walls. Bigger than this will cause the field to immediately fail.</li>
 				<li>Interact with the gyrotron control computer and set all the gyrotrons power and timing to 1.</li>
 				<li>Start the gyrotrons and wait for the field to heat up. Once the field is fully visible, you may switch off the gyrotrons to save power.</li>
 				<li>Insert a can of phoron in the cold loop (green and blue) and a can of CO2 in the hot loop (red and orange).</li>

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -276,7 +276,7 @@
 				<br><br>
 				<ol>
 				<li>Enable and max output and input on the SMES in the engine room. This is to power the gyrotrons and pumps.</li>
-				<li>Go into the control room, interact with the fusion core control console. Raise the field size to 400 and turn it on. Any smaller will cause the gyrotrons to blast out the walls. Bigger than this will cause the field to immediately fail.</li>
+				<li>Go into the control room, interact with the fusion core control console. Raise the field size to 301 and turn it on. Any smaller will cause the gyrotrons to blast out the walls. Bigger than this will cause the field to immediately fail.</li>
 				<li>Interact with the gyrotron control computer and set all the gyrotrons power and timing to 1.</li>
 				<li>Start the gyrotrons and wait for the field to heat up. Once the field is fully visible, you may switch off the gyrotrons to save power.</li>
 				<li>Insert a can of phoron in the cold loop (green and blue) and a can of CO2 in the hot loop (red and orange).</li>


### PR DESCRIPTION
## About The Pull Request

I changed a 700 to a 301. This 700 wasn't even code. It was a line of text. It caused multiple meltdowns of the R-UST. If we have in-game manuals, can we at least make sure they work.

## Why It's Good For The Game

The manual for the R-UST no longer causes an EMP blast capable of murder.

## Changelog
:cl:
balance: Nerfs the R-UST Operating Manual. It no longer causes an EMP blast strong enough to murder any robot on-site.
/:cl:
