### PR TITLE
Holster lifehacks

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -101,6 +101,7 @@
 	icon_state = "c_tube"
 	throwforce = 1
 	w_class = ITEMSIZE_SMALL
+	slot_flags = SLOT_HOLSTER
 	throw_speed = 4
 	throw_range = 5
 

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -162,7 +162,7 @@
 	icon_state = "holster_machete"
 	concealed_holster = 0
 	can_hold = list(/obj/item/material/knife/machete, /obj/item/melee/energy/hfmachete, /obj/item/reagent_containers/spray, /obj/item/soap, 
-		/obj/item/c_tube)
+		/obj/item/c_tube, /obj/item/bikehorn)
 	cant_hold = list(/obj/item/material/knife/machete/armblade)
 	sound_in = 'sound/effects/holster/sheathin.ogg'
 	sound_out = 'sound/effects/holster/sheathout.ogg'

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -161,7 +161,8 @@
 	desc = "A handsome synthetic leather scabbard with matching belt."
 	icon_state = "holster_machete"
 	concealed_holster = 0
-	can_hold = list(/obj/item/material/knife/machete, /obj/item/melee/energy/hfmachete)
+	can_hold = list(/obj/item/material/knife/machete, /obj/item/melee/energy/hfmachete, /obj/item/reagent_containers/spray, /obj/item/soap, 
+		/obj/item/c_tube)
 	cant_hold = list(/obj/item/material/knife/machete/armblade)
 	sound_in = 'sound/effects/holster/sheathin.ogg'
 	sound_out = 'sound/effects/holster/sheathout.ogg'


### PR DESCRIPTION
Lets you put the spraybottle, soap, bikehorn and cardboard tube in the machete holster like you can with the regular holster.

## Changelog
:cl:
tweak: The machete scabbard now fits the cardboard tube, soap, spray bottle and bikehorn like the regular holster
/:cl:
