### PR TITLE
Allows people with synthetic voiceboxes to use synthetic emotes

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -33,7 +33,8 @@
 		//Machine-only emotes
 		if("ping", "beep", "buzz", "yes", "ye", "no", "dwoop", "scary", "rcough", "rsneeze", "honk", "buzz2", "warn", "chime", "startup", "shutdown", "error", "die")
 
-			if(!isSynthetic())
+			var/obj/item/organ/o = internal_organs_by_name[O_VOICE]
+			if(!isSynthetic() && (!o || !(o.robotic >= ORGAN_ASSISTED)))
 				to_chat(src, "<span class='warning'>You are not a synthetic.</span>")
 				return
 
@@ -186,7 +187,7 @@
 				if (param)
 					message = "extends their inner jaw outwards giving [param] a kiss."
 			m_type = 1
-	
+
 		if("kiss")
 			var/next_to_target = FALSE
 			var/M = null
@@ -220,7 +221,7 @@
 				if (param)
 					message = "smooches [param]."
 			m_type = 1
-		
+
 		if ("blink")
 			message = "blinks."
 			m_type = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the synthetic check to also factor in synthetic voiceboxes for the purpose of synth emotes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows more emote flexibility for those logically able to use synthetic emotes.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Allows anyone with a synthetic voicebox to use synthetic emotes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
