### PR TITLE
Renames CentCom's Orbital Station

### DIFF
--- a/maps/rift/rift_defines.dm
+++ b/maps/rift/rift_defines.dm
@@ -75,7 +75,7 @@
 
 	station_name  = "NSB Atlas"
 	station_short = "Atlas"
-	dock_name     = "NSS Raytheon"
+	dock_name     = "NSS Demeter"
 	dock_type     = "surface"
 	boss_name     = "Central Command"
 	boss_short    = "CentCom"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. *Changes the name of the station from Raytheon to Demeter.*

## Why It's Good For The Game

1. _Naming the overhead station after an extant military contractor stoked some discontent among the staff team. Although I have no horse in that particular race, it is worthwhile to change the name of the vessel. This is the structural equivalent of my prior issues with Sergal naming conventions, and I am correcting it for that reason. The current staff pick for a rename is Demeter. This may change._

## Changelog
:cl:
tweak: Changes name of CentCom Station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
