### PR TITLE
Five misc fixes

### DIFF
--- a/code/__HELPERS/vfx/shake_camera.dm
+++ b/code/__HELPERS/vfx/shake_camera.dm
@@ -16,7 +16,7 @@
 		var/old_x = C.pixel_x
 		var/old_y = C.pixel_y
 		for(var/i in 1 to duration)
-			if(i == 0)
+			if(i == 1)
 				animate(C, pixel_x = rand(min, max), pixel_y = rand(min, max), time = 1)
 			else
 				animate(pixel_x = rand(min, max), pixel_y = rand(min, max), time = 1)

--- a/code/game/objects/items/devices/communicator/messaging.dm
+++ b/code/game/objects/items/devices/communicator/messaging.dm
@@ -66,7 +66,7 @@
 		im_list += list(list("address" = origin_address, "to_address" = exonet.address, "im" = text))
 	else if(istype(candidate, /obj/item/integrated_circuit))
 		var/obj/item/integrated_circuit/CIRC = candidate
-		who = CIRC
+		who = (CIRC.displayed_name)
 		im_list += list(list("address" = origin_address, "to_address" = exonet.address, "im" = text))
 	else return
 

--- a/code/modules/cargo/supplypacks/materials.dm
+++ b/code/modules/cargo/supplypacks/materials.dm
@@ -28,7 +28,7 @@
 	container_type = /obj/structure/closet/crate
 	container_name = "Wooden planks crate"
 
-/datum/supply_pack/materials/wood50
+/datum/supply_pack/materials/hardwood50
 	name = "50 hardwood planks"
 	contains = list(/obj/fiftyspawner/hardwood)
 	cost = 50

--- a/code/modules/client/preference_setup/vore/02_size.dm
+++ b/code/modules/client/preference_setup/vore/02_size.dm
@@ -33,7 +33,7 @@
 	S["fuzzy"]				<< pref.fuzzy
 
 /datum/category_item/player_setup_item/vore/size/sanitize_character()
-	pref.weight_vr			= sanitize_integer(pref.weight_vr, WEIGHT_MIN, WEIGHT_MAX, initial(pref.weight_vr))
+	pref.weight_vr			= isnum(pref.weight_vr) ? round(clamp(pref.weight_vr, WEIGHT_MIN, WEIGHT_MAX)) : initial(pref.weight_vr)
 	pref.weight_gain		= sanitize_integer(pref.weight_gain, WEIGHT_CHANGE_MIN, WEIGHT_CHANGE_MAX, initial(pref.weight_gain))
 	pref.weight_loss		= sanitize_integer(pref.weight_loss, WEIGHT_CHANGE_MIN, WEIGHT_CHANGE_MAX, initial(pref.weight_loss))
 	pref.fuzzy				= sanitize_integer(pref.fuzzy, 0, 1, initial(pref.fuzzy))

--- a/tgui/packages/tgui/interfaces/SeedStorage.js
+++ b/tgui/packages/tgui/interfaces/SeedStorage.js
@@ -45,12 +45,13 @@ export const SeedStorage = (props, context) => {
                 </Button>
               </Flex.Item>
               <Flex.Item grow={1}>
-                <Button
+                <Button.Confirm
+                  confirm
                   fluid
                   icon="trash"
                   onClick={() => act("purge", { id: seed.id })}>
                   Purge
-                </Button>
+                </Button.Confirm>
               </Flex.Item>
             </Flex>
           ))}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## About The Pull Request

1. shake_camera() : Beginning of loop skipped, causing animation to crash out.
2. IPv2 circuits : In messages circuit.name is always displayed as sender.
3. Wood crates : Overwritten by hardwood.
4. Persistent weight : Value returns to default when at either extreme at round end.
5. Seed storage : Accidental disposal of seeds.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

1. Trigger value set to 1 in line with initial loop value.
2. circuit.displayed_name is used, allowing for custom sender names.
3. Hardwood crates have correct path.
4. Refactor sanitize_integer into the proc to avoid double processing in the default var.
5. Button changed to Button.Confrim.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
fix: Camera shaking, IPv2 circuits, wood supply crates, persistent weight and seed storage emergency disposal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
