### PR TITLE
Adds an Open Space Pitfall Trap

### DIFF
--- a/code/game/objects/effects/traps.dm
+++ b/code/game/objects/effects/traps.dm
@@ -305,6 +305,7 @@ Add those other swinging traps you mentioned above!
 	var/burst_shots = 3
 	var/last_shot = 0
 	var/shot_number = 0
+	var/faction = "trap"
 
 	var/burst_delay = 2
 	var/initial_fire_delay = 5

--- a/code/game/objects/effects/traps.dm
+++ b/code/game/objects/effects/traps.dm
@@ -305,7 +305,6 @@ Add those other swinging traps you mentioned above!
 	var/burst_shots = 3
 	var/last_shot = 0
 	var/shot_number = 0
-	var/faction = "trap"
 
 	var/burst_delay = 2
 	var/initial_fire_delay = 5

--- a/code/game/objects/effects/traps.dm
+++ b/code/game/objects/effects/traps.dm
@@ -153,6 +153,9 @@ Add those other swinging traps you mentioned above!
 /obj/effect/trap/pit/blood/deep
 	trap_floor_type = /turf/simulated/floor/water/blood/deep
 
+/obj/effect/trap/pit/open_space
+	trap_floor_type = /turf/simulated/open
+
 //Punji Spear Traps
 /obj/effect/trap/pit/punji
 	icon_state = "punji"

--- a/code/game/objects/effects/traps.dm
+++ b/code/game/objects/effects/traps.dm
@@ -339,7 +339,7 @@ Add those other swinging traps you mentioned above!
 		playsound(src.loc, projectile_sound, 25, 1)
 
 		var/obj/item/projectile/bullet/shotgun/stake/P = get_projectile()
-		P.firer = src
+		//P.firer = src
 		P.fire(dir2angle(dir))
 
 /obj/effect/trap/launcher/proc/get_initial_fire_delay()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Adds a pitfall trap that drops you down a Z level.**
2. **Gives Launchers a Faction.**

## Why It's Good For The Game

1. _Heheheh. Chutes and ladders._
2. _I don't know why this is necessary, but checks are runtiming when the launchers fire without having one._

## Changelog
:cl:
add: Adds an open space turf.
add: Adds a faction to launchers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
