### PR TITLE
you can no longer see people examining UI buttons + things inside themselves/carried by them

### DIFF
--- a/code/__HELPERS/atom_movables.dm
+++ b/code/__HELPERS/atom_movables.dm
@@ -1,3 +1,19 @@
+/**
+ * returns the topmost atom on a turf we're in, or null
+ * if a non movable is passed, itself is returned
+ */
+/proc/get_top_level_atom(atom/movable/AM)
+	// if turf or area, return itself
+	if(!istype(AM))
+		return AM
+	// if nullspace, return null
+	if(!AM.loc)
+		return
+	// keep going up until we are on a turf
+	whlie(!isturf(AM.loc))
+		AM = AM.loc
+	return AM
+
 /proc/get_turf_pixel(atom/movable/AM)
 	if(!istype(AM))
 		return

--- a/code/__HELPERS/atom_movables.dm
+++ b/code/__HELPERS/atom_movables.dm
@@ -10,7 +10,7 @@
 	if(!AM.loc)
 		return
 	// keep going up until we are on a turf
-	whlie(!isturf(AM.loc))
+	while(!isturf(AM.loc))
 		AM = AM.loc
 	return AM
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -269,13 +269,12 @@
 		return
 
 	face_atom(A)
-	if(!isobserver(src) && !isturf(A) && A != src)
-		if(A.loc != src)
-			for(var/mob/M in viewers(4, src))
-				if(M == src || M.is_blind())
-					continue
-				if(M.client && M.client.is_preference_enabled(/datum/client_preference/examine_look))
-					to_chat(M, SPAN_TINYNOTICE("<b>\The [src]</b> looks at \the [A]."))
+	if(!isobserver(src) && !isturf(A) && (get_top_level_atom(A) != src) && get_turf(A))
+		for(var/mob/M in viewers(4, src))
+			if(M == src || M.is_blind())
+				continue
+			if(M.client && M.client.is_preference_enabled(/datum/client_preference/examine_look))
+				to_chat(M, SPAN_TINYNOTICE("<b>\The [src]</b> looks at \the [A]."))
 
 	var/list/result
 	if(client)


### PR DESCRIPTION

## About The Pull Request

tin

## Why It's Good For The Game

this makes zero sense

if you wanna be toxic and spam-click examine on the toxin bar when someone you don't like you should do it before we merge this

for the latter, well, it'd really suck if you could spot people examining their own backpack gear and know what name it is on a "stealth gameplay" basis.

## Changelog
:cl:
fix: visible examines showing for atoms not in the world
fix: visible examines showing for atoms within oneself
/:cl:
