### PR TITLE
Oregen to Station Z levels, Rocks and fauna generation to snow turfs

### DIFF
--- a/citadel.dme
+++ b/citadel.dme
@@ -1555,6 +1555,7 @@
 #include "code\game\objects\structures\crates_lockers\closets\secure\secure_closets.dm"
 #include "code\game\objects\structures\crates_lockers\closets\secure\security.dm"
 #include "code\game\objects\structures\flora\grass.dm"
+#include "code\game\objects\structures\flora\rocks.dm"
 #include "code\game\objects\structures\flora\trees.dm"
 #include "code\game\objects\structures\ghost_pods\ghost_pods.dm"
 #include "code\game\objects\structures\ghost_pods\human.dm"

--- a/code/game/objects/random/mapping.dm
+++ b/code/game/objects/random/mapping.dm
@@ -972,3 +972,21 @@
 /obj/random/crystal/normal_ice/item_to_spawn()
 	return pick(/obj/machinery/crystal/ice,
 				/obj/machinery/crystal)
+
+/obj/random/snow_debris
+	name = "random snow and ice debri"
+	desc = "for all your cold needs and fun :)"
+	icon = 'icons/obj/snowman.dmi'
+	icon_state = "snowman"
+
+/obj/random/snow_debris/item_to_spawn()
+	return pick(prob(100);/obj/structure/flora/rock/ice,
+				prob(100);/obj/structure/flora/rock/ice/alternative_1,
+				prob(100);/obj/structure/flora/rock/ice/alternative_2,
+				prob(80);/obj/structure/flora/grass/both,
+				prob(60);/obj/structure/flora/bush,
+				prob(40);/obj/structure/flora/tree/dead,
+				prob(1);/obj/structure/snowman,
+				prob(1);/obj/structure/snowman/borg,
+				prob(1);/obj/structure/snowman/spider,
+				prob(1);/obj/machinery/crystal/ice)

--- a/code/game/objects/structures/flora/rocks.dm
+++ b/code/game/objects/structures/flora/rocks.dm
@@ -1,0 +1,38 @@
+/obj/structure/flora/rock
+	name = "rock"
+	desc = "A large rock"
+	density = 1
+	plane = MOB_PLANE // You know what, let's play it safe.
+	layer = ABOVE_MOB_LAYER
+	icon = 'icons/obj/flora/rocks.dmi'
+	icon_state = "basalt1"
+	randomize_size = TRUE
+	var/mindrop = 0
+	var/upperdrop = 4
+	var/outcropdrop = /obj/item/ore/glass
+
+/obj/structure/flora/rock/alternative_1
+	icon_state = "basalt2"
+
+/obj/structure/flora/rock/alternative_2
+	icon_state = "basalt3"
+
+/obj/structure/flora/rock/ice
+	color = "#afe7fa"
+
+/obj/structure/flora/rock/ice/alternative_1
+	icon_state = "basalt2"
+
+/obj/structure/flora/rock/ice/alternative_2
+	icon_state = "basalt3"
+
+
+/obj/structure/flora/rock/attackby(obj/item/W as obj, mob/user as mob)		//Shamelessly copied from mine_outcrops.dm
+	if (istype(W, /obj/item/pickaxe))
+		to_chat(user, "<span class='notice'>[user] begins to hack away at \the [src].</span>")
+		if(do_after(user,40))
+			to_chat(user, "<span class='notice'>You have finished digging!</span>")
+			for(var/i=0;i<(rand(mindrop,upperdrop));i++)
+				new outcropdrop(get_turf(src))
+			qdel(src)
+			return

--- a/code/modules/random_map/automata/map_specific/rift_automata.dm
+++ b/code/modules/random_map/automata/map_specific/rift_automata.dm
@@ -2,3 +2,6 @@
 	wall_type = /turf/simulated/mineral/icerock/lythios43c
 	floor_type = /turf/simulated/mineral/icerock/floor/lythios43c
 	target_turf_type = /turf/simulated/mineral/icerock/floor/lythios43c
+
+/datum/random_map/automata/cave_system/no_cracks/rift_nocaves
+	initial_wall_cell = 100

--- a/maps/rift/rift_defines.dm
+++ b/maps/rift/rift_defines.dm
@@ -307,6 +307,11 @@
 	new /datum/random_map/automata/cave_system/no_cracks/rift(null, 3, 3, Z_LEVEL_WEST_DEEP, world.maxx - 3, world.maxy - 3)         // Create the mining ore distribution map.
 	new /datum/random_map/automata/cave_system/no_cracks/rift(null, 3, 3, Z_LEVEL_WEST_BASE, world.maxx - 3, world.maxy - 3)         // Create the mining ore distribution map.
 	new /datum/random_map/automata/cave_system/no_cracks/rift(null, 3, 3, Z_LEVEL_UNDERGROUND_FLOOR, world.maxx - 3, world.maxy - 3)         // Create the mining ore distribution map.
+	new /datum/random_map/automata/cave_system/no_cracks/rift_nocaves(null, 3, 3, Z_LEVEL_SURFACE_HIGH, world.maxx - 3, world.maxy - 3)
+	new /datum/random_map/automata/cave_system/no_cracks/rift_nocaves(null, 3, 3, Z_LEVEL_SURFACE_MID, world.maxx - 3, world.maxy - 3)
+	new /datum/random_map/automata/cave_system/no_cracks/rift_nocaves(null, 3, 3, Z_LEVEL_SURFACE_LOW, world.maxx - 3, world.maxy - 3)
+	new /datum/random_map/automata/cave_system/no_cracks/rift_nocaves(null, 3, 3, Z_LEVEL_UNDERGROUND, world.maxx - 3, world.maxy - 3)
+	new /datum/random_map/automata/cave_system/no_cracks/rift_nocaves(null, 3, 3, Z_LEVEL_UNDERGROUND_DEEP, world.maxx - 3, world.maxy - 3)
 
 	return 1
 

--- a/maps/rift/rift_turfs.dm
+++ b/maps/rift/rift_turfs.dm
@@ -52,9 +52,37 @@ LYTHIOS43C_TURF_CREATE_UN(/turf/simulated/mineral/icerock/floor/ignore_cavegen)
 /turf/simulated/mineral/icerock/ignore_cavegen/lythios43c
 	baseturfs = /turf/simulated/mineral/icerock/floor/ignore_cavegen/lythios43c
 
+/// Object Generation for snow turfs. It'd prolly be nice to put this down lower on the type path for future use but for now just gonna have this on rift snow
+/*	/// Basically just coppied the code from grass.dm for this, putting it down below for furture reference (and so I dont forget where I got it from -Bloop)
+/turf/simulated/floor/outdoors/grass/sif
+	name = "growth"
+	icon_state = "grass_sif"
+	initial_flooring = /decl/flooring/outdoors/grass/sif
+	grass_chance = 5
+	var/tree_chance = 2
+
+	grass_types = list(
+		/obj/structure/flora/sif/eyes = 1,
+		/obj/structure/flora/sif/tendrils = 10
+		)
+
+	catalogue_data = list(/datum/category_item/catalogue/flora/sif_grass)
+	catalogue_delay = 2 SECONDS
+
+/turf/simulated/floor/outdoors/grass/sif/Initialize(mapload)
+	if(tree_chance && prob(tree_chance) && !check_density())
+		new /obj/structure/flora/tree/sif(src)
+	. = ..()
+*/
+
 /turf/simulated/floor/outdoors/snow/lythios43c
 	baseturfs = /turf/simulated/floor/outdoors/safeice/lythios43c
+	var/object_spawn_chance = 3
 
+/turf/simulated/floor/outdoors/snow/lythios43c/Initialize(mapload)
+	if(object_spawn_chance && prob(object_spawn_chance) && !check_density())
+		new /obj/random/snow_debris(src)	///mapping.dm is where this obj's at
+	. = ..()
 /// Indoor Variants (Cause we need em). It bugs me that outdoor varients are the default but what can you do -Bloop
 /turf/simulated/floor/outdoors/safeice/indoors
 	outdoors = FALSE /* So that we don't get weather effects for the ice used indoors. Convuluted, I know, but this
@@ -264,3 +292,5 @@ LYTHIOS43C_TURF_CREATE_UN(/turf/unsimulated/mineral/icerock)
 	dir = EAST
 /turf/simulated/sky/lythios43c/moving/west
 	dir = WEST
+
+


### PR DESCRIPTION
## About The Pull Request

This adds oregen to the station z levels (without cave generation) as well as impliments a simple system to generate rocks, plants, various snowman, and ice crystals on the snow around the station and west planes. 

A follow up PR will be needed to change the mineral turfs on the upper levels to only generate low value ores but for now they are generating standard ore distribution (will require touching all the rocks again and changing them to a different variant in a map editor). 

## Why It's Good For The Game

Oregen is something that was missing from the station z levels and anything that helps the west plains be something other than GM_Flatgrass with snow is good. To note any mineral floor turfs mapped into the station z levels will need to be a ignore_cavegen variant otherwise oregen will turn them into a rock wall (this will not affect anything right now but its good to document this stuff).

## Changelog
:cl:
add: Oregen to Station Z levels and added object generation to lythios snow turfs
/:cl:

## Project Board

Completes these two Project board pins

https://github.com/Citadel-Station-13/Citadel-Station-13-RP/projects/39#card-82789433

https://github.com/Citadel-Station-13/Citadel-Station-13-RP/projects/39#card-82789715
