### PR TITLE
adds a warning about assuming location-change precedence on dropped()

### DIFF
--- a/code/modules/mob/inventory/items.dm
+++ b/code/modules/mob/inventory/items.dm
@@ -70,6 +70,9 @@
 /**
  * called when a mob drops an item
  *
+ * ! WARNING: You CANNOT assume we are post or pre-move on dropped.
+ * ! If unequipped() deletes the item, loc will be null. Sometimes, loc won't change at all!
+ *
  * dropping is defined as moving out of both equipment slots and hand slots
  */
 /obj/item/proc/dropped(mob/user, flags, atom/newLoc)


### PR DESCRIPTION
people keep doing this historically and it will result in issues.