### PR TITLE
Doubles Announce Time for Vines

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -1,7 +1,7 @@
 /var/global/spacevines_spawned = 0
 
 /datum/event/spacevine
-	announceWhen = 60
+	announceWhen = 120
 
 /datum/event/spacevine/start()
 	spacevine_infestation()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Increases Vine Announce Time From 1 Min to 2 Min.**

## Why It's Good For The Game

1. _Vines often get caught before they can really spread far enough. This adds one minute to the announce timer to give the vines a better chance. May drop if necessary._

## Changelog
:cl:
tweak: Adds 1min to vine announce timer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
