### PR TITLE
Removes all nurses, the spider queen, and spiderlings from the cave

### DIFF
--- a/_maps/map_files/rift/rift-06-surface3.dmm
+++ b/_maps/map_files/rift/rift-06-surface3.dmm
@@ -2821,7 +2821,6 @@
 	opacity = 0
 	},
 /obj/machinery/door/airlock/glass_command/polarized{
-	id_tag = null;
 	id_tint = "bridge_tint";
 	name = "Bridge"
 	},
@@ -3576,7 +3575,6 @@
 "fR" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
-	id_tag = null;
 	name = "Laundry"
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -5941,8 +5939,7 @@
 	id = "captaindoor";
 	name = "Office Door";
 	pixel_x = -28;
-	pixel_y = -24;
-	req_one_access = null
+	pixel_y = -24
 	},
 /obj/machinery/light_switch{
 	pixel_x = -18;
@@ -8288,7 +8285,6 @@
 	opacity = 0
 	},
 /obj/machinery/door/airlock/glass_command/polarized{
-	id_tag = null;
 	id_tint = "bridge_tint";
 	name = "Bridge"
 	},
@@ -11592,10 +11588,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/hop)
-"uw" = (
-/obj/effect/spider/spiderling/virgo,
-/turf/simulated/floor/outdoors/safeice/lythios43c/indoors,
-/area/rift/surfacebase/outside/outside3)
 "ux" = (
 /turf/simulated/floor/tiled/monotile,
 /area/rift/trade_shop/landing_pad)
@@ -13352,10 +13344,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/exploration)
-"xA" = (
-/mob/living/simple_mob/animal/giant_spider/nurse,
-/turf/simulated/floor/outdoors/safeice/lythios43c/indoors,
-/area/rift/surfacebase/outside/outside3)
 "xB" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/effect/decal/cleanable/flour,
@@ -19829,7 +19817,6 @@
 	opacity = 0
 	},
 /obj/machinery/door/airlock/glass_command/polarized{
-	id_tag = null;
 	id_tint = "bridge_tint";
 	name = "Bridge"
 	},
@@ -21836,7 +21823,6 @@
 "NN" = (
 /obj/machinery/door/airlock/hatch{
 	icon_state = "door_locked";
-	id_tag = null;
 	locked = 1;
 	name = "AI Core";
 	req_access = list(16)
@@ -22501,8 +22487,7 @@
 	id = "kitchen_shutters";
 	name = "Kitchen Shutter control";
 	pixel_x = -26;
-	pixel_y = 24;
-	req_one_access = null
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -27469,10 +27454,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"Yb" = (
-/mob/living/simple_mob/animal/giant_spider/nurse/queen,
-/turf/simulated/floor/outdoors/safeice/lythios43c/indoors,
-/area/rift/surfacebase/outside/outside3)
 "Yc" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -54283,9 +54264,9 @@ fq
 qY
 fq
 sH
-uw
+GO
 xR
-uw
+GO
 GO
 xR
 sH
@@ -54477,12 +54458,12 @@ fq
 qY
 fq
 GO
-uw
+GO
 GO
 sH
 GO
 GO
-uw
+GO
 fq
 fq
 fq
@@ -54672,7 +54653,7 @@ qY
 fq
 sH
 ya
-xA
+GO
 GO
 xR
 sH
@@ -54868,7 +54849,7 @@ fq
 yd
 GO
 GO
-uw
+GO
 GO
 GO
 GO
@@ -55061,7 +55042,7 @@ fq
 fq
 xR
 GO
-uw
+GO
 Vb
 GO
 GO
@@ -57207,11 +57188,11 @@ Xd
 GO
 fq
 fq
-xA
-uw
 GO
 GO
-uw
+GO
+GO
+GO
 fq
 fq
 fq
@@ -57386,10 +57367,10 @@ fq
 qY
 qY
 fq
-uw
+GO
 As
 GO
-uw
+GO
 GO
 fq
 fq
@@ -57602,7 +57583,7 @@ fq
 fq
 xR
 GO
-uw
+GO
 sH
 fq
 qY
@@ -57774,8 +57755,8 @@ fq
 qY
 fq
 GO
-xA
-uw
+GO
+GO
 GO
 GO
 fq
@@ -58757,7 +58738,7 @@ GO
 GO
 fq
 GO
-uw
+GO
 XH
 GO
 fq
@@ -58944,11 +58925,11 @@ fq
 fq
 fq
 fq
-uw
+GO
 xR
 GO
 GO
-uw
+GO
 GO
 GO
 fq
@@ -59347,11 +59328,11 @@ fq
 fq
 fq
 fq
-uw
+GO
 UF
 GO
 GO
-uw
+GO
 fq
 qY
 fq
@@ -59733,7 +59714,7 @@ fq
 fq
 sH
 Up
-xA
+GO
 GO
 GO
 GO
@@ -59930,7 +59911,7 @@ sH
 JV
 GO
 UF
-Yb
+GO
 GO
 fq
 fq

--- a/_maps/map_files/rift/rift-06-surface3.dmm
+++ b/_maps/map_files/rift/rift-06-surface3.dmm
@@ -20437,10 +20437,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/exploration/explorer_prep)
-"KZ" = (
-/obj/effect/spider/eggcluster/small/frost,
-/turf/simulated/floor/outdoors/safeice/lythios43c/indoors,
-/area/rift/surfacebase/outside/outside3)
 "La" = (
 /obj/structure/grille,
 /obj/structure/foamedmetal,
@@ -24476,7 +24472,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/barrestroom)
 "Sr" = (
-/obj/effect/spider/eggcluster,
 /obj/random/multiple/corp_crate,
 /turf/simulated/floor/outdoors/safeice/lythios43c/indoors,
 /area/rift/surfacebase/outside/outside3)
@@ -25420,10 +25415,6 @@
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/general)
-"Up" = (
-/obj/effect/spider/eggcluster,
-/turf/simulated/floor/outdoors/safeice/lythios43c/indoors,
-/area/rift/surfacebase/outside/outside3)
 "Uq" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -25828,10 +25819,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hydroponics)
-"Vb" = (
-/obj/effect/spider/eggcluster/small,
-/turf/simulated/floor/outdoors/safeice/lythios43c/indoors,
-/area/rift/surfacebase/outside/outside3)
 "Vc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -54071,7 +54058,7 @@ qY
 fq
 fq
 sH
-KZ
+GO
 sH
 GO
 fq
@@ -55043,7 +55030,7 @@ fq
 xR
 GO
 GO
-Vb
+GO
 GO
 GO
 GO
@@ -55235,7 +55222,7 @@ qY
 fq
 fq
 fq
-Vb
+GO
 As
 sH
 GO
@@ -58358,7 +58345,7 @@ fq
 fq
 fq
 sH
-Up
+GO
 fq
 fq
 fq
@@ -58943,7 +58930,7 @@ GO
 GO
 As
 GO
-Up
+GO
 fq
 fq
 qY
@@ -59713,7 +59700,7 @@ fq
 fq
 fq
 sH
-Up
+GO
 GO
 GO
 GO
@@ -60298,7 +60285,7 @@ fq
 fq
 fq
 sH
-Up
+GO
 Ub
 fq
 fq


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Exactly what it says on the tin

## Why It's Good For The Game

Having a cave nearby with things for Security to shoot at when bored is fine and dandy, but allowing this threat to be able to multiply to a constant threat to a valuable research facility and it's staff is utterly unacceptable, and there is no logical reason why NanoTrasen wouldn't have completely cleared out this cave, given it's proximity to the station. I find neutering their growth a acceptable compromise

## Changelog
:cl:
del: Removed a bunch of spiders, and the spider cave's exponential growth
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
