### PR TITLE
Fixes Prometheans glow

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -285,7 +285,13 @@
 			set_light(0)
 	else
 		if(species.species_appearance_flags & RADIATION_GLOWS)
-			set_light(max(1,min(5,radiation/15)), max(1,min(10,radiation/25)), species.get_flesh_colour(src))
+			var/rad_glow_range = max(1,min(5,radiation/15))
+			var/rad_glow_intensity = max(1,min(10,radiation/25))
+			if(glow_toggle)//if body glow is larger or brighter than rad glow, it wins
+				if(glow_range > rad_glow_range || glow_intensity > rad_glow_intensity)
+					set_light(glow_range, glow_intensity, glow_color)
+			else
+				set_light(rad_glow_range, rad_glow_intensity, species.get_flesh_colour(src))
 		// END DOGSHIT SNOWFLAKE
 
 		var/obj/item/organ/internal/diona/nutrients/rad_organ = locate() in internal_organs

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -221,6 +221,10 @@
 		set_light(glow_range, glow_intensity, glow_color)
 
 	else
+		if(istype(src, /mob/living/carbon))
+			var/mob/living/carbon/C = src
+			if(C.species?.species_appearance_flags & RADIATION_GLOWS)
+				return FALSE//When we glow with rads this is handled in handle_mutations_and_radiation()
 		set_light(0)
 		return FALSE
 


### PR DESCRIPTION
## Changelog
:cl:
fix: fixed radiation glow on creatures
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
