### PR TITLE
Removes Cult Mobs from Surt

### DIFF
--- a/_maps/map_levels/192x192/lavaland.dmm
+++ b/_maps/map_levels/192x192/lavaland.dmm
@@ -20,10 +20,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/lavaland/central/base/common)
-"bJ" = (
-/mob/living/simple_mob/construct/shade/surt,
-/turf/simulated/floor/outdoors/lavaland,
-/area/lavaland/central/explored)
 "bM" = (
 /turf/simulated/wall/lavaland,
 /area/lavaland/central/transit)
@@ -6775,13 +6771,13 @@ MX
 MX
 MX
 gy
-bJ
 gy
 gy
 gy
 gy
 gy
-bJ
+gy
+gy
 gy
 MX
 MX
@@ -8414,7 +8410,7 @@ DG
 DG
 DG
 MX
-bJ
+gy
 MX
 MX
 MX
@@ -9194,7 +9190,7 @@ MX
 MX
 MX
 MX
-bJ
+gy
 MX
 MX
 gy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Removes the Shades from Surt.**

## Why It's Good For The Game

1. _These guys were thrown in before we got the cyberhorror storyline set up. Now that the horror aura works, it's a little less fun to keep them around._

## Changelog
:cl:
del: Removes cult mobs from Surt.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
