### PR TITLE
Fixes Bone Plantcutter Icon Issue

### DIFF
--- a/_maps/submaps/level_specific/lavaland/ashlandercamp.dmm
+++ b/_maps/submaps/level_specific/lavaland/ashlandercamp.dmm
@@ -26,6 +26,9 @@
 /obj/fiftyspawner/wood,
 /obj/fiftyspawner/wood,
 /obj/fiftyspawner/bone,
+/obj/item/shovel/spade/bone{
+	pixel_x = -2
+	},
 /obj/item/pickaxe/bone,
 /turf/simulated/floor/outdoors/lavaland/indoors,
 /area/lavaland/ashlander_camp)
@@ -34,14 +37,12 @@
 /obj/item/seeds/ashlander/bentars,
 /obj/item/seeds/ashlander/juhtak,
 /obj/item/seeds/ashlander,
-/obj/item/shovel/spade/bone{
-	pixel_x = -2
-	},
+/obj/item/tool/wirecutters/clippers/bone,
+/obj/item/material/minihoe/bone,
 /obj/item/material/knife/machete/hatchet/bone{
 	pixel_x = 2;
 	pixel_y = 2
 	},
-/obj/item/tool/wirecutters/clippers/bone,
 /turf/simulated/floor/outdoors/lavaland/indoors,
 /area/lavaland/ashlander_camp)
 "R" = (

--- a/code/modules/hydroponics/trays/tray_tools.dm
+++ b/code/modules/hydroponics/trays/tray_tools.dm
@@ -3,6 +3,7 @@
 /obj/item/tool/wirecutters/clippers
 	name = "plant clippers"
 	desc = "A tool used to take samples from plants."
+	random_color = FALSE
 
 /obj/item/tool/wirecutters/clippers/bone
 	name = "bone plant clippers"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Fixes color change inheritance on plantcutters.**

## Why It's Good For The Game

1. _As it says._

## Changelog
:cl:
fix: Corrects inheritance of color changing var.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
