### PR TITLE
Minor Refactor to human examine/tooltip

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -99,17 +99,14 @@
 
 	var/speciesblurb
 	var/skip_species = FALSE
+
 	if(skipface || get_visible_name() == "Unknown")
 		skip_species = TRUE
+
 	else if(looks_synth)
-		var/synth_gender = "a synthetic"
-		if(gender == MALE)
-			synth_gender = "an android"
-		else if(gender == FEMALE)
-			synth_gender = "a gynoid"
-		speciesblurb += "a <font color='#555555'>[synth_gender]!</font>"
+		speciesblurb += "a <font color='#555555'>[get_display_species()]</font>"
 	else
-		speciesblurb += "a <font color='[species.get_flesh_colour(src)]'>[dna.custom_species ? dna.custom_species : species.get_examine_name()]</font>"
+		speciesblurb += "a <font color='[species.get_flesh_colour(src)]'>[get_display_species()]</font>"
 
 	// The first line of the examine block.
 	. += SPAN_INFO("[icon2html(src, user)] This is <EM>[src.name]</EM>[skip_species? ". [SPAN_WARNING("You can't make out what species they are.")]" : ", [T.he] [T.is] [speciesblurb]!"]")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1519,23 +1519,24 @@
 		else
 			set_base_layer(HIDING_LAYER)
 
+/**
+ * Shows species in tooltips and examine.
+ *
+ * Get custom species name if set, otherwise use the species name
+ * Beepboops get extra special text based on gender if obviously beepboop
+ * Else species name
+ */
 /mob/living/carbon/human/proc/get_display_species()
-	//Shows species in tooltip
-	if(src.custom_species)
-		return custom_species
-	//Beepboops get special text if obviously beepboop
-	if(looksSynthetic())
-		if(gender == MALE)
-			return "Android"
-		else if(gender == FEMALE)
-			return "Gynoid"
+	var/species_name = src.custom_species ? custom_species : species.get_examine_name()
+	switch(gender) //Not identifying_gender as this is relating to physical traits.
+		if(MALE)
+			return "[looksSynthetic() ? "[species_name] Android" : species_name]"
+		if(FEMALE)
+			return "[looksSynthetic() ? "[species_name] Gynoid" : species_name]"
+		if(NEUTER, PLURAL)
+			return "[looksSynthetic() ? "Synthetic [species_name]" : species_name]"
 		else
-			return "Synthetic"
-	//Else species name
-	if(species)
-		return species.get_examine_name()
-	//Else CRITICAL FAILURE!
-	return ""
+			return SPAN_WARNING("Unknown")
 
 /mob/living/carbon/human/get_nametag_name(mob/user)
 	return name //Could do fancy stuff here?


### PR DESCRIPTION
## Changelog
:cl:
fix: You'll no longer be "a a gynoid" / "an a android"
refactor: Species examine text is de-duplicated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
