### PR TITLE
Gives Xeno-Hybrids Sonar

### DIFF
--- a/code/modules/species/station/xenomorph_hybrids/xeno_hybrids.dm
+++ b/code/modules/species/station/xenomorph_hybrids/xeno_hybrids.dm
@@ -44,6 +44,7 @@
 	inherent_verbs = list(
 		/mob/living/proc/shred_limb,
 		/mob/living/carbon/human/proc/tie_hair,
+		/mob/living/carbon/human/proc/sonar_ping,
 		/mob/living/carbon/human/proc/psychic_whisper,
 		//mob/living/carbon/human/proc/neurotoxin,//need the acid organ which I dont wanna just give them
 		/mob/living/carbon/human/proc/hybrid_resin,


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives Xeno-Hybrids the sonar ability

## Why It's Good For The Game

Xeno-Hybrids are an eyeless race, they see through vibrations picked up by their dorsal spines on their back. Sonar for them just makes sense.

## Changelog
:cl:
tweak: Xeno-Hybrids not having Sonar
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
