### PR TITLE
Updates DreamAnnotate to v2

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -45,7 +45,7 @@ jobs:
           tools/bootstrap/python -m mapmerge2.dmm_test
           ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
       - name: Annotate Lints
-        uses: yogstation13/DreamAnnotate@v1
+        uses: yogstation13/DreamAnnotate@v2
         if: always()
         with:
           outputFile: output-annotations.txt


### PR DESCRIPTION
Github deprecated Node12 for workflows, which DreamAnnotate V1 uses. DreamAnnotate V2 uses Node16 instead. This PR isn't urgent, but shouldn't affect much in theory.