### PR TITLE
Hub refresh 2022 - Cleans up hub desc code, adds some more config options, and more!

### DIFF
--- a/code/_globalvars/lists/misc.dm
+++ b/code/_globalvars/lists/misc.dm
@@ -2,6 +2,8 @@ GLOBAL_LIST_INIT(char_directory_tags, list("Pred", "Prey", "Switch", "Non-Vore",
 GLOBAL_LIST_INIT(char_directory_erptags, list("Top", "Bottom", "Switch", "No ERP", "Unset"))
 GLOBAL_LIST_EMPTY(meteor_list)
 
+GLOBAL_LIST_INIT(server_taglines, file2list("config/strings/server_taglines.txt"))
+
 /// List of wire colors for each object type of that round. One for airlocks, one for vendors, etc.
 GLOBAL_LIST_EMPTY(wire_color_directory) // This is an associative list with the `holder_type` as the key, and a list of colors as the value.
 

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -32,5 +32,11 @@
 	config_entry_value = null
 	min_val = 0
 
+/datum/config_entry/string/community_shortname
+
+/datum/config_entry/string/community_link
+
 /datum/config_entry/string/tagline
 	config_entry_value = "<br><small><a href='https://discord.gg/citadelstation'>Roleplay focused 18+ server with extensive species choices.</a></small></br>"
+
+/datum/config_entry/flag/usetaglinestrings

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -387,8 +387,8 @@ GLOBAL_REAL_VAR(world_log_redirected) = FALSE
 	var/stationname = station_name()
 	var/defaultstation = GLOB.using_map ? GLOB.using_map.station_name : stationname
 	if(servername || stationname != defaultstation)
-		. += (servername ? "<b>[servername] - " : "<b>")
-		. += (stationname != defaultstation ? "[stationname]</b>\] " : "</b>\] ")
+		. += (servername ? "<b>[servername]" : "<b>")
+		. += (stationname != defaultstation ? "[servername ? " - " : ""][stationname]</b>\] " : "</b>\] ")
 
 	var/communityname = CONFIG_GET(string/community_shortname)
 	var/communitylink = CONFIG_GET(string/community_link)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -377,61 +377,41 @@ GLOBAL_REAL_VAR(world_log_redirected) = FALSE
 				D.associate(GLOB.directory[ckey])
 
 /world/proc/update_status()
-	var/s = ""
+	. = ""
+	if(!config)
+		status = "<b>SERVER LOADING OR BROKEN.</b> (18+)"
+		return
 
-	if (config_legacy?.server_name)
-		s += "<b>[config_legacy.server_name]</b> &#8212; "
+	// ---Hub title---
+	var/servername = config_legacy?.server_name
+	var/stationname = station_name()
+	var/defaultstation = GLOB.using_map ? GLOB.using_map.station_name : stationname
+	if(servername || stationname != defaultstation)
+		. += (servername ? "<b>[servername] - " : "<b>")
+		. += (stationname != defaultstation ? "[stationname]</b>\] " : "</b>\] ")
 
-	s += "<b>[station_name()]</b>";
-	s += " ("
-	s += "<a href=\"http://\">" //Change this to wherever you want the hub to link to.
-//	s += "[game_version]"
-	s += "Citadel"  //Replace this with something else. Or ever better, delete it and uncomment the game version.	CITADEL CHANGE - modifies hub entry to match main
-	s += "</a>"
-	s += ")\]" //CITADEL CHANGE - encloses the server title in brackets to make the hub entry fancier
-	s += CONFIG_GET(string/tagline)
+	var/communityname = CONFIG_GET(string/community_shortname)
+	var/communitylink = CONFIG_GET(string/community_link)
+	if(communityname)
+		. += (communitylink ? "(<a href=\"[communitylink]\">[communityname]</a>) " : "([communityname]) ")
 
-	s += ")"
+	. += "(18+)<br>" //This is obligatory for obvious reasons.
 
-	var/list/features = list()
+	// ---Hub body---
+	var/tagline = (CONFIG_GET(flag/usetaglinestrings) ? pick(GLOB.server_taglines) : CONFIG_GET(string/tagline))
+	if(tagline)
+		. += "[tagline]<br>"
 
-	if(SSticker)
-		if(master_mode)
-			features += master_mode
-	else
-		features += "<b>STARTING</b>"
+	// ---Hub footer---
+	. += "\["
+	if(GLOB.using_map)
+		. += "[GLOB.using_map.station_short], "
 
-	/*if (!config_legacy.enter_allowed)	CITADEL CHANGE - removes useless info from hub entry
-		features += "closed"
+	. += "[get_security_level()] alert, "
+	
+	. += "[GLOB.clients.len] players"
 
-	features += config_legacy.abandon_allowed ? "respawn" : "no respawn"
-
-	if (config && config_legacy.allow_vote_mode)
-		features += "vote"
-
-	if (config && config_legacy.allow_ai)
-		features += "AI allowed"*/
-
-	var/n = 0
-	for (var/mob/M in player_list)
-		if (M.client)
-			n++
-
-	if (n > 1)
-		features += "~[n] players"
-	else if (n > 0)
-		features += "~[n] player"
-
-
-	if (config && config_legacy.hostedby)
-		features += "hosted by <b>[config_legacy.hostedby]</b>"
-
-	if (features)
-		s += "\[[jointext(features, ", ")]"	//CITADEL CHANGE - replaces colon with left bracket to make the hub entry a little fancier
-
-	/* does this help? I do not know */
-	if (src.status != s)
-		src.status = s
+	status = .
 
 #define FAILED_DB_CONNECTION_CUTOFF 5
 var/failed_db_connections = 0

--- a/config/config.txt
+++ b/config/config.txt
@@ -9,6 +9,7 @@ $include entries/fail2topic.txt
 $include entries/game_options.txt
 $include entries/lobby.txt
 $include entries/urls.txt
+$include entries/hub.txt
 
 
 # You can use the @ character at the beginning of a config option to lock it from being edited in-game
@@ -42,7 +43,3 @@ CLIENT_ERROR_VERSION 511
 CLIENT_ERROR_MESSAGE Your version of byond is not supported. Please upgrade.
 ## The minimum build needed for joining the server, if using 512, a good minimum build would be 1421 as that disables the Middle Mouse Button exploit.
 CLIENT_ERROR_BUILD 1421
-
-## TAGLINE - Hub tagline
-TAGLINE <br><small><a href='https://discord.gg/citadelstation'>Roleplay focused 18+ server with extensive species choices.</a></small></br>
-

--- a/config/entries/hub.txt
+++ b/config/entries/hub.txt
@@ -1,0 +1,12 @@
+## Community short-name: This appears in parentheses after the server's active station name
+# COMMUNITYSHORTNAME virgo???
+
+## Community link: Requires a community short-name defined. Attaches a link to the community's shortname, and requires a short-name defined.
+## You could alternatively just add raw HTML to the above, but this is more newbie-friendly
+# COMMUNITYLINK http://crouton.net
+
+## TAGLINE - Hub tagline
+TAGLINE <br><small><a href='https://discord.gg/citadelstation'>Roleplay focused 18+ server with extensive species choices.</a></small></br>
+
+## Use tagline strings: Uncomment to have the server's tagline be randomly selected from taglines.txt
+# USETAGLINESTRINGS

--- a/config/strings/server_taglines.txt
+++ b/config/strings/server_taglines.txt
@@ -1,0 +1,1 @@
+Fill in your own community quotes and memery here!


### PR DESCRIPTION
## About The Pull Request
This PR is largely a mirror of Citadel-Station-13/Citadel-Station-13#15610 , though this PR also brings RP's hub description up to parity with that of Main.

The popcap display and change to only display active players are both missing from this port, though, as RP lacks equivalent procs and config options. However, this does make some changes that're new for RP. Notably, the map's shortname is now displayed in the footer like map names are on Main, the security level's displayed there, and the display of the active gamemode has been axed.

All other changes are more or less the same as the above PR. The station name is now hidden if it's the same as the default, the community name and link can now be modified via the config, there's now an 18+ tag at all times, the tagline can be configured to pull from a strings file, and the hub description code's been brought up to modern SS13 code standards.

## Changelog
:cl: Bhijn & Myr
tweak: The server's hub description has had a refresh! More things are customizable via the config, there's now an 18+ tag that always displays, and more!
tweak: Additionally, the server's hub description has been brought up to parity with that of Main. The footer now displays the map name and security level, and it no longer displays the gamemode outright.
add: The server's hub tagline now has the option to pull random strings from config/strings/server_taglines.txt!
/:cl:
