### PR TITLE
Removes an un-necessary double-call on borg alt-clicking

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -119,7 +119,6 @@
 	A.BorgCtrlClick(src)
 
 /mob/living/silicon/robot/AltClickOn(var/atom/A)
-	. = ..()
 	A.BorgAltClick(src)
 
 /atom/proc/BorgCtrlShiftClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden


### PR DESCRIPTION
## About The Pull Request
Stops a double-call of the altclick() action for borgs which broke some interactions such as ovens

## Changelog
:cl:
fix: Fixes alt-clicking for borgs to not double-call AltClick() thereby breaking some interactions
/:cl: