### PR TITLE
Adds a gun overlay for Science-Hounds (and maybe science borgs?)

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_vr.dm
@@ -93,6 +93,8 @@
 			add_overlay("laser")
 		if(istype(module_active,/obj/item/gun/energy/taser/mounted/cyborg))
 			add_overlay("taser")
+		if(istype(module_active,/obj/item/gun/energy/taser/xeno/robot))
+			add_overlay("taser")
 		if(lights_on)
 			add_overlay("eyes-[module_sprites[icontype]]-lights")
 		if(resting)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes sci-hounds have a visible overlay when they have a xeno-tazer equipped, maybe also regular sci borgs, but I do not believe they have proper overlays set up.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
now Hawke can know when he's about to get shot to shit.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: added borg xeno-tazer to the borg overlay system
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
