### PR TITLE
Tyrmalin Heavy Charges Now Have to be Crafted

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -286,6 +286,17 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
+/datum/crafting_recipe/tyrmalin_heavy
+	name = "Tyrmalin heavy-duty mining charge"
+	result = /obj/item/grenade/explosive/ied/tyrmalin/large
+	reqs = list(/obj/item/grenade/explosive/ied/tyrmalin = 4,
+				/obj/item/duct_tape_piece = 8)
+	parts = list(/obj/item/grenade/explosive/ied/tyrmalin = 4,
+				/obj/item/duct_tape_piece = 8)
+	time = 15
+	category = CAT_WEAPONRY
+	subcategory = CAT_OTHER
+
 //////////////////
 ///GUNS CRAFTING//
 //////////////////
@@ -513,7 +524,7 @@
 	time = 5
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
-	
+
 /datum/crafting_recipe/leadball
 	name = "Lead Ball"
 	result = /obj/item/ammo_casing/musket

--- a/code/modules/cargo/supplypacks/supply.dm
+++ b/code/modules/cargo/supplypacks/supply.dm
@@ -145,7 +145,6 @@
 	contains = list(
 			/obj/item/melee/thermalcutter = 1,
 			/obj/item/pickaxe/tyrmalin = 2,
-			/obj/item/grenade/explosive/ied/tyrmalin/large = 1,
 			/obj/item/grenade/explosive/ied/tyrmalin = 2
 			)
 	cost = 120


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Changes Tyrmalin Heavy Charges to craftables.**

## Why It's Good For The Game

1. _Four Tyrmalin charges and eight pieces of duct tape = one heavy charge. Supply packs currently only provide two charges, so you can't just print one out straight out of the gate._

## Changelog
:cl:
balance: Tweaks Tyrmalin heavy charge distribution.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
