### PR TITLE
Hopefully fixes simple mobs dropping organs

### DIFF
--- a/code/modules/mob/living/butchering.dm
+++ b/code/modules/mob/living/butchering.dm
@@ -27,6 +27,8 @@
 
 	/// Does it gib when butchered?
 	var/gib_on_butchery = FALSE
+	/// Does it drop or spawn in organs to drop when butchered?
+	var/butchery_drops_organs = TRUE
 	/// Associated list, path = number.
 	var/list/butchery_loot
 
@@ -63,7 +65,7 @@
 				butchery_loot.Cut()
 				butchery_loot = null
 
-		if(LAZYLEN(organs))
+		if(LAZYLEN(organs)&& butchery_drops_organs)
 			organs_by_name.Cut()
 
 			for(var/path in organs)
@@ -85,7 +87,7 @@
 				OR.removed()
 				organs -= OR
 
-		if(LAZYLEN(internal_organs))
+		if(LAZYLEN(internal_organs)&& butchery_drops_organs)
 			internal_organs_by_name.Cut()
 
 			for(var/path in internal_organs)

--- a/code/modules/mob/living/organs.dm
+++ b/code/modules/mob/living/organs.dm
@@ -21,20 +21,21 @@
 	return organs_by_name[zone]
 
 /mob/living/gib()
-	for(var/path in internal_organs)
-		if(ispath(path))
-			var/obj/item/organ/neworg = new path(src, TRUE)
-			internal_organs -= path
-			neworg.name = "[name] [neworg.name]"
-			neworg.meat_type = meat_type
-			internal_organs |= neworg
+	if(butchery_drops_organs)
+		for(var/path in internal_organs)
+			if(ispath(path))
+				var/obj/item/organ/neworg = new path(src, TRUE)
+				internal_organs -= path
+				neworg.name = "[name] [neworg.name]"
+				neworg.meat_type = meat_type
+				internal_organs |= neworg
 
-	for(var/obj/item/organ/I in internal_organs)
-		I.removed()
-		if(isturf(I?.loc)) // Some organs qdel themselves or other things when removed
-			I.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),30)
+		for(var/obj/item/organ/I in internal_organs)
+			I.removed()
+			if(isturf(I?.loc)) // Some organs qdel themselves or other things when removed
+				I.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),30)
 
-	for(var/obj/item/organ/external/E in src.organs)
-		if(!ispath(E))
-			E.droplimb(0,DROPLIMB_EDGE,1)
+		for(var/obj/item/organ/external/E in src.organs)
+			if(!ispath(E))
+				E.droplimb(0,DROPLIMB_EDGE,1)
 	..()

--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -247,6 +247,9 @@
 	var/limb_icon
 	/// Used for if the mob can drop limbs. Overrides the icon cache key, so it doesn't keep remaking the icon needlessly.
 	var/limb_icon_key
+	
+	///Does the simple mob drop organs when butchered?
+	butchery_drops_organs = FALSE
 
 //* randomization code. *//
 /mob/living/simple_mob/proc/randomize()


### PR DESCRIPTION
## About The Pull Request

Apparently simple mobs still dropped organs after being gibbed or butchered for whatever reason, of which has been used for hilarious but detrimental effect when people get insta-deaded by a pile of mouse livers and lungs rocketing at them

## Why It's Good For The Game

Should also help claw back a little bit of processing as it's no longer keeping track of fifty mob organs all in varying levels of decay as time passes.

## Changelog

add: Added a var for mobs to have organs drop on gibbing, humans have this on by default but simple mobs do not. (many monkeys died to test this out.)
fix: Fixed simple mobs dropping organs that they weren't supposed to have in the first place upon being butchered or gibbed. (Apparently it'd spawn them an entirely fresh new set of organs upon being gibbed for whatever reason, even holodeck carp)
/:cl:
