### PR TITLE
adds a parallax disable option

### DIFF
--- a/code/_rendering/parallax/parallax_holder.dm
+++ b/code/_rendering/parallax/parallax_holder.dm
@@ -166,6 +166,8 @@
 	if(QDELETED(C))
 		return
 	. = list()
+	if(!C.is_preference_enabled(/datum/client_preference/parallax))
+		return
 	for(var/atom/movable/screen/parallax_layer/L in layers)
 		// if(L.parallax_intensity > owner.prefs.parallax)
 		// 	continue
@@ -307,5 +309,6 @@
 /client/proc/CreateParallax()
 	if(!parallax_holder)
 		parallax_holder = new(src)
+
 /atom/movable/screen/parallax_vis
 	screen_loc = "CENTER,CENTER"

--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -269,6 +269,15 @@ var/list/_client_preferences_by_type
 		var/datum/plane_holder/PH = preference_mob.plane_holder
 		PH.set_vis(VIS_STATUS, enabled)
 
+/datum/client_preference/parallax
+	description = "Parallax (fancy space, disable for FPS issues"
+	key = "PARALLAX_ENABLED"
+	enabled_description = "Enabled"
+	disabled_description = "Disabled"
+
+/datum/client_preference/parallax/toggled(mob/preference_mob, enabled)
+	. = ..()
+	preference_mob?.client?.parallax_holder?.Reset()
 
 /********************
 * Staff Preferences *


### PR DESCRIPTION
turns out parallax is really FPS-damaging for people with bad laptops
they can now disable it.