### PR TITLE
Who made organ_owner, we have owner for a reason.

### DIFF
--- a/code/modules/organs/internal/species/alraune.dm
+++ b/code/modules/organs/internal/species/alraune.dm
@@ -41,7 +41,6 @@
 	var/short_emote_descriptor = list("picks", "grabs")
 	var/self_emote_descriptor = list("grab", "pick", "snatch")
 	var/fruit_type = "apple"
-	var/mob/organ_owner = null
 	var/gen_cost = 0.5
 
 /obj/item/organ/internal/fruitgland/Initialize(mapload)
@@ -49,22 +48,23 @@
 	create_reagents(usable_volume)
 
 /obj/item/organ/internal/fruitgland/process(delta_time)
-	if(!owner) return
+	if(!owner)
+		return
 	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 	var/before_gen
-	if(parent && generated_reagents && organ_owner) //Is it in the chest/an organ, has reagents, and is 'activated'
+	if(parent && generated_reagents && owner) //Is it in the chest/an organ, has reagents, and is 'activated'
 		before_gen = reagents.total_volume
 		if(reagents.total_volume < reagents.maximum_volume)
-			if(organ_owner.nutrition >= gen_cost)
+			if(owner.nutrition >= gen_cost)
 				do_generation()
 
 	if(reagents)
 		if(reagents.total_volume == reagents.maximum_volume * 0.05)
-			to_chat(organ_owner, "<span class='notice'>[pick(empty_message)]</span>")
+			to_chat(owner, SPAN_NOTICE("[pick(empty_message)]"))
 		else if(reagents.total_volume == reagents.maximum_volume && before_gen < reagents.maximum_volume)
-			to_chat(organ_owner, "<span class='warning'>[pick(full_message)]</span>")
+			to_chat(owner, SPAN_WARNING("[pick(full_message)]"))
 
 /obj/item/organ/internal/fruitgland/proc/do_generation()
-	organ_owner.nutrition -= gen_cost
+	owner.nutrition -= gen_cost
 	for(var/reagent in generated_reagents)
 		reagents.add_reagent(reagent, generated_reagents[reagent])

--- a/code/modules/organs/internal/species/diona.dm
+++ b/code/modules/organs/internal/species/diona.dm
@@ -77,7 +77,7 @@
 
 /obj/item/organ/internal/brain/cephalon/Initialize(mapload)
 	. = ..()
-	spawn(30 SECONDS)	// FBP Dionaea need some way to be disassembled through surgery, if absolutely necessary.
+	spawn(30 SECONDS) // FBP Dionaea need some way to be disassembled through surgery, if absolutely necessary.
 		if(!owner.isSynthetic())
 			vital = FALSE
 

--- a/code/modules/species/station/alraune.dm
+++ b/code/modules/species/station/alraune.dm
@@ -354,8 +354,7 @@
 			fruit_gland.fruit_type = selection
 		verbs |= /mob/living/carbon/human/proc/alraune_fruit_pick
 		verbs -= /mob/living/carbon/human/proc/alraune_fruit_select
-		fruit_gland.organ_owner = src
-		fruit_gland.emote_descriptor = list("fruit right off of [fruit_gland.organ_owner]!", "a fruit from [fruit_gland.organ_owner]!")
+		fruit_gland.emote_descriptor = list("fruit right off of [fruit_gland.owner]!", "a fruit from [fruit_gland.owner]!")
 
 	else
 		to_chat(src, SPAN_NOTICE("You lack the organ required to produce fruit."))

--- a/code/modules/species/station/apidaen.dm
+++ b/code/modules/species/station/apidaen.dm
@@ -97,7 +97,6 @@
 	var/short_emote_descriptor = list("coaxes", "scoops")
 	var/self_emote_descriptor = list("scoop", "coax", "heave")
 	var/nectar_type = "nectar (honey)"
-	var/mob/organ_owner = null
 	var/gen_cost = 5
 
 /obj/item/organ/internal/honey_stomach/Initialize(mapload)
@@ -108,20 +107,20 @@
 	. = ..()
 	if(.)
 		return
-	
+
 	var/before_gen = reagents.total_volume
 	if(reagents.total_volume < reagents.maximum_volume)
-		if(organ_owner.nutrition >= gen_cost)
+		if(owner.nutrition >= gen_cost)
 			do_generation()
 
 	if(reagents)
 		if(reagents.total_volume == reagents.maximum_volume * 0.05)
-			to_chat(organ_owner, SPAN_NOTICE("[pick(empty_message)]"))
+			to_chat(owner, SPAN_NOTICE("[pick(empty_message)]"))
 		else if(reagents.total_volume == reagents.maximum_volume && before_gen < reagents.maximum_volume)
-			to_chat(organ_owner, SPAN_WARNING("[pick(full_message)]"))
+			to_chat(owner, SPAN_WARNING("[pick(full_message)]"))
 
 /obj/item/organ/internal/honey_stomach/proc/do_generation()
-	organ_owner.nutrition -= gen_cost
+	owner.nutrition -= gen_cost
 	for(var/reagent in generated_reagents)
 		reagents.add_reagent(reagent, generated_reagents[reagent])
 
@@ -142,8 +141,7 @@
 			honey_stomach.nectar_type = selection
 		verbs |= /mob/living/carbon/human/proc/nectar_pick
 		verbs -= /mob/living/carbon/human/proc/nectar_select
-		honey_stomach.organ_owner = src
-		honey_stomach.emote_descriptor = list("nectar fresh from [honey_stomach.organ_owner]!", "nectar from [honey_stomach.organ_owner]!")
+		honey_stomach.emote_descriptor = list("nectar fresh from [honey_stomach.owner]!", "nectar from [honey_stomach.owner]!")
 
 	else
 		to_chat(src, SPAN_NOTICE("You lack the organ required to produce nectar."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Noticed a metric ton of runtimes of null.nutrition from a apidean, found out all our snowflake organs had a unneccessary var for holding the organ's owner, even though we have owner.
## Changelog
:cl:
fix: Alarune and apidaen "cannot read null.nutrition" runtimes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
