### PR TITLE
Fixes borg alt-click to show turf objects

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -119,6 +119,8 @@
 	A.BorgCtrlClick(src)
 
 /mob/living/silicon/robot/AltClickOn(var/atom/A)
+	if(!A.AltClick(src))
+		altclick_listed_turf(A)
 	A.BorgAltClick(src)
 
 /atom/proc/BorgCtrlShiftClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden
@@ -136,7 +138,6 @@
 	if(user.bolt && !user.bolt.malfunction)
 		return
 	AIShiftClick(user)
-
 
 /atom/proc/BorgCtrlClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden
 	CtrlClick(user)
@@ -157,7 +158,6 @@
 	AICtrlClick(user)
 
 /atom/proc/BorgAltClick(var/mob/living/silicon/robot/user)
-	AltClick(user)
 	return
 
 /obj/machinery/door/airlock/BorgAltClick(mob/living/silicon/robot/user) // Eletrifies doors. Forwards to AI code.


### PR DESCRIPTION
## Changelog
:cl:
fix: Fixes borg alt-click to show objects on a turf
/:cl:
