### PR TITLE
(probably) fixes an infinite loop from an """optimization""" in my perspectives code and fixes some ""edge cases""

### DIFF
--- a/code/datums/perspective.dm
+++ b/code/datums/perspective.dm
@@ -64,7 +64,11 @@
 	virtual_eye = null
 	return ..()
 
+/// ONLY CALL FROM CLIENT.SET_PERSPECTIVE
+/// I DO NOT TRUST PEOPLE TO NOT SCREW THIS UP
 /datum/perspective/proc/AddClient(client/C)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	SHOULD_CALL_PARENT(TRUE)
 	if(C in clients)
 		return
 	if(C.using_perspective)
@@ -74,7 +78,11 @@
 	SEND_SIGNAL(src, COMSIG_PERSPECTIVE_CLIENT_REGISTER, C)
 	Apply(C)
 
+/// ONLY CALL FROM CLIENT.SET_PERSPECTIVE
+/// I DO NOT TRUST PEOPLE TO NOT SCREW THIS UP
 /datum/perspective/proc/RemoveClient(client/C, switching = FALSE)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	SHOULD_CALL_PARENT(TRUE)
 	if(!(C in clients))
 		return
 	clients -= C
@@ -112,6 +120,7 @@
  * registers as a mob's current perspective
  */
 /datum/perspective/proc/AddMob(mob/M)
+	SHOULD_CALL_PARENT(TRUE)
 	if(M.using_perspective)
 		CRASH("mob already had perspective")
 	if(reset_on_logout && !M.client)	// nah
@@ -124,6 +133,7 @@
  * unregisters as a mob's current perspective
  */
 /datum/perspective/proc/RemoveMob(mob/M, switching = FALSE)
+	SHOULD_CALL_PARENT(TRUE)
 	mobs -= M
 	SEND_SIGNAL(src, COMSIG_PERSPECTIVE_MOB_REMOVE, M, switching)
 	if(M.using_perspective == src)
@@ -137,6 +147,7 @@
  * applys screen objs, etc, stuff that shouldn't be updated regularly
  */
 /datum/perspective/proc/Apply(client/C)
+	SHOULD_CALL_PARENT(TRUE)
 	C.screen += screens
 	C.images += images
 	Update(C)
@@ -313,12 +324,13 @@
 	return where
 
 /**
- * temporary perspectives generated - automatically deletes when last client is gone
+ * temporary perspectives generated - automatically deletes when last mob is gone
  */
 /datum/perspective/self/temporary
 
-/datum/perspective/self/temporary/RemoveClient(client/C)
-	if(!clients.len)
+/datum/perspective/self/temporary/RemoveMob(mob/M, switching)
+	. = ..()
+	if(!mobs.len)
 		qdel(src)
 
 /**

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -732,7 +732,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		perspective = EYE_PERSPECTIVE
 		return
 	P.AddClient(src)
-	using_perspective = P
+	if(using_perspective != P)
+		stack_trace("using perspective didn't set")
 
 /**
  * reset perspective to default - usually to our mob's

--- a/code/modules/mob/perspective.dm
+++ b/code/modules/mob/perspective.dm
@@ -12,11 +12,16 @@
   * - no_optimizations - if true, it'll be a true reset. use for things like cancel camera view which should always force updates.
   */
 /mob/proc/reset_perspective(datum/perspective/P, apply = TRUE, forceful = TRUE, no_optimizations)
-	if(!no_optimizations && (P? ((ismovable(P) && istype(using_perspective, /datum/perspective/self/temporary))? (using_perspective?.eye == P) : (P == using_perspective)) : (using_perspective && (using_perspective == self_perspective))))
+	ASSERT(istype(P) || ismovable(P))
+	if(!no_optimizations && (
+		P?	(ismovable(P)? (istype(using_perspective, /datum/perspective/self/temporary) && (using_perspective.eye == P)) : (using_perspective == P))
+		:
+			(using_perspective && (using_perspective == self_perspective))
+	))
 		// if we don't need to reset, assume it's an update.
 		// this is bad practice but stuff like mechs need this to work, since
 		// they reset for brainmobs but only need to update for others.
-		update_perspective()
+		update_perspective(TRUE)
 		return
 	if(ismovable(P))
 		var/atom/movable/AM = P
@@ -83,11 +88,13 @@
 /**
  * updates our curent perspective
  */
-/mob/proc/update_perspective()
+/mob/proc/update_perspective(shunted)
 	if(!client)
 		return
 	if(using_perspective != client.using_perspective)	// shunt them back in, useful if something's temporarily shunted our client away
-		reset_perspective(using_perspective)
+		if(shunted)
+			CRASH("Caught an infinite loop. What's going on here?")
+		reset_perspective(using_perspectivew)
 		return
 	SEND_SIGNAL(src, COMSIG_MOB_UPDATE_PERSPECTIVE)
 	using_perspective?.Update(client)

--- a/code/modules/mob/perspective.dm
+++ b/code/modules/mob/perspective.dm
@@ -12,7 +12,8 @@
   * - no_optimizations - if true, it'll be a true reset. use for things like cancel camera view which should always force updates.
   */
 /mob/proc/reset_perspective(datum/perspective/P, apply = TRUE, forceful = TRUE, no_optimizations)
-	ASSERT(istype(P) || ismovable(P))
+	if(P)
+		ASSERT(istype(P) || ismovable(P))
 	if(!no_optimizations && (																																\
 		P?	(ismovable(P)? (istype(using_perspective, /datum/perspective/self/temporary) && (using_perspective.eye == P)) : (using_perspective == P))		\
 		:																																					\

--- a/code/modules/mob/perspective.dm
+++ b/code/modules/mob/perspective.dm
@@ -13,10 +13,10 @@
   */
 /mob/proc/reset_perspective(datum/perspective/P, apply = TRUE, forceful = TRUE, no_optimizations)
 	ASSERT(istype(P) || ismovable(P))
-	if(!no_optimizations && (
-		P?	(ismovable(P)? (istype(using_perspective, /datum/perspective/self/temporary) && (using_perspective.eye == P)) : (using_perspective == P))
-		:
-			(using_perspective && (using_perspective == self_perspective))
+	if(!no_optimizations && (																																\
+		P?	(ismovable(P)? (istype(using_perspective, /datum/perspective/self/temporary) && (using_perspective.eye == P)) : (using_perspective == P))		\
+		:																																					\
+			(using_perspective && (using_perspective == self_perspective))																					\
 	))
 		// if we don't need to reset, assume it's an update.
 		// this is bad practice but stuff like mechs need this to work, since

--- a/code/modules/mob/perspective.dm
+++ b/code/modules/mob/perspective.dm
@@ -92,6 +92,9 @@
 	if(!client)
 		return
 	if(using_perspective != client.using_perspective)	// shunt them back in, useful if something's temporarily shunted our client away
+		if(!client.using_perspective)
+			reset_perspective(using_perspective)
+			CRASH("client had no using perspective, how? in mob/update_perspective")
 		if(shunted)
 			CRASH("Caught an infinite loop. What's going on here?")
 		reset_perspective(using_perspectivew)

--- a/code/modules/mob/perspective.dm
+++ b/code/modules/mob/perspective.dm
@@ -97,7 +97,7 @@
 			CRASH("client had no using perspective, how? in mob/update_perspective")
 		if(shunted)
 			CRASH("Caught an infinite loop. What's going on here?")
-		reset_perspective(using_perspectivew)
+		reset_perspective(using_perspective)
 		return
 	SEND_SIGNAL(src, COMSIG_MOB_UPDATE_PERSPECTIVE)
 	using_perspective?.Update(client)

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -70,6 +70,12 @@
 // Management of mob view displacement. look to shift view to the ship on the overmap; unlook to shift back.
 
 /obj/machinery/computer/ship/proc/look(mob/user)
+	var/WR = WEAKREF(user)
+	if(WR in viewers)
+		return
+	RegisterSignal(user, COMSIG_MOVABLE_MOVED, /obj/machinery/computer/ship/proc/unlook)
+	// TODO GLOB.stat_set_event.register(user, src, /obj/machinery/computer/ship/proc/unlook)
+	LAZYDISTINCTADD(viewers, WR)
 	if(linked)
 		user.reset_perspective(linked)
 	user.set_machine(src)
@@ -78,16 +84,9 @@
 		L.looking_elsewhere = 1
 		L.handle_vision()
 	user.set_viewsize(world.view + extra_view)
-	var/WR = WEAKREF(user)
-	if(WR in viewers)
-		return
-	RegisterSignal(user, COMSIG_MOVABLE_MOVED, /obj/machinery/computer/ship/proc/unlook)
-	// TODO GLOB.stat_set_event.register(user, src, /obj/machinery/computer/ship/proc/unlook)
-	LAZYDISTINCTADD(viewers, WR)
 
 /obj/machinery/computer/ship/proc/unlook(mob/user)
 	user.reset_perspective()
-	user.set_viewsize()	// Reset to default
 	UnregisterSignal(user, COMSIG_MOVABLE_MOVED, /obj/machinery/computer/ship/proc/unlook)
 	if(isliving(user))
 		var/mob/living/L = user


### PR DESCRIPTION
changing perspective is expensive and people reset_perspective() for no reason all the time

so i fixed it by optimizing it to update_perspective()

problem:
update_perspective() calls reset_perspective() if it detects something's wrong, and in this case, there was **another** bug that's going on that triggers this.

this stops that.