### PR TITLE
Adds some Warden alt titles.

### DIFF
--- a/code/modules/jobs/job_types/station/security/warden.dm
+++ b/code/modules/jobs/job_types/station/security/warden.dm
@@ -20,6 +20,20 @@
 						prisoners that have been processed and brigged, and are responsible for their well being. The Warden is also in charge of distributing \
 						Armoury gear in a crisis, and retrieving it when the crisis has passed. In an emergency, the Warden may be called upon to direct the \
 						Security Department as a whole."
+	alt_titles = list(
+		"Brig Governor" = /datum/alt_title/warden/brig_governor,
+		"Jailor" = /datum/alt_title/warden/jailor,
+		"Dispatch Officer" = /datum/alt_title/warden/dispatch_officer
+		)
+
+/datum/alt_title/warden/brig_governor
+	title = "Brig Governor"
+
+/datum/alt_title/warden/jailor
+	title = "Jailor"
+
+/datum/alt_title/warden/dispatch_officer
+	title = "Dispatch Officer"
 
 /datum/outfit/job/station/warden
 	name = OUTFIT_JOB_NAME("Warden")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fun Fact: Warden is the one carbon job that has zero alternate titles.
Now they all have them.
The titles are; Brig Governor, Jailor and Dispatch Officer.


## Why It's Good For The Game

Consistency and flavour.

## Changelog
:cl:
add: Adds some Warden alt titles. Brig Governor, Jailor and Dispatch Officer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
