### PR TITLE
fixes medibot construction not using get_turf

### DIFF
--- a/code/modules/mob/living/bot/medibot.dm
+++ b/code/modules/mob/living/bot/medibot.dm
@@ -631,7 +631,7 @@
 				if(!can_finish_build(W, user))
 					return
 				qdel(W)
-				var/mob/living/bot/medibot/S = new(drop_location(), skin)
+				var/mob/living/bot/medibot/S = new(get_turf(src), skin)
 				to_chat(user, SPAN_NOTICE("You complete the Medibot! Beep boop."))
 				S.name = created_name
 				S.firstaid = firstaid


### PR DESCRIPTION
this is annoying because it doesn't fix being unable to make it while inside a closet without having it pop out but not until storage refactor i guess