### PR TITLE
Removes Nanopaste Self-Heal from Cyborgs

### DIFF
--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -16,6 +16,9 @@
 /obj/item/stack/nanopaste/attack(mob/living/M as mob, mob/user as mob)
 	if (!istype(M) || !istype(user))
 		return 0
+	if (istype(M,/mob/living/silicon/robot) && istype(user))
+		to_chat(user, "<span class='notice'>You are unable to apply this paste to yourself.</span>")
+		return 0
 	if (istype(M,/mob/living/silicon/robot))	//Repairing cyborgs
 		var/mob/living/silicon/robot/R = M
 		if (R.getBruteLoss() || R.getFireLoss())

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/medical.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/medical.dm
@@ -62,7 +62,7 @@
 	synths += medicine
 
 	var/obj/item/stack/medical/advanced/ointment/O = new /obj/item/stack/medical/advanced/ointment(src)
-	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
+	//var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
 	O.uses_charge = 1
 	O.charge_costs = list(1000)
@@ -157,7 +157,7 @@
 
 	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(15000) // BEGIN CITADEL CHANGES - adds trauma kits to medihounds
 	synths += medicine
-	var/obj/item/stack/nanopaste/P = new /obj/item/stack/nanopaste(src)
+	//var/obj/item/stack/nanopaste/P = new /obj/item/stack/nanopaste(src)
 	var/obj/item/stack/medical/advanced/ointment/K = new /obj/item/stack/medical/advanced/ointment(src)
 	var/obj/item/stack/medical/advanced/bruise_pack/L = new /obj/item/stack/medical/advanced/bruise_pack(src)
 	P.uses_charge = 1

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/medical.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/medical.dm
@@ -67,14 +67,16 @@
 	O.uses_charge = 1
 	O.charge_costs = list(1000)
 	O.synths = list(medicine)
+	/*
 	N.uses_charge = 1
 	N.charge_costs = list(1000)
 	N.synths = list(medicine)
+	*/
 	B.uses_charge = 1
 	B.charge_costs = list(1000)
 	B.synths = list(medicine)
 	src.modules += O
-	src.modules += N
+	//src.modules += N
 	src.modules += B
 
 /obj/item/robot_module/robot/medical/surgeon/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
@@ -160,9 +162,11 @@
 	//var/obj/item/stack/nanopaste/P = new /obj/item/stack/nanopaste(src)
 	var/obj/item/stack/medical/advanced/ointment/K = new /obj/item/stack/medical/advanced/ointment(src)
 	var/obj/item/stack/medical/advanced/bruise_pack/L = new /obj/item/stack/medical/advanced/bruise_pack(src)
+	/*
 	P.uses_charge = 1
 	P.charge_costs = list(1000)
 	P.synths = list(medicine)
+	*/
 	K.uses_charge = 1
 	K.charge_costs = list(1000)
 	K.synths = list(medicine)
@@ -171,7 +175,7 @@
 	L.synths = list(medicine)
 	src.modules += K
 	src.modules += L
-	src.modules += P
+	//src.modules += P
 	// END CITADEL CHANGES
 
 	R.icon = 'icons/mob/widerobot_vr.dmi'

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/medical.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/medical.dm
@@ -62,21 +62,19 @@
 	synths += medicine
 
 	var/obj/item/stack/medical/advanced/ointment/O = new /obj/item/stack/medical/advanced/ointment(src)
-	//var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
+	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
 	O.uses_charge = 1
 	O.charge_costs = list(1000)
 	O.synths = list(medicine)
-	/*
 	N.uses_charge = 1
-	N.charge_costs = list(1000)
+	N.charge_costs = list(20000)
 	N.synths = list(medicine)
-	*/
 	B.uses_charge = 1
 	B.charge_costs = list(1000)
 	B.synths = list(medicine)
 	src.modules += O
-	//src.modules += N
+	src.modules += N
 	src.modules += B
 
 /obj/item/robot_module/robot/medical/surgeon/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
@@ -159,14 +157,12 @@
 
 	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(15000) // BEGIN CITADEL CHANGES - adds trauma kits to medihounds
 	synths += medicine
-	//var/obj/item/stack/nanopaste/P = new /obj/item/stack/nanopaste(src)
+	var/obj/item/stack/nanopaste/P = new /obj/item/stack/nanopaste(src)
 	var/obj/item/stack/medical/advanced/ointment/K = new /obj/item/stack/medical/advanced/ointment(src)
 	var/obj/item/stack/medical/advanced/bruise_pack/L = new /obj/item/stack/medical/advanced/bruise_pack(src)
-	/*
 	P.uses_charge = 1
 	P.charge_costs = list(1000)
 	P.synths = list(medicine)
-	*/
 	K.uses_charge = 1
 	K.charge_costs = list(1000)
 	K.synths = list(medicine)
@@ -175,7 +171,7 @@
 	L.synths = list(medicine)
 	src.modules += K
 	src.modules += L
-	//src.modules += P
+	src.modules += P
 	// END CITADEL CHANGES
 
 	R.icon = 'icons/mob/widerobot_vr.dmi'

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
@@ -47,13 +47,11 @@
 	var/datum/matter_synth/wire = new /datum/matter_synth/wire()						//Added to allow repairs, would rather add cable now than be asked to add it later,
 	synths += wire																		//Cable code, taken from engiborg,
 
-	/*
 	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	N.uses_charge = 1
 	N.charge_costs = list(1000)
 	N.synths = list(nanite)
 	src.modules += N
-	*/
 
 	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)	//Cable code, taken from engiborg,
 	C.synths = list(wire)
@@ -119,13 +117,11 @@
 	var/datum/matter_synth/wire = new /datum/matter_synth/wire()
 	synths += wire
 
-	/*
 	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	N.uses_charge = 1
-	N.charge_costs = list(1000)
+	N.charge_costs = list(20000)
 	N.synths = list(nanite)
 	src.modules += N
-	*/
 
 	var/obj/item/dogborg/tongue/T = new /obj/item/dogborg/tongue(src)
 	T.water = water

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
@@ -47,7 +47,7 @@
 	var/datum/matter_synth/wire = new /datum/matter_synth/wire()						//Added to allow repairs, would rather add cable now than be asked to add it later,
 	synths += wire																		//Cable code, taken from engiborg,
 
-	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
+	//var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	N.uses_charge = 1
 	N.charge_costs = list(1000)
 	N.synths = list(nanite)
@@ -117,7 +117,7 @@
 	var/datum/matter_synth/wire = new /datum/matter_synth/wire()
 	synths += wire
 
-	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
+	//var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	N.uses_charge = 1
 	N.charge_costs = list(1000)
 	N.synths = list(nanite)

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
@@ -47,11 +47,13 @@
 	var/datum/matter_synth/wire = new /datum/matter_synth/wire()						//Added to allow repairs, would rather add cable now than be asked to add it later,
 	synths += wire																		//Cable code, taken from engiborg,
 
-	//var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
+	/*
+	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	N.uses_charge = 1
 	N.charge_costs = list(1000)
 	N.synths = list(nanite)
 	src.modules += N
+	*/
 
 	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)	//Cable code, taken from engiborg,
 	C.synths = list(wire)
@@ -117,11 +119,13 @@
 	var/datum/matter_synth/wire = new /datum/matter_synth/wire()
 	synths += wire
 
-	//var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
+	/*
+	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	N.uses_charge = 1
 	N.charge_costs = list(1000)
 	N.synths = list(nanite)
 	src.modules += N
+	*/
 
 	var/obj/item/dogborg/tongue/T = new /obj/item/dogborg/tongue(src)
 	T.water = water

--- a/code/modules/mob/living/silicon/robot/robot_modules/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/syndicate.dm
@@ -108,7 +108,7 @@
 
 	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	N.uses_charge = 1
-	N.charge_costs = list(1000)
+	N.charge_costs = list(20000)
 	N.synths = list(nanite)
 	src.modules += N
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Removes Nanopaste Self Heal from Cyborgs.**

## Why It's Good For The Game

1. _Cyborgs retain their access to Nanopaste stacks, but can no longer heal themselves._

## Changelog
:cl:
balance: Adds a check to prevent self-healing with nanopaste modules.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
