### PR TITLE
Removes redundant UI elements from canisters

### DIFF
--- a/tgui/packages/tgui/interfaces/Canister.js
+++ b/tgui/packages/tgui/interfaces/Canister.js
@@ -51,11 +51,6 @@ export const Canister = (props, context) => {
                       onClick={() => act('restricted')} />
                   )}
                   <Button
-                    icon={data.shielding ? 'power-off' : 'times'}
-                    content={data.shielding ? 'Shielding-ON' : 'Shielding-OFF'}
-                    selected={data.shielding}
-                    onClick={() => act('shielding')} />
-                  <Button
                     icon="pencil-alt"
                     content="Relabel"
                     onClick={() => act('relabel')} />
@@ -146,13 +141,6 @@ export const Canister = (props, context) => {
                   </Tooltip>
                 </LabeledControls.Item>
               </LabeledControls>
-            </Section>
-            <Section>
-              <Box>
-                {data.has_cell ? (
-                  "Cell charge at: " + data.cell_charge + "%"
-                ) : "Missing Cell"}
-              </Box>
             </Section>
           </Flex.Item>
           <Flex.Item grow={1}>


### PR DESCRIPTION

## About The Pull Request

Removes the redundant shielding and cell UI elements from the Canister UI

## Changelog
:cl:
del: Removed redundant shielding and cell UI elements from the atmospheric canister UI
/:cl: