### PR TITLE
makes veymed skrell prosthetics use the same spriteset as regular veymed

### DIFF
--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -363,17 +363,13 @@ var/const/cyberbeast_monitor_styles= "blank=cyber_blank;\
 	robo_burn_mod = 1.1
 	modular_bodyparts = MODULAR_BODYPART_INVALID
 
-/datum/robolimb/veymed_skrell
+/datum/robolimb/veymed/skrell
 	company = "Vey-Med - Skrell"
-	desc = "This high quality limb is nearly indistinguishable from an organic one."
-	icon = 'icons/mob/human_races/cyberlimbs/veymed/veymed_skrell.dmi'
 	species_cannot_use = list(SPECIES_TESHARI, SPECIES_PROMETHEAN, SPECIES_TAJ, SPECIES_HUMAN, SPECIES_VOX, SPECIES_HUMAN_VATBORN, SPECIES_UNATHI, SPECIES_DIONA, SPECIES_ZADDAT)
 	blood_color = "#4451cf"
-	blood_name = "coolant"
 	speech_bubble_appearance = "normal"
 	robo_brute_mod = 1.05
 	robo_burn_mod = 1.05
-	modular_bodyparts = MODULAR_BODYPART_INVALID
 
 // thanks kraso
 /datum/robolimb/moth


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
title

## Why It's Good For The Game

don't ask but makes the veymed skrell usable
why not have regular veymed available to all species instead?
uhh idk don't ask omg look over there is that ICON LAYER CODE? YOU BETTER LOOK OVER THERE.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak:veymed skrell prosthetics usable again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
