### PR TITLE
removes an old Debug log entry I forgot

### DIFF
--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -175,7 +175,6 @@ var/global/list/limb_icon_cache = list()
 				mob_icon = new /icon('icons/mob/cyberlimbs/robotic.dmi', "[icon_name][s_base ? "[s_base]" : ""][gender ? "_[gender]" : ""]")
 			else
 				mob_icon = new /icon(species.get_icobase(owner, (status & ORGAN_MUTATED)), "[icon_name][s_base ? "_[s_base]" : ""][gender ? "_[gender]" : ""]")
-				log_qdel("generated a [species] specific [src] with [icon_name] and _[s_base]")
 			apply_colouration(mob_icon)
 
 			//Body markings, actually does not include head this time. Done separately above.


### PR DESCRIPTION

## Changelog
:cl:
code: removes an old debug log entry I forgot about....
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
