### PR TITLE
Removes Black-Eyed Shadekin hollow bones

### DIFF
--- a/code/modules/organs/external/species/shadekin.dm
+++ b/code/modules/organs/external/species/shadekin.dm
@@ -1,37 +1,37 @@
 //! Blackeyed limbs.
 
 /obj/item/organ/external/chest/crewkin
-	min_broken_damage = 20
+	min_broken_damage = 31 // Original 20, raised to 31 to be at 0.9 of default
 
 /obj/item/organ/external/groin/crewkin
-	min_broken_damage = 20
+	min_broken_damage = 31 // Original 20, raised to 31 to be at 0.9 of default
 
 /obj/item/organ/external/head/vr/crewkin
-	min_broken_damage = 15
+	min_broken_damage = 31 // Original 15, raised to 31 to be at 0.9 of default
 
 	eye_icons_vr = 'icons/mob/human_face_vr.dmi'
 	eye_icon_vr = "eyes_shadekin_station"
 
 /obj/item/organ/external/arm/crewkin
-	min_broken_damage = 15
+	min_broken_damage = 27 // Original 15, raised to 27 to be at 0.9 of default
 
 /obj/item/organ/external/arm/right/crewkin
-	min_broken_damage = 15
+	min_broken_damage = 27 // Original 15, raised to 27 to be at 0.9 of default
 
 /obj/item/organ/external/leg/crewkin
-	min_broken_damage = 15
+	min_broken_damage = 27 // Original 15, raised to 27 to be at 0.9 of default
 
 /obj/item/organ/external/leg/right/crewkin
-	min_broken_damage = 15
+	min_broken_damage = 27 // Original 15, raised to 27 to be at 0.9 of default
 
 /obj/item/organ/external/foot/crewkin
-	min_broken_damage = 7
+	min_broken_damage = 13 // Original 7, raised to 13 to be at 0.9 of default
 
 /obj/item/organ/external/foot/right/crewkin
-	min_broken_damage = 7
+	min_broken_damage = 13 // Original 7, raised to 13 to be at 0.9 of default
 
 /obj/item/organ/external/hand/crewkin
-	min_broken_damage = 7
+	min_broken_damage = 13 // Original 7, raised to 13 to be at 0.9 of default
 
 /obj/item/organ/external/hand/right/crewkin
-	min_broken_damage = 7
+	min_broken_damage = 13 // Original 7, raised to 13 to be at 0.9 of default

--- a/code/modules/species/shadekin/shadekin_blackeyed.dm
+++ b/code/modules/species/shadekin/shadekin_blackeyed.dm
@@ -35,7 +35,7 @@
 	item_slowdown_mod = 1.5 // They're not as fit as them, though, slowed down more by heavy gear.
 
 	total_health = 75   // Fragile
-	brute_mod    = 1 // Originally 1.25, lowered to 1 in an attempt to make bone breaking less likely. Change raises damage needed for bones to break from 18 to 22.5
+	brute_mod    = 1 // Originally 1.25, lowered to 1 because lower HP and increased damage is a bit heavy.
 	burn_mod     = 1.25 // Furry
 
 	blood_volume  = 500 // Slightly less blood than human baseline.

--- a/code/modules/species/shadekin/shadekin_blackeyed.dm
+++ b/code/modules/species/shadekin/shadekin_blackeyed.dm
@@ -35,7 +35,7 @@
 	item_slowdown_mod = 1.5 // They're not as fit as them, though, slowed down more by heavy gear.
 
 	total_health = 75   // Fragile
-	brute_mod    = 1.25 // Frail
+	brute_mod    = 1 // Originally 1.25, lowered to 1 in an attempt to make bone breaking less likely. Change raises damage needed for bones to break from 18 to 22.5
 	burn_mod     = 1.25 // Furry
 
 	blood_volume  = 500 // Slightly less blood than human baseline.


### PR DESCRIPTION
## About The Pull Request
Turns out that while Black-Eyed Shadekin didn't have the Brittle Bones or Hollow Bones trait, they had it hardcoded that all their limbs had between 42% and 57% of the minimum damage needed to break bones.
Giving Black-Eyed Shadekin hollow bones was deemed silly and will now be changed. The values have been replaced to be between 85% and 90% of the original values.
In addition, the Brute_Mod of Black-Eyed Shadekin has been reduced from 1.25 to 1, since having both lower HP and higher damage mod is a lot of pain. The Burn_Mod was intentionally kept.

## Why It's Good For The Game

Crewkin are a powerful species and I am all for nerfing powerful people. But this was more along the lines of CBT.

## Changelog
:cl:
balance: Lowered Crewkin Brute_Mod
balance: Raised Crewkin minimum limb damage to break bones
/:cl:
