### PR TITLE
[MDB IGNORE] fixes map spawners not being /obj

### DIFF
--- a/_maps/away_missions/archive/labyrinth.dmm
+++ b/_maps/away_missions/archive/labyrinth.dmm
@@ -108,14 +108,14 @@
 	},
 /area/awaymission/labyrinth/temple/north_east)
 "av" = (
-/atom/movable/spawner/corpse/scientist,
+/obj/spawner/corpse/scientist,
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "asteroidfloor"
 	},
 /area/awaymission/labyrinth/temple/north_west)
 "ax" = (
-/atom/movable/spawner/corpse/scientist,
+/obj/spawner/corpse/scientist,
 /obj/effect/debris/cleanable/blood,
 /turf/unsimulated/floor{
 	dir = 8;
@@ -123,7 +123,7 @@
 	},
 /area/awaymission/labyrinth/temple/north_east)
 "ay" = (
-/atom/movable/spawner/corpse/scientist,
+/obj/spawner/corpse/scientist,
 /obj/effect/debris/cleanable/blood{
 	icon_state = "gibmid3"
 	},
@@ -133,7 +133,7 @@
 	},
 /area/awaymission/labyrinth/temple/north_east)
 "az" = (
-/atom/movable/spawner/corpse/scientist,
+/obj/spawner/corpse/scientist,
 /obj/effect/debris/cleanable/blood{
 	icon_state = "mfloor5"
 	},
@@ -161,7 +161,7 @@
 	},
 /area/awaymission/labyrinth/temple/center)
 "aD" = (
-/atom/movable/spawner/corpse/scientist,
+/obj/spawner/corpse/scientist,
 /obj/effect/debris/cleanable/blood{
 	icon_state = "mgibbl4"
 	},
@@ -194,7 +194,7 @@
 	},
 /area/awaymission/labyrinth/temple/west)
 "aJ" = (
-/atom/movable/spawner/corpse/scientist,
+/obj/spawner/corpse/scientist,
 /obj/effect/debris/cleanable/blood{
 	icon_state = "mgibbl3"
 	},
@@ -238,7 +238,7 @@
 	},
 /area/awaymission/labyrinth/temple/center)
 "aU" = (
-/atom/movable/spawner/corpse/scientist,
+/obj/spawner/corpse/scientist,
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "asteroidfloor"
@@ -263,7 +263,7 @@
 	},
 /area/awaymission/labyrinth/temple/south_east)
 "aZ" = (
-/atom/movable/spawner/corpse/scientist,
+/obj/spawner/corpse/scientist,
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "asteroidfloor"
@@ -1504,7 +1504,7 @@
 	},
 /area/awaymission/labyrinth/cave)
 "dU" = (
-/atom/movable/spawner/corpse/scientist,
+/obj/spawner/corpse/scientist,
 /obj/effect/debris/cleanable/blood{
 	icon_state = "mfloor5"
 	},
@@ -1559,7 +1559,7 @@
 	},
 /area/awaymission/labyrinth/boss)
 "ea" = (
-/atom/movable/spawner/corpse/scientist,
+/obj/spawner/corpse/scientist,
 /obj/effect/debris/cleanable/blood{
 	icon_state = "mgibbl1"
 	},

--- a/_maps/away_missions/archive/spacebattle.dmm
+++ b/_maps/away_missions/archive/spacebattle.dmm
@@ -400,7 +400,7 @@
 /turf/simulated/floor,
 /area/awaymission/spacebattle/cruiser)
 "cs" = (
-/atom/movable/spawner/corpse/engineer{
+/obj/spawner/corpse/engineer{
 	mobname = "Rosen Miller";
 	name = "Rosen Miller"
 	},
@@ -517,7 +517,7 @@
 	},
 /area/awaymission/spacebattle/cruiser)
 "cU" = (
-/atom/movable/spawner/corpse/engineer{
+/obj/spawner/corpse/engineer{
 	mobname = "Bill Sanchez";
 	name = "Bill Sanchez"
 	},
@@ -581,7 +581,7 @@
 	},
 /area/awaymission/spacebattle/cruiser)
 "di" = (
-/atom/movable/spawner/corpse/engineer{
+/obj/spawner/corpse/engineer{
 	mobname = "John Locke";
 	name = "John Locke"
 	},
@@ -605,7 +605,7 @@
 /turf/simulated/floor,
 /area/awaymission/spacebattle/cruiser)
 "do" = (
-/atom/movable/spawner/corpse/doctor{
+/obj/spawner/corpse/doctor{
 	mobname = "Daniel Kalla";
 	name = "Daniel Kalla"
 	},
@@ -619,7 +619,7 @@
 	},
 /area/awaymission/spacebattle/cruiser)
 "dz" = (
-/atom/movable/spawner/corpse/chef{
+/obj/spawner/corpse/chef{
 	mobname = "Nathaniel Waters";
 	name = "Nathaniel Waters"
 	},
@@ -704,7 +704,7 @@
 /turf/simulated/floor,
 /area/awaymission/spacebattle/cruiser)
 "ea" = (
-/atom/movable/spawner/corpse/engineer/rig{
+/obj/spawner/corpse/engineer/rig{
 	corpseidjob = "Gunner";
 	mobname = "Andrew Thorn";
 	name = "Andrew Thorn"
@@ -728,7 +728,7 @@
 	},
 /area/awaymission/spacebattle/cruiser)
 "ed" = (
-/atom/movable/spawner/corpse/engineer{
+/obj/spawner/corpse/engineer{
 	mobname = "Clay Dawson";
 	name = "Clay Dawson"
 	},
@@ -836,7 +836,7 @@
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "eB" = (
-/atom/movable/spawner/corpse/bridgeofficer{
+/obj/spawner/corpse/bridgeofficer{
 	mobname = "Davis Hume";
 	name = "Davis Hume"
 	},
@@ -864,7 +864,7 @@
 /mob/living/simple_mob/humanoid/merc/melee/sword/space,
 /area/awaymission/spacebattle/cruiser)
 "eK" = (
-/atom/movable/spawner/corpse/engineer/rig{
+/obj/spawner/corpse/engineer/rig{
 	corpseidjob = "Gunner";
 	mobname = "Peter West";
 	name = "Peter West"
@@ -929,13 +929,13 @@
 /turf/simulated/floor,
 /area/awaymission/spacebattle/cruiser)
 "fa" = (
-/atom/movable/spawner/corpse/syndicatesoldier,
+/obj/spawner/corpse/syndicatesoldier,
 /obj/item/melee/energy/sword,
 /obj/effect/debris/cleanable/blood,
 /turf/simulated/floor,
 /area/awaymission/spacebattle/cruiser)
 "fb" = (
-/atom/movable/spawner/corpse/bridgeofficer{
+/obj/spawner/corpse/bridgeofficer{
 	mobname = "Kurt Kliest";
 	name = "Kurt Kliest"
 	},
@@ -953,7 +953,7 @@
 /turf/simulated/floor,
 /area/awaymission/spacebattle/cruiser)
 "fe" = (
-/atom/movable/spawner/corpse/engineer/rig{
+/obj/spawner/corpse/engineer/rig{
 	corpseidjob = "Gunner";
 	mobname = "Eric Abnett";
 	name = "Eric Abnett"
@@ -995,7 +995,7 @@
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "ft" = (
-/atom/movable/spawner/corpse/syndicatesoldier,
+/obj/spawner/corpse/syndicatesoldier,
 /obj/item/gun/projectile/automatic/c20r,
 /obj/item/ammo_casing/a10mm,
 /obj/item/ammo_casing/a10mm,
@@ -1003,7 +1003,7 @@
 /turf/simulated/floor,
 /area/awaymission/spacebattle/cruiser)
 "fv" = (
-/atom/movable/spawner/corpse/bridgeofficer{
+/obj/spawner/corpse/bridgeofficer{
 	mobname = "Walter Strider";
 	name = "Walter Strider"
 	},
@@ -1017,7 +1017,7 @@
 /obj/item/ammo_casing/a357,
 /obj/item/ammo_casing/a357,
 /obj/item/gun/projectile/revolver/mateba,
-/atom/movable/spawner/corpse/commander{
+/obj/spawner/corpse/commander{
 	mobname = "Aaron Bowden";
 	name = "Aaron Bowden"
 	},
@@ -1053,7 +1053,7 @@
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "gh" = (
-/atom/movable/spawner/corpse/bridgeofficer{
+/obj/spawner/corpse/bridgeofficer{
 	mobname = "Robert Faver";
 	name = "Robert Faver"
 	},
@@ -1146,7 +1146,7 @@
 	},
 /area/awaymission/spacebattle/cruiser)
 "gK" = (
-/atom/movable/spawner/corpse/doctor{
+/obj/spawner/corpse/doctor{
 	mobname = "Adam Smith";
 	name = "Adam Smith"
 	},
@@ -1183,7 +1183,7 @@
 /turf/simulated/floor,
 /area/awaymission/spacebattle/cruiser)
 "gT" = (
-/atom/movable/spawner/corpse/engineer/rig{
+/obj/spawner/corpse/engineer/rig{
 	corpseidjob = "Gunner";
 	name = "Jeremy Tailor"
 	},
@@ -1211,7 +1211,7 @@
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "ha" = (
-/atom/movable/spawner/corpse/doctor{
+/obj/spawner/corpse/doctor{
 	mobname = "Allan Yoshimaru";
 	name = "Allan Yoshimaru"
 	},
@@ -1252,7 +1252,7 @@
 /turf/simulated/floor/wood,
 /area/awaymission/spacebattle/cruiser)
 "hm" = (
-/atom/movable/spawner/corpse/engineer/rig{
+/obj/spawner/corpse/engineer/rig{
 	corpseidjob = "Gunner";
 	mobname = "Dan Hedricks";
 	name = "Dan Hedricks"
@@ -1402,7 +1402,7 @@
 /turf/simulated/floor/wood,
 /area/awaymission/spacebattle/cruiser)
 "hP" = (
-/atom/movable/spawner/corpse/engineer{
+/obj/spawner/corpse/engineer{
 	corpseidjob = "Gunner";
 	mobname = "William Gannon";
 	name = "William Gannon"
@@ -1435,7 +1435,7 @@
 	},
 /area/awaymission/spacebattle/cruiser)
 "hV" = (
-/atom/movable/spawner/corpse/engineer{
+/obj/spawner/corpse/engineer{
 	mobname = "Javier Wismer";
 	name = "Javier Wismer"
 	},
@@ -1498,7 +1498,7 @@
 /turf/simulated/floor,
 /area/awaymission/spacebattle/cruiser)
 "im" = (
-/atom/movable/spawner/corpse/doctor{
+/obj/spawner/corpse/doctor{
 	mobname = "Herbert West";
 	name = "Herbert West"
 	},
@@ -1506,7 +1506,7 @@
 /turf/simulated/floor,
 /area/awaymission/spacebattle/cruiser)
 "in" = (
-/atom/movable/spawner/corpse/engineer{
+/obj/spawner/corpse/engineer{
 	mobname = "Carth Robinson";
 	name = "Carth Robinson"
 	},
@@ -1529,7 +1529,7 @@
 /turf/simulated/floor,
 /area/awaymission/spacebattle/cruiser)
 "iw" = (
-/atom/movable/spawner/corpse/engineer{
+/obj/spawner/corpse/engineer{
 	mobname = "Cyrion";
 	name = "Cyrion"
 	},
@@ -1538,12 +1538,12 @@
 /turf/simulated/floor,
 /area/awaymission/spacebattle/cruiser)
 "iy" = (
-/atom/movable/spawner/corpse/syndicatesoldier,
+/obj/spawner/corpse/syndicatesoldier,
 /obj/item/gun/projectile/automatic/c20r,
 /turf/simulated/floor,
 /area/awaymission/spacebattle/cruiser)
 "iA" = (
-/atom/movable/spawner/corpse/engineer{
+/obj/spawner/corpse/engineer{
 	mobname = "Mercutio";
 	name = "Mercutio"
 	},
@@ -1555,7 +1555,7 @@
 /turf/space,
 /area)
 "iC" = (
-/atom/movable/spawner/corpse/syndicatesoldier,
+/obj/spawner/corpse/syndicatesoldier,
 /turf/space,
 /area)
 "iD" = (
@@ -1577,7 +1577,7 @@
 	},
 /area)
 "iH" = (
-/atom/movable/spawner/corpse/syndicatesoldier,
+/obj/spawner/corpse/syndicatesoldier,
 /turf/simulated/floor/airless{
 	dir = 10
 	},

--- a/_maps/away_missions/archive/wildwest.dmm
+++ b/_maps/away_missions/archive/wildwest.dmm
@@ -149,7 +149,7 @@
 /turf/simulated/floor/cult,
 /area/awaymission/wwvault)
 "aK" = (
-/atom/movable/spawner/corpse/miner/rig,
+/obj/spawner/corpse/miner/rig,
 /turf/simulated/floor/cult,
 /area/awaymission/wwvault)
 "aL" = (
@@ -177,7 +177,7 @@
 /turf/simulated/floor/plating,
 /area/awaymission/wwmines)
 "aU" = (
-/atom/movable/spawner/corpse/syndicatecommando,
+/obj/spawner/corpse/syndicatecommando,
 /turf/simulated/floor/cult,
 /area/awaymission/wwvault)
 "aV" = (
@@ -207,7 +207,7 @@
 /turf/simulated/floor/plating,
 /area/awaymission/wwrefine)
 "bi" = (
-/atom/movable/spawner/corpse/miner/rig,
+/obj/spawner/corpse/miner/rig,
 /obj/effect/mine/dnascramble,
 /turf/simulated/floor/plating,
 /area/awaymission/wwmines)
@@ -231,7 +231,7 @@
 /turf/simulated/floor/plating,
 /area/awaymission/wwrefine)
 "bq" = (
-/atom/movable/spawner/corpse/miner/rig,
+/obj/spawner/corpse/miner/rig,
 /turf/simulated/floor/plating,
 /area/awaymission/wwrefine)
 "br" = (
@@ -424,7 +424,7 @@
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "cd" = (
-/atom/movable/spawner/corpse/chef{
+/obj/spawner/corpse/chef{
 	mobname = "Chef"
 	},
 /turf/simulated/floor{
@@ -550,7 +550,7 @@
 /turf/simulated/floor,
 /area/awaymission/wwgov)
 "cH" = (
-/atom/movable/spawner/corpse/chef{
+/obj/spawner/corpse/chef{
 	mobname = "Chef"
 	},
 /turf/simulated/floor,
@@ -560,7 +560,7 @@
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "cM" = (
-/atom/movable/spawner/corpse/miner/rig,
+/obj/spawner/corpse/miner/rig,
 /turf/simulated/floor/wood,
 /area/awaymission/wwgov)
 "cN" = (
@@ -637,7 +637,7 @@
 /turf/simulated/floor,
 /area/awaymission/wwgov)
 "dh" = (
-/atom/movable/spawner/corpse/syndicatecommando{
+/obj/spawner/corpse/syndicatecommando{
 	mobname = "Syndicate Commando"
 	},
 /turf/simulated/floor/carpet,
@@ -700,7 +700,7 @@
 /turf/simulated/floor/plating,
 /area/awaymission/wwmines)
 "dy" = (
-/atom/movable/spawner/corpse/miner/rig,
+/obj/spawner/corpse/miner/rig,
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "dB" = (
@@ -963,7 +963,7 @@
 /area/awaymission/wwmines)
 "eL" = (
 /obj/effect/debris/cleanable/blood/splatter,
-/atom/movable/spawner/corpse/miner/rig,
+/obj/spawner/corpse/miner/rig,
 /turf/simulated/floor/carpet,
 /area/awaymission/wwmines)
 "eM" = (
@@ -1045,7 +1045,7 @@
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "fh" = (
-/atom/movable/spawner/corpse/doctor{
+/obj/spawner/corpse/doctor{
 	mobname = "Doctor Mugabee"
 	},
 /turf/simulated/floor/plating,
@@ -1195,7 +1195,7 @@
 /area/awaymission/wwmines)
 "fR" = (
 /obj/effect/mine/dnascramble,
-/atom/movable/spawner/corpse/miner/rig,
+/obj/spawner/corpse/miner/rig,
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "fS" = (
@@ -1265,7 +1265,7 @@
 /turf/simulated/floor,
 /area)
 "ge" = (
-/atom/movable/spawner/corpse/miner/rig,
+/obj/spawner/corpse/miner/rig,
 /turf/simulated/floor,
 /area/awaymission/wwrefine)
 "gf" = (
@@ -1335,7 +1335,7 @@
 /turf/simulated/floor/plating,
 /area/awaymission/wwmines)
 "gy" = (
-/atom/movable/spawner/corpse/syndicatecommando{
+/obj/spawner/corpse/syndicatecommando{
 	mobname = "Syndicate Commando"
 	},
 /turf/simulated/floor/grass,

--- a/_maps/away_missions/archive/zresearchlabs.dmm
+++ b/_maps/away_missions/archive/zresearchlabs.dmm
@@ -1890,7 +1890,7 @@
 	},
 /area/awaymission/labs/researchdivision)
 "fL" = (
-/atom/movable/spawner/corpse/scientist{
+/obj/spawner/corpse/scientist{
 	mobname = "Steve Smith";
 	name = "Steve Smith"
 	},
@@ -1925,7 +1925,7 @@
 	},
 /area/awaymission/labs/militarydivision)
 "fP" = (
-/atom/movable/spawner/corpse/doctor{
+/obj/spawner/corpse/doctor{
 	mobname = "Amando Cruz";
 	name = "Amando Cruz"
 	},
@@ -2323,7 +2323,7 @@
 /area/awaymission/labs/researchdivision)
 "gL" = (
 /obj/effect/debris/cleanable/blood,
-/atom/movable/spawner/corpse/scientist{
+/obj/spawner/corpse/scientist{
 	mobname = "James MacDonald";
 	name = "James MacDonald"
 	},
@@ -2571,7 +2571,7 @@
 	},
 /area/awaymission/labs/researchdivision)
 "hs" = (
-/atom/movable/spawner/corpse/scientist{
+/obj/spawner/corpse/scientist{
 	mobname = "Mikhail Ruznov";
 	name = "Mikhail Ruznov"
 	},
@@ -6153,7 +6153,7 @@
 /turf/simulated/floor/outdoors/dirt,
 /area/awaymission/labs/cave)
 "qd" = (
-/atom/movable/spawner/corpse/chef{
+/obj/spawner/corpse/chef{
 	mobname = "Harold Brown";
 	name = "Harold Brown"
 	},
@@ -7118,7 +7118,7 @@
 /area/awaymission/labs/medical)
 "ta" = (
 /obj/effect/debris/cleanable/blood,
-/atom/movable/spawner/corpse/doctor{
+/obj/spawner/corpse/doctor{
 	mobname = "Elias Smith";
 	name = "Elias Smith"
 	},

--- a/_maps/map_files/rift/rift-01-underground3.dmm
+++ b/_maps/map_files/rift/rift-01-underground3.dmm
@@ -37,7 +37,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor/phoron{
 	pixel_y = 28;
 	pixel_x = 30
@@ -99,7 +99,7 @@
 	name = "Mining Outpost Airlock"
 	},
 /obj/structure/catwalk,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -159,7 +159,7 @@
 	dir = 1;
 	pixel_x = -2
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	frequency = 1379
 	},
@@ -365,7 +365,7 @@
 	name = "Mining Outpost Airlock"
 	},
 /obj/structure/catwalk,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button/airlock_interior{
 	pixel_y = -28;
 	master_tag = "mining_underground_airlock"
@@ -539,7 +539,7 @@
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Mining Outpost Airlock"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/embedded_controller/radio/airlock/phoron{
 	pixel_y = 26;
 	id_tag = "mining_underground_airlock"
@@ -578,7 +578,7 @@
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Mining Outpost Airlock"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button/airlock_exterior{
 	pixel_y = -28;
 	master_tag = "mining_underground_airlock"
@@ -816,7 +816,7 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	frequency = 1379
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/quartermaster/mining_airlock)
 "XL" = (

--- a/_maps/map_files/rift/rift-04-surface1.dmm
+++ b/_maps/map_files/rift/rift-04-surface1.dmm
@@ -2505,7 +2505,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 1
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Nebula Trade Shop"
 	},
@@ -3424,7 +3424,7 @@
 	id = "main_ext_shutter";
 	name = "Surface External Shutter"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -4735,7 +4735,7 @@
 	id_tag = "shop_airlock_pump";
 	power_rating = 10000
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/embedded_controller/radio/airlock/phoron{
 	id_tag = "shop_airlock";
 	name = "Frost Lock Controller";
@@ -5292,7 +5292,7 @@
 	id = "main_ext_blast";
 	name = "Surface External Blast Door"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 6
 	},
@@ -5815,7 +5815,7 @@
 	id = "main_ext_blast";
 	name = "Surface External Blast Door"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 9
 	},
@@ -6495,7 +6495,7 @@
 	pixel_y = -6
 	},
 /obj/structure/grille,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/plating,
 /area/rift/surfaceeva/airlock/main/secondary)
 "esT" = (
@@ -7591,7 +7591,7 @@
 	opacity = 0
 	},
 /obj/structure/fans/tiny,
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/surfaceeva/cargodock)
 "frd" = (
@@ -7704,7 +7704,7 @@
 	id_tag = "central_airlock_pump"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/rift/surfaceeva/airlock/main)
 "fvk" = (
@@ -10452,7 +10452,7 @@
 	id = "main_ext_blast";
 	name = "Surface External Blast Door"
 	},
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/surfaceeva/cargodock)
 "hkO" = (
@@ -11962,7 +11962,7 @@
 	id = "main_ext_shutter";
 	name = "Surface External Shutter"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -12142,7 +12142,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 1
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/trade_shop)
 "ipC" = (
@@ -12389,7 +12389,7 @@
 	id = "main_ext_shutter";
 	name = "Surface External Shutter"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 6
 	},
@@ -13005,7 +13005,7 @@
 	id = "main_ext_shutter";
 	name = "Surface External Shutter"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 9
 	},
@@ -18263,7 +18263,7 @@
 	id_tag = "central_airlock_pump"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/rift/surfaceeva/airlock/main)
 "mhi" = (
@@ -20607,7 +20607,7 @@
 	pixel_y = 6
 	},
 /obj/structure/grille,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/plating,
 /area/rift/surfaceeva/airlock/main)
 "nAu" = (
@@ -25332,7 +25332,7 @@
 	id_tag = "central_airlock_two_pump"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/rift/surfaceeva/airlock/main/secondary)
 "qnr" = (
@@ -28528,7 +28528,7 @@
 	id = "main_ext_blast";
 	name = "Surface External Blast Door"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 6
 	},
@@ -30384,7 +30384,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Nebula Trade Shop"
 	},
@@ -30571,7 +30571,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Nebula Trade Shop"
 	},
@@ -31828,7 +31828,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1379;
@@ -32515,7 +32515,7 @@
 	pixel_x = 38;
 	pixel_y = 24
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -36085,7 +36085,7 @@
 	id = "main_ext_blast";
 	name = "Surface External Blast Door"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 10
 	},
@@ -36350,7 +36350,7 @@
 	id_tag = "central_airlock_two_pump"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/rift/surfaceeva/airlock/main/secondary)
 "xld" = (

--- a/_maps/map_files/rift/rift-06-surface3.dmm
+++ b/_maps/map_files/rift/rift-06-surface3.dmm
@@ -1987,7 +1987,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 4
@@ -3358,8 +3358,8 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(19,43,67)
 	},
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 6;
 	frequency = 1380;
@@ -3749,7 +3749,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 1
 	},
@@ -6541,7 +6541,7 @@
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Public External Airlock"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 8
 	},
@@ -6806,8 +6806,8 @@
 /area/shuttle/civvie/cockpit)
 "lR" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	frequency = 1380;
 	id_tag = "emt_shuttle_exterior_sensor";
@@ -6828,7 +6828,7 @@
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Public External Airlock"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 4
@@ -8344,7 +8344,7 @@
 /area/crew_quarters/bar)
 "oI" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1380;
@@ -8478,7 +8478,7 @@
 	frequency = 1380;
 	id_tag = "expshuttle_docker_pump_in_external"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},
@@ -8580,7 +8580,7 @@
 	pixel_x = 38;
 	pixel_y = 24
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -8593,7 +8593,7 @@
 	frequency = 1379;
 	id_tag = "sec_fore_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/pump_out_external,
+/obj/map_helper/airlock/atmos/pump_out_external,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
@@ -8800,7 +8800,7 @@
 	frequency = 1380;
 	id_tag = "expshuttle_docker_pump_out_external"
 	},
-/atom/movable/map_helper/airlock/atmos/pump_out_internal,
+/obj/map_helper/airlock/atmos/pump_out_internal,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/excursion/general)
 "pB" = (
@@ -8835,7 +8835,7 @@
 /area/bridge/bunker)
 "pE" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/structure/fans/tiny,
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
@@ -9042,7 +9042,7 @@
 	frequency = 1379;
 	id_tag = "trade_airlock_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/embedded_controller/radio/airlock/phoron{
 	id_tag = "trade_airlock";
 	name = "Frost Lock Controller";
@@ -9309,7 +9309,7 @@
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Public External Airlock"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 4
 	},
@@ -9478,7 +9478,7 @@
 	frequency = 1379;
 	id_tag = "trade_airlock_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/rift/trade_shop/landing_pad)
@@ -9733,7 +9733,7 @@
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Public External Airlock"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 8
 	},
@@ -9788,7 +9788,7 @@
 /area/rift/surfacebase/shuttle)
 "rA" = (
 /obj/machinery/door/airlock/voidcraft/vertical,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/plating,
 /area/shuttle/courser/general)
 "rB" = (
@@ -10196,7 +10196,7 @@
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Public External Airlock"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 8
 	},
@@ -10262,7 +10262,7 @@
 	frequency = 1380;
 	id_tag = "expshuttle_docker_pump_out_external"
 	},
-/atom/movable/map_helper/airlock/atmos/pump_out_internal,
+/obj/map_helper/airlock/atmos/pump_out_internal,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/excursion/general)
 "sx" = (
@@ -10351,14 +10351,14 @@
 	pixel_x = 38;
 	pixel_y = -24
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/trade_shop/landing_pad)
 "sG" = (
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Public External Airlock"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 8
 	},
@@ -10745,7 +10745,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 4
@@ -11115,7 +11115,7 @@
 	pixel_x = 26;
 	pixel_y = -8
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/trade_shop/landing_pad)
 "ua" = (
@@ -12197,7 +12197,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor/phoron{
 	dir = 9;
 	id_tag = "civ_airlock_two_sensor";
@@ -12961,7 +12961,7 @@
 /area/hydroponics)
 "xq" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/emt/general)
 "xr" = (
@@ -13126,7 +13126,7 @@
 /area/bridge/bunker)
 "xG" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button{
 	dir = 1;
 	frequency = 1380;
@@ -13361,8 +13361,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/voidcraft/vertical,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	frequency = 1380;
 	id_tag = "courser_exterior_sensor";
@@ -13838,7 +13838,7 @@
 	frequency = 1380;
 	id_tag = "civvie_docker_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/handrail{
 	dir = 8
 	},
@@ -13927,7 +13927,7 @@
 	frequency = 1379;
 	id_tag = "civ_airlock_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/rift/surfaceeva/airlock/arrivals)
 "zo" = (
@@ -14467,7 +14467,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
 "Ao" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1380;
@@ -14542,7 +14542,7 @@
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/cafeteria)
 "Aw" = (
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
 	id_tag = "emt_shuttle_docker";
@@ -15376,7 +15376,7 @@
 	frequency = 1379;
 	id_tag = "civ_airlock_two_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/embedded_controller/radio/airlock/phoron{
 	id_tag = "civ_airlock_two";
 	name = "Frost Lock Controller";
@@ -15549,7 +15549,7 @@
 	frequency = 1380;
 	id_tag = "expshuttle_docker_pump_in_external"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/oxygen_pump{
 	pixel_y = 30
 	},
@@ -16107,7 +16107,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 1
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/trade_shop/landing_pad)
 "Dx" = (
@@ -16116,7 +16116,7 @@
 	pixel_x = 24;
 	pixel_y = 26
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/excursion/general)
 "Dy" = (
@@ -16143,7 +16143,7 @@
 	frequency = 1380;
 	id_tag = "expshuttle_docker_pump_in_external"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -16234,7 +16234,7 @@
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Public External Airlock"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 4
@@ -16304,7 +16304,7 @@
 	frequency = 1380;
 	id_tag = "civvie_docker_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/handrail{
 	dir = 8
 	},
@@ -16679,7 +16679,7 @@
 	frequency = 1380;
 	id_tag = "emt_shuttle_docker_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/handrail{
 	dir = 4
 	},
@@ -16744,7 +16744,7 @@
 	id_tag = "civvie_docker";
 	pixel_x = 24
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
 "EL" = (
@@ -18897,13 +18897,13 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
 	id_tag = "expshuttle_docker_pump_out_external"
 	},
-/atom/movable/map_helper/airlock/atmos/pump_out_internal,
+/obj/map_helper/airlock/atmos/pump_out_internal,
 /obj/machinery/oxygen_pump{
 	pixel_y = 30
 	},
@@ -19632,7 +19632,7 @@
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Nebula Trade Shop"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/trade_shop/landing_pad)
 "Ko" = (
@@ -19925,7 +19925,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 1
 	},
@@ -20318,7 +20318,7 @@
 	pixel_x = 38;
 	pixel_y = 24
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/surfaceeva/airlock/arrivals)
 "LH" = (
@@ -22278,7 +22278,7 @@
 /area/security/nuke_storage)
 "Pq" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
 "Pr" = (
@@ -22762,7 +22762,7 @@
 	frequency = 1380;
 	id_tag = "civvie_docker_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/closet/walllocker/emerglocker{
 	pixel_x = -30
 	},
@@ -23060,7 +23060,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/station/exploration)
 "QN" = (
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},
@@ -23415,7 +23415,7 @@
 	frequency = 1379;
 	id_tag = "civ_airlock_two_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/rift/surfaceeva/airlock/arrivals/secondary)
 "Rs" = (
@@ -23730,7 +23730,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/exploration)
 "RR" = (
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
@@ -23817,7 +23817,7 @@
 	pixel_x = 26;
 	pixel_y = 8
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/trade_shop/landing_pad)
 "Sa" = (
@@ -23847,7 +23847,7 @@
 	frequency = 1379;
 	id_tag = "civ_airlock_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/embedded_controller/radio/airlock/phoron{
 	id_tag = "civ_airlock";
 	name = "Frost Lock Controller";
@@ -24206,7 +24206,7 @@
 	frequency = 1380;
 	id_tag = "civvie_docker_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/closet/walllocker/emerglocker{
 	pixel_x = -30
 	},
@@ -24283,7 +24283,7 @@
 	pixel_x = -6;
 	pixel_y = -26
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1379;
@@ -25159,8 +25159,8 @@
 /area/shuttle/excursion/cockpit)
 "UD" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	frequency = 1380;
 	id_tag = "civvie_docker_exterior_sensor";
@@ -26220,7 +26220,7 @@
 	pixel_y = -22
 	},
 /obj/structure/catwalk,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/plating,
 /area/shuttle/courser/general)
 "WE" = (
@@ -26339,7 +26339,7 @@
 	id_tag = "courser_docker_pump";
 	power_rating = 20000
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shuttle/courser/general)
@@ -26725,7 +26725,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button/airlock_interior{
 	dir = 4;
 	frequency = 1380;
@@ -26742,7 +26742,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1379;
@@ -27684,7 +27684,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 4
@@ -27809,13 +27809,13 @@
 	id_tag = "courser_docker_pump";
 	power_rating = 20000
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
 	id_tag = "courser_docker";
 	pixel_x = -24
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/structure/handrail{
 	dir = 4
 	},
@@ -27868,7 +27868,7 @@
 /area/hallway/primary/surfacethree)
 "ZN" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;

--- a/_maps/map_files/tether/tether-01-surface1.dmm
+++ b/_maps/map_files/tether/tether-01-surface1.dmm
@@ -128,7 +128,7 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/medical/mentalhealth)
 "aas" = (
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -146,7 +146,7 @@
 	pixel_x = 25;
 	pixel_y = 8
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
 	frequency = 1379;
 	icon_state = "door_locked";
@@ -262,7 +262,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1379;
@@ -459,7 +459,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/embedded_controller/radio/airlock/phoron{
 	id_tag = "northciv_airlock";
 	pixel_x = 25;
@@ -8546,7 +8546,7 @@
 	frequency = 1379;
 	id_tag = "civ_airlock_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/storage/surface_eva/external)
 "aot" = (
@@ -8561,7 +8561,7 @@
 	frequency = 1379;
 	id_tag = "civ_airlock_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/storage/surface_eva/external)
 "aou" = (
@@ -8877,7 +8877,7 @@
 	id_tag = "civ_airlock_outer";
 	locked = 1
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/storage/surface_eva/external)
 "aoX" = (
@@ -8925,7 +8925,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/storage/surface_eva/external)
 "apa" = (
@@ -9296,7 +9296,7 @@
 	id_tag = "civ_airlock_outer";
 	locked = 1
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/storage/surface_eva/external)
 "apI" = (
@@ -9319,7 +9319,7 @@
 	pixel_x = 25;
 	pixel_y = -40
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled,
 /area/storage/surface_eva/external)
 "apK" = (
@@ -9330,7 +9330,7 @@
 	id_tag = "civ_airlock_inner";
 	locked = 1
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/storage/surface_eva/external)
 "apL" = (
@@ -21981,7 +21981,7 @@
 	id_tag = "rnd_s_airlock_inner";
 	locked = 1
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/external)
 "aKN" = (
@@ -21998,7 +21998,7 @@
 	locked = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/external)
 "aKO" = (
@@ -22238,7 +22238,7 @@
 	pixel_x = 11;
 	pixel_y = 30
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled,
 /area/rnd/external)
 "aLp" = (
@@ -22297,7 +22297,7 @@
 	frequency = 1379;
 	id_tag = "rnd_s_airlock_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/rnd/external)
 "aLs" = (
@@ -23031,7 +23031,7 @@
 	id_tag = "rnd_s_airlock_outer";
 	locked = 1
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/external)
 "aMK" = (
@@ -23047,7 +23047,7 @@
 	id_tag = "rnd_s_airlock_outer";
 	locked = 1
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/external)
 "aML" = (
@@ -30640,7 +30640,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals3{
 	dir = 5
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/rnd/external)
 "bcV" = (
@@ -33141,7 +33141,7 @@
 /area/rnd/hallway)
 "hpB" = (
 /obj/machinery/door/firedoor/glass,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
 	frequency = 1379;
 	icon_state = "door_locked";
@@ -33456,7 +33456,7 @@
 "hYh" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},

--- a/_maps/map_files/tether/tether-03-surface3.dmm
+++ b/_maps/map_files/tether/tether-03-surface3.dmm
@@ -32997,7 +32997,7 @@
 	frequency = 1379;
 	id_tag = "southciv_airlock_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/topairlock)
 "bhZ" = (
@@ -33008,7 +33008,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/grille,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	frequency = 1379;
 	id_tag = "southciv_airlock_pump"
@@ -33060,7 +33060,7 @@
 	id_tag = "southciv_airlock_outer";
 	locked = 1
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/surfacebase/topairlock)
 "bif" = (
@@ -33108,7 +33108,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/surfacebase/topairlock)
 "bii" = (
@@ -33247,7 +33247,7 @@
 	pixel_x = -8;
 	pixel_y = -25
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
 	frequency = 1379;
 	icon_state = "door_locked";
@@ -33276,12 +33276,12 @@
 	pixel_x = 25;
 	pixel_y = -40
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/topairlock)
 "bir" = (
 /obj/machinery/door/firedoor/glass,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
 	frequency = 1379;
 	icon_state = "door_locked";
@@ -38545,7 +38545,7 @@
 	frequency = 1380;
 	id_tag = "tourbus_right"
 	},
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/tourbus/general)
 "jYD" = (

--- a/_maps/map_files/tether/tether-05-station1.dmm
+++ b/_maps/map_files/tether/tether-05-station1.dmm
@@ -12745,7 +12745,7 @@
 	name = "Engineering Starboard External Access"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor,
 /area/engineering/engineering_airlock)
 "aCC" = (
@@ -13266,7 +13266,7 @@
 	frequency = 1379;
 	id_tag = "eng_starboard_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engineering_airlock)
 "aEb" = (
@@ -13370,7 +13370,7 @@
 	req_one_access = list(13)
 	},
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docks)
 "aEq" = (
@@ -13740,8 +13740,8 @@
 	id_tag = "eng_starboard_airlock";
 	pixel_x = 28
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engineering_airlock)
 "aFL" = (
@@ -13797,8 +13797,8 @@
 	frequency = 1380;
 	id_tag = "dock_d1a1_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docks)
 "aFX" = (
@@ -13822,7 +13822,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docks)
 "aFZ" = (
@@ -13914,7 +13914,7 @@
 	name = "Engineering Starboard Internal Access"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engineering_airlock)
 "aHT" = (
@@ -13927,7 +13927,7 @@
 	name = "Engineering Starboard Internal Access"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engineering_airlock)
 "aHY" = (
@@ -17244,7 +17244,7 @@
 	req_one_access = list(13)
 	},
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docks)
 "bPx" = (
@@ -17252,7 +17252,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docks)
 "bPz" = (
@@ -17272,8 +17272,8 @@
 	id_tag = "dock_d2a1";
 	pixel_y = 28
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docks)
 "bPD" = (
@@ -17906,11 +17906,11 @@
 	id_tag = "securiship_docker";
 	pixel_x = -28
 	},
-/atom/movable/map_helper/airlock/atmos/pump_out_internal,
+/obj/map_helper/airlock/atmos/pump_out_internal,
 /obj/machinery/airlock_sensor{
 	pixel_y = 28
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/effect/shuttle_landmark{
 	base_area = /area/space;
 	base_turf = /turf/space;
@@ -18285,7 +18285,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/eris/techmaint_panels,
 /area/shuttle/medivac/general)
 "dgF" = (
@@ -18530,7 +18530,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/tiled,
 /area/security/customs)
 "dIr" = (
@@ -18665,7 +18665,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/escape/medical_escape_pod_hallway)
 "dYK" = (
@@ -20981,8 +20981,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/eris/techmaint_panels,
 /area/shuttle/medivac/general)
 "jKd" = (
@@ -21054,7 +21054,7 @@
 	name = "Medivac Bay"
 	},
 /obj/effect/overmap/visitable/ship/landable/medivac,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/eris/steel/gray_perforated,
 /area/shuttle/medivac/general)
 "jNj" = (
@@ -22241,7 +22241,7 @@
 /area/security/checkpoint/science)
 "nhu" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/tiled,
 /area/security/customs)
 "njI" = (
@@ -23473,7 +23473,7 @@
 "qgS" = (
 /obj/machinery/door/airlock/glass_external,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/escape/medical_escape_pod_hallway)
 "qgW" = (
@@ -23730,7 +23730,7 @@
 /area/shuttle/securiship/general)
 "qUd" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/eris/techmaint_panels,
 /area/shuttle/medivac/general)
 "qWf" = (
@@ -23798,12 +23798,12 @@
 /area/engineering/gravity_lobby)
 "rcu" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 4;
 	pixel_y = -28
 	},
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/tiled/eris/techmaint_panels,
 /area/shuttle/securiship/general)
 "rgd" = (
@@ -24468,7 +24468,7 @@
 	id_tag = "medivac_docker_pump_out_external"
 	},
 /obj/effect/floor_decal/industrial/warning/full,
-/atom/movable/map_helper/airlock/atmos/pump_out_external,
+/obj/map_helper/airlock/atmos/pump_out_external,
 /turf/simulated/floor/airless,
 /area/shuttle/medivac/general)
 "sqw" = (
@@ -24842,8 +24842,8 @@
 	frequency = 1380;
 	id_tag = "medivac_docker_pump_out_internal"
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/pump_out_internal,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/pump_out_internal,
 /turf/simulated/floor/tiled/eris/steel/gray_perforated,
 /area/shuttle/medivac/general)
 "tfs" = (
@@ -24884,7 +24884,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/eris/techmaint_panels,
 /area/shuttle/securiship/general)
 "tjt" = (
@@ -25433,7 +25433,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -26088,7 +26088,7 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/atmos/pump_out_external,
+/obj/map_helper/airlock/atmos/pump_out_external,
 /turf/simulated/floor/airless,
 /area/shuttle/securiship/general)
 "vYM" = (
@@ -26371,7 +26371,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume/aux,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -26433,7 +26433,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = 28
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /turf/simulated/floor/tiled/eris/steel/gray_perforated,
 /area/shuttle/securiship/general)
 "wTJ" = (
@@ -26848,7 +26848,7 @@
 "xJU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/eris/techmaint_panels,
 /area/shuttle/medivac/general)
 "xMb" = (
@@ -26966,7 +26966,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/eris/techmaint_panels,
 /area/shuttle/securiship/general)
 "xTY" = (

--- a/_maps/map_files/tether/tether-06-station2.dmm
+++ b/_maps/map_files/tether/tether-06-station2.dmm
@@ -4336,7 +4336,7 @@
 	frequency = 1380;
 	id_tag = "expshuttle_docker_pump_out_external"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
@@ -5802,7 +5802,7 @@
 /turf/simulated/open,
 /area/tether/exploration)
 "ati" = (
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/airlock_sensor{
 	dir = 8;
 	pixel_x = 26;
@@ -6351,7 +6351,7 @@
 	name = "EXTERNAL AIRLOCK";
 	pixel_y = -32
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
 "auM" = (
@@ -6375,8 +6375,8 @@
 	pixel_y = -28
 	},
 /obj/machinery/camera/network/command,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
 "auO" = (
@@ -6391,7 +6391,7 @@
 	pixel_y = -26;
 	req_access = list(18)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
 "auP" = (
@@ -7047,7 +7047,7 @@
 	frequency = 1380;
 	id_tag = "expshuttle_docker_pump_out_external"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/light,
 /obj/effect/shuttle_landmark{
 	base_area = /area/tether/exploration;
@@ -9158,8 +9158,8 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
 	},
@@ -10209,7 +10209,7 @@
 	id_tag = "expshuttle_docker";
 	pixel_y = 28
 	},
-/atom/movable/map_helper/airlock/atmos/pump_out_internal,
+/obj/map_helper/airlock/atmos/pump_out_internal,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1380;
@@ -10503,7 +10503,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_core_foyer)
 "aMZ" = (
-/atom/movable/map_helper/airlock/atmos/pump_out_external,
+/obj/map_helper/airlock/atmos/pump_out_external,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	frequency = 1379;
 	id_tag = "sec_fore_pump"
@@ -10882,8 +10882,8 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = 28
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/pump_out_internal,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/pump_out_internal,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1380;
@@ -11063,7 +11063,7 @@
 	frequency = 1380;
 	id_tag = "expshuttle_docker_pump_out_external"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
 	},
@@ -13876,7 +13876,7 @@
 /area/shuttle/large_escape_pod1)
 "aYI" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/shuttle/floor,
 /area/shuttle/large_escape_pod1)
 "aYM" = (
@@ -14634,7 +14634,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/general)
 "bUK" = (
@@ -15017,7 +15017,7 @@
 /area/tether/station/dock_one)
 "cQI" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "cRn" = (
@@ -15443,11 +15443,11 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "dGA" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/airlock_sensor{
 	pixel_y = 28
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1379;
@@ -15856,7 +15856,7 @@
 	req_one_access = list(13)
 	},
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "ejm" = (
@@ -17929,7 +17929,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "hMg" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1379;
@@ -18092,8 +18092,8 @@
 	frequency = 1380;
 	id_tag = "dock_d2a_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "hZK" = (
@@ -18363,7 +18363,7 @@
 	dir = 4;
 	id = "QMLoad2"
 	},
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
 "iAx" = (
@@ -18800,7 +18800,7 @@
 /area/crew_quarters/sleep/spacedorm1)
 "jpv" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /obj/machinery/door/airlock/multi_tile/glass,
 /turf/simulated/floor/tiled/monofloor{
 	dir = 8
@@ -19137,7 +19137,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "jSo" = (
@@ -19875,7 +19875,7 @@
 /area/tether/station/burial)
 "lfm" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
@@ -19939,7 +19939,7 @@
 "lms" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "loC" = (
@@ -19991,7 +19991,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
 "lvY" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	frequency = 1379;
 	id_tag = "belter_access_pump"
@@ -20042,7 +20042,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "lGU" = (
@@ -20393,7 +20393,7 @@
 	req_one_access = list(13)
 	},
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "mnz" = (
@@ -20475,13 +20475,13 @@
 	id_tag = "dock_d2r";
 	pixel_y = 28
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "mCB" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "mDI" = (
@@ -21680,7 +21680,7 @@
 	req_access = list(13)
 	},
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "ozR" = (
@@ -22111,7 +22111,7 @@
 	dir = 4;
 	id = "QMLoad"
 	},
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
 "pdh" = (
@@ -22333,8 +22333,8 @@
 	id_tag = "dock_cshutt";
 	pixel_y = 28
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "pyf" = (
@@ -23129,7 +23129,7 @@
 /area/tether/exploration/pilot_office)
 "qOb" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
@@ -23454,7 +23454,7 @@
 	frequency = 1380;
 	id_tag = "dock_d1l_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "ruj" = (
@@ -23533,7 +23533,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "rDG" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -23727,8 +23727,8 @@
 	pixel_x = 30;
 	pixel_y = 8
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "rSM" = (
@@ -23752,7 +23752,7 @@
 	req_one_access = list(13)
 	},
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "rYs" = (
@@ -24152,8 +24152,8 @@
 	id_tag = "dock_d2b";
 	pixel_y = 28
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "sRw" = (
@@ -25778,7 +25778,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "vLQ" = (
@@ -25836,7 +25836,7 @@
 	req_one_access = list(13)
 	},
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
 "vSZ" = (
@@ -26566,7 +26566,7 @@
 /turf/simulated/floor/wood,
 /area/tether/exploration/pathfinder_office)
 "xjm" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	id_tag = "belter_access_airlock";
 	pixel_y = 28
@@ -27156,7 +27156,7 @@
 /area/maintenance/station/cargo)
 "yht" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},

--- a/_maps/map_files/triumph/triumph-01-deck1.dmm
+++ b/_maps/map_files/triumph/triumph-01-deck1.dmm
@@ -155,7 +155,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "aH" = (
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/access_button/airlock_interior{
 	frequency = 1380;
@@ -3511,7 +3511,7 @@
 /area/maintenance/engineering)
 "mp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/door/airlock/glass_external,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -3688,8 +3688,8 @@
 	dir = 8;
 	id_tag = "deck1_airlock"
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
 "mS" = (
@@ -6917,8 +6917,8 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/airlock_sensor{
 	dir = 8;
 	id_tag = "deck1_airlock2";
@@ -12740,7 +12740,7 @@
 /area/engineering/atmos)
 "Rp" = (
 /obj/machinery/shield_diffuser,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
@@ -13098,7 +13098,7 @@
 /area/engineering/storage)
 "Sm" = (
 /obj/machinery/shield_diffuser,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button/airlock_exterior{
 	frequency = 1380;
 	master_tag = "deck1_airlock";
@@ -13147,7 +13147,7 @@
 /turf/simulated/floor/carpet,
 /area/maintenance/dormitory)
 "Sw" = (
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -13184,7 +13184,7 @@
 /area/engineering/hallway)
 "SA" = (
 /obj/machinery/shield_diffuser,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button/airlock_exterior{
 	master_tag = "deck1_airlock2";
 	pixel_x = 24
@@ -13605,7 +13605,7 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos/storage)
 "Ud" = (
@@ -14110,7 +14110,7 @@
 /turf/simulated/floor/tiled,
 /area/station/stairs_one)
 "VG" = (
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
@@ -14335,7 +14335,7 @@
 	dir = 8;
 	id_tag = "deck1_airlock"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
 "Wv" = (
@@ -14969,7 +14969,7 @@
 /area/engineering/atmos/monitoring)
 "YE" = (
 /obj/machinery/shield_diffuser,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos/storage)

--- a/_maps/map_files/triumph/triumph-02-deck2.dmm
+++ b/_maps/map_files/triumph/triumph-02-deck2.dmm
@@ -194,7 +194,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/dormitory)
 "aA" = (
@@ -1081,7 +1081,7 @@
 "dq" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "dr" = (
@@ -2506,7 +2506,7 @@
 	id = "QMLoad2"
 	},
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/plating,
 /area/quartermaster/warehouse)
 "hh" = (
@@ -3995,7 +3995,7 @@
 	id = "QMLoad"
 	},
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/plating,
 /area/quartermaster/warehouse)
 "lo" = (
@@ -4778,7 +4778,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/dormitory)
 "nn" = (
@@ -7485,7 +7485,7 @@
 	id_tag = "solar_dock";
 	pixel_x = -24
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/dormitory)
 "uC" = (
@@ -7864,7 +7864,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button/airlock_interior{
 	frequency = 1380;
 	master_tag = "triumph_annex_dock";
@@ -8724,8 +8724,8 @@
 	frequency = 1380;
 	id_tag = "triumph_annex_dock_pump"
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "yt" = (
@@ -12099,7 +12099,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/dormitory)
 "In" = (
@@ -12375,7 +12375,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/shield_diffuser,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
 	name = "Bar External Access"
 	},
@@ -14713,7 +14713,7 @@
 "Qh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/firedoor,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
 	name = "Bar Internal Access"
 	},
@@ -14949,7 +14949,7 @@
 	},
 /obj/machinery/shield_diffuser,
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/plating,
 /area/quartermaster/warehouse)
 "Rc" = (
@@ -15492,7 +15492,7 @@
 "SA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/shield_diffuser,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button/airlock_exterior{
 	frequency = 1380;
 	master_tag = "triumph_annex_dock";
@@ -16260,7 +16260,7 @@
 	},
 /obj/machinery/shield_diffuser,
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/plating,
 /area/quartermaster/warehouse)
 "UI" = (
@@ -17518,7 +17518,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/shield_diffuser,
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "XK" = (

--- a/_maps/map_files/triumph/triumph-03-deck3.dmm
+++ b/_maps/map_files/triumph/triumph-03-deck3.dmm
@@ -2364,7 +2364,7 @@
 /area/medical/medbay3)
 "bWI" = (
 /obj/machinery/door/firedoor/glass,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/voidcraft/vertical{
 	frequency = 1380;
 	id_tag = null
@@ -2483,7 +2483,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -5703,7 +5703,7 @@
 	dir = 4;
 	id_tag = "deck3_airlock"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
 	id_tag = "deck3_airlock";
@@ -6512,7 +6512,7 @@
 	pixel_x = -30;
 	pixel_y = 10
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
 "fqT" = (
@@ -9987,7 +9987,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "ieP" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
@@ -11591,7 +11591,7 @@
 	name = "Public Airlock"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
@@ -11750,7 +11750,7 @@
 /area/medical/recoveryrestroom)
 "jNn" = (
 /obj/machinery/door/firedoor/glass,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/voidcraft/vertical{
 	frequency = 1380;
 	id_tag = null
@@ -13054,7 +13054,7 @@
 	id_tag = "emt_shuttle_dock";
 	pixel_y = 26
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
@@ -13565,7 +13565,7 @@
 /area/rnd/research)
 "lhX" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
@@ -13827,7 +13827,7 @@
 /obj/machinery/camera/network/civilian{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 4;
 	id_tag = "deck3_airlock"
@@ -14328,8 +14328,8 @@
 	id_tag = "deck3_airlock";
 	pixel_y = -22
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 4;
 	id_tag = "deck3_airlock"
@@ -16139,7 +16139,7 @@
 /obj/machinery/door/airlock/glass_external{
 	name = "Public Airlock"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
@@ -16827,8 +16827,8 @@
 /area/maintenance/fore)
 "nRz" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
 	id_tag = "emt_shuttle_docker";
@@ -18656,7 +18656,7 @@
 "pfl" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button/airlock_exterior{
 	dir = 1;
 	frequency = 1380;
@@ -19461,7 +19461,7 @@
 /turf/simulated/floor/tiled,
 /area/rnd/test_area)
 "pFM" = (
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
@@ -20730,7 +20730,7 @@
 	pixel_x = -20;
 	pixel_y = -5
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
 "qzn" = (
@@ -22572,7 +22572,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
 "rLP" = (
@@ -24235,7 +24235,7 @@
 	name = "Public Airlock"
 	},
 /obj/machinery/shield_diffuser,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
@@ -28011,7 +28011,7 @@
 "vXc" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button/airlock_interior{
 	dir = 1;
 	frequency = 1380;

--- a/_maps/map_files/triumph/triumph-04-deck4.dmm
+++ b/_maps/map_files/triumph/triumph-04-deck4.dmm
@@ -1166,7 +1166,7 @@
 /area/bridge)
 "aUx" = (
 /obj/machinery/shield_diffuser,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
@@ -2199,7 +2199,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external,
 /obj/machinery/access_button/airlock_interior{
 	dir = 4;
@@ -2660,7 +2660,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/voidcraft/vertical,
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
@@ -2937,7 +2937,7 @@
 /area/security/brig)
 "cgx" = (
 /obj/machinery/shield_diffuser,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external,
 /obj/machinery/access_button/airlock_exterior{
 	dir = 1;
@@ -3261,7 +3261,7 @@
 	name = "Docking Port Airlock"
 	},
 /obj/machinery/shield_diffuser,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button/airlock_exterior{
 	dir = 1;
 	frequency = 1380;
@@ -3450,8 +3450,8 @@
 	id_tag = "expshuttle_dock";
 	pixel_y = -24
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
@@ -3577,7 +3577,7 @@
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/cyan,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
 	id_tag = "civvie_docker";
 	pixel_y = -24
@@ -4574,8 +4574,8 @@
 	id_tag = "deck4_airlock";
 	pixel_y = -22
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "duu" = (
@@ -4951,7 +4951,7 @@
 /area/security/riot_control)
 "dFN" = (
 /obj/machinery/door/firedoor,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(19,43,67)
 	},
@@ -5358,7 +5358,7 @@
 	pixel_x = 5;
 	pixel_y = 25
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/voidcraft/vertical,
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
@@ -6375,7 +6375,7 @@
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/cockpit)
 "eCD" = (
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
 	id_tag = "civvie_dock";
@@ -6422,7 +6422,7 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(19,43,67)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "eEq" = (
@@ -8540,7 +8540,7 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/captain)
 "fUd" = (
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -9787,7 +9787,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/voidcraft/vertical,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button/airlock_exterior{
 	frequency = 1380;
 	master_tag = "courser_docker";
@@ -10948,7 +10948,7 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(19,43,67)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "hCx" = (
@@ -12424,7 +12424,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
@@ -12607,7 +12607,7 @@
 	frequency = 1380;
 	id_tag = "expshuttle_dock_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "iEd" = (
@@ -12952,7 +12952,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
 	id_tag = "expshuttle_docker";
 	pixel_x = 24
@@ -12962,7 +12962,7 @@
 	id_tag = "expshuttle_docker_pump";
 	power_rating = 20000
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/general)
@@ -13428,7 +13428,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/shield_diffuser,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
@@ -13821,7 +13821,7 @@
 	pixel_y = -8
 	},
 /obj/machinery/door/firedoor,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled,
 /area/exploration/pilot_prep)
 "jxD" = (
@@ -13936,7 +13936,7 @@
 /area/maintenance/chapel)
 "jCa" = (
 /obj/machinery/door/firedoor,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/voidcraft/vertical,
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
@@ -14799,7 +14799,7 @@
 	id_tag = "courser_dock";
 	pixel_x = 25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
 	id_tag = "courser_dock";
@@ -15034,7 +15034,7 @@
 	id_tag = "civvie_docker_pump"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
 "kvv" = (
@@ -16097,7 +16097,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button/airlock_interior{
 	dir = 4;
 	frequency = 1380;
@@ -18310,7 +18310,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button/airlock_exterior{
 	frequency = 1380;
 	master_tag = "courser_dock";
@@ -18715,7 +18715,7 @@
 	req_one_access = list(19,43,67)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "mTK" = (
@@ -19005,7 +19005,7 @@
 /area/maintenance/security/starboard)
 "nfc" = (
 /obj/machinery/shield_diffuser,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external,
 /obj/machinery/access_button/airlock_exterior{
 	dir = 1;
@@ -19447,7 +19447,7 @@
 /area/security/eva)
 "nuT" = (
 /obj/machinery/shield_diffuser,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external,
 /obj/machinery/access_button/airlock_exterior{
 	dir = 8;
@@ -19554,7 +19554,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/aft)
 "nyt" = (
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external,
 /obj/machinery/access_button/airlock_interior{
 	dir = 1;
@@ -19762,7 +19762,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
@@ -21081,7 +21081,7 @@
 	name = "Docking Port Airlock"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button/airlock_interior{
 	dir = 1;
 	frequency = 1380;
@@ -21441,7 +21441,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/firedoor,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled,
 /area/exploration/pilot_prep)
 "oPJ" = (
@@ -21570,7 +21570,7 @@
 /area/security/brig)
 "oUI" = (
 /obj/machinery/door/airlock/voidcraft/vertical,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/plating,
 /area/shuttle/courser/general)
 "oUQ" = (
@@ -22659,7 +22659,7 @@
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/tram)
 "pFz" = (
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/voidcraft/vertical,
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
@@ -23076,7 +23076,7 @@
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "pSB" = (
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button/airlock_interior{
 	frequency = 1380;
 	master_tag = "expshuttle_docker";
@@ -23865,7 +23865,7 @@
 	frequency = 1380;
 	id_tag = "courser_dock_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/exploration/pilot_prep)
 "qnU" = (
@@ -25733,7 +25733,7 @@
 	frequency = 1380;
 	id_tag = "civvie_docker_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
 "rsP" = (
@@ -25878,8 +25878,8 @@
 	frequency = 1380;
 	id_tag = "deck4_dockarm1_pump"
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "rBF" = (
@@ -26731,7 +26731,7 @@
 	id_tag = "courser_docker_pump";
 	power_rating = 20000
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shuttle/courser/general)
@@ -26795,7 +26795,7 @@
 /obj/machinery/door/airlock/voidcraft/vertical{
 	name = "cockpit hatch"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button/airlock_interior{
 	dir = 4;
 	frequency = 1380;
@@ -26856,7 +26856,7 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(19,43,67)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "skS" = (
@@ -26883,8 +26883,8 @@
 	id_tag = "deck4_dockarm2";
 	pixel_x = 23
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "slE" = (
@@ -27245,7 +27245,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1380;
@@ -27928,7 +27928,7 @@
 /area/shuttle/courser/cockpit)
 "sPW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
@@ -28090,7 +28090,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
@@ -28581,13 +28581,13 @@
 	id_tag = "courser_docker_pump";
 	power_rating = 20000
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
 	id_tag = "courser_docker";
 	pixel_x = -24
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/structure/handrail{
 	dir = 4
 	},
@@ -29633,7 +29633,7 @@
 /turf/simulated/floor/wood,
 /area/library)
 "ufP" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 1;
@@ -30194,7 +30194,7 @@
 /obj/machinery/door/airlock/glass_external{
 	name = "Docking Port Airlock"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "uxl" = (
@@ -34776,7 +34776,7 @@
 	name = "Docking Port Airlock"
 	},
 /obj/machinery/shield_diffuser,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "xte" = (
@@ -35331,7 +35331,7 @@
 /turf/simulated/floor/tiled,
 /area/security/hanger)
 "xOo" = (
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external,
 /obj/machinery/access_button/airlock_interior{
 	dir = 1;

--- a/_maps/map_levels/140x140/lavaland.dmm
+++ b/_maps/map_levels/140x140/lavaland.dmm
@@ -625,7 +625,7 @@
 	pixel_y = 25;
 	req_one_access = list(48)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(48)
 	},
@@ -761,7 +761,7 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(48)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button{
 	dir = 4;
 	frequency = 1384;
@@ -816,7 +816,7 @@
 	id_tag = "mining_engine";
 	power_rating = 20000
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "pQ" = (
@@ -986,7 +986,7 @@
 	id_tag = "mining_engine";
 	pixel_y = -25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "rV" = (
@@ -1031,7 +1031,7 @@
 	id_tag = "mining_outpost";
 	pixel_y = -25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 1;
@@ -1039,7 +1039,7 @@
 	id_tag = "mining_outpost";
 	power_rating = 20000
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "sQ" = (
@@ -1329,7 +1329,7 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(48)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button{
 	dir = 8;
 	frequency = 1384;
@@ -1500,7 +1500,7 @@
 /obj/machinery/door/firedoor{
 	req_one_access = list(48)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(48)
 	},
@@ -1635,7 +1635,7 @@
 /turf/simulated/floor/tiled/old_tile,
 /area/lavaland/central/base/common)
 "Fe" = (
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior{
 	dir = 4;
 	frequency = 1384;
@@ -1940,7 +1940,7 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/lavaland/central/base/common)
 "KB" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1384;
@@ -1965,7 +1965,7 @@
 	id_tag = "mining_engine";
 	power_rating = 20000
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "KX" = (
@@ -1980,7 +1980,7 @@
 	pixel_y = -25;
 	req_one_access = list(48)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(48)
 	},
@@ -2208,7 +2208,7 @@
 	id_tag = "mining_outpost";
 	power_rating = 20000
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "Qo" = (
@@ -2231,7 +2231,7 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(48)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
@@ -2269,7 +2269,7 @@
 	pixel_x = -22;
 	pixel_y = -4
 	},
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/outdoors/lavaland,
 /area/lavaland/central/base/common)
 "RJ" = (
@@ -2408,7 +2408,7 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(48)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "TQ" = (
@@ -2601,7 +2601,7 @@
 /obj/machinery/door/firedoor{
 	req_one_access = list(48)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(48)
 	},

--- a/_maps/map_levels/140x140/talon/talon1.dmm
+++ b/_maps/map_levels/140x140/talon/talon1.dmm
@@ -135,7 +135,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external,
 /turf/simulated/floor/plating,
 /area/talon/maintenance/deckone_port)
@@ -1307,7 +1307,7 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(301)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/deckone_starboard)
 "lb" = (
@@ -1419,8 +1419,8 @@
 	pixel_x = -28;
 	req_one_access = list(301)
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -1533,7 +1533,7 @@
 /turf/simulated/floor/plating,
 /area/talon/maintenance/deckone_port)
 "ne" = (
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor{
 	dir = 8;
 	pixel_x = 28;
@@ -1605,7 +1605,7 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(301)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},
@@ -1772,7 +1772,7 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(301)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},
@@ -1869,7 +1869,7 @@
 	id_tag = "talon_boat";
 	pixel_x = 28
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
@@ -2285,7 +2285,7 @@
 /turf/simulated/wall,
 /area/talon/deckone/central_hallway)
 "ta" = (
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 10
 	},
@@ -2352,7 +2352,7 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(301)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/plating,
 /area/talon/maintenance/deckone_port)
 "tE" = (
@@ -2462,7 +2462,7 @@
 /turf/simulated/floor/plating,
 /area/talon/maintenance/deckone_starboard)
 "uF" = (
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(301)
@@ -2520,8 +2520,8 @@
 	pixel_y = -30;
 	req_one_access = list(301)
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
 	pixel_y = 28;
 	req_one_access = list(301)
@@ -2641,7 +2641,7 @@
 	dir = 1;
 	icon_state = "4-8"
 	},
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/tiled/eris/dark/techfloor,
 /area/shuttle/talonboat)
 "vW" = (
@@ -2770,7 +2770,7 @@
 	pixel_y = 28;
 	req_one_access = list(301)
 	},
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/structure/catwalk,
 /turf/simulated/floor/airless,
 /area/talon/maintenance/deckone_starboard)
@@ -3654,7 +3654,7 @@
 /area/talon/deckone/brig)
 "CU" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1380;
@@ -3876,8 +3876,8 @@
 	req_one_access = list(301);
 	tag_airpump = "talon_port_wing_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
 	pixel_y = 28;
 	req_one_access = list(301)
@@ -4190,7 +4190,7 @@
 	pixel_y = 28;
 	req_one_access = list(301)
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},
@@ -4600,8 +4600,8 @@
 /area/talon/deckone/central_hallway)
 "JF" = (
 /obj/machinery/light/small,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
 	id_tag = "talon_port";
@@ -5345,7 +5345,7 @@
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/deckone/central_hallway)
 "QD" = (
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(301)
 	},
@@ -5353,7 +5353,7 @@
 	pixel_x = 28;
 	pixel_y = -4
 	},
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/tiled/eris/dark/gray_perforated,
 /area/shuttle/talonboat)
 "QM" = (
@@ -6442,7 +6442,7 @@
 	pixel_y = 28;
 	req_one_access = list(301)
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},

--- a/_maps/map_levels/140x140/talon/talon2.dmm
+++ b/_maps/map_levels/140x140/talon/talon2.dmm
@@ -239,7 +239,7 @@
 	pixel_y = -28;
 	req_one_access = list(301)
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/atmospherics/pipe/simple/visible/aux{
 	dir = 10
 	},
@@ -2537,7 +2537,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon/decktwo/lifeboat)
 "Cu" = (
@@ -2710,7 +2710,7 @@
 /turf/simulated/floor/tiled/eris/white,
 /area/talon/decktwo/central_hallway)
 "DO" = (
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(301)
 	},
@@ -2765,7 +2765,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -2901,8 +2901,8 @@
 	pixel_x = 28;
 	req_one_access = list(301)
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
@@ -3068,7 +3068,7 @@
 	pixel_y = 28;
 	req_one_access = list(301)
 	},
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/hull/airless,
 /area/talon/maintenance/decktwo_aft)
 "Ht" = (
@@ -3197,7 +3197,7 @@
 /turf/simulated/floor/bluegrid,
 /area/talon/decktwo/tech)
 "Ju" = (
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/visible/aux,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(301)

--- a/_maps/map_levels/140x140/tradeport.dmm
+++ b/_maps/map_levels/140x140/tradeport.dmm
@@ -927,8 +927,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "di" = (
@@ -1038,7 +1038,7 @@
 /obj/machinery/door/firedoor{
 	req_one_access = list(160)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
 "dA" = (
@@ -1064,7 +1064,7 @@
 	frequency = null;
 	name = "Ship Hatch"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "dD" = (
@@ -1743,7 +1743,7 @@
 /obj/machinery/door/firedoor{
 	req_one_access = list(160)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
 	name = "Nebula Gas - Employees Only"
 	},
@@ -1920,7 +1920,7 @@
 	frequency = null;
 	name = "Ship Hatch"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "gV" = (
@@ -2089,7 +2089,7 @@
 /obj/machinery/door/firedoor{
 	req_one_access = list(160)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1380;
@@ -2803,7 +2803,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
 	frequency = null;
 	name = "Ship Hatch"
@@ -3488,7 +3488,7 @@
 /obj/machinery/door/firedoor{
 	req_one_access = list(160)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1380;
@@ -3826,7 +3826,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
 "nP" = (
@@ -4887,7 +4887,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1380;
@@ -5653,7 +5653,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = -25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/plating,
 /area/tradeport/pads)
 "up" = (
@@ -6029,7 +6029,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/tradeport/medical)
 "vD" = (
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
 	frequency = null;
 	name = "Ship Hatch"
@@ -6209,7 +6209,7 @@
 /area/tradeport/facility)
 "wc" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1380;
@@ -6385,7 +6385,7 @@
 /turf/space,
 /area/space)
 "wQ" = (
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
 	pixel_y = -25
 	},
@@ -6400,7 +6400,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -6545,7 +6545,7 @@
 /obj/machinery/door/airlock/external/glass{
 	req_access = list(160)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	pixel_x = -10;
@@ -6873,8 +6873,8 @@
 	master_tag = null;
 	pixel_x = 25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "yi" = (
@@ -6934,7 +6934,7 @@
 	frequency = null;
 	name = "Ship Hatch"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "yr" = (
@@ -7101,12 +7101,12 @@
 /turf/simulated/floor/tiled/old_tile/white,
 /area/tradeport)
 "yZ" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/airlock_sensor{
 	pixel_x = -25;
 	pixel_y = 25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	frequency = 1380;
 	id_tag = "trade_pumps"
@@ -7355,7 +7355,7 @@
 	frequency = 1380;
 	id_tag = "trade_docks"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor,
 /area/tradeport/pads)
 "zV" = (
@@ -7567,7 +7567,7 @@
 /area/tradeport/medical)
 "Bi" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/tradeport/pads)
 "Bj" = (
@@ -7577,7 +7577,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
 	name = "Nebula Gas - Employees Only"
 	},
@@ -8153,7 +8153,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1380;
@@ -8372,7 +8372,7 @@
 	id_tag = "tradeport_hangar_dock";
 	pixel_x = 25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
 "Em" = (
@@ -8420,7 +8420,7 @@
 /turf/simulated/floor/wood,
 /area/tradeport/cyndi)
 "Eu" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	frequency = 1380;
 	id_tag = "trade_pumps"
@@ -9913,7 +9913,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
 	frequency = null;
 	name = "Ship Hatch"
@@ -10952,7 +10952,7 @@
 /obj/machinery/door/firedoor{
 	req_one_access = list(160)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
 	name = "Nebula Gas - Employees Only"
 	},
@@ -10989,7 +10989,7 @@
 	frequency = null;
 	name = "Ship Hatch"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "Op" = (
@@ -11759,7 +11759,7 @@
 	frequency = 1380;
 	id_tag = "tradeport_hangar_dock_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
 "Rd" = (
@@ -11797,7 +11797,7 @@
 /obj/machinery/door/airlock/glass_external{
 	name = "Nebula Gas - External Access"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button/airlock_exterior{
 	frequency = 1380;
 	master_tag = "trade_docks";
@@ -12095,7 +12095,7 @@
 /obj/machinery/door/airlock/glass_external{
 	name = "Nebula Gas - External Access"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -13524,7 +13524,7 @@
 	frequency = 1380;
 	id_tag = "trade_docks"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	frequency = 1380;
 	id_tag = "trade_docks";
@@ -13569,7 +13569,7 @@
 	pixel_x = -25;
 	pixel_y = 25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor,
 /area/tradeport/pads)
@@ -14087,7 +14087,7 @@
 /obj/machinery/door/airlock/external/glass{
 	req_access = list(160)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	pixel_x = 10;

--- a/_maps/map_levels/192x192/lavaland.dmm
+++ b/_maps/map_levels/192x192/lavaland.dmm
@@ -549,7 +549,7 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(48)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button{
 	dir = 4;
 	frequency = 1384;
@@ -568,7 +568,7 @@
 	id_tag = "mining_engine";
 	pixel_y = -25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "mh" = (
@@ -578,7 +578,7 @@
 	id_tag = "mining_engine";
 	power_rating = 20000
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "mm" = (
@@ -868,7 +868,7 @@
 	id_tag = "mining_engine";
 	power_rating = 20000
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "pQ" = (
@@ -1500,7 +1500,7 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(48)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button{
 	dir = 8;
 	frequency = 1384;
@@ -1657,7 +1657,7 @@
 /turf/simulated/floor/tiled/old_tile,
 /area/lavaland/central/base/common)
 "Fe" = (
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior{
 	dir = 4;
 	frequency = 1384;
@@ -1941,7 +1941,7 @@
 	pixel_y = 25;
 	req_one_access = list(48)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(48)
 	},
@@ -1978,7 +1978,7 @@
 /obj/machinery/door/firedoor{
 	req_one_access = list(48)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(48)
 	},
@@ -2114,7 +2114,7 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(48)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
@@ -2166,14 +2166,14 @@
 /obj/machinery/door/firedoor{
 	req_one_access = list(48)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(48)
 	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "RJ" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1384;
@@ -2212,7 +2212,7 @@
 	id_tag = "mining_outpost";
 	pixel_y = -25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 1;
@@ -2220,7 +2220,7 @@
 	id_tag = "mining_outpost";
 	power_rating = 20000
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "Sm" = (
@@ -2230,7 +2230,7 @@
 	id_tag = "mining_outpost";
 	power_rating = 20000
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "Ss" = (
@@ -2245,7 +2245,7 @@
 	pixel_y = -25;
 	req_one_access = list(48)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(48)
 	},
@@ -2340,7 +2340,7 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(48)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "TW" = (
@@ -2456,7 +2456,7 @@
 	pixel_x = -22;
 	pixel_y = -4
 	},
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/outdoors/lavaland,
 /area/lavaland/central/base/common)
 "Wb" = (

--- a/_maps/map_levels/192x192/tradeport.dmm
+++ b/_maps/map_levels/192x192/tradeport.dmm
@@ -178,7 +178,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
 "aK" = (
@@ -499,7 +499,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = -25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/plating,
 /area/tradeport/pads)
 "bZ" = (
@@ -1697,12 +1697,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tradeport/dock)
 "gn" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/airlock_sensor{
 	pixel_x = -25;
 	pixel_y = 25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	frequency = 1380;
 	id_tag = "trade_pumps"
@@ -2604,7 +2604,7 @@
 /obj/machinery/door/firedoor{
 	req_one_access = list(160)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1380;
@@ -3181,7 +3181,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1380;
@@ -3245,7 +3245,7 @@
 /obj/machinery/door/airlock/glass_external{
 	name = "Nebula Gas - External Access"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button/airlock_exterior{
 	frequency = 1380;
 	master_tag = "trade_docks";
@@ -3564,7 +3564,7 @@
 /obj/machinery/door/airlock/external/glass{
 	req_access = list(160)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	pixel_x = 10;
@@ -3908,7 +3908,7 @@
 	frequency = 1380;
 	id_tag = "tradeport_hangar_dock_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
 "ov" = (
@@ -4325,7 +4325,7 @@
 /obj/machinery/door/firedoor{
 	req_one_access = list(160)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
 	name = "Nebula Gas - Employees Only"
 	},
@@ -5065,7 +5065,7 @@
 /obj/machinery/door/airlock/external/glass{
 	req_access = list(160)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	pixel_x = -10;
@@ -5262,7 +5262,7 @@
 	frequency = null;
 	name = "Ship Hatch"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "tR" = (
@@ -5870,7 +5870,7 @@
 /area/shuttle/trade_ship/general)
 "vP" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/tradeport/pads)
 "vR" = (
@@ -6473,7 +6473,7 @@
 /obj/machinery/door/firedoor{
 	req_one_access = list(160)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1380;
@@ -6975,7 +6975,7 @@
 	frequency = null;
 	name = "Ship Hatch"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "zJ" = (
@@ -7019,8 +7019,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "zQ" = (
@@ -7252,7 +7252,7 @@
 /obj/machinery/door/firedoor{
 	req_one_access = list(160)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
 	name = "Nebula Gas - Employees Only"
 	},
@@ -7437,7 +7437,7 @@
 	frequency = null;
 	name = "Ship Hatch"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "Bs" = (
@@ -7569,7 +7569,7 @@
 /turf/simulated/shuttle/floor/white,
 /area/tradeport/commons)
 "BU" = (
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
 	frequency = null;
 	name = "Ship Hatch"
@@ -7779,7 +7779,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
 	name = "Nebula Gas - Employees Only"
 	},
@@ -8475,7 +8475,7 @@
 /turf/simulated/floor/tiled/old_tile/beige,
 /area/tradeport/commhall)
 "Fc" = (
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
 	pixel_y = -25
 	},
@@ -8490,7 +8490,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -8934,7 +8934,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1380;
@@ -8998,7 +8998,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
 	frequency = null;
 	name = "Ship Hatch"
@@ -9969,7 +9969,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
 	frequency = null;
 	name = "Ship Hatch"
@@ -10605,7 +10605,7 @@
 /area/tradeport/engineering)
 "MZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1380;
@@ -10682,7 +10682,7 @@
 	pixel_x = -25;
 	pixel_y = 25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor,
 /area/tradeport/pads)
@@ -10774,7 +10774,7 @@
 /obj/machinery/door/airlock/glass_external{
 	name = "Nebula Gas - External Access"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -11438,8 +11438,8 @@
 	master_tag = null;
 	pixel_x = 25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "PP" = (
@@ -11936,7 +11936,7 @@
 	frequency = null;
 	name = "Ship Hatch"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "RL" = (
@@ -12229,7 +12229,7 @@
 	id_tag = "tradeport_hangar_dock";
 	pixel_x = 25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
 "SP" = (
@@ -12581,7 +12581,7 @@
 /obj/machinery/door/firedoor{
 	req_one_access = list(160)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
 "Ui" = (
@@ -12824,7 +12824,7 @@
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/facility)
 "UW" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	frequency = 1380;
 	id_tag = "trade_pumps"
@@ -12945,7 +12945,7 @@
 	frequency = 1380;
 	id_tag = "trade_docks"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	frequency = 1380;
 	id_tag = "trade_docks";
@@ -12961,7 +12961,7 @@
 	frequency = 1380;
 	id_tag = "trade_docks"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor,
 /area/tradeport/pads)
 "VF" = (

--- a/_maps/submaps/level_specific/class_d/hiddenbunkerD.dmm
+++ b/_maps/submaps/level_specific/class_d/hiddenbunkerD.dmm
@@ -41,7 +41,7 @@
 /area/class_d/Mountain)
 "hZ" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/class_d/Mountain)
 "is" = (
@@ -90,7 +90,7 @@
 	id_tag = "bunkerD_internal";
 	locked = 1
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled,
 /area/class_d/Mountain)
 "pq" = (
@@ -353,8 +353,8 @@
 	frequency = 1379;
 	id_tag = "rnd_s_airlock_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
 	frequency = 804;
 	id_tag = "bunkerD_sensor";
@@ -400,7 +400,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled,
 /area/class_d/Mountain)
 "Ys" = (
@@ -420,7 +420,7 @@
 	id_tag = "bunkerD_external";
 	locked = 1
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled,
 /area/class_d/Mountain)
 

--- a/_maps/submaps/level_specific/class_h/desertsaloon.dmm
+++ b/_maps/submaps/level_specific/class_h/desertsaloon.dmm
@@ -25,7 +25,7 @@
 	dir = 8
 	},
 /obj/effect/debris/cleanable/blood,
-/atom/movable/spawner/corpse/syndicatesoldier,
+/obj/spawner/corpse/syndicatesoldier,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -226,7 +226,7 @@
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 8
 	},
-/atom/movable/spawner/corpse/clown,
+/obj/spawner/corpse/clown,
 /obj/effect/debris/cleanable/blood,
 /turf/simulated/floor/carpet/blucarpet,
 /area/class_h/POIs/saloon)

--- a/_maps/submaps/level_specific/class_h/highnoonH.dmm
+++ b/_maps/submaps/level_specific/class_h/highnoonH.dmm
@@ -21,7 +21,7 @@
 /area/class_h/POIs/WW_Town)
 "dI" = (
 /obj/structure/bed/padded,
-/atom/movable/spawner/corpse/syndicatesoldier,
+/obj/spawner/corpse/syndicatesoldier,
 /turf/simulated/floor/wood/classh,
 /area/class_h/POIs/WW_Town)
 "dR" = (

--- a/_maps/submaps/level_specific/debrisfield_vr/gecko_cr_wreck.dmm
+++ b/_maps/submaps/level_specific/debrisfield_vr/gecko_cr_wreck.dmm
@@ -156,7 +156,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = -25
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -454,8 +454,8 @@
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/gecko_cr_wreck)
 "kd" = (
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 6;
 	pixel_x = 7;
@@ -681,7 +681,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},
@@ -862,8 +862,8 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = 21
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump,
 /obj/structure/handrail,
 /obj/machinery/light{
@@ -1215,8 +1215,8 @@
 /area/shuttle/gecko_cr_engineering_wreck)
 "yE" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 10;
 	pixel_x = -8;
@@ -1241,7 +1241,7 @@
 /area/shuttle/gecko_cr_engineering_wreck)
 "zx" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/gecko_cr_cockpit_wreck)
@@ -1359,7 +1359,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},
@@ -1429,7 +1429,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = 26
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -1855,7 +1855,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},
@@ -2184,7 +2184,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump,
 /obj/structure/handrail,
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
@@ -2268,7 +2268,7 @@
 "PD" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/gecko_cr_cockpit_wreck)
 "PI" = (
@@ -2522,8 +2522,8 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = 21
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump,
 /obj/structure/handrail,
 /obj/machinery/light{
@@ -2834,7 +2834,7 @@
 /area/shuttle/gecko_cr_engineering_wreck)
 "Yj" = (
 /obj/effect/floor_decal/industrial/warning/corner,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump,
 /obj/structure/handrail,
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
@@ -2850,7 +2850,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},

--- a/_maps/submaps/level_specific/debrisfield_vr/mackerel_lc_wreck.dmm
+++ b/_maps/submaps/level_specific/debrisfield_vr/mackerel_lc_wreck.dmm
@@ -170,8 +170,8 @@
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -223,8 +223,8 @@
 /area/shuttle/mackerel_lc_wreck)
 "pZ" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 10;
 	pixel_x = -8;
@@ -304,7 +304,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = 24
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/railing/grey,
 /obj/random/empty_or_lootable_crate,
@@ -543,8 +543,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/mackerel_lc_wreck)
 "FL" = (
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 6;
 	pixel_x = 7;
@@ -610,7 +610,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/mackerel_lc_wreck)
 "Ib" = (
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/hatch,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/mackerel_lc_wreck)
@@ -724,7 +724,7 @@
 	},
 /area/shuttle/mackerel_lc_wreck)
 "PL" = (
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/hatch{
 	density = 0;
 	icon_state = "door_open";
@@ -787,7 +787,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = -25
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
@@ -810,8 +810,8 @@
 	dir = 1
 	},
 /obj/structure/handrail,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -893,7 +893,7 @@
 /area/shuttle/mackerel_lc_wreck)
 "Zp" = (
 /obj/effect/debris/cleanable/blood,
-/atom/movable/spawner/corpse/vintage/pilot,
+/obj/spawner/corpse/vintage/pilot,
 /turf/simulated/floor/tiled/techmaint/airless,
 /area/shuttle/mackerel_lc_wreck)
 "ZJ" = (

--- a/_maps/submaps/level_specific/debrisfield_vr/salamander_wreck.dmm
+++ b/_maps/submaps/level_specific/debrisfield_vr/salamander_wreck.dmm
@@ -1,14 +1,14 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ab" = (
 /obj/machinery/door/airlock/glass_external/public,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/salamander_wreck)
 "aK" = (
 /obj/machinery/door/airlock/glass_external/public,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 1;
 	pixel_x = 24;
@@ -47,7 +47,7 @@
 	},
 /area/shuttle/salamander_wreck_head)
 "bu" = (
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/machinery/airlock_sensor{
 	dir = 4;
@@ -185,7 +185,7 @@
 /area/shuttle/salamander_wreck_head)
 "cX" = (
 /obj/machinery/door/airlock/glass_external/public,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/salamander_wreck)
@@ -276,7 +276,7 @@
 	},
 /area/shuttle/salamander_wreck_q2)
 "eJ" = (
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/airlock_sensor{
 	dir = 8;
 	pixel_x = 21
@@ -890,8 +890,8 @@
 	},
 /area/shuttle/salamander_wreck_engineering)
 "mg" = (
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	pixel_x = 24;
 	pixel_y = -11
@@ -1002,7 +1002,7 @@
 /area/shuttle/salamander_wreck)
 "oe" = (
 /obj/machinery/door/airlock/glass_external/public,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/salamander_wreck)
 "oi" = (
@@ -1091,7 +1091,7 @@
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/closet/walllocker/emerglocker/east,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/salamander_wreck)
@@ -1372,7 +1372,7 @@
 	},
 /area/shuttle/salamander_wreck)
 "BE" = (
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external/public{
 	density = 0;
 	icon_state = "door_open"
@@ -1544,7 +1544,7 @@
 /turf/simulated/floor/tiled/techmaint/airless,
 /area/shuttle/salamander_wreck)
 "Kw" = (
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
@@ -1683,7 +1683,7 @@
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/closet/walllocker/emerglocker/east,
 /turf/simulated/floor/tiled/techmaint/airless,
 /area/shuttle/salamander_wreck)
@@ -1811,7 +1811,7 @@
 	density = 0;
 	icon_state = "door_open"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/techmaint/airless,
 /area/shuttle/salamander_wreck)
 "Vh" = (

--- a/_maps/submaps/level_specific/debrisfield_vr/tinycarrier.dmm
+++ b/_maps/submaps/level_specific/debrisfield_vr/tinycarrier.dmm
@@ -39,7 +39,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/monofloor,
 /area/submap/debrisfield_vr/tinyshuttle/crew)
 "ag" = (
@@ -59,7 +59,7 @@
 	pixel_x = -4;
 	pixel_y = 8
 	},
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/wall/thull,
 /area/submap/debrisfield_vr/tinyshuttle/crew)
 "aj" = (
@@ -83,7 +83,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_external/public,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/monofloor{
 	dir = 4
 	},
@@ -108,8 +108,8 @@
 	pixel_x = 26;
 	pixel_y = 6
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/effect/overmap/visitable/ship/landable/tinycarrier,
 /turf/simulated/floor/tiled/monotile,
 /area/submap/debrisfield_vr/tinyshuttle/crew)
@@ -169,7 +169,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},

--- a/_maps/templates/admin/dojo.dmm
+++ b/_maps/templates/admin/dojo.dmm
@@ -229,7 +229,7 @@
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/Dooruranium.dmi'
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/unsimulated/floor{
 	icon_state = "plating";
 	name = "plating"
@@ -250,13 +250,13 @@
 	name = "Outer Airlock";
 	opacity = 0
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/airlock_sensor{
 	dir = 8;
 	pixel_y = -27;
 	req_access = list(150)
 	},
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/shuttle/ninja)
 "aL" = (
@@ -271,7 +271,7 @@
 	pixel_y = 28;
 	req_access = list(150)
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/effect/overmap/visitable/ship/landable/ninja,
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/shuttle/ninja)
@@ -329,7 +329,7 @@
 	name = "ship lockdown control";
 	pixel_x = -25
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/shuttle/ninja)
 "aT" = (
@@ -342,7 +342,7 @@
 	name = "Ship Internal Hatch";
 	req_access = list(150)
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/shuttle/ninja)
 "aU" = (
@@ -395,7 +395,7 @@
 	pixel_x = -27;
 	req_access = list(150)
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/computer/station_alert{
 	dir = 4
 	},
@@ -889,7 +889,7 @@
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/Dooruranium.dmi'
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/unsimulated/floor{
 	icon_state = "plating";
 	name = "plating"

--- a/_maps/templates/admin/ert.dmm
+++ b/_maps/templates/admin/ert.dmm
@@ -9,13 +9,13 @@
 /area/ship/ert/dock_port)
 "ae" = (
 /obj/machinery/door/airlock/external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/airlock_sensor/airlock_exterior{
 	dir = 1;
 	pixel_x = 24;
 	pixel_y = 11
 	},
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_port)
 "af" = (
@@ -39,7 +39,7 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -52,7 +52,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = 24
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -199,7 +199,7 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -217,7 +217,7 @@
 /area/ship/ert/atmos)
 "ch" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_star)
 "ci" = (
@@ -316,7 +316,7 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -478,13 +478,13 @@
 /area/ship/ert/dock_port)
 "dY" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_port)
 "ee" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_port)
 "ef" = (
@@ -896,7 +896,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = 21
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -1326,8 +1326,8 @@
 	pixel_x = 24;
 	pixel_y = -11
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_star)
 "lz" = (
@@ -1608,7 +1608,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = -23
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -2818,7 +2818,7 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/sign/vacuum{
 	pixel_x = -32
@@ -3287,7 +3287,7 @@
 /area/ship/ert/hallways_aft)
 "yo" = (
 /obj/machinery/door/airlock/external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_star)
 "yp" = (
@@ -5300,7 +5300,7 @@
 /area/ship/ert/med_surg)
 "LR" = (
 /obj/machinery/door/airlock/external,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_port)
 "LV" = (
@@ -6172,7 +6172,7 @@
 /area/ship/ert/engineering)
 "Rh" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_star)
@@ -6904,7 +6904,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "XM" = (
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
 	pixel_x = 24
 	},

--- a/_maps/templates/admin/kk_mercship.dmm
+++ b/_maps/templates/admin/kk_mercship.dmm
@@ -2332,7 +2332,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hallways_aft)
 "lg" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume,
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
 	id_tag = "merc_port";
@@ -4248,9 +4248,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hallways_star)
 "uN" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
 	pixel_y = 24
 	},
@@ -4528,7 +4528,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hallways_port)
 "vV" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume,
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
 	id_tag = "merc_star";
@@ -5369,8 +5369,8 @@
 /area/ship/manta/holding)
 "yT" = (
 /obj/machinery/door/airlock/external,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior{
 	dir = 6;
 	pixel_x = 7;
@@ -6229,9 +6229,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/armoury_as)
 "Di" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
 	pixel_y = 24
 	},
@@ -6946,8 +6946,8 @@
 /area/ship/manta/dock_star)
 "Ha" = (
 /obj/machinery/door/airlock/external,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior{
 	dir = 10;
 	pixel_x = -8;
@@ -7669,7 +7669,7 @@
 /area/ship/manta/recreation)
 "KI" = (
 /obj/machinery/door/airlock/external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
@@ -8391,7 +8391,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = -23
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/techfloor{
 	dir = 6
 	},
@@ -9508,7 +9508,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = -23
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/techfloor{
 	dir = 10
 	},
@@ -10567,7 +10567,7 @@
 /area/ship/manta/bridge)
 "YZ" = (
 /obj/machinery/door/airlock/external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
 	dir = 1

--- a/_maps/templates/shuttles/overmaps/generic/bearcat.dmm
+++ b/_maps/templates/shuttles/overmaps/generic/bearcat.dmm
@@ -559,18 +559,18 @@
 /turf/simulated/floor/plating,
 /area/shuttle/bearcat/unused2)
 "bo" = (
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 10;
 	pixel_x = -6;
 	pixel_y = 24
 	},
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/door/airlock/glass_external/public,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/dock_port)
 "bp" = (
-/atom/movable/map_helper/airlock/atmos/pump_out_internal,
+/obj/map_helper/airlock/atmos/pump_out_internal,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/dock_port)
@@ -581,12 +581,12 @@
 /turf/simulated/wall/rshull,
 /area/shuttle/bearcat/dock_starboard)
 "br" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 4;
 	icon_state = "map_vent"
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor/airlock_interior{
 	pixel_x = -8;
 	pixel_y = 26
@@ -601,7 +601,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/dock_port)
 "bs" = (
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -677,7 +677,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/dock_starboard)
 "bC" = (
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -685,13 +685,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/dock_starboard)
 "bD" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
 	id_tag = "expshuttle_docker_pump_out_external"
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor/airlock_interior{
 	pixel_x = 8;
 	pixel_y = 26
@@ -706,7 +706,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/dock_starboard)
 "bF" = (
-/atom/movable/map_helper/airlock/atmos/pump_out_internal,
+/obj/map_helper/airlock/atmos/pump_out_internal,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume,
 /obj/effect/shuttle_landmark/shuttle_initializer/bearcat,
 /obj/effect/overmap/visitable/ship/landable/bearcat,
@@ -720,8 +720,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/dock_starboard)
 "bH" = (
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 6;
 	pixel_x = 6;
@@ -735,7 +735,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = -26
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -846,7 +846,7 @@
 /turf/simulated/floor/airless,
 /area/shuttle/bearcat/crew_toilets)
 "ca" = (
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/airlock_sensor{
 	pixel_x = 26
 	},
@@ -3261,7 +3261,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/bearcat/maintenance_power)
 "gX" = (
-/atom/movable/map_helper/airlock/atmos/pump_out_external,
+/obj/map_helper/airlock/atmos/pump_out_external,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 1
 	},
@@ -3290,7 +3290,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/bearcat/maintenance_engine)
 "hc" = (
-/atom/movable/map_helper/airlock/atmos/pump_out_external,
+/obj/map_helper/airlock/atmos/pump_out_external,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 1
 	},

--- a/_maps/templates/shuttles/overmaps/generic/gecko_cr.dmm
+++ b/_maps/templates/shuttles/overmaps/generic/gecko_cr.dmm
@@ -161,7 +161,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = -25
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -447,8 +447,8 @@
 /area/shuttle/gecko_cr_cockpit)
 "kd" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 6;
 	pixel_x = 7;
@@ -674,7 +674,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},
@@ -858,8 +858,8 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = 21
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump,
 /obj/structure/handrail,
 /obj/machinery/light{
@@ -1249,8 +1249,8 @@
 /area/shuttle/gecko_cr_engineering)
 "yE" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 10;
 	pixel_x = -8;
@@ -1302,7 +1302,7 @@
 /area/shuttle/gecko_cr_engineering)
 "zx" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/gecko_cr_cockpit)
@@ -1419,7 +1419,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},
@@ -1504,7 +1504,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = 26
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -1966,7 +1966,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},
@@ -2286,7 +2286,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump,
 /obj/structure/handrail,
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
@@ -2346,7 +2346,7 @@
 "PD" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/gecko_cr_cockpit)
 "PI" = (
@@ -2608,8 +2608,8 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = 21
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump,
 /obj/structure/handrail,
 /obj/machinery/light{
@@ -2925,7 +2925,7 @@
 /area/shuttle/gecko_cr_engineering)
 "Yj" = (
 /obj/effect/floor_decal/industrial/warning/corner,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump,
 /obj/structure/handrail,
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
@@ -2939,7 +2939,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},

--- a/_maps/templates/shuttles/overmaps/generic/gecko_sh.dmm
+++ b/_maps/templates/shuttles/overmaps/generic/gecko_sh.dmm
@@ -210,7 +210,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = -25
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -465,8 +465,8 @@
 /area/shuttle/gecko_sh)
 "kd" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 6;
 	pixel_x = 7;
@@ -662,7 +662,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},
@@ -773,8 +773,8 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = 21
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump,
 /obj/structure/handrail,
 /obj/machinery/light{
@@ -1186,8 +1186,8 @@
 /area/shuttle/gecko_sh)
 "yE" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 10;
 	pixel_x = -8;
@@ -1220,7 +1220,7 @@
 /area/shuttle/gecko_sh_engineering)
 "zx" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
@@ -1354,7 +1354,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},
@@ -1445,7 +1445,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = 26
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -1848,7 +1848,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},
@@ -2097,7 +2097,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump,
 /obj/structure/handrail,
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
@@ -2141,7 +2141,7 @@
 /area/shuttle/gecko_sh)
 "PD" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
@@ -2383,8 +2383,8 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = 21
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump,
 /obj/structure/handrail,
 /obj/machinery/light{
@@ -2634,7 +2634,7 @@
 /area/shuttle/gecko_sh_engineering)
 "Yj" = (
 /obj/effect/floor_decal/industrial/warning/corner,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump,
 /obj/structure/handrail,
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
@@ -2651,7 +2651,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},

--- a/_maps/templates/shuttles/overmaps/generic/generic_shuttle.dmm
+++ b/_maps/templates/shuttles/overmaps/generic/generic_shuttle.dmm
@@ -624,7 +624,7 @@
 /area/shuttle/generic_shuttle/gen)
 "bo" = (
 /obj/machinery/door/airlock/glass_external,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/plating,
 /area/shuttle/generic_shuttle/gen)
 "bp" = (
@@ -633,7 +633,7 @@
 	frequency = 1380;
 	id_tag = "expshuttle_vent"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
 	id_tag = "generic_shuttle_docker";
@@ -652,8 +652,8 @@
 	frequency = 1380;
 	id_tag = "expshuttle_vent"
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/airlock_sensor{
 	pixel_y = 28
 	},
@@ -669,7 +669,7 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1380;

--- a/_maps/templates/shuttles/overmaps/generic/itglight.dmm
+++ b/_maps/templates/shuttles/overmaps/generic/itglight.dmm
@@ -226,7 +226,7 @@
 	id_tag = "itglightshuttle_docker_hatch";
 	name = "Shuttle Hatch"
 	},
-/atom/movable/map_helper/airlock/door/simple,
+/obj/map_helper/airlock/door/simple,
 /obj/structure/cable/pink{
 	d1 = 4;
 	d2 = 8;
@@ -2011,8 +2011,8 @@
 /turf/simulated/floor,
 /area/itglight/portengi)
 "lV" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
 	id_tag = "itglight_port_sensor";
@@ -2248,7 +2248,7 @@
 /turf/simulated/floor,
 /area/itglight/starboardengi)
 "nR" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	dir = 1;
 	frequency = 1380;
@@ -3316,7 +3316,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/itglight/passengersleeping)
 "wt" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	dir = 1;
 	frequency = 1380;
@@ -3527,7 +3527,7 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/itglight/lockers)
 "xj" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1380;
@@ -3709,7 +3709,7 @@
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -3810,7 +3810,7 @@
 /turf/simulated/floor/tiled/eris/steel/gray_platform,
 /area/itglight/starboardcargo)
 "yT" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1380;
@@ -3918,7 +3918,7 @@
 /turf/space,
 /area/itglight/portengi)
 "zG" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1380;
@@ -4130,8 +4130,8 @@
 	frequency = 1380;
 	id_tag = "itglight_starboard_pump"
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
 	id_tag = "itglight_starboard_sensor";
@@ -4162,7 +4162,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/itglight/lockers)
 "Bj" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1380;
@@ -4294,7 +4294,7 @@
 /area/itglight/porthighsec)
 "Ca" = (
 /obj/machinery/door/firedoor/glass,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
 	icon_state = "door_locked";
@@ -4487,7 +4487,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1380;
@@ -4748,7 +4748,7 @@
 /area/itglight/forehall)
 "EC" = (
 /obj/machinery/door/firedoor/glass,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/structure/cable/pink{
 	d1 = 4;
 	d2 = 8;
@@ -4938,7 +4938,7 @@
 /area/itglight/portengi)
 "Fe" = (
 /obj/machinery/door/firedoor/glass,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
 	icon_state = "door_locked";
@@ -5108,7 +5108,7 @@
 	frequency = 1380;
 	id_tag = "itglight_starboard_inner"
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1380;
@@ -5244,7 +5244,7 @@
 /turf/simulated/floor/tiled/eris/steel/gray_platform,
 /area/itglight/portcargo)
 "GI" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
@@ -5367,7 +5367,7 @@
 /turf/simulated/floor,
 /area/itglight/readyroom)
 "HD" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
@@ -5415,7 +5415,7 @@
 /turf/simulated/floor,
 /area/itglight/portengi)
 "HN" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1380;
@@ -5448,7 +5448,7 @@
 /turf/simulated/floor,
 /area/itglight/portengi)
 "HR" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
@@ -5463,7 +5463,7 @@
 /turf/simulated/floor,
 /area/itglight/starboardengi)
 "HW" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
@@ -5524,7 +5524,7 @@
 	id_tag = "itglight_dock_1_sensor";
 	pixel_y = -25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/itglight/portdocking)
@@ -5584,7 +5584,7 @@
 	id_tag = "itglight_dock_2_sensor";
 	pixel_y = -25
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/itglight/starboarddocking)
@@ -5622,7 +5622,7 @@
 	id_tag = "itglight_starboard_outer";
 	name = "Starboard Solars External Airlock"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1380;
@@ -5637,7 +5637,7 @@
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
 /area/itglight/common)
 "Jk" = (
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
@@ -7722,7 +7722,7 @@
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8"
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1380;

--- a/_maps/templates/shuttles/overmaps/generic/mackerel_hc.dmm
+++ b/_maps/templates/shuttles/overmaps/generic/mackerel_hc.dmm
@@ -166,8 +166,8 @@
 /area/shuttle/mackerel_hc)
 "mw" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 10;
 	pixel_x = -8;
@@ -359,8 +359,8 @@
 /area/shuttle/mackerel_hc)
 "zY" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 6;
 	pixel_x = 7;
@@ -464,8 +464,8 @@
 	dir = 1
 	},
 /obj/structure/handrail,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -632,7 +632,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = -25
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
@@ -669,8 +669,8 @@
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -765,7 +765,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = 26
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/light{
 	dir = 4
@@ -875,7 +875,7 @@
 "ZK" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/door/firedoor/glass,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/mackerel_hc)
 "ZZ" = (

--- a/_maps/templates/shuttles/overmaps/generic/mackerel_hc_skel.dmm
+++ b/_maps/templates/shuttles/overmaps/generic/mackerel_hc_skel.dmm
@@ -96,8 +96,8 @@
 /area/shuttle/mackerel_hc_skel_cockpit)
 "eh" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 6;
 	pixel_x = 7;
@@ -247,8 +247,8 @@
 /area/shuttle/mackerel_hc_skel)
 "mw" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 10;
 	pixel_x = -8;
@@ -636,8 +636,8 @@
 	dir = 1
 	},
 /obj/structure/handrail,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -788,7 +788,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = -25
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -861,8 +861,8 @@
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -918,7 +918,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = 26
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -1084,7 +1084,7 @@
 "ZK" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/door/firedoor/glass,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/mackerel_hc_skel)

--- a/_maps/templates/shuttles/overmaps/generic/mackerel_lc.dmm
+++ b/_maps/templates/shuttles/overmaps/generic/mackerel_lc.dmm
@@ -183,8 +183,8 @@
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -224,8 +224,8 @@
 /area/shuttle/mackerel_lc)
 "pZ" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 10;
 	pixel_x = -8;
@@ -295,7 +295,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = 26
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/railing/grey,
 /obj/random/multiple/corp_crate,
@@ -500,8 +500,8 @@
 /area/shuttle/mackerel_lc)
 "FL" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 6;
 	pixel_x = 7;
@@ -641,7 +641,7 @@
 "PL" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/door/firedoor/glass,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/mackerel_lc)
 "Qu" = (
@@ -699,7 +699,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = -25
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
@@ -718,8 +718,8 @@
 	dir = 1
 	},
 /obj/structure/handrail,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4

--- a/_maps/templates/shuttles/overmaps/generic/mackerel_sh.dmm
+++ b/_maps/templates/shuttles/overmaps/generic/mackerel_sh.dmm
@@ -186,8 +186,8 @@
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 1
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/airlock_sensor{
 	pixel_x = -8;
 	pixel_y = 21
@@ -227,8 +227,8 @@
 /area/shuttle/mackerel_sh)
 "pZ" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 10;
 	pixel_x = -8;
@@ -306,7 +306,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = 26
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/railing/grey,
 /turf/simulated/floor/tiled/techfloor,
@@ -523,8 +523,8 @@
 /area/shuttle/mackerel_sh)
 "FL" = (
 /obj/machinery/door/airlock/hatch,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 6;
 	pixel_x = 7;
@@ -692,7 +692,7 @@
 "PL" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/door/firedoor/glass,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/mackerel_sh)
 "Qu" = (
@@ -759,7 +759,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = -25
 	},
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
@@ -777,8 +777,8 @@
 	dir = 1
 	},
 /obj/structure/handrail,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/overmap/visitable/ship/landable/mackerel_sh,
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/warning{

--- a/_maps/templates/shuttles/overmaps/generic/salamander.dmm
+++ b/_maps/templates/shuttles/overmaps/generic/salamander.dmm
@@ -1,14 +1,14 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ab" = (
 /obj/machinery/door/airlock/glass_external/public,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/salamander)
 "aK" = (
 /obj/machinery/door/airlock/glass_external/public,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 1;
 	pixel_x = 24;
@@ -46,7 +46,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/salamander_head)
 "bu" = (
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/machinery/airlock_sensor{
 	dir = 4;
@@ -181,7 +181,7 @@
 /area/shuttle/salamander_head)
 "cX" = (
 /obj/machinery/door/airlock/glass_external/public,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/salamander)
@@ -269,7 +269,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/salamander_q2)
 "eJ" = (
-/atom/movable/map_helper/airlock/sensor/int_sensor,
+/obj/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/airlock_sensor{
 	dir = 8;
 	pixel_x = 21;
@@ -880,8 +880,8 @@
 /area/shuttle/salamander_engineering)
 "mg" = (
 /obj/machinery/door/airlock/glass_external/public,
-/atom/movable/map_helper/airlock/door/ext_door,
-/atom/movable/map_helper/airlock/sensor/ext_sensor,
+/obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	pixel_x = 24;
 	pixel_y = -11
@@ -1009,7 +1009,7 @@
 /area/shuttle/salamander)
 "oe" = (
 /obj/machinery/door/airlock/glass_external/public,
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/salamander)
 "oi" = (
@@ -1088,7 +1088,7 @@
 /obj/machinery/atmospherics/component/unary/vent_pump{
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/closet/walllocker/emerglocker/east,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/salamander)
@@ -1537,7 +1537,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/salamander)
 "Kw" = (
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
@@ -1793,7 +1793,7 @@
 /area/shuttle/salamander)
 "UT" = (
 /obj/machinery/door/airlock/glass_external/public,
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/salamander)
 "Vh" = (

--- a/_maps/templates/shuttles/overmaps/generic/shelter_5.dmm
+++ b/_maps/templates/shuttles/overmaps/generic/shelter_5.dmm
@@ -79,7 +79,7 @@
 	id_tag = "escapepod_shuttle_docker";
 	pixel_y = 28
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/handrail{
 	dir = 8
 	},
@@ -87,7 +87,7 @@
 	frequency = 1380;
 	pixel_y = 22
 	},
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = 0
@@ -135,7 +135,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/shuttle/deployable/escapepod)
 "o" = (
@@ -150,7 +150,7 @@
 	icon_state = "warning";
 	dir = 8
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1380;

--- a/_maps/templates/shuttles/overmaps/generic/shelter_6.dmm
+++ b/_maps/templates/shuttles/overmaps/generic/shelter_6.dmm
@@ -527,7 +527,7 @@
 	pixel_x = -5;
 	pixel_y = -26
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/tabiranth)
 "aE" = (
@@ -545,8 +545,8 @@
 	frequency = 1380;
 	pixel_y = 25
 	},
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -664,7 +664,7 @@
 	pixel_x = 5;
 	pixel_y = 26
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/tabiranth)
 "aL" = (
@@ -682,7 +682,7 @@
 	pixel_x = -5;
 	pixel_y = 26
 	},
-/atom/movable/map_helper/airlock/door/int_door,
+/obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/tabiranth)
 "aM" = (
@@ -1548,8 +1548,8 @@
 	},
 /obj/effect/shuttle_landmark/shuttle_initializer/tabiranth,
 /obj/effect/overmap/visitable/ship/landable/tabiranth,
-/atom/movable/map_helper/airlock/sensor/chamber_sensor,
-/atom/movable/map_helper/airlock/atmos/chamber_pump,
+/obj/map_helper/airlock/sensor/chamber_sensor,
+/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/handrail{
 	dir = 1
 	},
@@ -1693,7 +1693,7 @@
 /obj/machinery/door/airlock/alien/blue/locked{
 	req_one_access = list(101)
 	},
-/atom/movable/map_helper/airlock/door/ext_door,
+/obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1380;

--- a/code/game/machinery/embedded_controller/mapping_helpers.dm
+++ b/code/game/machinery/embedded_controller/mapping_helpers.dm
@@ -6,7 +6,7 @@ Any frequency works, it's self-setting, but it seems like people have decided 13
 
 */
 
-/atom/movable/map_helper/airlock
+/obj/map_helper/airlock
 	name = "use a subtype!"
 	icon = 'icons/misc/map_helpers.dmi'
 	plane = 20 //I dunno just high.
@@ -21,7 +21,7 @@ Any frequency works, it's self-setting, but it seems like people have decided 13
 	//Most things have a radio tag of some sort that needs adjusting
 	var/tag_addon
 
-/atom/movable/map_helper/airlock/Initialize(mapload)
+/obj/map_helper/airlock/Initialize(mapload)
 	..()
 	my_controller = get_controller(get_area(src))
 	my_device = locate(my_device_type) in get_turf(src)
@@ -35,12 +35,12 @@ Any frequency works, it's self-setting, but it seems like people have decided 13
 		setup()
 	return INITIALIZE_HINT_QDEL
 
-/atom/movable/map_helper/airlock/Destroy()
+/obj/map_helper/airlock/Destroy()
 	my_controller = null
 	my_device = null
 	return ..()
 
-/atom/movable/map_helper/airlock/proc/get_controller(var/area/A)
+/obj/map_helper/airlock/proc/get_controller(var/area/A)
 	if(!A)
 		return null
 
@@ -71,35 +71,35 @@ Any frequency works, it's self-setting, but it seems like people have decided 13
 
 	return closest
 
-/atom/movable/map_helper/airlock/proc/setup()
+/obj/map_helper/airlock/proc/setup()
 	return //Stub for subtypes
 
 
 /*
 	Doors
 */
-/atom/movable/map_helper/airlock/door
+/obj/map_helper/airlock/door
 	name = "use a subtype! - airlock door"
 	my_device_type = /obj/machinery/door/airlock
 
-/atom/movable/map_helper/airlock/door/setup()
+/obj/map_helper/airlock/door/setup()
 	var/obj/machinery/door/airlock/my_airlock = my_device
 	my_airlock.lock()
 	my_airlock.id_tag = my_controller.id_tag + tag_addon
 	my_airlock.frequency = my_controller.frequency
 	my_airlock.set_frequency(my_controller.frequency)
 
-/atom/movable/map_helper/airlock/door/ext_door
+/obj/map_helper/airlock/door/ext_door
 	name = "exterior airlock door"
 	icon_state = "doorout"
 	tag_addon = "_outer"
 
-/atom/movable/map_helper/airlock/door/int_door
+/obj/map_helper/airlock/door/int_door
 	name = "interior airlock door"
 	icon_state = "doorin"
 	tag_addon = "_inner"
 
-/atom/movable/map_helper/airlock/door/simple
+/obj/map_helper/airlock/door/simple
 	name = "simple docking controller hatch"
 	icon_state = "doorsimple"
 	tag_addon = "_hatch"
@@ -109,26 +109,26 @@ Any frequency works, it's self-setting, but it seems like people have decided 13
 /*
 	Atmos
 */
-/atom/movable/map_helper/airlock/atmos
+/obj/map_helper/airlock/atmos
 	name = "use a subtype! - airlock pump"
 	my_device_type = /obj/machinery/atmospherics/component/unary/vent_pump
 
-/atom/movable/map_helper/airlock/atmos/setup()
+/obj/map_helper/airlock/atmos/setup()
 	var/obj/machinery/atmospherics/component/unary/vent_pump/my_pump = my_device
 	my_pump.frequency = my_controller.frequency //Unlike doors, these set up their radios in atmos init, so they won't have gone before us.
 	my_pump.id_tag = my_controller.id_tag + tag_addon
 
-/atom/movable/map_helper/airlock/atmos/chamber_pump
+/obj/map_helper/airlock/atmos/chamber_pump
 	name = "chamber pump"
 	icon_state = "pump"
 	tag_addon = "_pump"
 
-/atom/movable/map_helper/airlock/atmos/pump_out_internal
+/obj/map_helper/airlock/atmos/pump_out_internal
 	name = "air dump intake"
 	icon_state = "pumpdin"
 	tag_addon = "_pump_out_internal"
 
-/atom/movable/map_helper/airlock/atmos/pump_out_external
+/obj/map_helper/airlock/atmos/pump_out_external
 	name = "air dump output"
 	icon_state = "pumpdout"
 	tag_addon = "_pump_out_external"
@@ -137,12 +137,12 @@ Any frequency works, it's self-setting, but it seems like people have decided 13
 /*
 	Sensors - did you know they function as buttons? You don't also need a button.
 */
-/atom/movable/map_helper/airlock/sensor
+/obj/map_helper/airlock/sensor
 	name = "use a subtype! - airlock sensor"
 	my_device_type = /obj/machinery/airlock_sensor
 	var/command
 
-/atom/movable/map_helper/airlock/sensor/setup()
+/obj/map_helper/airlock/sensor/setup()
 	var/obj/machinery/airlock_sensor/my_sensor = my_device
 	my_sensor.id_tag = my_controller.id_tag + tag_addon
 	my_sensor.master_tag = my_controller.id_tag
@@ -151,19 +151,19 @@ Any frequency works, it's self-setting, but it seems like people have decided 13
 	if(command)
 		my_sensor.command = command
 
-/atom/movable/map_helper/airlock/sensor/ext_sensor
+/obj/map_helper/airlock/sensor/ext_sensor
 	name = "exterior sensor"
 	icon_state = "sensout"
 	tag_addon = "_exterior_sensor"
 	command = "cycle_exterior"
 
-/atom/movable/map_helper/airlock/sensor/chamber_sensor
+/obj/map_helper/airlock/sensor/chamber_sensor
 	name = "chamber sensor"
 	icon_state = "sens"
 	tag_addon = "_sensor"
 	command = "cycle"
 
-/atom/movable/map_helper/airlock/sensor/int_sensor
+/obj/map_helper/airlock/sensor/int_sensor
 	name = "interior sensor"
 	icon_state = "sensin"
 	tag_addon = "_interior_sensor"
@@ -173,5 +173,5 @@ Any frequency works, it's self-setting, but it seems like people have decided 13
 	Buttons
 */
 
-/atom/movable/map_helper/airlock/buttons
+/obj/map_helper/airlock/buttons
 	name = "Just use a sensor instead. They are actually buttons."

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -1,7 +1,7 @@
 /**
  * used to create a corpse of a human
  */
-/atom/movable/spawner/corpse
+/obj/spawner/corpse
 	name = "Unknown"
 	var/mobname = "Unknown"  //Unused now but it'd fuck up maps to remove it now
 	var/corpseuniform = null //Set this to an object path to have the slot filled with said object on the corpse.
@@ -22,12 +22,12 @@
 	var/corpseidicon = null //For setting it to be a gold, silver, CentCom etc ID
 	var/species = /datum/species/human
 
-/atom/movable/spawner/corpse/Initialize(mapload)
+/obj/spawner/corpse/Initialize(mapload)
 	. = ..()
 	createCorpse()
 	return INITIALIZE_HINT_QDEL
 
-/atom/movable/spawner/corpse/proc/createCorpse() //Creates a mob and checks for gear in each slot before attempting to equip it.
+/obj/spawner/corpse/proc/createCorpse() //Creates a mob and checks for gear in each slot before attempting to equip it.
 	SHOULD_NOT_SLEEP(TRUE)	// HMMM MOB INIT ISSUES?
 	var/mob/living/carbon/human/M = new /mob/living/carbon/human (src.loc)
 	. = M
@@ -78,7 +78,7 @@
 		M.equip_to_slot_or_del(W, SLOT_ID_WORN_ID)
 	INVOKE_ASYNC(M, /mob/proc/death)
 
-/atom/movable/spawner/corpse/syndicatesoldier
+/obj/spawner/corpse/syndicatesoldier
 	name = "Mercenary"
 	corpseuniform = /obj/item/clothing/under/syndicate
 	corpsesuit = /obj/item/clothing/suit/armor/vest
@@ -94,7 +94,7 @@
 
 
 
-/atom/movable/spawner/corpse/syndicatecommando
+/obj/spawner/corpse/syndicatecommando
 	name = "Syndicate Commando"
 	corpseuniform = /obj/item/clothing/under/syndicate
 	corpsesuit = /obj/item/clothing/suit/space/void/merc
@@ -113,7 +113,7 @@
 
 ///////////Civilians//////////////////////
 
-/atom/movable/spawner/corpse/chef
+/obj/spawner/corpse/chef
 	name = "Chef"
 	corpseuniform = /obj/item/clothing/under/rank/chef
 	corpsesuit = /obj/item/clothing/suit/chef/classic
@@ -126,7 +126,7 @@
 	corpseidaccess = "Chef"
 
 
-/atom/movable/spawner/corpse/doctor
+/obj/spawner/corpse/doctor
 	name = "Doctor"
 	corpseradio = /obj/item/radio/headset/headset_med
 	corpseuniform = /obj/item/clothing/under/rank/medical
@@ -138,7 +138,7 @@
 	corpseidjob = "Medical Doctor"
 	corpseidaccess = "Medical Doctor"
 
-/atom/movable/spawner/corpse/engineer
+/obj/spawner/corpse/engineer
 	name = "Engineer"
 	corpseradio = /obj/item/radio/headset/headset_eng
 	corpseuniform = /obj/item/clothing/under/rank/engineer
@@ -151,12 +151,12 @@
 	corpseidjob = "Station Engineer"
 	corpseidaccess = "Station Engineer"
 
-/atom/movable/spawner/corpse/engineer/rig
+/obj/spawner/corpse/engineer/rig
 	corpsesuit = /obj/item/clothing/suit/space/void/engineering
 	corpsemask = /obj/item/clothing/mask/breath
 	corpsehelmet = /obj/item/clothing/head/helmet/space/void/engineering
 
-/atom/movable/spawner/corpse/clown
+/obj/spawner/corpse/clown
 	name = "Clown"
 	corpseuniform = /obj/item/clothing/under/rank/clown
 	corpseshoes = /obj/item/clothing/shoes/clown_shoes
@@ -168,7 +168,7 @@
 	corpseidjob = "Clown"
 	corpseidaccess = "Clown"
 
-/atom/movable/spawner/corpse/scientist
+/obj/spawner/corpse/scientist
 	name = "Scientist"
 	corpseradio = /obj/item/radio/headset/headset_sci
 	corpseuniform = /obj/item/clothing/under/rank/scientist
@@ -179,7 +179,7 @@
 	corpseidjob = "Scientist"
 	corpseidaccess = "Scientist"
 
-/atom/movable/spawner/corpse/miner
+/obj/spawner/corpse/miner
 	corpseradio = /obj/item/radio/headset/headset_cargo
 	corpseuniform = /obj/item/clothing/under/rank/miner
 	corpsegloves = /obj/item/clothing/gloves/black
@@ -189,7 +189,7 @@
 	corpseidjob = "Shaft Miner"
 	corpseidaccess = "Shaft Miner"
 
-/atom/movable/spawner/corpse/miner/rig
+/obj/spawner/corpse/miner/rig
 	corpsesuit = /obj/item/clothing/suit/space/void/mining
 	corpsemask = /obj/item/clothing/mask/breath
 	corpsehelmet = /obj/item/clothing/head/helmet/space/void/mining
@@ -197,7 +197,7 @@
 
 /////////////////Officers//////////////////////
 
-/atom/movable/spawner/corpse/bridgeofficer
+/obj/spawner/corpse/bridgeofficer
 	name = "Bridge Officer"
 	corpseradio = /obj/item/radio/headset/heads/hop
 	corpseuniform = /obj/item/clothing/under/rank/centcom
@@ -208,7 +208,7 @@
 	corpseidjob = "Bridge Officer"
 	corpseidaccess = "Captain"
 
-/atom/movable/spawner/corpse/commander
+/obj/spawner/corpse/commander
 	name = "Commander"
 	corpseuniform = /obj/item/clothing/under/rank/centcom
 	corpsesuit = /obj/item/clothing/suit/armor/bulletproof
@@ -223,7 +223,7 @@
 	corpseidjob = "Commander"
 	corpseidaccess = "Captain"
 
-/atom/movable/spawner/corpse/vintage/pilot
+/obj/spawner/corpse/vintage/pilot
 	name = "Unknown Pilot"
 	corpsesuit = /obj/item/clothing/suit/space/void/refurb/pilot
 	corpsehelmet = /obj/item/clothing/head/helmet/space/void/refurb/pilot
@@ -231,7 +231,7 @@
 
 //List of different corpse types
 
-/atom/movable/spawner/corpse/syndicatesoldier
+/obj/spawner/corpse/syndicatesoldier
 	name = "Mercenary"
 	corpseuniform = /obj/item/clothing/under/syndicate
 	corpsesuit = /obj/item/clothing/suit/armor/vest
@@ -245,7 +245,7 @@
 	corpseidjob = "Operative"
 	corpseidaccess = "Syndicate"
 
-/atom/movable/spawner/corpse/solarpeacekeeper
+/obj/spawner/corpse/solarpeacekeeper
 	name = "Mercenary"
 	corpseuniform = /obj/item/clothing/under/syndicate
 	corpsesuit = /obj/item/clothing/suit/armor/pcarrier/blue/sol
@@ -259,7 +259,7 @@
 	corpseidjob = "Peacekeeper"
 	corpseidaccess = "Syndicate"
 
-/atom/movable/spawner/corpse/syndicatecommando
+/obj/spawner/corpse/syndicatecommando
 	name = "Syndicate Commando"
 	corpseuniform = /obj/item/clothing/under/syndicate
 	corpsesuit = /obj/item/clothing/suit/space/void/merc
@@ -276,7 +276,7 @@
 
 
 
-/atom/movable/spawner/corpse/clown
+/obj/spawner/corpse/clown
 	name = "Clown"
 	corpseuniform = /obj/item/clothing/under/rank/clown
 	corpseshoes = /obj/item/clothing/shoes/clown_shoes
@@ -288,7 +288,7 @@
 	corpseidjob = "Clown"
 	corpseidaccess = "Clown"
 
-/atom/movable/spawner/corpse/clown/clownop
+/obj/spawner/corpse/clown/clownop
 	name = "Clown Commando"
 	corpseuniform = /obj/item/clothing/under/rank/clown
 	corpsesuit = /obj/item/clothing/suit/armor/pcarrier/clownop
@@ -301,7 +301,7 @@
 	corpseidjob = "Commando"
 	corpseidaccess = "Syndicate"
 
-/atom/movable/spawner/corpse/clown/clownop/space
+/obj/spawner/corpse/clown/clownop/space
 	name = "Clown Commando"
 	corpseuniform = /obj/item/clothing/under/rank/clown
 	corpsesuit = /obj/item/clothing/suit/space/void/clownop
@@ -314,7 +314,7 @@
 	corpseidjob = "Commando"
 	corpseidaccess = "Syndicate"
 
-/atom/movable/spawner/corpse/clown/clownop/space/alt
+/obj/spawner/corpse/clown/clownop/space/alt
 	name = "Clown Commando"
 	corpseuniform = /obj/item/clothing/under/rank/clown
 	corpsesuit = /obj/item/clothing/suit/space/void/clownop
@@ -327,24 +327,24 @@
 	corpseidjob = "Commando"
 	corpseidaccess = "Syndicate"
 
-/atom/movable/spawner/corpse/russian
+/obj/spawner/corpse/russian
 	name = "Russian"
 	corpseuniform = /obj/item/clothing/under/soviet
 	corpseshoes = /obj/item/clothing/shoes/boots/jackboots
 	corpsehelmet = /obj/item/clothing/head/bearpelt
 
-/atom/movable/spawner/corpse/russian/ranged
+/obj/spawner/corpse/russian/ranged
 	corpsehelmet = /obj/item/clothing/head/ushanka
 
 //Diorama Corpses
-/atom/movable/spawner/corpse/shogun
+/obj/spawner/corpse/shogun
 	name = "Shogun's Bodyguard"
 	corpseuniform = /obj/item/clothing/under/color/black
 	corpsesuit = /obj/item/clothing/suit/kamishimo
 	corpseshoes = /obj/item/clothing/shoes/sandal
 	corpsehelmet = /obj/item/clothing/head/rice
 
-/atom/movable/spawner/corpse/safari
+/obj/spawner/corpse/safari
 	name = "Colonial Adventurer"
 	corpseuniform = /obj/item/clothing/under/safari
 	corpseshoes = /obj/item/clothing/shoes/boots/workboots
@@ -354,14 +354,14 @@
 //		Vox Bodies
 //////////////////////////
 
-/atom/movable/spawner/corpse/vox
+/obj/spawner/corpse/vox
 	name = "vox"
 	corpseid = 0
 	species = /datum/species/vox
 
 //Types of Vox corpses:
 
-/atom/movable/spawner/corpse/vox/pirate
+/obj/spawner/corpse/vox/pirate
 	name = "vox pirate"
 	corpseuniform = /obj/item/clothing/under/color/black
 	corpsesuit = /obj/item/clothing/suit/armor/vox_scrap
@@ -370,7 +370,7 @@
 	corpsemask = /obj/item/clothing/mask/breath
 	corpseid = 0
 
-/atom/movable/spawner/corpse/vox/boarder_m
+/obj/spawner/corpse/vox/boarder_m
 	name = "vox melee boarder"
 	corpseuniform = /obj/item/clothing/under/vox/vox_casual
 	corpsesuit = /obj/item/clothing/suit/armor/vox_scrap
@@ -379,7 +379,7 @@
 	corpsemask = /obj/item/clothing/mask/breath
 	corpseid = 0
 
-/atom/movable/spawner/corpse/vox/boarder_r
+/obj/spawner/corpse/vox/boarder_r
 	name = "vox ranged boarder"
 	corpseuniform = /obj/item/clothing/under/rank/bartender
 	corpsesuit = /obj/item/clothing/suit/armor/bulletproof
@@ -387,7 +387,7 @@
 	corpsemask = /obj/item/clothing/mask/breath
 	corpseid = 0
 
-/atom/movable/spawner/corpse/vox/boarder_t
+/obj/spawner/corpse/vox/boarder_t
 	name = "vox salvage technician"
 	corpseuniform = /obj/item/clothing/under/rank/bartender
 	corpsesuit = /obj/item/clothing/suit/armor/bulletproof
@@ -395,7 +395,7 @@
 	corpsemask = /obj/item/clothing/mask/breath
 	corpseid = 0
 
-/atom/movable/spawner/corpse/vox/suppressor
+/obj/spawner/corpse/vox/suppressor
 	name = "vox suppressor"
 	corpseuniform = /obj/item/clothing/under/color/red
 	corpsesuit = /obj/item/clothing/suit/storage/toggle/fr_jacket
@@ -404,7 +404,7 @@
 	corpsemask = /obj/item/clothing/mask/gas/half
 	corpseid = 0
 
-/atom/movable/spawner/corpse/vox/captain
+/obj/spawner/corpse/vox/captain
 	name = "vox captain"
 	corpseuniform = /obj/item/clothing/under/color/black
 	corpsesuit = /obj/item/clothing/suit/space/vox/carapace
@@ -414,7 +414,7 @@
 	corpsehelmet = /obj/item/clothing/head/helmet/riot
 	corpseid = 0
 
-/atom/movable/spawner/corpse/syndicatecommando
+/obj/spawner/corpse/syndicatecommando
 	name = "Mercenary Commando"
 
 //////////////////////////
@@ -422,25 +422,25 @@
 //////////////////////////
 //I'm sorry for how huge this list is. I didn't really consider the ramifications of creating a diverse crew of pirates.
 
-/atom/movable/spawner/corpse/pirate
+/obj/spawner/corpse/pirate
 	name = "Pirate"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine/tan
 
-/atom/movable/spawner/corpse/pirate/melee
+/obj/spawner/corpse/pirate/melee
 	corpsesuit = /obj/item/clothing/suit/unathi/mantle
 	corpseshoes = /obj/item/clothing/shoes/boots/workboots
 	corpseglasses = /obj/item/clothing/glasses/eyepatch
 	corpsebelt = /obj/item/storage/belt/security/tactical
 	corpseback = /obj/item/storage/backpack/rebel
 
-/atom/movable/spawner/corpse/pirate/melee_machete
+/obj/spawner/corpse/pirate/melee_machete
 	name = "Pirate Brush Cutter"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine
 	corpseshoes = /obj/item/clothing/shoes/boots/workboots
 	corpsemask = /obj/item/clothing/mask/balaclava
 	corpseback = /obj/item/storage/backpack/dufflebag/syndie
 
-/atom/movable/spawner/corpse/pirate/melee_machete_armor
+/obj/spawner/corpse/pirate/melee_machete_armor
 	name = "Armored Brush Cutter"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine/green
 	corpsesuit = /obj/item/clothing/suit/storage/vest/tactical
@@ -448,21 +448,21 @@
 	corpsehelmet = /obj/item/clothing/head/welding
 	corpseback = /obj/item/storage/backpack/rebel
 
-/atom/movable/spawner/corpse/pirate/melee_energy_armor
+/obj/spawner/corpse/pirate/melee_energy_armor
 	name = "Armored Duelist"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine/tan
 	corpsesuit = /obj/item/clothing/suit/armor/pcarrier/navy
 	corpseshoes = /obj/item/clothing/accessory/armor/legguards/riot
 	corpsemask = /obj/item/clothing/mask/gas/jackal
 
-/atom/movable/spawner/corpse/pirate/melee_shield
+/obj/spawner/corpse/pirate/melee_shield
 	name = "Pirate Buckler"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine/green
 	corpseshoes = /obj/item/clothing/shoes/boots/workboots
 	corpsehelmet = /obj/item/clothing/head/tajaran/scarf
 	corpseback = /obj/item/storage/backpack/dufflebag/syndie
 
-/atom/movable/spawner/corpse/pirate/melee_shield_machete_armor
+/obj/spawner/corpse/pirate/melee_shield_machete_armor
 	name = "Armored Sword and Boarder"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine/green
 	corpsesuit = /obj/item/clothing/suit/armor/pcarrier/navy
@@ -471,7 +471,7 @@
 	corpsebelt = /obj/item/storage/belt/security/tactical
 	corpseback = /obj/item/storage/backpack/rebel
 
-/atom/movable/spawner/corpse/pirate/ranged
+/obj/spawner/corpse/pirate/ranged
 	name = "Pirate Pistolier"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine
 	corpseshoes = /obj/item/clothing/shoes/boots/workboots
@@ -479,14 +479,14 @@
 	corpsebelt = /obj/item/storage/belt/security/tactical
 	corpseback = /obj/item/storage/backpack/dufflebag/syndie
 
-/atom/movable/spawner/corpse/pirate/ranged_armor
+/obj/spawner/corpse/pirate/ranged_armor
 	name = "Armored Pistolier"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine
 	corpsesuit = /obj/item/clothing/suit/storage/vest/tactical
 	corpseshoes = /obj/item/clothing/shoes/boots/jackboots
 	corpsebelt = /obj/item/storage/belt/security/tactical
 
-/atom/movable/spawner/corpse/pirate/ranged_laser
+/obj/spawner/corpse/pirate/ranged_laser
 	name = "Pirate Handcannon"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine
 	corpseshoes = /obj/item/clothing/shoes/boots/workboots
@@ -494,14 +494,14 @@
 	corpsebelt = /obj/item/storage/belt/security/tactical
 	corpseback = /obj/item/storage/backpack/dufflebag/syndie
 
-/atom/movable/spawner/corpse/pirate/ranged_laser_armor
+/obj/spawner/corpse/pirate/ranged_laser_armor
 	name = "Armored Handcannon"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine
 	corpsesuit = /obj/item/clothing/suit/storage/vest/tactical
 	corpseshoes = /obj/item/clothing/shoes/boots/jackboots
 	corpsebelt = /obj/item/storage/belt/security/tactical
 
-/atom/movable/spawner/corpse/pirate/ranged_blunderbuss
+/obj/spawner/corpse/pirate/ranged_blunderbuss
 	name = "Pirate Blunderbuster"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine
 	corpseshoes = /obj/item/clothing/shoes/boots/workboots
@@ -509,7 +509,7 @@
 	corpsebelt = /obj/item/storage/belt/security/tactical/bandolier
 	corpseback = /obj/item/storage/backpack/rebel
 
-/atom/movable/spawner/corpse/pirate/ranged_blunderbuss_armor
+/obj/spawner/corpse/pirate/ranged_blunderbuss_armor
 	name = "Armored Blunderbuster"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine/tan
 	corpsesuit = /obj/item/clothing/suit/storage/vest/tactical
@@ -518,19 +518,19 @@
 	corpsebelt = /obj/item/storage/belt/security/tactical/bandolier
 	corpseback = /obj/item/storage/backpack/rebel
 
-/atom/movable/spawner/corpse/pirate/mate
+/obj/spawner/corpse/pirate/mate
 	name = "First Mate"
 	corpseuniform = /obj/item/clothing/under/worn_fatigues
 	corpsesuit = /obj/item/clothing/suit/armor/riot/alt
 	corpseshoes = /obj/item/clothing/accessory/armor/legguards/riot
 	corpsemask = /obj/item/clothing/mask/gas/commando
 
-/atom/movable/spawner/corpse/pirate/mate/rifle
+/obj/spawner/corpse/pirate/mate/rifle
 	name = "Mate Marksman"
 	corpseshoes = /obj/item/clothing/shoes/boots/jackboots
 	corpsemask = null
 
-/atom/movable/spawner/corpse/pirate/bosun
+/obj/spawner/corpse/pirate/bosun
 	name = "Bosun"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine/green
 	corpsesuit = /obj/item/clothing/suit/armor/tactical/pirate
@@ -538,7 +538,7 @@
 	corpseglasses = /obj/item/clothing/glasses/eyepatch
 	corpseback = /obj/item/storage/backpack/rebel
 
-/atom/movable/spawner/corpse/pirate/captain
+/obj/spawner/corpse/pirate/captain
 	name = "Pirate Captain"
 	corpseuniform = /obj/item/clothing/under/worn_fatigues
 	corpsesuit = /obj/item/clothing/suit/armor/tactical/pirate
@@ -547,37 +547,37 @@
 	corpsehelmet = /obj/item/clothing/head/helmet/pirate
 
 //Akula
-/atom/movable/spawner/corpse/akula
+/obj/spawner/corpse/akula
 	species = /datum/species/akula
-/atom/movable/spawner/corpse/pirate/melee_armor
+/obj/spawner/corpse/pirate/melee_armor
 	name = "Armored Pirate"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine
 	corpsesuit = /obj/item/clothing/suit/storage/vest/tactical
 	corpseshoes = /obj/item/clothing/accessory/armor/legguards/riot
 	corpsehelmet = /obj/item/clothing/head/helmet/cyberpunk
 
-/atom/movable/spawner/corpse/pirate/melee_energy
+/obj/spawner/corpse/pirate/melee_energy
 	name = "Pirate Duelist"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine/tan
 	corpsesuit = /obj/item/clothing/suit/unathi/mantle
 	corpseshoes = /obj/item/clothing/accessory/armor/legguards/riot
 	corpsehelmet = /obj/item/clothing/head/welding
 
-/atom/movable/spawner/corpse/pirate/mate/shotgun
+/obj/spawner/corpse/pirate/mate/shotgun
 	name = "Mate Blunderbuster"
 	corpseshoes = /obj/item/clothing/shoes/boots/jackboots
 	corpsemask = /obj/item/clothing/mask/gas/jackal
 
 //Vulpkanin
-/atom/movable/spawner/corpse/vulpkanin
+/obj/spawner/corpse/vulpkanin
 	species = /datum/species/vulpkanin
 
-/atom/movable/spawner/corpse/pirate/melee_shield_machete
+/obj/spawner/corpse/pirate/melee_shield_machete
 	name = "Sword and Boarder"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine/tan
 	corpseshoes = /obj/item/clothing/shoes/boots/workboots
 
-/atom/movable/spawner/corpse/pirate/melee_shield_armor
+/obj/spawner/corpse/pirate/melee_shield_armor
 	name = "Armored Buckler"
 	corpseuniform = /obj/item/clothing/under/oricon/utility/marine/green
 	corpsesuit = /obj/item/clothing/suit/armor/pcarrier/navy
@@ -586,20 +586,20 @@
 	corpsebelt = /obj/item/storage/belt/security/tactical
 	corpseback = /obj/item/storage/backpack/rebel
 
-/atom/movable/spawner/corpse/pirate/mate/pistol
+/obj/spawner/corpse/pirate/mate/pistol
 	name = "Mate Pistolier"
 	corpseshoes = /obj/item/clothing/shoes/boots/jackboots
 	corpsehelmet = /obj/item/clothing/head/helmet/cyberpunk
 
 /*
-/atom/movable/spawner/corpse/pirate
+/obj/spawner/corpse/pirate
 	name = "Pirate"
 	corpseuniform = /obj/item/clothing/under/pirate
 	corpseshoes = /obj/item/clothing/shoes/boots/jackboots
 	corpseglasses = /obj/item/clothing/glasses/eyepatch
 	corpsehelmet = /obj/item/clothing/head/bandana
 
-/atom/movable/spawner/corpse/pirate/ranged
+/obj/spawner/corpse/pirate/ranged
 	name = "Pirate Gunner"
 	corpsesuit = /obj/item/clothing/suit/pirate
 	corpsehelmet = /obj/item/clothing/head/pirate

--- a/code/modules/mapping/map_helpers/_map_helpers.dm
+++ b/code/modules/mapping/map_helpers/_map_helpers.dm
@@ -1,24 +1,24 @@
 //Landmarks and other helpers which speed up the mapping process and reduce the number of unique instances/subtypes of items/turf/ect
-/atom/movable/map_helper
+/obj/map_helper
 	icon = 'icons/mapping/helpers/mapping_helpers.dmi'
 	icon_state = ""
 	var/late = FALSE
 
-/atom/movable/map_helper/Initialize(mapload)
+/obj/map_helper/Initialize(mapload)
 	. = ..()
 	return late ? INITIALIZE_HINT_LATELOAD : INITIALIZE_HINT_QDEL
 
 /* these need renaming because airlock already exist!
 
 //airlock helpers
-/atom/movable/map_helper/airlock
+/obj/map_helper/airlock
 	layer = DOOR_HELPER_LAYER
 
-/atom/movable/map_helper/airlock/cyclelink_helper
+/obj/map_helper/airlock/cyclelink_helper
 	name = "airlock cyclelink helper"
 	icon_state = "airlock_cyclelink_helper"
 
-/atom/movable/map_helper/airlock/cyclelink_helper/Initialize(mapload)
+/obj/map_helper/airlock/cyclelink_helper/Initialize(mapload)
 	. = ..()
 	if(!mapload)
 		log_mapping("[src] spawned outside of mapload!")
@@ -33,11 +33,11 @@
 		log_mapping("[src] failed to find an airlock at [AREACOORD(src)]")
 
 
-/atom/movable/map_helper/airlock/locked
+/obj/map_helper/airlock/locked
 	name = "airlock lock helper"
 	icon_state = "airlock_locked_helper"
 
-/atom/movable/map_helper/airlock/locked/Initialize(mapload)
+/obj/map_helper/airlock/locked/Initialize(mapload)
 	. = ..()
 	if(!mapload)
 		log_mapping("[src] spawned outside of mapload!")
@@ -51,11 +51,11 @@
 	else
 		log_mapping("[src] failed to find an airlock at [AREACOORD(src)]")
 
-/atom/movable/map_helper/airlock/unres
+/obj/map_helper/airlock/unres
 	name = "airlock unresctricted side helper"
 	icon_state = "airlock_unres_helper"
 
-/atom/movable/map_helper/airlock/unres/Initialize(mapload)
+/obj/map_helper/airlock/unres/Initialize(mapload)
 	. = ..()
 	if(!mapload)
 		log_mapping("[src] spawned outside of mapload!")
@@ -68,19 +68,19 @@
 
 
 //needs to do its thing before spawn_rivers() is called
-INITIALIZE_IMMEDIATE(/atom/movable/map_helper/no_lava)
+INITIALIZE_IMMEDIATE(/obj/map_helper/no_lava)
 
-/atom/movable/map_helper/no_lava
+/obj/map_helper/no_lava
 	icon_state = "no_lava"
 
-/atom/movable/map_helper/no_lava/Initialize(mapload)
+/obj/map_helper/no_lava/Initialize(mapload)
 	. = ..()
 	var/turf/T = get_turf(src)
 	T.flags_1 |= NO_LAVA_GEN
 */
 
 //This helper applies components to things on the map directly.
-/atom/movable/map_helper/component_injector
+/obj/map_helper/component_injector
 	name = "Component Injector"
 	late = TRUE
 	var/target_type
@@ -88,7 +88,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/map_helper/no_lava)
 	var/component_type
 
 //Late init so everything is likely ready and loaded (no warranty)
-/atom/movable/map_helper/component_injector/LateInitialize()
+/obj/map_helper/component_injector/LateInitialize()
 	if(!ispath(component_type,/datum/component))
 		CRASH("Wrong component type in [type] - [component_type] is not a component")
 	var/turf/T = get_turf(src)
@@ -104,17 +104,17 @@ INITIALIZE_IMMEDIATE(/atom/movable/map_helper/no_lava)
 		qdel(src)
 		return
 
-/atom/movable/map_helper/component_injector/proc/build_args()
+/obj/map_helper/component_injector/proc/build_args()
 	return list(component_type)
 
 /*
-/atom/movable/map_helper/component_injector/infective
+/obj/map_helper/component_injector/infective
 	name = "Infective Injector"
 	icon_state = "component_infective"
 	component_type = /datum/component/infective
 	var/disease_type
 
-/atom/movable/map_helper/component_injector/infective/build_args()
+/obj/map_helper/component_injector/infective/build_args()
 	if(!ispath(disease_type,/datum/disease))
 		CRASH("Wrong disease type passed in.")
 	var/datum/disease/D = new disease_type()

--- a/code/modules/mapping/map_helpers/network_builder/_network_builder.dm
+++ b/code/modules/mapping/map_helpers/network_builder/_network_builder.dm
@@ -1,6 +1,6 @@
 // Builds networks like power cables/atmos lines/etc
 // Just a holder parent type for now..
-/atom/movable/map_helper/network_builder
+/obj/map_helper/network_builder
 	icon = 'icons/mapping/helpers/mapping_helpers.dmi'
 	late = TRUE
 	invisibility = INVISIBILITY_MAXIMUM
@@ -11,7 +11,7 @@
 	/// our base type
 	var/base_type
 
-/atom/movable/map_helper/network_builder/Initialize(mapload)
+/obj/map_helper/network_builder/Initialize(mapload)
 	. = ..()
 	if(!mapload)
 		/// if it isn't adminspawned i am going to come find you
@@ -28,29 +28,29 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /// How this works: On LateInitialize, detect all directions that this should be applicable to, and do what it needs to do, and then inform all network builders in said directions that it's been around since it won't be around afterwards.
-/atom/movable/map_helper/network_builder/LateInitialize()
+/obj/map_helper/network_builder/LateInitialize()
 	build()
 	qdel(src)
 
-/atom/movable/map_helper/network_builder/proc/duplicates()
+/obj/map_helper/network_builder/proc/duplicates()
 	CRASH("Base abstract network builder tried to check duplicates.")
 
-/atom/movable/map_helper/network_builder/proc/scan()
+/obj/map_helper/network_builder/proc/scan()
 	CRASH("Base abstract network builder tried to scan directions.")
 
-/atom/movable/map_helper/network_builder/proc/build()
+/obj/map_helper/network_builder/proc/build()
 	CRASH("Base abstract network builder tried to build network.")
 
-/atom/movable/map_helper/network_builder/proc/teardown()
+/obj/map_helper/network_builder/proc/teardown()
 	for(var/atom/movable/AM as anything in duplicates())
 		ASSERT(istype(AM))
 		qdel(AM)
 
-/atom/movable/map_helper/network_builder/proc/rebuild(propagate = TRUE)
+/obj/map_helper/network_builder/proc/rebuild(propagate = TRUE)
 	teardown()
 	if(propagate)
 		for(var/d in GLOB.cardinal)
-			var/atom/movable/map_helper/network_builder/NB = locate(base_type) in get_step(src, d)
+			var/obj/map_helper/network_builder/NB = locate(base_type) in get_step(src, d)
 			if(NB)
 				NB.rebuild(FALSE)
 	network_directions = scan()

--- a/code/modules/mapping/map_helpers/network_builder/power_cable.dm
+++ b/code/modules/mapping/map_helpers/network_builder/power_cable.dm
@@ -3,10 +3,10 @@
 #define KNOT_FORCED 2
 
 /// Automatically links on init to power cables and other cable builder helpers. Only supports cardinals.
-/atom/movable/map_helper/network_builder/power_cable
+/obj/map_helper/network_builder/power_cable
 	name = "power line autobuilder"
 	icon_state = "powerlinebuilder"
-	base_type = /atom/movable/map_helper/network_builder/power_cable
+	base_type = /obj/map_helper/network_builder/power_cable
 	color = "#ff0000"
 
 	/// Whether or not we forcefully make a knot
@@ -15,16 +15,16 @@
 	var/cable_color = "red"
 
 
-/atom/movable/map_helper/network_builder/power_cable/duplicates()
+/obj/map_helper/network_builder/power_cable/duplicates()
 	. = list()
-	for(var/atom/movable/map_helper/network_builder/power_cable/B in loc)
+	for(var/obj/map_helper/network_builder/power_cable/B in loc)
 		if(B == src)
 			continue
 		. += B
 	for(var/obj/structure/cable/C in loc)
 		. += C
 
-/atom/movable/map_helper/network_builder/power_cable/scan()
+/obj/map_helper/network_builder/power_cable/scan()
 	. = NONE
 	for(var/i in GLOB.cardinal)
 		var/turf/T = get_step(src, i)
@@ -37,7 +37,7 @@
 				. |= i
 				continue
 
-/atom/movable/map_helper/network_builder/power_cable/build()
+/obj/map_helper/network_builder/power_cable/build()
 	if(!network_directions)
 		return
 	var/knot = KNOT_FORCED || (KNOT_AUTO && detect_knot())
@@ -57,14 +57,14 @@
 			new /obj/structure/cable(loc, capitalize(cable_color), last, i, TRUE)
 			last = i
 
-/atom/movable/map_helper/network_builder/power_cable/proc/detect_knot()
+/obj/map_helper/network_builder/power_cable/proc/detect_knot()
 	return (locate(/obj/machinery/power)) in src
 
-/atom/movable/map_helper/network_builder/power_cable/knot
+/obj/map_helper/network_builder/power_cable/knot
 	icon_state = "powerlinebuilderknot"
 	knot = KNOT_FORCED
 
-/atom/movable/map_helper/network_builder/power_cable/auto
+/obj/map_helper/network_builder/power_cable/auto
 	icon_state = "powerlinebuilderauto"
 	knot = KNOT_AUTO
 
@@ -90,15 +90,15 @@
 	WORK_SMARTER_NOT_HARDER("Brown", COLOR_BROWN)
 
 #define WORK_SMARTER_NOT_HARDER(c, v)								\
-/atom/movable/map_helper/network_builder/power_cable{				\
+/obj/map_helper/network_builder/power_cable{				\
 	color = v;														\
 	cable_color = c;												\
 }																	\
-/atom/movable/map_helper/network_builder/power_cable/auto{			\
+/obj/map_helper/network_builder/power_cable/auto{			\
 	color = v;														\
 	cable_color = c;												\
 }																	\
-/atom/movable/map_helper/network_builder/power_cable/knot{			\
+/obj/map_helper/network_builder/power_cable/knot{			\
 	color = v;														\
 	cable_color = c;												\
 }

--- a/code/modules/mapping/spawner/_spawner.dm
+++ b/code/modules/mapping/spawner/_spawner.dm
@@ -1,14 +1,14 @@
 /**
  * our only job is to spawn something and then self-delete
  */
-/atom/movable/spawner
+/obj/spawner
 	icon = 'icons/mapping/spawners/spawners.dmi'
 	icon_state = ""
 	layer = MID_LANDMARK_LAYER
 	/// lateload?
 	var/late = FALSE
 
-/atom/movable/spawner/Initialize(mapload)
+/obj/spawner/Initialize(mapload)
 	SHOULD_CALL_PARENT(FALSE)
 	flags |= INITIALIZED
 	if(!late)
@@ -20,20 +20,20 @@
 				// do not use late unless you absolutely know what you're doing
 		return INITIALIZE_HINT_LATELOAD
 
-/atom/movable/spawner/LateInitialize()
+/obj/spawner/LateInitialize()
 	Spawn()
 
-/atom/movable/spawner/proc/Spawn()
+/obj/spawner/proc/Spawn()
 	return
 
 /**
  * simple spawner - spawn a typepath x times
  */
-/atom/movable/spawner/simple
+/obj/spawner/simple
 	var/path
 	var/amount
 
-/atom/movable/spawner/simple/Spawn()
+/obj/spawner/simple/Spawn()
 	for(var/i in 1 to min(50, amount))
 		new path(loc)
 
@@ -41,10 +41,10 @@
  * multi spawner - spawn a typepath x times for paths in list
  * paths can be text as **byond params**, not json.
  */
-/atom/movable/spawner/multi
+/obj/spawner/multi
 	var/list/paths
 
-/atom/movable/spawner/multi/Spawn()
+/obj/spawner/multi/Spawn()
 	// check lists
 	var/list/_paths = list()
 	// if is text, params2list

--- a/code/modules/mapping/spawner/window.dm
+++ b/code/modules/mapping/spawner/window.dm
@@ -1,4 +1,4 @@
-/atom/movable/spawner/window
+/obj/spawner/window
 	icon = 'icons/mapping/spawners/windows.dmi'
 	icon_state = "glass_grille_pane"
 	late = TRUE
@@ -14,18 +14,18 @@
 	/// found dirs
 	var/found_dirs = NONE
 
-/atom/movable/spawner/window/Initialize(mapload)
+/obj/spawner/window/Initialize(mapload)
 	if(!full_window)
 		find_dirs()
 	return ..()
 
-/atom/movable/spawner/window/proc/find_dirs()
+/obj/spawner/window/proc/find_dirs()
 	for(var/d in GLOB.cardinal)
-		var/atom/movable/spawner/window/WS = locate() in get_step(src, d)
+		var/obj/spawner/window/WS = locate() in get_step(src, d)
 		if(WS)
 			found_dirs |= d
 
-/atom/movable/spawner/window/Spawn()
+/obj/spawner/window/Spawn()
 	if(spawn_grille)
 		new /obj/structure/grille(loc)
 	if(!full_window)
@@ -39,33 +39,33 @@
 			W = new window_pane_path(loc)
 			W.setDir(d)
 
-/atom/movable/spawner/window/full
+/obj/spawner/window/full
 	full_window = TRUE
 	icon_state = "glass_grille_full"
 
-/atom/movable/spawner/window/reinforced
+/obj/spawner/window/reinforced
 	icon_state = "rglass_grille_pane"
 	window_pane_path = /obj/structure/window/reinforced
 	window_full_path = /obj/structure/window/reinforced/full
 
-/atom/movable/spawner/window/reinforced/full
+/obj/spawner/window/reinforced/full
 	icon_state = "rglass_grille_full"
 	full_window = TRUE
 
-/atom/movable/spawner/window/borosillicate
+/obj/spawner/window/borosillicate
 	icon_state = "phoron_grille_pane"
 	window_pane_path = /obj/structure/window/phoronbasic
 	window_full_path = /obj/structure/window/phoronbasic/full
 
-/atom/movable/spawner/window/borosillicate/full
+/obj/spawner/window/borosillicate/full
 	icon_state = "phoron_grille_full"
 	full_window = TRUE
 
-/atom/movable/spawner/window/borosillicate/reinforced
+/obj/spawner/window/borosillicate/reinforced
 	icon_state = "rphoron_grille_pane"
 	window_pane_path = /obj/structure/window/phoronreinforced
 	window_full_path = /obj/structure/window/phoronreinforced/full
 
-/atom/movable/spawner/window/borosillicate/reinforced/full
+/obj/spawner/window/borosillicate/reinforced/full
 	icon_state = "rphoron_grille_full"
 	full_window = TRUE

--- a/code/modules/maps/away_missions/archive/labyrinth.dm
+++ b/code/modules/maps/away_missions/archive/labyrinth.dm
@@ -185,7 +185,7 @@
 		do_after_cooldown()
 		return
 
-/atom/movable/spawner/corpse/tunnelclown
+/obj/spawner/corpse/tunnelclown
 	name = "dead tunnel clown"
 	corpseuniform = /obj/item/clothing/under/rank/clown
 	corpseshoes = /obj/item/clothing/shoes/clown_shoes
@@ -194,7 +194,7 @@
 	corpsemask = /obj/item/clothing/mask/gas/clown_hat
 	corpsepocket1 = /obj/item/bikehorn
 
-/atom/movable/spawner/corpse/tunnelclown/sentinel
+/obj/spawner/corpse/tunnelclown/sentinel
 	name = "dead clown sentinel"
 	corpsesuit = /obj/item/clothing/suit/cultrobes
 	corpsehelmet = /obj/item/clothing/head/culthood
@@ -217,7 +217,7 @@
 //	emote_hear = list("honks")
 //	speak_chance = 1
 	a_intent = "harm"
-	var/corpse = /atom/movable/spawner/corpse/tunnelclown
+	var/corpse = /obj/spawner/corpse/tunnelclown
 	var/weapon1 = /obj/item/twohanded/fireaxe
 	stop_when_pulled = 0
 	maxHealth = 100
@@ -250,7 +250,7 @@
 	icon_state = "sentinelclown"
 	icon_living = "sentinelclown"
 	icon_dead = "clown_dead"
-	corpse = /atom/movable/spawner/corpse/tunnelclown/sentinel
+	corpse = /obj/spawner/corpse/tunnelclown/sentinel
 	weapon1 = /obj/item/material/twohanded/spear
 	maxHealth = 150
 	health = 150

--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/clown.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/clown.dm
@@ -101,7 +101,7 @@
 	attacktext = list("slashed", "stabbed")
 	armor = list(melee = 40, bullet = 40, laser = 60, energy = 35, bomb = 30, bio = 100, rad = 100)	// Same armor values as the vest they drop, plus simple mob immunities
 
-	corpse = /atom/movable/spawner/corpse/clown/clownop
+	corpse = /obj/spawner/corpse/clown/clownop
 	loot_list = list(/obj/item/melee/clownop = 100)	// Might as well give it the knife
 
 	ai_holder_type = /datum/ai_holder/simple_mob/merc
@@ -232,7 +232,7 @@
 	max_n2 = 0
 	minbodytemp = 0
 
-	corpse = /atom/movable/spawner/corpse/clown/clownop/space
+	corpse = /obj/spawner/corpse/clown/clownop/space
 	loot_list = list(/obj/item/melee/clownstaff = 100)
 
 /mob/living/simple_mob/humanoid/clown/commando/melee/space/Process_Spacemove(var/check_drift = 0)
@@ -241,7 +241,7 @@
 /mob/living/simple_mob/humanoid/clown/commando/melee/space/alt
 	icon_state = "clownop_space_alt_melee"
 	icon_living = "clownop_space_alt_melee"
-	corpse = /atom/movable/spawner/corpse/clown/clownop/space/alt
+	corpse = /obj/spawner/corpse/clown/clownop/space/alt
 
 // Ranged Space Clown
 /mob/living/simple_mob/humanoid/clown/commando/ranged/space
@@ -265,7 +265,7 @@
 	max_n2 = 0
 	minbodytemp = 0
 
-	corpse = /atom/movable/spawner/corpse/clown/clownop/space
+	corpse = /obj/spawner/corpse/clown/clownop/space
 	loot_list = list(/obj/item/gun/projectile/automatic/clown_rifle = 100,
 					/obj/item/ammo_magazine/mcompressedbio/large/banana = 30,
 					/obj/item/ammo_magazine/mcompressedbio/large/banana = 30
@@ -280,4 +280,4 @@
 /mob/living/simple_mob/humanoid/clown/commando/ranged/space/alt
 	icon_state = "clownop_space_alt_ranged"
 	icon_living = "clownop_space_alt_ranged"
-	corpse = /atom/movable/spawner/corpse/clown/clownop/space/alt
+	corpse = /obj/spawner/corpse/clown/clownop/space/alt

--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs.dm
@@ -71,7 +71,7 @@
 	attacktext = list("slashed", "stabbed")
 	armor = list(melee = 40, bullet = 30, laser = 30, energy = 10, bomb = 10, bio = 100, rad = 100)	// Same armor values as the vest they drop, plus simple mob immunities
 
-	corpse = /atom/movable/spawner/corpse/syndicatesoldier
+	corpse = /obj/spawner/corpse/syndicatesoldier
 	loot_list = list(/obj/item/material/knife/tacknife = 100)	// Might as well give it the knife
 
 	ai_holder_type = /datum/ai_holder/simple_mob/merc
@@ -228,7 +228,7 @@
 	icon_living = "blueforranged_smg"
 	catalogue_data = list(/datum/category_item/catalogue/fauna/mercenary/human/peacekeeper)
 
-	corpse = /atom/movable/spawner/corpse/solarpeacekeeper
+	corpse = /obj/spawner/corpse/solarpeacekeeper
 	loot_list = list(/obj/item/gun/projectile/automatic/c20r = 100)
 
 	base_attack_cooldown = 5 // Two attacks a second or so.
@@ -348,7 +348,7 @@
 	max_n2 = 0
 	minbodytemp = 0
 
-	corpse = /atom/movable/spawner/corpse/syndicatecommando
+	corpse = /obj/spawner/corpse/syndicatecommando
 
 /mob/living/simple_mob/humanoid/merc/melee/sword/space/Process_Spacemove(var/check_drift = 0)
 	return
@@ -374,7 +374,7 @@
 	max_n2 = 0
 	minbodytemp = 0
 
-	corpse = /atom/movable/spawner/corpse/syndicatecommando
+	corpse = /obj/spawner/corpse/syndicatecommando
 
 	base_attack_cooldown = 5 // Two attacks a second or so.
 	reload_max = 20
@@ -617,7 +617,7 @@
 	max_n2 = 0
 	minbodytemp = 0
 
-	corpse = /atom/movable/spawner/corpse/vox/pirate
+	corpse = /obj/spawner/corpse/vox/pirate
 	loot_list = list(/obj/item/gun/projectile/shotgun/pump/rifle/vox_hunting = 100,
 					/obj/item/ammo_magazine/clip/c762 = 30,
 					/obj/item/ammo_magazine/clip/c762 = 30
@@ -660,7 +660,7 @@
 	attack_edge = 1
 
 	ai_holder_type = /datum/ai_holder/simple_mob/melee/evasive
-	corpse = /atom/movable/spawner/corpse/vox/boarder_m
+	corpse = /obj/spawner/corpse/vox/boarder_m
 	loot_list = list(/obj/item/melee/energy/sword = 100)
 
 // They're good with the swords? I dunno. I like the idea they can deflect.
@@ -703,7 +703,7 @@
 	projectilesound = 'sound/weapons/Gunshot_shotgun.ogg'
 
 	ai_holder_type = /datum/ai_holder/simple_mob/ranged/aggressive
-	corpse = /atom/movable/spawner/corpse/vox/boarder_r
+	corpse = /obj/spawner/corpse/vox/boarder_r
 	loot_list = list(/obj/item/gun/projectile/shotgun/pump/combat = 100,
 					/obj/item/ammo_magazine/m12gdrum = 30,
 					/obj/item/ammo_magazine/m12gdrum = 30
@@ -734,7 +734,7 @@
 	projectilesound = 'sound/weapons/Laser.ogg'
 
 	ai_holder_type = /datum/ai_holder/simple_mob/ranged/kiting
-	corpse = /atom/movable/spawner/corpse/vox/boarder_t
+	corpse = /obj/spawner/corpse/vox/boarder_t
 	loot_list = list(/obj/item/gun/energy/ionrifle)
 
 	needs_reload = TRUE
@@ -766,7 +766,7 @@
 	projectilesound = 'sound/effects/basscannon.ogg'
 
 	ai_holder_type = /datum/ai_holder/simple_mob/destructive
-	corpse = /atom/movable/spawner/corpse/vox/suppressor
+	corpse = /obj/spawner/corpse/vox/suppressor
 	loot_list = list(/obj/item/gun/energy/sonic = 100)
 
 	base_attack_cooldown = 5 // Two attacks a second or so.
@@ -798,7 +798,7 @@
 	projectilesound = 'sound/weapons/eLuger.ogg'
 
 	ai_holder_type = /datum/ai_holder/simple_mob/destructive
-	corpse = /atom/movable/spawner/corpse/vox/captain
+	corpse = /obj/spawner/corpse/vox/captain
 	loot_list = list(/obj/item/gun/energy/darkmatter = 100)
 
 	needs_reload = TRUE

--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/pirates.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/pirates.dm
@@ -44,7 +44,7 @@
 
 	loot_list = list(/obj/item/material/knife/tacknife = 100)
 
-	corpse = /atom/movable/spawner/corpse/pirate/melee
+	corpse = /obj/spawner/corpse/pirate/melee
 
 	ai_holder_type = /datum/ai_holder/simple_mob/merc
 	say_list_type = /datum/say_list/pirate
@@ -60,7 +60,7 @@
 	armor = list(melee = 30, bullet = 20, laser = 20, energy = 5, bomb = 5, bio = 100, rad = 100)
 	loot_list = list(/obj/item/material/knife/tacknife = 100, /obj/item/clothing/accessory/armor/armorplate/stab = 100)
 
-	corpse = /atom/movable/spawner/corpse/pirate/melee_armor
+	corpse = /obj/spawner/corpse/pirate/melee_armor
 
 ///////////////////////////////
 //		Machete Priate
@@ -88,7 +88,7 @@
 
 	loot_list = list(/obj/item/material/knife/machete = 100)
 
-	corpse = /atom/movable/spawner/corpse/pirate/melee_machete
+	corpse = /obj/spawner/corpse/pirate/melee_machete
 
 //Armored Variant
 
@@ -101,7 +101,7 @@
 	armor = list(melee = 30, bullet = 20, laser = 20, energy = 5, bomb = 5, bio = 100, rad = 100)
 	loot_list = list(/obj/item/material/knife/machete = 100, /obj/item/clothing/accessory/armor/armorplate/stab = 100)
 
-	corpse = /atom/movable/spawner/corpse/pirate/melee_machete_armor
+	corpse = /obj/spawner/corpse/pirate/melee_machete_armor
 
 ///////////////////////////////
 //		E-Sword Priate
@@ -124,7 +124,7 @@
 
 	loot_list = list(/obj/item/melee/energy/sword/pirate = 100)
 
-	corpse = /atom/movable/spawner/corpse/pirate/melee_energy
+	corpse = /obj/spawner/corpse/pirate/melee_energy
 
 //Armored Variant
 /mob/living/simple_mob/humanoid/pirate/las/armored
@@ -136,7 +136,7 @@
 	armor = list(melee = 30, bullet = 20, laser = 20, energy = 5, bomb = 5, bio = 100, rad = 100)
 	loot_list = list(/obj/item/melee/energy/sword/pirate = 100, /obj/item/clothing/accessory/armor/armorplate/stab = 100)
 
-	corpse = /atom/movable/spawner/corpse/pirate/melee_energy_armor
+	corpse = /obj/spawner/corpse/pirate/melee_energy_armor
 
 
 ///////////////////////////////
@@ -148,7 +148,7 @@
 	icon_state = "piratemelee-shield"
 	icon_living = "piratemelee-shield"
 
-	corpse = /atom/movable/spawner/corpse/pirate/melee_shield
+	corpse = /obj/spawner/corpse/pirate/melee_shield
 
 //This Should Allow all childs of the shield priate to block
 /mob/living/simple_mob/humanoid/pirate/shield/attackby(var/obj/item/O as obj, var/mob/user as mob)
@@ -184,7 +184,7 @@
 	armor = list(melee = 30, bullet = 20, laser = 20, energy = 5, bomb = 5, bio = 100, rad = 100)
 	loot_list = list(/obj/item/material/knife/tacknife = 100, /obj/item/shield/riot/tower = 100)
 
-	corpse = /atom/movable/spawner/corpse/pirate/melee_shield_armor
+	corpse = /obj/spawner/corpse/pirate/melee_shield_armor
 
 ///////////////////////////////
 //	Shield Machete Pirate
@@ -210,7 +210,7 @@
 
 	loot_list = list(/obj/item/material/knife/machete = 100)
 
-	corpse = /atom/movable/spawner/corpse/pirate/melee_shield_machete
+	corpse = /obj/spawner/corpse/pirate/melee_shield_machete
 
 // Armored Variant
 /mob/living/simple_mob/humanoid/pirate/shield/machete/armored
@@ -222,7 +222,7 @@
 	armor = list(melee = 30, bullet = 20, laser = 20, energy = 5, bomb = 5, bio = 100, rad = 100)
 	loot_list = list(/obj/item/material/knife/machete = 100, /obj/item/shield/riot/tower = 100)
 
-	corpse = /atom/movable/spawner/corpse/pirate/melee_shield_machete_armor
+	corpse = /obj/spawner/corpse/pirate/melee_shield_machete_armor
 
 ///////////////////////////////
 //		Pirate Pistolier
@@ -246,7 +246,7 @@
 
 	ai_holder_type = /datum/ai_holder/simple_mob/merc/ranged
 
-	corpse = /atom/movable/spawner/corpse/pirate/ranged
+	corpse = /obj/spawner/corpse/pirate/ranged
 
 
 //Armored Variant
@@ -259,7 +259,7 @@
 	armor = list(melee = 30, bullet = 20, laser = 20, energy = 5, bomb = 5, bio = 100, rad = 100)
 	loot_list = list(/obj/item/material/knife/tacknife = 100, /obj/item/gun/projectile/pirate = 100, /obj/item/clothing/accessory/armor/armorplate/bulletproof = 100)
 
-	corpse = /atom/movable/spawner/corpse/pirate/ranged_armor
+	corpse = /obj/spawner/corpse/pirate/ranged_armor
 
 ///////////////////////////////
 //		Pirate Blunderbuster
@@ -283,7 +283,7 @@
 
 	ai_holder_type = /datum/ai_holder/simple_mob/ranged/aggressive
 
-	corpse = /atom/movable/spawner/corpse/pirate/ranged_blunderbuss
+	corpse = /obj/spawner/corpse/pirate/ranged_blunderbuss
 
 //Armored Variant
 /mob/living/simple_mob/humanoid/pirate/ranged/shotgun/armored
@@ -295,7 +295,7 @@
 	armor = list(melee = 30, bullet = 20, laser = 20, energy = 5, bomb = 5, bio = 100, rad = 100)
 	loot_list = list(/obj/item/material/knife/tacknife = 100, /obj/item/gun/projectile/shotgun/doublebarrel/sawn = 100, /obj/item/clothing/accessory/armor/armorplate/bulletproof = 100)
 
-	corpse = /atom/movable/spawner/corpse/pirate/ranged_blunderbuss_armor
+	corpse = /obj/spawner/corpse/pirate/ranged_blunderbuss_armor
 
 ///////////////////////////////
 //		Pirate Ziplas
@@ -319,7 +319,7 @@
 
 	ai_holder_type = /datum/ai_holder/simple_mob/ranged/aggressive
 
-	corpse = /atom/movable/spawner/corpse/pirate/ranged_laser
+	corpse = /obj/spawner/corpse/pirate/ranged_laser
 
 //Armored Variant
 /mob/living/simple_mob/humanoid/pirate/ranged/handcannon/armored
@@ -331,7 +331,7 @@
 	armor = list(melee = 30, bullet = 20, laser = 20, energy = 5, bomb = 5, bio = 100, rad = 100)
 	loot_list = list(/obj/item/material/knife/tacknife = 100, /obj/item/gun/energy/zip = 100, /obj/item/clothing/accessory/armor/armorplate/bulletproof = 100)
 
-	corpse = /atom/movable/spawner/corpse/pirate/ranged_laser_armor
+	corpse = /obj/spawner/corpse/pirate/ranged_laser_armor
 
 ///////////////////////////////
 //		First Mate
@@ -354,7 +354,7 @@
 
 	loot_list = list(/obj/item/melee/energy/sword/pirate = 100, /obj/item/clothing/suit/armor/riot/alt = 100)
 
-	corpse = /atom/movable/spawner/corpse/pirate/mate
+	corpse = /obj/spawner/corpse/pirate/mate
 
 ///////////////////////////////
 //		Mate Pistolier
@@ -384,7 +384,7 @@
 
 	ai_holder_type = /datum/ai_holder/simple_mob/merc/ranged
 
-	corpse = /atom/movable/spawner/corpse/pirate/mate/pistol
+	corpse = /obj/spawner/corpse/pirate/mate/pistol
 
 /mob/living/simple_mob/humanoid/pirate/mate/ranged/bosun /// Special Mech Pilot Pirate
 	name = "Bosun"
@@ -395,7 +395,7 @@
 
 	loot_list = list(/obj/item/gun/energy/retro = 100, /obj/item/clothing/suit/armor/riot/alt = 100)
 
-	corpse = /atom/movable/spawner/corpse/pirate/bosun
+	corpse = /obj/spawner/corpse/pirate/bosun
 
 ///////////////////////////////
 //		Mate Sweeper
@@ -423,7 +423,7 @@
 
 	loot_list = list(/obj/item/gun/projectile/shotgun/doublebarrel/quad = 100, /obj/item/clothing/suit/armor/riot/alt = 100)
 
-	corpse = /atom/movable/spawner/corpse/pirate/mate/shotgun
+	corpse = /obj/spawner/corpse/pirate/mate/shotgun
 
 ///////////////////////////////
 //		Mate Marksman
@@ -451,7 +451,7 @@
 
 	loot_list = list(/obj/item/gun/projectile/shotgun/pump/rifle = 100, /obj/item/clothing/suit/armor/riot/alt = 100)
 
-	corpse = /atom/movable/spawner/corpse/pirate/mate/rifle
+	corpse = /obj/spawner/corpse/pirate/mate/rifle
 
 ///////////////////////////////
 //		Pirate Captain
@@ -471,7 +471,7 @@
 	projectilesound = 'sound/weapons/weaponsounds_laserstrong.ogg'
 	base_attack_cooldown = 5
 
-	corpse = /atom/movable/spawner/corpse/pirate/captain
+	corpse = /obj/spawner/corpse/pirate/captain
 
 	loot_list = list(/obj/item/gun/energy/zip = 100, /obj/item/gun/energy/zip = 100, /obj/item/gun/energy/zip = 100, /obj/item/gun/energy/zip = 100) //Belt of pistols
 
@@ -761,7 +761,7 @@
 	projectilesound = 'sound/weapons/weaponsounds_laserstrong.ogg'
 	base_attack_cooldown = 5
 
-	//corpse = /atom/movable/spawner/corpse/pirate/ranged
+	//corpse = /obj/spawner/corpse/pirate/ranged
 
 	loot_list = list(/obj/item/gun/energy/zip = 100, /obj/item/gun/energy/zip = 100, /obj/item/gun/energy/zip = 100, /obj/item/gun/energy/zip = 100) //Belt of pistols
 

--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/possessed.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/possessed.dm
@@ -49,7 +49,7 @@
 	ai_holder_type = /datum/ai_holder/simple_mob/merc
 	say_list_type = /datum/say_list/possessed //Set to Null on silenced.
 
-//	corpse = /atom/movable/spawner/corpse/possessed
+//	corpse = /obj/spawner/corpse/possessed
 // Will eventually leave a full corpse with an activated RIG on it. But not yet.
 
 //Miasma Cloud "Item"

--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/russian.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/russian.dm
@@ -34,7 +34,7 @@
 
 	loot_list = list(/obj/item/material/knife = 100)
 
-	corpse = /atom/movable/spawner/corpse/russian
+	corpse = /obj/spawner/corpse/russian
 
 /mob/living/simple_mob/humanoid/russian/ranged
 	icon_state = "russianranged"
@@ -46,4 +46,4 @@
 
 	loot_list = list(/obj/item/gun/projectile/revolver/mateba = 100)
 
-	corpse = /atom/movable/spawner/corpse/russian/ranged
+	corpse = /obj/spawner/corpse/russian/ranged

--- a/maps/REGEXING_MAP_PORTS.md
+++ b/maps/REGEXING_MAP_PORTS.md
@@ -1,5 +1,7 @@
 # Regexing Map Ports
 
+## Primary
+
 // TODO: ADD PYTHON SCRIPT TO AUTOMATE THIS
 
 Yeah so we're (me) all a bunch of idiots (insane).
@@ -7,8 +9,6 @@ As such we have a *ton* of path replacements.
 All of these regexes are for VSC. They are not necessarily optimized, so, if you're good at regexes, do help!
 
 Apply regexes in this order:
-
-`/obj/effect/map_helper`-`/atom/movable/map_helper`
 
 // TODO: tape roll
 // todo: devices/weapons
@@ -32,7 +32,6 @@ Apply regexes in this order:
 
 // TODO: MAKE SURE NO / AFTER COSTUME
 `/obj/landmark/costume`-`/obj/landmark/costume/random`
-`/obj/landmark/mobcorpse`-`/atom/movable/spawner/corpse`
 
 // ATMOSPHERICS
 `/obj/machinery/atmospherics/omni`-`/obj/machinery/atmospherics/component/quaternary`


### PR DESCRIPTION
please start using these instead of manually mapping windows.