### PR TITLE
sanity check for job equip id proc

### DIFF
--- a/code/modules/jobs/outfit.dm
+++ b/code/modules/jobs/outfit.dm
@@ -15,6 +15,8 @@
 
 /datum/outfit/job/equip_id(mob/living/carbon/human/H, rank, assignment)
 	var/obj/item/card/id/C = ..()
+	if(!C)
+		return
 	var/datum/job/J = job_master.GetJob(rank)
 	if(J)
 		C.access = J.get_access()


### PR DESCRIPTION
if we don't spawn an ID for some reason we should probably not runtime