### PR TITLE
Clarifies Pop-Up Traps

### DIFF
--- a/code/game/objects/effects/traps.dm
+++ b/code/game/objects/effects/traps.dm
@@ -94,7 +94,7 @@ Add those other swinging traps you mentioned above!
 	deploy_location.ChangeTurf(trap_floor_type)
 
 /obj/effect/trap/proc/Break()
-	desc = desc + " Whatever nefarious purpose this one once had, it's broken now."
+	desc += " Whatever nefarious purpose this one once had, it's broken now."
 	update_icon()
 	broken = TRUE
 
@@ -444,17 +444,17 @@ Add those other swinging traps you mentioned above!
 
 		if(WT.remove_fuel(0, user))
 			if(health < maxhealth)
-				to_chat(user, "<span class='notice'>You begin repairing \the [src.name] with \the [WT].</span>")
+				to_chat(user, SPAN_NOTICE("You begin repairing \the [src.name] with \the [WT].>"))
 			if(do_after(user, 20, src))
 				health = maxhealth
 				broken = FALSE
-			playsound(src.loc, 'sound/items/Welder.ogg', 100, 1)
+			playsound(src.loc, 'sound/items/Welder.ogg', 100, TRUE)
 
 	if(broken)
 		return
 	if((health <= 0))
 		Break()
-		src.visible_message("<span class='danger'>\The [src] breaks! It was a trap!</span>")
+		src.visible_message(SPAN_DANGER(">\The [src] breaks! It was a trap!"))
 		return
 	if(W.attack_verb.len)
 		src.visible_message("<span class='danger'>\The [src] has been [pick(W.attack_verb)] with \the [W][(user ? " by [user]." : ".")]</span>")
@@ -470,7 +470,7 @@ Add those other swinging traps you mentioned above!
 /obj/effect/trap/pop_up/proc/healthcheck()
 	if((health <= 0))
 		Break()
-		src.visible_message("<span class='danger'>\The [src] breaks! It was a trap!</span>")
+		src.visible_message(SPAN_DANGER(">\The [src] breaks! It was a trap!"))
 
 /obj/effect/trap/pop_up/update_icon()
 	if(!tripped)

--- a/code/game/objects/effects/traps.dm
+++ b/code/game/objects/effects/traps.dm
@@ -94,6 +94,7 @@ Add those other swinging traps you mentioned above!
 	deploy_location.ChangeTurf(trap_floor_type)
 
 /obj/effect/trap/proc/Break()
+	desc = desc + " Whatever nefarious purpose this one once had, it's broken now."
 	update_icon()
 	broken = TRUE
 
@@ -438,8 +439,11 @@ Add those other swinging traps you mentioned above!
 	return
 
 /obj/effect/trap/pop_up/attackby(var/obj/item/W, var/mob/user)
+	if(broken)
+		return
 	if((health <= 0))
 		Break()
+		src.visible_message("<span class='danger'>\The [src] breaks! It was a trap!</span>")
 		return
 	if(W.attack_verb.len)
 		src.visible_message("<span class='danger'>\The [src] has been [pick(W.attack_verb)] with \the [W][(user ? " by [user]." : ".")]</span>")
@@ -463,6 +467,7 @@ Add those other swinging traps you mentioned above!
 /obj/effect/trap/pop_up/proc/healthcheck()
 	if((health <= 0))
 		Break()
+		src.visible_message("<span class='danger'>\The [src] breaks! It was a trap!</span>")
 
 /obj/effect/trap/pop_up/update_icon()
 	if(!tripped)
@@ -504,6 +509,8 @@ Add those other swinging traps you mentioned above!
 //Spinning Blade Column
 
 /obj/effect/trap/pop_up/pillar
+	name = "loose tile"
+	desc = "The edges of this tile are bent strangely."
 	icon_state = "popup_pillar"
 	min_damage = 10
 	max_damage = 30
@@ -552,6 +559,8 @@ if (istype(AM, /mob/living))
 
 /obj/effect/trap/pop_up/buzzsaw
 	icon_state = "popup_saw"
+	name = "loose tile"
+	desc = "This tile has straight slits running along it."
 	min_damage = 25
 	max_damage = 45
 
@@ -580,6 +589,8 @@ if (istype(AM, /mob/living))
 //Flame Trap
 
 /obj/effect/trap/pop_up/flame
+	name = "loose tile"
+	desc = "The edges of this tile shine strangely."
 	icon_state = "popup_flame"
 	min_damage = 5
 	max_damage = 15

--- a/code/game/objects/effects/traps.dm
+++ b/code/game/objects/effects/traps.dm
@@ -439,6 +439,17 @@ Add those other swinging traps you mentioned above!
 	return
 
 /obj/effect/trap/pop_up/attackby(var/obj/item/W, var/mob/user)
+	if(istype(W, /obj/item/weldingtool))
+		var/obj/item/weldingtool/WT = W
+
+		if(WT.remove_fuel(0, user))
+			if(health < maxhealth)
+				to_chat(user, "<span class='notice'>You begin repairing \the [src.name] with \the [WT].</span>")
+			if(do_after(user, 20, src))
+				health = maxhealth
+				broken = FALSE
+			playsound(src.loc, 'sound/items/Welder.ogg', 100, 1)
+
 	if(broken)
 		return
 	if((health <= 0))
@@ -451,15 +462,7 @@ Add those other swinging traps you mentioned above!
 		src.visible_message("<span class='danger'>\The [src] has been attacked with \the [W][(user ? " by [user]." : ".")]</span>")
 	var/damage = W.force / 4.0
 
-	if(istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = W
 
-		if(WT.remove_fuel(0, user))
-			if(health < maxhealth)
-				to_chat(user, "<span class='notice'>You begin repairing \the [src.name] with \the [WT].</span>")
-			if(do_after(user, 20, src))
-				health = maxhealth
-			playsound(src.loc, 'sound/items/Welder.ogg', 100, 1)
 
 	src.health -= damage
 	healthcheck()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Gives chat and inspection feedback to pop-up traps once they are broken. Adds a name and a description to some traps.

## Why It's Good For The Game

This gives any dungeon dwelling people feedback about the state of hidden traps if they are already trying to disarm them. This also removes the annoying "Contact admins" debug message on inspection of properly mapped traps.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: pop-up trap feedback
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
