### PR TITLE
Fixes borg interactions with grinders

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -258,7 +258,7 @@
 	if(!user)
 		return FALSE
 	if(beaker)
-		if(!user.incapacitated() && Adjacent(user))
+		if(!user.incapacitated() && Adjacent(user) && !isrobot(user))
 			user.put_in_hands(beaker)
 		else
 			beaker.forceMove(drop_location())


### PR DESCRIPTION
Fixed borgs being unable to interact with the grinder without sending the beaker to the nether realm

## Changelog
:cl:
fix: Borgs can now remove beakers from the grinder correctly
/:cl: