### PR TITLE
Fixes Turf Edge Blending (Because otherwise you'll all just deal with pink triangles and do nothing for a year.)

### DIFF
--- a/code/game/turfs/simulated/floor_types_eris.dm
+++ b/code/game/turfs/simulated/floor_types_eris.dm
@@ -874,7 +874,7 @@
 /turf/simulated/floor/outdoors/grass/heavy
 	name = "heavy grass"
 	icon_state = "grass-heavy0"
-	edge_blending_priority = 4
+	edge_blending_priority = 0
 	initial_flooring = /decl/flooring/grass/heavy
 	baseturfs = /turf/simulated/floor/outdoors/dirt
 	grass_chance = 40
@@ -887,6 +887,7 @@
     name = "heavy grass"
     desc = "A dense sheet of harvested turf used in interior decoration."
     outdoors = FALSE
+
 //=========Eris Plating==========\\
 // This is the light grey tiles with random geometric shapes extruded
 /decl/flooring/eris_plating

--- a/code/game/turfs/simulated/floors/dirt.dm
+++ b/code/game/turfs/simulated/floors/dirt.dm
@@ -6,6 +6,9 @@
 	initial_flooring = /decl/flooring/outdoors/dirt
 	baseturfs = /turf/baseturf_bottom
 
+/turf/simulated/floor/outdoors/dirt
+	outdoors = FALSE
+
 /turf/simulated/floor/outdoors/dirtlight
 	name = "dirt"
 	desc = "Quite dirty!"
@@ -13,3 +16,6 @@
 	edge_blending_priority = 0
 	initial_flooring = /decl/flooring/outdoors/dirt
 	baseturfs = /turf/baseturf_bottom
+
+/turf/simulated/floor/outdoors/dirtlight
+	outdoors = FALSE

--- a/code/game/turfs/simulated/floors/dirt.dm
+++ b/code/game/turfs/simulated/floors/dirt.dm
@@ -2,7 +2,7 @@
 	name = "dirt"
 	desc = "Quite dirty!"
 	icon_state = "dirt-dark"
-	edge_blending_priority = 2
+	edge_blending_priority = 0
 	initial_flooring = /decl/flooring/outdoors/dirt
 	baseturfs = /turf/baseturf_bottom
 
@@ -10,6 +10,6 @@
 	name = "dirt"
 	desc = "Quite dirty!"
 	icon_state = "dirt-light"
-	edge_blending_priority = 2
+	edge_blending_priority = 0
 	initial_flooring = /decl/flooring/outdoors/dirt
 	baseturfs = /turf/baseturf_bottom

--- a/code/game/turfs/simulated/floors/grass.dm
+++ b/code/game/turfs/simulated/floors/grass.dm
@@ -5,7 +5,6 @@ var/list/grass_types = list(
 /turf/simulated/floor/outdoors/grass
 	name = "grass"
 	icon_state = "grass"
-	edge_blending_priority = 4
 	initial_flooring = /decl/flooring/outdoors/grass
 	baseturfs = /turf/simulated/floor/outdoors/dirt
 	var/grass_chance = 20
@@ -27,7 +26,6 @@ var/list/grass_types = list(
 	name = "growth"
 	icon_state = "grass_sif"
 	initial_flooring = /decl/flooring/outdoors/grass/sif
-	edge_blending_priority = 4
 	grass_chance = 5
 	var/tree_chance = 2
 
@@ -59,12 +57,9 @@ var/list/grass_types = list(
 	icon_state = "grass-dark"
 	grass_chance = 80
 	//tree_chance = 20
-	edge_blending_priority = 5
 
 /turf/simulated/floor/outdoors/grass/sif/forest
 	name = "thick growth"
 	icon_state = "grass_sif_dark"
-	edge_blending_priority = 5
 	tree_chance = 10
 	grass_chance = 0
-

--- a/code/game/turfs/simulated/floors/lava.dm
+++ b/code/game/turfs/simulated/floors/lava.dm
@@ -6,7 +6,7 @@
 	gender = PLURAL // So it says "That's some lava." on examine.
 	icon = 'icons/turf/outdoors.dmi'
 	icon_state = "lava"
-	edge_blending_priority = 4
+	edge_blending_priority = 1
 	light_range = 2
 	light_power = 0.75
 	light_color = LIGHT_COLOR_LAVA

--- a/code/game/turfs/simulated/floors/outdoors.dm
+++ b/code/game/turfs/simulated/floors/outdoors.dm
@@ -12,13 +12,11 @@
 /turf/simulated/floor/outdoors/mud
 	name = "mud"
 	icon_state = "mud_dark"
-	edge_blending_priority = 3
 
 /turf/simulated/floor/outdoors/rocks
 	name = "rocks"
 	desc = "Hard as a rock."
 	icon_state = "rock"
-	edge_blending_priority = 1
 	baseturfs = /turf/baseturf_bottom
 
 /turf/simulated/floor/outdoors/rocks/caves

--- a/code/game/turfs/simulated/floors/snow.dm
+++ b/code/game/turfs/simulated/floors/snow.dm
@@ -1,7 +1,7 @@
 /turf/simulated/floor/outdoors/snow
 	name = "snow"
 	icon_state = "snow"
-	edge_blending_priority = 6
+	edge_blending_priority = 1
 	movement_cost = 2
 	initial_flooring = /decl/flooring/snow
 	baseturfs = /turf/simulated/floor/outdoors/dirt

--- a/code/game/turfs/simulated/floors/water.dm
+++ b/code/game/turfs/simulated/floors/water.dm
@@ -6,7 +6,6 @@
 	icon_state = "seashallow" // So it shows up in the map editor as water.
 	var/water_state = "water_shallow"
 	var/under_state = "rock"
-	edge_blending_priority = -1
 	edge_icon_state = "water_shallow"
 	movement_cost = 4
 	outdoors = TRUE
@@ -96,7 +95,6 @@
 	desc = "A body of water.  It seems quite deep."
 	icon_state = "seadeep" // So it shows up in the map editor as water.
 	under_state = "abyss"
-	edge_blending_priority = -2
 	movement_cost = 8
 	depth = 2
 
@@ -212,7 +210,6 @@ turf/simulated/floor/water/contaminated/Entered(atom/movable/AM, atom/oldloc)
 	icon_state = "acid_shallow"
 	var/acid_state = "acid_shallow"
 	under_state = "rock"
-	edge_blending_priority = 0
 	movement_cost = 4
 	depth = 4
 	layer = WATER_FLOOR_LAYER
@@ -313,7 +310,6 @@ turf/simulated/floor/water/contaminated/Entered(atom/movable/AM, atom/oldloc)
 	desc = "A body of sickly green liquid. It emanates an acrid stench.  It seems quite deep."
 	icon_state = "acid_deep"
 	under_state = "abyss"
-	edge_blending_priority = -2
 	movement_cost = 8
 	depth = 5
 
@@ -325,7 +321,6 @@ turf/simulated/floor/water/contaminated/Entered(atom/movable/AM, atom/oldloc)
 	icon_state = "acidb_shallow"
 	var/blood_state = "acidb_shallow"
 	under_state = "rock"
-	edge_blending_priority = -1
 	movement_cost = 4
 	layer = WATER_FLOOR_LAYER
 	depth = 6
@@ -411,6 +406,5 @@ turf/simulated/floor/water/contaminated/Entered(atom/movable/AM, atom/oldloc)
 	desc = "A body of crimson fluid. It smells like pennies and gasoline.  It seems quite deep."
 	icon_state = "acidb_deep"
 	under_state = "abyss"
-	edge_blending_priority = -2
 	movement_cost = 8
 	depth = 7

--- a/maps/nsv_triumph/submaps/lavaland/_lavaland.dm
+++ b/maps/nsv_triumph/submaps/lavaland/_lavaland.dm
@@ -97,6 +97,7 @@
 	icon_state = "asteroid"
 	outdoors = 1
 	base_icon_state = "asteroid"
+	edge_blending_priority = 0
 	baseturfs = /turf/simulated/mineral/floor/lavaland
 	initial_flooring = /decl/flooring/outdoors/lavaland
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Adjusts the Edge Blending Priorities for Turfs.**

## Why It's Good For The Game

1. _These numbers are open to change. I'm just doing quick math and adjustments off the top of my head with limited testing here._

## Changelog
:cl:
fix: Fixes turf edge blending.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
