### PR TITLE
just nulls out fading ion trails instead of setting them to an invalid state

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -417,7 +417,7 @@ steam.start() -- spawns the effect
 			oldposition = current
 			I.setDir(src.holder.dir)
 			flick("ion_fade", I)
-			I.icon_state = "blank"
+			I.icon_state = null
 			QDEL_IN(I, 20)
 
 /datum/effect_system/ion_trail_follow/proc/stop()


### PR DESCRIPTION
bad practice to do the latter, the former isn't much better but it's cheap when the last fix pr to fix the null state is done.