### PR TITLE
prevents derlict drone fabricators from showing on the join as drone list, until secured

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -75,6 +75,8 @@
 	. = ..()
 	if(produce_drones && drone_progress >= 100 && istype(user,/mob/observer/dead) && config_legacy.allow_drone_spawn && count_drones() < config_legacy.max_maint_drones)
 		. += "<BR><B>A drone is prepared. Select 'Join As Drone' from the Ghost tab to spawn as a maintenance drone.</B>"
+	if(!is_spawn_safe)
+		. += "<BR> It seems this fabricator has gone into safety lockdown, maybe you can reset it."
 
 /obj/machinery/drone_fabricator/proc/create_drone(var/client/player)
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -24,11 +24,13 @@
 	var/produce_drones = 2
 	var/time_last_drone = 500
 	var/drone_type = /mob/living/silicon/robot/drone
+	var/is_spawn_safe = TRUE
 
 /obj/machinery/drone_fabricator/derelict
 	name = "construction drone fabricator"
 	fabricator_tag = "Upper Level Construction"
 	drone_type = /mob/living/silicon/robot/drone/construction
+	is_spawn_safe = FALSE
 
 /obj/machinery/drone_fabricator/mining
 	name = "mining drone fabricator"
@@ -146,6 +148,8 @@
 	for(var/obj/machinery/drone_fabricator/DF in GLOB.machines)
 		if(DF.machine_stat & NOPOWER || !DF.produce_drones)
 			continue
+		if(!DF.is_spawn_safe)
+			continue
 		if(DF.drone_progress >= 100)
 			all_fabricators[DF.fabricator_tag] = DF
 
@@ -157,3 +161,8 @@
 	if(choice)
 		var/obj/machinery/drone_fabricator/chosen_fabricator = all_fabricators[choice]
 		chosen_fabricator.create_drone(src.client)
+
+/obj/machinery/drone_fabricator/attack_hand(mob/user)
+	if(!is_spawn_safe)
+		is_spawn_safe = TRUE
+		to_chat(user, "You inform the fabricator that it is safe for drones to roam around.")


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
tweak: tweaked derlict drone fab dont show on the list until cleared by a player
code: adds a var to drone fabricators to signal them to not show up on the drone list until cleared
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
