### PR TITLE
[S] Fixes a small vulnerability in fail2topic

### DIFF
--- a/code/controllers/subsystem/fail2topic.dm
+++ b/code/controllers/subsystem/fail2topic.dm
@@ -47,6 +47,11 @@ SUBSYSTEM_DEF(fail2topic)
 /datum/controller/subsystem/fail2topic/Shutdown()
 	DropFirewallRule()
 
+/datum/controller/subsystem/fail2topic/vv_edit_var(var_name, var_value)
+	if(var_name == NAMEOF(src, rule_name))
+		return FALSE
+	return ..()
+
 /datum/controller/subsystem/fail2topic/CanProcCall(procname)
 	. = ..()
 	if(.)

--- a/code/controllers/subsystem/fail2topic.dm
+++ b/code/controllers/subsystem/fail2topic.dm
@@ -47,7 +47,19 @@ SUBSYSTEM_DEF(fail2topic)
 /datum/controller/subsystem/fail2topic/Shutdown()
 	DropFirewallRule()
 
+/datum/controller/subsystem/fail2topic/CanProcCall(procname)
+	. = ..()
+	if(.)
+		switch(procname)
+			if("IsRateLimited")
+				return FALSE
+			if("BanFromFirewall")
+				return FALSE
+
 /datum/controller/subsystem/fail2topic/proc/IsRateLimited(ip)
+	if(IsAdminAdvancedProcCall())
+		return
+
 	var/last_attempt = rate_limiting[ip]
 
 	var/static/datum/config_entry/keyed_list/topic_rate_limit_whitelist/cached_whitelist_entry
@@ -84,6 +96,8 @@ SUBSYSTEM_DEF(fail2topic)
 
 /datum/controller/subsystem/fail2topic/proc/BanFromFirewall(ip)
 	if (!enabled)
+		return
+	if(IsAdminAdvancedProcCall())
 		return
 
 	active_bans[ip] = world.time


### PR DESCRIPTION
No changelog due to no player-facing changes. This disables the ability for admins to call the procs that handle firewall blacklisting in fail2topic, patching a vulnerability in the process.