### PR TITLE
Black-Eyed Shadekin BruteMod lowering to make bone breaking less likely

### DIFF
--- a/code/modules/species/shadekin/shadekin_blackeyed.dm
+++ b/code/modules/species/shadekin/shadekin_blackeyed.dm
@@ -35,7 +35,7 @@
 	item_slowdown_mod = 1.5 // They're not as fit as them, though, slowed down more by heavy gear.
 
 	total_health = 75   // Fragile
-	brute_mod    = 1.25 // Frail
+	brute_mod    = 1 // Originally 1.25, lowered to 1 in an attempt to make bone breaking less likely. Change raises damage needed for bones to break from 18 to 22.5
 	burn_mod     = 1.25 // Furry
 
 	blood_volume  = 500 // Slightly less blood than human baseline.


### PR DESCRIPTION
## About The Pull Request

Lowers the Black-Eyed Shadekin BruteMod so that it now should take 22.5 instead of 18 Brute damage to break bones, in an attempt to make it not feel like Shadekin have hollow bones.

## Why It's Good For The Game

Currently, with the lower HP and a BruteMod of 1.25, broken bones happened rather quickly. So quickly in fact, that multiple people assumed they have hollow bones. Nerfing a powerful race is completely understandable, but both lowering HP and increasing BruteMod might have gone too far with the way we calculate for bones breaking.

## Changelog
:cl:
balance: Black-Eyed Shadekin BruteMod lowered from 1.25 to 1
/:cl:
