### PR TITLE
"Fixes" a xenoarcheology bug that prevented artifacts from being found ever

### DIFF
--- a/code/controllers/subsystem/xenoarch.dm
+++ b/code/controllers/subsystem/xenoarch.dm
@@ -109,6 +109,8 @@ SUBSYSTEM_DEF(xenoarch)
 		to_make += pick_n_take(artifact_spawning_turfs)
 
 	var/list/artifacts_spawnturf_temp = to_make.Copy()
+	LAZYCLEARLIST(artifact_spawning_turfs)
+	artifact_spawning_turfs = LAZYCOPY(to_make)
 	while(artifacts_spawnturf_temp.len)
 		var/turf/simulated/mineral/artifact_turf = artifacts_spawnturf_temp[artifacts_spawnturf_temp.len]
 		--artifacts_spawnturf_temp.len

--- a/code/modules/xenoarcheaology/tools/tools.dm
+++ b/code/modules/xenoarcheaology/tools/tools.dm
@@ -66,8 +66,6 @@
 						if(nearestTargetDist < 0 || cur_dist < nearestTargetDist)
 							nearestTargetDist = cur_dist + rand() * 2 - 1
 							nearestTargetId = T.artifact_find.artifact_id
-				else
-					SSxenoarch.artifact_spawning_turfs.Remove(T)
 
 			for(var/A in SSxenoarch.digsite_spawning_turfs)
 				var/turf/simulated/mineral/T = A


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
For some reason the anomaly scanner deletes the subsystem list (all of it). I instead move the list pruning to where it should be -- when artifacts are actually generated. 

the code is hot shit and this fix is hot shit
but it works roughly as intended now
## Why It's Good For The Game
you can find artifacts now

## Changelog
:cl:
fix:xenoarch bug
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
