### PR TITLE
Bugfix: IC memory circuits & power cells

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -292,7 +292,19 @@
 			return TRUE
 
 	else if(I.is_crowbar())
+		if(!opened)
+			return FALSE
+		if(!battery)
+			to_chat(usr, SPAN_WARNING("There's no power cell to remove from \the [src]."))
+			return FALSE
+		battery.forceMove(get_turf(src))
 		playsound(get_turf(src), 'sound/items/Crowbar.ogg', 50, 1)
+		to_chat(user, SPAN_NOTICE("You pull \the [battery] out of \the [src]'s power supplier."))
+		battery = null
+		return TRUE
+
+	else if(I.is_screwdriver())
+		playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 50, 1)
 		opened = !opened
 		to_chat(user, SPAN_NOTICE("You [opened ? "opened" : "closed"] \the [src]."))
 		update_icon()

--- a/code/modules/integrated_electronics/subtypes/memory.dm
+++ b/code/modules/integrated_electronics/subtypes/memory.dm
@@ -12,11 +12,11 @@
 	var/number_of_pins = 1
 
 /obj/item/integrated_circuit/memory/Initialize(mapload)
-	. = ..()
 	for(var/i = 1 to number_of_pins)
 		inputs["input [i]"] = IC_PINTYPE_ANY // This is just a string since pins don't get built until ..() is called.
 		outputs["output [i]"] = IC_PINTYPE_ANY
 	complexity = number_of_pins
+	. = ..()
 
 /obj/item/integrated_circuit/memory/examine(mob/user)
 	. = ..()
@@ -37,7 +37,7 @@
 		var/datum/integrated_io/I = inputs[i]
 		var/datum/integrated_io/O = outputs[i]
 		O.data = I.data
-		O.push_data()
+		push_data()
 	activate_pin(2)
 
 /obj/item/integrated_circuit/memory/tiny


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes 3 long standing bugs. Memory circuits failed due to two separate bugs, both simple mistakes. Power cells had no way of being removed from assemblies. The proposed change is to use crowbars to keep it in line with removing cells from other devices and move opening and closing assemblies to a screwdriver action.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Cohesion. No more unga opening.

## Changelog
:cl:
tweak: Screwdrivers required for opening.
fix: Memory circuits and cell removal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
