### PR TITLE
Salvation for Engineering

### DIFF
--- a/_maps/map_files/rift/rift-06-surface3.dmm
+++ b/_maps/map_files/rift/rift-06-surface3.dmm
@@ -3434,12 +3434,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway2)
 "fJ" = (
-/obj/structure/lattice,
-/obj/machinery/door/firedoor/glass,
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/simulated/floor/plating,
 /area/maintenance/bar)
 "fK" = (
 /obj/effect/floor_decal/spline/plain,
@@ -16121,6 +16119,13 @@
 /atom/movable/map_helper/airlock/sensor/int_sensor,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/excursion/general)
+"Dy" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
 "Dz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18370,7 +18375,8 @@
 /area/ai_upload)
 "HX" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Ground Defence Access"
+	name = "Ground Defence Access";
+	req_one_access = list(1,10,15)
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rift/surfaceeva/aa/cliff_south)
@@ -20321,7 +20327,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/rift/surfacebase/outside/outside3)
+/area/bridge/bunker)
 "LI" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/material/ashtray/glass,
@@ -21337,7 +21343,8 @@
 /area/shuttle/courser/cockpit)
 "NE" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Ground Defence Access"
+	name = "Ground Defence Access";
+	req_one_access = list(1,10,15)
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rift/surfaceeva/aa/cliff_north)
@@ -40306,7 +40313,7 @@ WU
 cH
 vz
 Rc
-aF
+Dy
 Zx
 su
 RF


### PR DESCRIPTION
the stupid unecessary atmos hole in bar maint is gone :crabdance:

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Removes the Open Space in Bar maint
Also fixes access on the surface 3 bunkers.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because Engineering suffers enough, they don't need a sinle uncessary open space venting a whole floor to the outside to make their jobs even more thankless.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Removed Open space in Bar Maint
fix: Access on Surface 3 Bunkers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
