### PR TITLE
monkey patches defibs to work again until we can refactor twohanding 

### DIFF
--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -248,6 +248,7 @@
 		icon_state = "defibpaddles[wielded]_cooldown"
 
 /obj/item/shockpaddles/proc/can_use(mob/user, mob/M)
+	update_held_icon()
 	if(busy)
 		return 0
 	if(!check_charge(chargecost))


### PR DESCRIPTION
whoever made perfect triggered-twohanding from /tg/code into automatic wielding should not be allowed to touch code ever again

words cannot describe how utterly deranged it is to make twohanding automatic when we all know how well our inventory code works