### PR TITLE
Fixes people in mechs not loading the z they're on

### DIFF
--- a/code/controllers/subsystem/ai.dm
+++ b/code/controllers/subsystem/ai.dm
@@ -24,8 +24,8 @@ SUBSYSTEM_DEF(ai)
 		for(var/played_mob in player_list)
 			if(!played_mob || isobserver(played_mob))
 				continue
-			var/mob/pm = played_mob
-			busy_z_levels |= pm.z
+			var/turf/player_turf = get_turf(played_mob)
+			busy_z_levels |= player_turf?.z
 
 	//cache for sanic speed (lists are references anyways)
 	var/list/currentrun = src.currentrun


### PR DESCRIPTION
## Changelog
:cl:
fix: fixed people in mechs not loading the z they are on
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
