### PR TITLE
Gave Maid and Bridge Officer spawn outfits.

### DIFF
--- a/code/modules/jobs/job_types/station/command/command_secretary.dm
+++ b/code/modules/jobs/job_types/station/command/command_secretary.dm
@@ -46,6 +46,7 @@
 
 /datum/alt_title/commsec/officer
 	title = "Bridge Officer"
+	title_outfit = /datum/outfit/job/station/command_secretary/bridge_officer
 
 /datum/outfit/job/station/command_secretary
 	name = OUTFIT_JOB_NAME("Command Secretary")
@@ -61,3 +62,20 @@
 		uniform = /obj/item/clothing/under/suit_jacket/female/skirt
 	else
 		uniform = /obj/item/clothing/under/suit_jacket/charcoal
+
+/datum/outfit/job/station/command_secretary/bridge_officer
+	name = OUTFIT_JOB_NAME("Bridge Officer")
+	shoes = /obj/item/clothing/shoes/laceup
+	id_type = /obj/item/card/id/silver/secretary
+	pda_type = /obj/item/pda/heads/hop
+	l_hand = /obj/item/clipboard
+	head = /obj/item/clothing/head/bocap
+	suit = /obj/item/clothing/suit/storage/bridgeofficer
+	glasses = /obj/item/clothing/glasses/sunglasses
+
+/datum/outfit/job/station/command_secretary/bridge_officer/pre_equip(mob/living/carbon/human/H)
+	..()
+	if(H.gender == FEMALE)
+		uniform = /obj/item/clothing/under/bridgeofficerskirt
+	else
+		uniform = /obj/item/clothing/under/bridgeofficer

--- a/code/modules/jobs/job_types/station/service/janitor.dm
+++ b/code/modules/jobs/job_types/station/service/janitor.dm
@@ -32,6 +32,7 @@
 
 /datum/alt_title/janitor/maid
 	title = "Maid"
+	title_outfit = /datum/outfit/job/station/janitor/maid
 
 /datum/outfit/job/station/janitor
 	name = OUTFIT_JOB_NAME("Janitor")
@@ -39,3 +40,8 @@
 	id_type = /obj/item/card/id/civilian/janitor
 	pda_type = /obj/item/pda/janitor
 	l_ear = /obj/item/radio/headset/headset_service
+
+/datum/outfit/job/station/janitor/maid
+	name = OUTFIT_JOB_NAME("Maid")
+	uniform = /obj/item/clothing/under/dress/maid
+	head = /obj/item/clothing/head/headband/maid


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alternative titles have a system where they spawn the player with alternate outfits, this is seemingly sparingly selected.
Yes, used would have been a better word, I like alliteration.
Anyway, this uses that system for the Bridge Officer (it'll even select pants or skirt depending on gender) and Maid (I went with the middle ground between sexy maid and janimaid. Mainly because Janimaid is an underused sprite on maid characters.)

## Why It's Good For The Game

Spawning with alternate costumes on alternate titles adds flavour.

## Changelog
:cl:
add: Gave Maid and Bridge Officer spawn outfits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
