### PR TITLE
make xenohybrid heal passive instead of active(effect stays same)

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -19,8 +19,6 @@
 	var/active_regen_delay = 300
 	var/spam_flag = FALSE	//throws byond:tm: errors if placed in human/emote, but not here
 
-	var/healing = FALSE
-
 /mob/living/carbon/human/Initialize(mapload, datum/species/new_species_or_path)
 	if(!dna)
 		dna = new /datum/dna(null)

--- a/code/modules/species/station/xenomorph_hybrids/hybrid_abilities.dm
+++ b/code/modules/species/station/xenomorph_hybrids/hybrid_abilities.dm
@@ -1,14 +1,3 @@
-/mob/living/carbon/human/proc/active_heal()
-    set name = "Focused Healing"
-    set desc = "You focus on regenerating your wounds."
-    set category = "Abilities"
-
-    src.healing = !src.healing
-    if(healing)
-        to_chat(src, "<span class='notice'>You begin to heal faster.</span>")
-    else
-        to_chat(src, "<span class='notice'>You stop healing faster.</span>")
-
 /mob/living/carbon/human/proc/hybrid_plant()
 	set name = "Plant Weed (10)"
 	set desc = "Plants some alien weeds"

--- a/code/modules/species/station/xenomorph_hybrids/xeno_hybrids.dm
+++ b/code/modules/species/station/xenomorph_hybrids/xeno_hybrids.dm
@@ -47,8 +47,7 @@
 		/mob/living/carbon/human/proc/psychic_whisper,
 		//mob/living/carbon/human/proc/neurotoxin,//need the acid organ which I dont wanna just give them
 		/mob/living/carbon/human/proc/hybrid_resin,
-		/mob/living/carbon/human/proc/hybrid_plant,//replaced from the normal weed node to place a singular weed
-		/mob/living/carbon/human/proc/active_heal
+		/mob/living/carbon/human/proc/hybrid_plant//replaced from the normal weed node to place a singular weed
 		)
 
 	total_health = 110	//Exoskeleton makes you tougher than baseline

--- a/code/modules/species/station/xenomorph_hybrids/xeno_hybrids.dm
+++ b/code/modules/species/station/xenomorph_hybrids/xeno_hybrids.dm
@@ -48,7 +48,7 @@
 		//mob/living/carbon/human/proc/neurotoxin,//need the acid organ which I dont wanna just give them
 		/mob/living/carbon/human/proc/hybrid_resin,
 		/mob/living/carbon/human/proc/hybrid_plant,//replaced from the normal weed node to place a singular weed
-        /mob/living/carbon/human/proc/active_heal
+		/mob/living/carbon/human/proc/active_heal
 		)
 
 	total_health = 110	//Exoskeleton makes you tougher than baseline
@@ -88,7 +88,7 @@
 		O_PLASMA =		/obj/item/organ/internal/xenos/plasmavessel/hunter,//Important for the xenomorph abilities, hunter to have a pretty small plasma capacity
 		O_STOMACH =		/obj/item/organ/internal/stomach,
 		O_INTESTINE =	/obj/item/organ/internal/intestine,
-		O_RESIN =    	/obj/item/organ/internal/xenos/resinspinner,
+		O_RESIN =		/obj/item/organ/internal/xenos/resinspinner,
 		)
 	vision_organ = O_BRAIN//Neomorphs have no (visible) Eyes, seeing without them should be possible.
 
@@ -98,38 +98,36 @@
 	return TRUE	//they dont quite breathe
 
 /datum/species/xenohybrid/handle_environment_special(var/mob/living/carbon/human/H)
-    if(H.healing)
+	var/heal_amount = min(H.nutrition, 200) / 50 //Not to much else we might as well give them a diona like healing
+	H.nutrition = max(H.nutrition-heal_amount,0)
 
-        var/heal_amount = min(H.nutrition, 200) / 50 //Not to much else we might as well give them a diona like healing
-        H.nutrition = max(H.nutrition-heal_amount,0)
+	if(H.resting)
+		heal_amount *= 1.05//resting allows you to heal a little faster
+	var/fire_damage = H.getFireLoss()
+	if(fire_damage >= heal_amount)
+		H.adjustFireLoss(-heal_amount)
+		heal_amount = 0;
+		return
+	if(fire_damage < heal_amount)
+		H.adjustFireLoss(-heal_amount)
+		heal_amount -= fire_damage
 
-        if(H.resting)
-            heal_amount *= 1.05//resting allows you to heal a little faster
-        var/fire_damage = H.getFireLoss()
-        if(fire_damage >= heal_amount)
-            H.adjustFireLoss(-heal_amount)
-            heal_amount = 0;
-            return
-        if(fire_damage < heal_amount)
-            H.adjustFireLoss(-heal_amount)
-            heal_amount -= fire_damage
+	var/trauma_damage = H.getBruteLoss()
+	if(trauma_damage >= heal_amount)
+		H.adjustBruteLoss(-heal_amount)
+		heal_amount = 0;
+		return
+	if(trauma_damage < heal_amount)
+		H.adjustBruteLoss(-heal_amount)
+		heal_amount -= trauma_damage
 
-        var/trauma_damage = H.getBruteLoss()
-        if(trauma_damage >= heal_amount)
-            H.adjustBruteLoss(-heal_amount)
-            heal_amount = 0;
-            return
-        if(trauma_damage < heal_amount)
-            H.adjustBruteLoss(-heal_amount)
-            heal_amount -= trauma_damage
+	var/posion_damage = H.getToxLoss()
+	if(posion_damage >= heal_amount)
+		H.adjustToxLoss(-heal_amount)
+		heal_amount = 0;
+		return
+	if(posion_damage < heal_amount)
+		H.adjustToxLoss(-heal_amount)
+		heal_amount -= posion_damage
 
-        var/posion_damage = H.getToxLoss()
-        if(posion_damage >= heal_amount)
-            H.adjustToxLoss(-heal_amount)
-            heal_amount = 0;
-            return
-        if(posion_damage < heal_amount)
-            H.adjustToxLoss(-heal_amount)
-            heal_amount -= posion_damage
-
-        H.nutrition += heal_amount
+	H.nutrition += heal_amount

--- a/code/modules/species/station/xenomorph_hybrids/xeno_hybrids.dm
+++ b/code/modules/species/station/xenomorph_hybrids/xeno_hybrids.dm
@@ -45,7 +45,6 @@
 		/mob/living/proc/shred_limb,
 		/mob/living/carbon/human/proc/tie_hair,
 		/mob/living/carbon/human/proc/psychic_whisper,
-		//mob/living/carbon/human/proc/neurotoxin,//need the acid organ which I dont wanna just give them
 		/mob/living/carbon/human/proc/hybrid_resin,
 		/mob/living/carbon/human/proc/hybrid_plant//replaced from the normal weed node to place a singular weed
 		)
@@ -54,13 +53,13 @@
 	brute_mod = 0.95 // Chitin is somewhat hard to crack
 	burn_mod = 1.5	// Natural enemy of xenomorphs is fire. Upgraded to Major Burn Weakness. Reduce to Minor if this is too harsh.
 	blood_volume = 560	//Baseline
-	darksight = 5 //Better hunters in the dark.
+	darksight = 6 //Better hunters in the dark.
 	hunger_factor = 0.1 //In exchange, they get hungry a tad faster.
 
 	slowdown = -0.2//Speedboost Tesh have -0.5
 
-	warning_low_pressure = 30//lower than baseline, still not vacuum prove
-	hazard_low_pressure = -1
+	warning_low_pressure = 30//lower than baseline
+	hazard_low_pressure = -1//Vacuum proof
 
 	warning_high_pressure = 325//Both baseline
 	hazard_high_pressure = 550


### PR DESCRIPTION


## Changelog
:cl:
tweak: Tweaked Xenohybrids lose the healing verb, because its passive now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
