### PR TITLE
Adjusts Horror Aura Subtyping

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/horror/Eddy.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/horror/Eddy.dm
@@ -40,6 +40,10 @@
 	hide_amount = 1
 	exotic_amount = 5
 
+/mob/living/simple_mob/horror/Eddy/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/horror_aura/weak)
+
 /mob/living/simple_mob/horror/Eddy/death()
 	playsound(src, 'sound/h_sounds/headcrab.ogg', 50, 1)
 	..()

--- a/code/modules/mob/living/simple_mob/subtypes/horror/Master.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/horror/Master.dm
@@ -41,6 +41,10 @@
 	hide_amount = 2
 	exotic_amount = 2
 
+/mob/living/simple_mob/horror/Master/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/horror_aura/strong)
+
 /mob/living/simple_mob/horror/Master/death()
 	playsound(src, 'sound/h_sounds/imbeciles.ogg', 50, 1)
 	..()

--- a/code/modules/mob/living/simple_mob/subtypes/horror/Rickey.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/horror/Rickey.dm
@@ -42,6 +42,10 @@
 	hide_amount = 2
 	exotic_amount = 2
 
+/mob/living/simple_mob/horror/Rickey/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/horror_aura/weak)
+
 /mob/living/simple_mob/horror/Rickey/death()
 	playsound(src, 'sound/h_sounds/headcrab.ogg', 50, 1)
 	..()

--- a/code/modules/mob/living/simple_mob/subtypes/horror/Smiley.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/horror/Smiley.dm
@@ -41,6 +41,10 @@
 	bone_amount = 10
 	hide_amount = 5
 
+/mob/living/simple_mob/horror/Smiley/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/horror_aura/weak)
+
 /mob/living/simple_mob/horror/Smiley/death()
 	playsound(src, 'sound/h_sounds/lynx.ogg', 50, 1)
 	..()

--- a/code/modules/mob/living/simple_mob/subtypes/horror/Steve.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/horror/Steve.dm
@@ -46,6 +46,10 @@
 	exotic_amount = 2
 	hide_amount = 1
 
+/mob/living/simple_mob/horror/Steve/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/horror_aura)
+
 /mob/living/simple_mob/horror/Steve/death()
 	playsound(src, 'sound/h_sounds/holla.ogg', 50, 1)
 	..()

--- a/code/modules/mob/living/simple_mob/subtypes/horror/Willy.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/horror/Willy.dm
@@ -42,6 +42,10 @@
 	hide_amount = 10
 	hide_type = /obj/item/stack/material/cloth
 
+/mob/living/simple_mob/horror/Willy/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/horror_aura)
+
 /mob/living/simple_mob/horror/Willy/death()
 	playsound(src, 'sound/h_sounds/sampler.ogg', 50, 1)
 	..()

--- a/code/modules/mob/living/simple_mob/subtypes/horror/bradley.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/horror/bradley.dm
@@ -40,6 +40,10 @@
 	hide_amount = 2
 	exotic_amount = 5
 
+/mob/living/simple_mob/horror/bradley/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/horror_aura/weak)
+
 /mob/living/simple_mob/horror/bradley/death()
 	playsound(src, 'sound/h_sounds/mumble.ogg', 50, 1)
 	..()

--- a/code/modules/mob/living/simple_mob/subtypes/horror/horror .dm
+++ b/code/modules/mob/living/simple_mob/subtypes/horror/horror .dm
@@ -59,7 +59,3 @@
 	max_n2 = 0
 	minbodytemp = 0
 	maxbodytemp = 700
-
-/mob/living/simple_mob/horror/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/horror_aura)

--- a/code/modules/mob/living/simple_mob/subtypes/horror/sally.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/horror/sally.dm
@@ -39,6 +39,10 @@
 	hide_amount = 10
 	exotic_amount = 5
 
+/mob/living/simple_mob/horror/Sally/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/horror_aura)
+
 /mob/living/simple_mob/horror/Sally/death()
 	playsound(src, 'sound/h_sounds/lynx.ogg', 50, 1)
 	..()

--- a/code/modules/mob/living/simple_mob/subtypes/horror/shittytim.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/horror/shittytim.dm
@@ -40,6 +40,10 @@
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/human
 	bone_amount = 3
 
+/mob/living/simple_mob/horror/BigTim/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/horror_aura)
+
 /mob/living/simple_mob/horror/BigTim/death()
 	playsound(src, 'sound/h_sounds/shitty_tim.ogg', 50, 1)
 	..()

--- a/code/modules/mob/living/simple_mob/subtypes/horror/timling.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/horror/timling.dm
@@ -40,6 +40,10 @@
 	hide_amount = 5
 	exotic_amount = 1
 
+/mob/living/simple_mob/horror/TinyTim/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/horror_aura)
+
 /mob/living/simple_mob/horror/TinyTim/death()
 	playsound(src, 'sound/h_sounds/shitty_tim.ogg', 50, 1)
 	..()

--- a/code/modules/mob/living/simple_mob/subtypes/occult/constructs/_construct.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/constructs/_construct.dm
@@ -133,7 +133,6 @@
 	for(var/spell in construct_spells)
 		src.add_spell(new spell, "const_spell_ready")
 	updateicon()
-	AddComponent(/datum/component/horror_aura/strong)
 
 /*
 /mob/living/simple_mob/construct/update_icon()

--- a/code/modules/mob/living/simple_mob/subtypes/occult/constructs/artificer.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/constructs/artificer.dm
@@ -41,6 +41,10 @@
 
 	ai_holder_type = /datum/ai_holder/mimic
 
+/mob/living/simple_mob/construct/artificer/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/horror_aura)
+
 ////////////////////////////
 //		Ranged Artificer
 ////////////////////////////

--- a/code/modules/mob/living/simple_mob/subtypes/occult/constructs/harvester.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/constructs/harvester.dm
@@ -52,6 +52,10 @@
 			/spell/rune_write
 		)
 
+/mob/living/simple_mob/construct/harvester/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/horror_aura/strong)
+
 ////////////////////////////
 //		Greater Harvester
 ////////////////////////////

--- a/code/modules/mob/living/simple_mob/subtypes/occult/constructs/juggernaut.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/constructs/juggernaut.dm
@@ -59,6 +59,10 @@
 	SetWeakened(0)
 	return ..()
 
+/mob/living/simple_mob/construct/juggernaut/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/horror_aura/strong)
+
 /mob/living/simple_mob/construct/juggernaut/bullet_act(var/obj/item/projectile/P)
 	var/reflectchance = 80 - round(P.damage/3)
 	if(prob(reflectchance))

--- a/code/modules/mob/living/simple_mob/subtypes/occult/constructs/proteon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/constructs/proteon.dm
@@ -31,3 +31,7 @@
 	catalogue_data = list(/datum/category_item/catalogue/fauna/construct/proteon)
 
 	ai_holder_type = /datum/ai_holder/simple_mob/melee/evasive
+
+/mob/living/simple_mob/construct/proteon/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/horror_aura)

--- a/code/modules/mob/living/simple_mob/subtypes/occult/constructs/shade.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/constructs/shade.dm
@@ -38,6 +38,10 @@
 
 	ai_holder_type = /datum/ai_holder/simple_mob/melee
 
+/mob/living/simple_mob/construct/shade/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/horror_aura/weak)
+
 /mob/living/simple_mob/construct/shade/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(istype(O, /obj/item/soulstone))
 		var/obj/item/soulstone/S = O;

--- a/code/modules/mob/living/simple_mob/subtypes/occult/constructs/wraith.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/constructs/wraith.dm
@@ -44,6 +44,10 @@
 
 //	environment_smash = 1	// Whatever this gets renamed to, Wraiths need to break things
 
+/mob/living/simple_mob/construct/wraith/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/horror_aura)
+
 /mob/living/simple_mob/construct/wraith/apply_melee_effects(var/atom/A)
 	if(isliving(A))
 		var/mob/living/L = A


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Assigns the Horror Aura to Individual Mob Types.**

## Why It's Good For The Game

1. _Originally the aura was applied to every type of a mob, which has led to some unexpected issues. I've added the aura directly to each mobtype to prevent issues like this in the future. This has also allowed for more fine tuning of the aura strength per mob._

## Changelog
:cl:
tweak: Tweaks how the horror aura is assigned to mobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
