### PR TITLE
Removes AR-V Goggles From Pathfinder Locker and Survey Vendor

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/explorer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/explorer.dm
@@ -155,7 +155,6 @@
 		/obj/item/reagent_containers/food/snacks/liquidfood,
 		/obj/item/reagent_containers/food/snacks/liquidprotein,
 		/obj/item/card/mining_point_card/survey/gimmick,
-		/obj/item/clothing/glasses/omnihud/exp,
 		/obj/item/cataloguer/compact/pathfinder)
 
 /obj/structure/closet/secure_closet/pathfinder/Initialize(mapload)

--- a/code/modules/mining/ore_redemption_machine/survey_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/survey_vendor.dm
@@ -35,6 +35,7 @@
 		new /datum/data/mining_equipment("Nanopaste Tube",				/obj/item/stack/nanopaste,									100),
 		new /datum/data/mining_equipment("Mini-Translocator",			/obj/item/perfect_tele/one_beacon,							120),
 		//new /datum/data/mining_equipment("UAV - Recon Skimmer",			/obj/item/uav,												400),
+		new /datum/data/mining_equipment("Binoculars",					/obj/item/binoculars,										100),
 		new /datum/data/mining_equipment("Space Cash",					/obj/item/spacecash/c100,									100),
 		new /datum/data/mining_equipment("Jump Boots",					/obj/item/clothing/shoes/bhop,								250),
 		new /datum/data/mining_equipment("Luxury Shelter Capsule",		/obj/item/survivalcapsule/luxury,							310),

--- a/code/modules/mining/ore_redemption_machine/survey_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/survey_vendor.dm
@@ -35,7 +35,6 @@
 		new /datum/data/mining_equipment("Nanopaste Tube",				/obj/item/stack/nanopaste,									100),
 		new /datum/data/mining_equipment("Mini-Translocator",			/obj/item/perfect_tele/one_beacon,							120),
 		//new /datum/data/mining_equipment("UAV - Recon Skimmer",			/obj/item/uav,												400),
-		new /datum/data/mining_equipment("AR-V Glasses",				/obj/item/clothing/glasses/omnihud/exp,						350),
 		new /datum/data/mining_equipment("Space Cash",					/obj/item/spacecash/c100,									100),
 		new /datum/data/mining_equipment("Jump Boots",					/obj/item/clothing/shoes/bhop,								250),
 		new /datum/data/mining_equipment("Luxury Shelter Capsule",		/obj/item/survivalcapsule/luxury,							310),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. *Removes AR-V Goggles from Pathfinder Locker and Survey Vendor.*

## Why It's Good For The Game

1. _Yay Explo powercreep. We're gonna just get rid of these._

## Changelog
:cl:
del: Removes AR-V vectors for Explo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
