### PR TITLE
Tweaks Red Armory Weaponry

### DIFF
--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -2608,7 +2608,11 @@
 	dir = 8
 	},
 /obj/structure/table/steel,
-/obj/machinery/recharger,
+/obj/item/storage/box/firingpins,
+/obj/item/storage/box/firingpins,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -22
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)
 "bVh" = (
@@ -20039,9 +20043,7 @@
 /turf/simulated/floor/wood/broken,
 /area/maintenance/security/starboard)
 "nTB" = (
-/obj/machinery/computer/teleporter{
-	dir = 2
-	},
+/obj/machinery/computer/teleporter,
 /turf/simulated/floor/tiled,
 /area/teleporter)
 "nTE" = (
@@ -33069,12 +33071,12 @@
 /area/exploration/excursion_dock)
 "wlC" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/storage/box/firingpins,
-/obj/item/storage/box/firingpins,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/item/gunbox/lethal,
+/obj/item/gunbox/lethal,
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)
 "wmt" = (
@@ -34395,8 +34397,6 @@
 /obj/structure/table/rack/shelf/steel,
 /obj/item/gun/energy/laser,
 /obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -34506,9 +34506,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/red,
-/obj/item/gun/energy/ionrifle{
-	pixel_y = 5
-	},
 /obj/item/gun/energy/ionrifle,
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. *Reduces Armory ion rifles from 2 to 1.*
2. *Reduces Armory laser rifles from 4 to 2.*
3. *Adds two lethal gunboxes to Red Armory.*
4. *Removes Red Armory cell charger and adds a new wall charger.*

## Why It's Good For The Game

1. _Tentative rebalancing. May not keep this weight._
2. _As the above._
3. _These were meant to be mapped in, but never were._
4. _Just QOL/space rearranging._

## Changelog
:cl:
tweak: Tweaks weapon allotment in the Red Armory.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
