### PR TITLE
Bunch of misc map changes, new deep maint bar

### DIFF
--- a/_maps/map_files/rift/rift-01-underground3.dmm
+++ b/_maps/map_files/rift/rift-01-underground3.dmm
@@ -135,7 +135,7 @@
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/turbolift/rmine/under3)
 "jq" = (
-/obj/structure/ladder/snake_eater/up,
+/obj/structure/ladder/up,
 /turf/simulated/floor/plating,
 /area/quartermaster/mining_airlock)
 "jJ" = (

--- a/_maps/map_files/rift/rift-02-underground2.dmm
+++ b/_maps/map_files/rift/rift-02-underground2.dmm
@@ -648,7 +648,8 @@
 /area/maintenance/lower/mining)
 "bz" = (
 /obj/machinery/door/airlock/maintenance/engi{
-	name = "Elevator Shaft Access"
+	name = "Elevator Shaft Access";
+	req_one_access = null
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
@@ -930,13 +931,21 @@
 /turf/simulated/floor/tiled/white,
 /area/rift/asylum/mess)
 "cm" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
 /obj/machinery/alarm{
 	desc = " ";
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = 32
 	},
-/turf/simulated/wall/r_wall,
-/area/engineering/engine_core)
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
 "cn" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
 	dir = 8
@@ -10176,8 +10185,8 @@
 /turf/simulated/floor,
 /area/rift/asylum/fitness)
 "Aj" = (
-/obj/structure/ladder/snake_eater,
 /obj/structure/railing,
+/obj/structure/ladder,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
 "Al" = (
@@ -11338,7 +11347,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/railing,
-/obj/structure/ladder/snake_eater/up,
+/obj/structure/ladder/up,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining)
 "GG" = (
@@ -29628,8 +29637,8 @@ bC
 bo
 ar
 lK
+bQ
 cm
-eW
 dn
 eW
 bQ

--- a/_maps/map_files/rift/rift-02-underground2.dmm
+++ b/_maps/map_files/rift/rift-02-underground2.dmm
@@ -931,21 +931,13 @@
 /turf/simulated/floor/tiled/white,
 /area/rift/asylum/mess)
 "cm" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	desc = " ";
 	dir = 8;
-	pixel_x = 24;
-	pixel_y = 32
+	pixel_x = 24
 	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_room)
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_core)
 "cn" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
 	dir = 8
@@ -29637,8 +29629,8 @@ bC
 bo
 ar
 lK
-bQ
 cm
+eW
 dn
 eW
 bQ

--- a/_maps/map_files/rift/rift-03-underground1.dmm
+++ b/_maps/map_files/rift/rift-03-underground1.dmm
@@ -4383,7 +4383,8 @@
 /turf/simulated/floor/plating,
 /area/rift/surfacebase/underground/under1)
 "iv" = (
-/obj/structure/ladder/up,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/stasis_cage,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/outpost/research/longtermstorage)
 "iw" = (
@@ -5038,7 +5039,6 @@
 /area/engineering/break_room)
 "jK" = (
 /obj/structure/table/steel,
-/obj/item/material/twohanded/baseballbat/metal,
 /turf/simulated/floor/plating,
 /area/maintenance/elevator)
 "jL" = (
@@ -5054,6 +5054,9 @@
 /obj/structure/cable/cyan,
 /obj/machinery/power/rad_collector,
 /obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
 	dir = 4
 	},
 /turf/simulated/floor/reinforced,
@@ -6592,6 +6595,9 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
 /turf/simulated/floor/reinforced,
 /area/engineering/engine_core)
 "mM" = (
@@ -6696,6 +6702,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
 /turf/simulated/floor/reinforced,
 /area/engineering/engine_core)
 "mT" = (
@@ -6770,6 +6779,7 @@
 	},
 /obj/machinery/power/rad_collector,
 /obj/structure/railing,
+/obj/structure/window/phoronreinforced,
 /turf/simulated/floor/reinforced,
 /area/engineering/engine_core)
 "nc" = (
@@ -6798,6 +6808,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
 /turf/simulated/floor/reinforced,
 /area/engineering/engine_core)
 "ne" = (
@@ -6806,6 +6819,7 @@
 	},
 /obj/machinery/power/rad_collector,
 /obj/structure/railing,
+/obj/structure/window/phoronreinforced,
 /turf/simulated/floor/reinforced,
 /area/engineering/engine_core)
 "ng" = (
@@ -10674,6 +10688,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/railing,
+/obj/structure/window/phoronreinforced,
 /turf/simulated/floor/reinforced,
 /area/engineering/engine_core)
 "uw" = (
@@ -11085,6 +11100,7 @@
 /area/maintenance/elevator)
 "we" = (
 /obj/machinery/space_heater,
+/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/outpost/research/longtermstorage)
 "wh" = (
@@ -12174,6 +12190,7 @@
 /obj/item/clothing/suit/storage/hooded/wintercoat/science,
 /obj/structure/table/rack/shelf,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/outpost/research/longtermstorage)
 "Ap" = (
@@ -12624,12 +12641,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering/upper)
 "Ci" = (
-/obj/structure/ladder/snake_eater/updown,
 /obj/effect/floor_decal/techfloor{
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/railing,
+/obj/structure/ladder/updown,
 /turf/simulated/floor/tiled/techfloor,
 /area/rift/surfacebase/underground/under1)
 "Cj" = (
@@ -13101,6 +13118,7 @@
 "Ep" = (
 /obj/structure/table/rack/shelf,
 /obj/item/extinguisher,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/outpost/research/longtermstorage)
 "Eq" = (
@@ -13260,8 +13278,9 @@
 /turf/simulated/floor/outdoors/snow/lythios43c,
 /area/rift/surfacebase/underground/under1)
 "ES" = (
-/obj/structure/bonfire/permanent,
-/obj/structure/catwalk,
+/obj/machinery/appliance/cooker/grill{
+	pixel_y = 4
+	},
 /turf/simulated/floor/lythios43c/indoors,
 /area/security/prison)
 "ET" = (
@@ -13438,6 +13457,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/outpost/research/longtermstorage)
 "FA" = (
@@ -13472,6 +13492,9 @@
 	},
 /obj/machinery/power/rad_collector,
 /obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
 	dir = 4
 	},
 /turf/simulated/floor/reinforced,
@@ -13853,6 +13876,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/outpost/research/longtermstorage)
 "GT" = (
@@ -14205,6 +14229,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
 /turf/simulated/floor/reinforced,
 /area/engineering/engine_core)
 "HU" = (
@@ -14429,6 +14456,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
 /turf/simulated/floor/reinforced,
 /area/engineering/engine_core)
 "IJ" = (
@@ -14556,6 +14586,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/rift/station/fighter_bay)
+"Jf" = (
+/obj/structure/ladder/up,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/outpost/research/longtermstorage)
 "Jh" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -15134,6 +15169,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
 /turf/simulated/floor/reinforced,
 /area/engineering/engine_core)
 "Ld" = (
@@ -15247,6 +15285,9 @@
 	},
 /obj/machinery/power/rad_collector,
 /obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
 	dir = 1
 	},
 /turf/simulated/floor/reinforced,
@@ -17757,6 +17798,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/outpost/research/longtermstorage)
 "Vk" = (
@@ -26536,7 +26578,7 @@ Oy
 Xr
 Fx
 zV
-MX
+Jf
 Qw
 ri
 Bd

--- a/_maps/map_files/rift/rift-04-surface1.dmm
+++ b/_maps/map_files/rift/rift-04-surface1.dmm
@@ -5752,6 +5752,10 @@
 /obj/machinery/light_construct/small{
 	dir = 4
 	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/maintenance/maint_bar)
 "dSI" = (
@@ -13845,8 +13849,15 @@
 /area/rnd/hallway)
 "jgE" = (
 /obj/structure/table/steel,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/box/lights/bulbs,
+/obj/item/storage/box/lights/bulbs{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/lights/bulbs_neon,
+/obj/item/storage/box/lights/bulbs_colored{
+	pixel_x = 4;
+	pixel_y = -4
+	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/maint_bar)
 "jgH" = (
@@ -18058,6 +18069,7 @@
 	},
 /obj/structure/table,
 /obj/random/junk,
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/maint_bar)
 "lQs" = (
@@ -36368,6 +36380,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/grass,
 /area/medical/psych)
 "wTy" = (

--- a/_maps/map_files/rift/rift-04-surface1.dmm
+++ b/_maps/map_files/rift/rift-04-surface1.dmm
@@ -1539,6 +1539,13 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/wood/broken,
 /area/maintenance/research/lower)
+"blt" = (
+/obj/random/junk,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "blH" = (
 /obj/structure/table/standard,
 /obj/item/folder/blue,
@@ -1771,6 +1778,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
+"bqY" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "brd" = (
 /obj/machinery/light{
 	dir = 1
@@ -2726,6 +2739,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research/lower)
+"ccD" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/r_wall,
+/area/maintenance/security/lower)
 "ccP" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/disposalpipe/segment,
@@ -3558,6 +3577,9 @@
 /area/tether/station/public_meeting_room)
 "cFW" = (
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/security/lower)
 "cGh" = (
@@ -6846,6 +6868,9 @@
 	name = "east bump";
 	pixel_x = 24
 	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/wood,
 /area/maintenance/maint_bar)
 "eEi" = (
@@ -7186,6 +7211,12 @@
 "eSr" = (
 /turf/simulated/floor/plating,
 /area/engineering/engine_eva)
+"eSY" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security/lower)
 "eTH" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -8769,6 +8800,12 @@
 /area/crew_quarters/medbreak)
 "ght" = (
 /turf/simulated/mineral/icerock/lythios43c,
+/area/maintenance/maint_bar)
+"ghD" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/broken,
 /area/maintenance/maint_bar)
 "ghF" = (
 /obj/machinery/door/airlock/glass_medical{
@@ -11684,6 +11721,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rnd/hallway)
+"hWC" = (
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security/lower)
 "hWJ" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/research{
@@ -15731,6 +15774,13 @@
 	},
 /turf/simulated/floor/tiled/monowhite,
 /area/security/forensics)
+"ksT" = (
+/obj/random/junk,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "ktw" = (
 /obj/structure/railing{
 	dir = 1
@@ -16436,6 +16486,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
+"kMr" = (
+/obj/structure/grille,
+/obj/structure/foamedmetal,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security/lower)
 "kMD" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister{
@@ -18155,6 +18213,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security/lower)
@@ -20676,8 +20737,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tool_storage)
 "ntn" = (
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
+/obj/structure/grille,
+/obj/structure/foamedmetal,
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/security/lower)
 "ntO" = (
@@ -22442,6 +22506,14 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfaceone)
+"omh" = (
+/obj/structure/grille,
+/obj/structure/foamedmetal,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security/lower)
 "omm" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
@@ -25225,6 +25297,14 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rnd/tankstorage)
+"pSQ" = (
+/obj/structure/grille,
+/obj/structure/foamedmetal,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security/lower)
 "pSZ" = (
 /obj/structure/sign/atmos/o2{
 	pixel_x = 32
@@ -27067,6 +27147,9 @@
 /area/security/prison)
 "rkh" = (
 /obj/item/stool/padded,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood/broken,
 /area/maintenance/maint_bar)
 "rku" = (
@@ -28052,6 +28135,9 @@
 /area/security/detectives_office)
 "rPR" = (
 /obj/item/stool/padded,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood,
 /area/maintenance/maint_bar)
 "rQb" = (
@@ -32844,6 +32930,12 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/snow/lythios43c,
 /area/rift/surfacebase/outside/outside1)
+"uEc" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall,
+/area/maintenance/security/lower)
 "uEs" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -35368,6 +35460,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security/lower)
@@ -57491,12 +57586,12 @@ iTF
 iTF
 iTF
 iTF
-pZn
-pZn
-pZn
-tdI
-dMX
-dMX
+ntn
+pSQ
+pSQ
+uEc
+eSY
+hWC
 dMX
 mpF
 dMX
@@ -57683,20 +57778,20 @@ fae
 erN
 tXC
 iTF
-pZn
-pZn
-pZn
+ntn
+pSQ
+kMr
 snT
 snT
 snT
 dMX
 cFW
-cFW
+vgW
 lUJ
-ntn
-ntn
-ntn
-ntn
+jAY
+jAY
+jAY
+jAY
 woB
 jAY
 jAY
@@ -57877,7 +57972,7 @@ aVt
 dCR
 acE
 iTF
-pZn
+omh
 snT
 snT
 snT
@@ -58071,7 +58166,7 @@ iTF
 iTF
 iTF
 iTF
-pZn
+omh
 snT
 eoq
 rnG
@@ -58260,12 +58355,12 @@ pZn
 pZn
 pZn
 pZn
-pZn
-pZn
-pZn
-pZn
-pZn
-pZn
+ntn
+pSQ
+pSQ
+pSQ
+pSQ
+kMr
 snT
 ivr
 ipK
@@ -58454,7 +58549,7 @@ kzX
 kzX
 kzX
 kzX
-kzX
+ccD
 kzX
 kzX
 kzX
@@ -59424,7 +59519,7 @@ dkv
 hcE
 mXL
 jhW
-mXL
+ghD
 mXL
 jhW
 dkv
@@ -59618,7 +59713,7 @@ dkv
 rWI
 mXL
 mXL
-sAz
+blt
 jhW
 nHc
 dkv
@@ -59812,7 +59907,7 @@ dkv
 jQE
 pDj
 xLN
-mXL
+ghD
 llz
 iAE
 dkv
@@ -60006,7 +60101,7 @@ dkv
 gvI
 kod
 jQE
-mXL
+ghD
 mXL
 hqO
 dkv
@@ -60200,7 +60295,7 @@ dkv
 xxZ
 wTT
 jxa
-jhW
+bqY
 jhW
 jKI
 dkv
@@ -60394,7 +60489,7 @@ dkv
 itT
 xen
 pDj
-weV
+ksT
 mXL
 kVC
 dkv
@@ -60588,7 +60683,7 @@ dkv
 jQE
 jxa
 xLN
-mXL
+ghD
 llz
 jxa
 dkv

--- a/_maps/map_files/rift/rift-04-surface1.dmm
+++ b/_maps/map_files/rift/rift-04-surface1.dmm
@@ -2427,7 +2427,7 @@
 "bPE" = (
 /obj/structure/table/woodentable,
 /obj/item/flashlight/lantern,
-/turf/simulated/floor/outdoors/snow/lythios43c,
+/turf/simulated/floor/snow,
 /area/rift/surfacebase/outside/outside1)
 "bPJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3674,8 +3674,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/office)
 "cIt" = (
-/obj/machinery/door/airlock/maintenance/common,
-/turf/simulated/wall,
+/obj/random/junk,
+/turf/simulated/floor/plating,
 /area/maintenance/maint_bar)
 "cIz" = (
 /obj/structure/cable/green{
@@ -6751,6 +6751,12 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume,
 /turf/simulated/floor/outdoors/grass/heavy/interior,
 /area/medical/virologyisolation)
+"exN" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maint_bar)
 "eym" = (
 /obj/machinery/door/airlock/medical{
 	name = "Patient Room B";
@@ -14044,7 +14050,7 @@
 /turf/simulated/wall,
 /area/rnd/outpost/xenobiology/outpost_decon)
 "jlF" = (
-/turf/simulated/floor/tiled/steel_dirty,
+/turf/simulated/floor/plating,
 /area/maintenance/maint_bar)
 "jmJ" = (
 /obj/item/radio/intercom{
@@ -22864,6 +22870,9 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"owx" = (
+/turf/simulated/floor/snow,
+/area/rift/surfacebase/outside/outside1)
 "owN" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/meter,
@@ -30633,7 +30642,7 @@
 /area/medical/psych)
 "toc" = (
 /obj/structure/table/bench/wooden,
-/turf/simulated/floor/outdoors/snow/lythios43c,
+/turf/simulated/floor/snow,
 /area/rift/surfacebase/outside/outside1)
 "toy" = (
 /obj/machinery/camera/network/medbay{
@@ -31105,7 +31114,7 @@
 /obj/structure/sign/poster{
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/steel_dirty,
+/turf/simulated/floor/plating,
 /area/maintenance/maint_bar)
 "tDU" = (
 /obj/structure/table/hardwoodtable,
@@ -59326,7 +59335,7 @@ xKh
 eGb
 ftg
 rPR
-jhW
+jlF
 aSt
 cBk
 xQZ
@@ -59712,7 +59721,7 @@ hgE
 dkv
 rWI
 mXL
-mXL
+jlF
 blt
 jhW
 nHc
@@ -59907,7 +59916,7 @@ dkv
 jQE
 pDj
 xLN
-ghD
+exN
 llz
 iAE
 dkv
@@ -60105,9 +60114,9 @@ ghD
 mXL
 hqO
 dkv
-iFN
+owx
 xSV
-iFN
+owx
 hgE
 hgE
 hgE
@@ -60296,13 +60305,13 @@ xxZ
 wTT
 jxa
 bqY
-jhW
+jlF
 jKI
 dkv
 toc
-iFN
-iFN
-iFN
+owx
+owx
+owx
 hgE
 hgE
 snT
@@ -60494,9 +60503,9 @@ mXL
 kVC
 dkv
 toc
-iFN
+owx
 wZo
-iFN
+owx
 hgE
 hgE
 snT
@@ -60688,9 +60697,9 @@ llz
 jxa
 dkv
 toc
-iFN
-iFN
-iFN
+owx
+owx
+owx
 hgE
 hgE
 snT
@@ -60875,7 +60884,7 @@ jlF
 hPe
 nKU
 mXL
-jhW
+jlF
 lje
 eDQ
 nyh
@@ -61068,7 +61077,7 @@ lQh
 mFn
 tDQ
 dkv
-cIt
+hhC
 dkv
 dkv
 dkv
@@ -61648,10 +61657,10 @@ hgE
 dkv
 vrL
 une
-weV
+cIt
 mXL
 mXL
-jhW
+mXL
 dkv
 vCn
 qdj
@@ -61844,7 +61853,7 @@ aCk
 wAc
 wXJ
 fRc
-jhW
+jlF
 ajI
 dkv
 cBk

--- a/_maps/map_files/rift/rift-04-surface1.dmm
+++ b/_maps/map_files/rift/rift-04-surface1.dmm
@@ -272,6 +272,10 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/snow/noblend/lythios43c,
 /area/rift/surfacebase/outside/outside1)
+"ajI" = (
+/obj/machinery/light_construct/small,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "akr" = (
 /obj/structure/table/standard,
 /obj/item/pen/red{
@@ -293,6 +297,23 @@
 "aml" = (
 /turf/simulated/wall,
 /area/security/security_cell_hallway)
+"ank" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/purple/border,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/xenobiology/outpost_hallway)
 "anT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -695,6 +716,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/central_heating/surface_one)
+"aCk" = (
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "aCm" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/white,
@@ -750,7 +777,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/rift/stairwell/primary/surfaceone)
 "aEQ" = (
-/turf/simulated/floor/tiled/monowhite,
+/turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "aFN" = (
 /obj/structure/table/hardwoodtable,
@@ -824,7 +851,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/rnd/hallway)
 "aJo" = (
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "aJt" = (
 /obj/effect/floor_decal/borderfloor{
@@ -947,6 +980,12 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel,
 /area/janitor)
+"aSt" = (
+/obj/effect/overlay/snow/floor/pointy{
+	dir = 1
+	},
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "aSW" = (
 /obj/structure/railing{
 	dir = 1
@@ -1167,6 +1206,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rnd/hallway)
+"bah" = (
+/obj/structure/flora/pottedplant/stoutbush,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "baN" = (
 /obj/machinery/light/fairy{
 	dir = 8
@@ -1242,7 +1285,7 @@
 /area/maintenance/research/lower)
 "bdv" = (
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/monowhite,
+/turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "bdy" = (
 /turf/simulated/floor/carpet/bcarpet,
@@ -1548,6 +1591,10 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/security/prison)
+"bny" = (
+/obj/effect/debris/cleanable/blood,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "bnG" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/beakers,
@@ -2064,6 +2111,12 @@
 	},
 /turf/simulated/floor/lino,
 /area/tether/surfacebase/entertainment/backstage)
+"bEb" = (
+/obj/structure/table/rack/shelf,
+/obj/random/maintenance/security,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "bEN" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -2110,9 +2163,6 @@
 /area/rift/station/public_garden)
 "bGX" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/floor_decal/corner/beige{
-	dir = 9
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -2361,6 +2411,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rift/trade_shop)
+"bPE" = (
+/obj/structure/table/woodentable,
+/obj/item/flashlight/lantern,
+/turf/simulated/floor/outdoors/snow/lythios43c,
+/area/rift/surfacebase/outside/outside1)
 "bPJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -2471,7 +2526,7 @@
 "bUK" = (
 /obj/structure/lattice,
 /turf/simulated/open/lythios43c,
-/area/space)
+/area/rift/surfacebase/outside/outside1)
 "bUV" = (
 /obj/structure/bed/chair/sofa/black/left{
 	dir = 4
@@ -2498,7 +2553,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/lythios43c,
-/area/space)
+/area/rift/surfacebase/outside/outside1)
 "bWw" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -3004,6 +3059,10 @@
 	},
 /turf/simulated/floor/tiled/monowhite,
 /area/medical/psych_ward)
+"coC" = (
+/obj/structure/bed/padded,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/security/lower)
 "coV" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/carpet,
@@ -3185,6 +3244,9 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
+/obj/machinery/camera/network/security{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel,
 /area/security/security_cell_hallway)
 "cwV" = (
@@ -3253,9 +3315,12 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/funny/mimeoffice)
 "cyn" = (
-/obj/structure/railing,
+/obj/machinery/door/blast/regular{
+	id = "viro_burn";
+	name = "Virology Burn Vent"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/area/medical/virologypurge)
 "cyu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3371,6 +3436,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virologypurge)
+"cBk" = (
+/turf/simulated/wall{
+	can_open = 1
+	},
+/area/maintenance/maint_bar)
 "cBn" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3512,9 +3582,6 @@
 /obj/structure/window/basic{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/beige{
-	dir = 6
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "cGU" = (
@@ -3584,6 +3651,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/office)
+"cIt" = (
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/wall,
+/area/maintenance/maint_bar)
 "cIz" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -4133,8 +4204,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security/lower)
 "dcS" = (
-/turf/simulated/mineral/icerock/lythios43c,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/psych_ward)
 "dcT" = (
 /obj/structure/sink{
 	dir = 4;
@@ -4391,6 +4471,14 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfaceone)
+"dix" = (
+/obj/structure/table/rack/shelf,
+/obj/fiftyspawner/hardwood,
+/obj/fiftyspawner/wood,
+/obj/fiftyspawner/rods,
+/obj/item/stack/cable_coil,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/maintenance/maint_bar)
 "diG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -4452,11 +4540,8 @@
 /turf/simulated/floor/lino,
 /area/security/detectives_office)
 "dkv" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/turf/simulated/wall,
+/area/maintenance/maint_bar)
 "dky" = (
 /obj/machinery/door/airlock{
 	name = "Internal Affairs";
@@ -4850,13 +4935,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rift/stairwell/primary/surfaceone)
-"dvH" = (
-/obj/machinery/atmospherics/component/unary/vent_pump/on,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/rnd/outpost/xenobiology/outpost_hallway)
 "dwr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock{
@@ -5179,11 +5257,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/purple/border,
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "dGe" = (
 /obj/effect/floor_decal/borderfloor{
@@ -5271,11 +5354,17 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/surfaceeva/airlock/main/secondary)
 "dHX" = (
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/component/unary/vent_pump/on,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "dIl" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -5554,13 +5643,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/office)
 "dQi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/monowhite,
+/turf/simulated/floor/tiled/white,
 /area/medical/psych)
 "dQB" = (
 /obj/effect/floor_decal/borderfloor{
@@ -5598,7 +5685,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/purple/border,
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "dQK" = (
 /obj/structure/closet/emcloset,
@@ -5656,6 +5745,15 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/civilian_hallway_mid)
+"dSz" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/light_construct/small{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/maintenance/maint_bar)
 "dSI" = (
 /obj/structure/disposalpipe/tagger/partial{
 	name = "partial tagger - Sorting Office";
@@ -5691,6 +5789,16 @@
 /obj/item/storage/briefcase/inflatable,
 /turf/simulated/floor/tiled/steel,
 /area/storage/surface_eva)
+"dTX" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/random/trash_pile,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "dTZ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -5815,10 +5923,17 @@
 /turf/simulated/floor/tiled/steel,
 /area/rift/stairwell/primary/surfaceone)
 "dXh" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/turf/simulated/open/lythios43c,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/psych)
 "dXn" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -5901,6 +6016,11 @@
 /obj/landmark/spawnpoint/job/paramedic,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_emt_bay)
+"dZn" = (
+/obj/effect/floor_decal/rust,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "dZO" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -6151,9 +6271,11 @@
 /turf/simulated/floor/plating,
 /area/tether/station/public_meeting_room)
 "egd" = (
-/obj/structure/catwalk,
-/turf/simulated/open/lythios43c,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/monowhite,
+/area/medical/psych)
 "egu" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6301,7 +6423,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monowhite,
+/turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "enu" = (
 /obj/structure/catwalk,
@@ -6714,6 +6836,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering/pumpstation)
+"eDQ" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "eEi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6723,6 +6853,11 @@
 "eFp" = (
 /turf/simulated/wall,
 /area/maintenance/engineering/pumpstation)
+"eFx" = (
+/obj/machinery/chemical_dispenser/bar_alc/full,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/reinforced,
+/area/maintenance/maint_bar)
 "eFH" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -6750,6 +6885,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
+"eGb" = (
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/turf/simulated/floor/plating,
+/area/maintenance/maint_bar)
 "eGx" = (
 /obj/machinery/door/airlock/glass_external{
 	name = "Medical Airlock";
@@ -7060,6 +7200,21 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
+"eTW" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass/hidden{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/xenobiology/outpost_hallway)
 "eUk" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -7069,7 +7224,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/rift/station/public_garden)
 "eUx" = (
-/turf/simulated/floor/tiled/steel_grid,
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "eVw" = (
 /obj/structure/bed/chair/wood{
@@ -7212,6 +7373,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
+"faL" = (
+/turf/simulated/floor/carpet/turcarpet,
+/area/maintenance/maint_bar)
 "faM" = (
 /obj/structure/flora/bush,
 /turf/simulated/floor/snow,
@@ -7269,7 +7433,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monowhite,
+/turf/simulated/floor/tiled/white,
 /area/medical/psych)
 "fdI" = (
 /obj/structure/catwalk,
@@ -7332,7 +7496,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/monowhite,
+/turf/simulated/floor/tiled/white,
 /area/medical/psych)
 "fhR" = (
 /obj/structure/bed,
@@ -7586,6 +7750,10 @@
 /obj/item/book/manual/standard_operating_procedure,
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/medical/mentalhealth)
+"ftg" = (
+/obj/structure/table,
+/turf/simulated/floor/reinforced,
+/area/maintenance/maint_bar)
 "ftp" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
@@ -7718,10 +7886,18 @@
 /turf/simulated/floor/tiled/steel,
 /area/security/security_cell_hallway)
 "fxS" = (
-/obj/structure/ladder,
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/outpost/xenobiology/outpost_stairs)
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/xenobiology/outpost_hallway)
 "fyf" = (
 /turf/simulated/wall,
 /area/rnd/outpost/xenobiology/outpost_decon)
@@ -8208,6 +8384,12 @@
 "fRa" = (
 /turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/medical/mentalhealth)
+"fRc" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/maintenance/maint_bar)
 "fRm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -8581,6 +8763,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/crew_quarters/medbreak)
+"ght" = (
+/turf/simulated/mineral/icerock/lythios43c,
+/area/maintenance/maint_bar)
 "ghF" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Paramedic Storage"
@@ -8991,6 +9176,13 @@
 	},
 /turf/simulated/floor/outdoors/safeice/lythios43c/indoors,
 /area/medical/virologytransiteast)
+"gvI" = (
+/obj/machinery/light_construct/small{
+	dir = 1
+	},
+/obj/structure/table,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "gvU" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -9666,6 +9858,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
+"gSP" = (
+/obj/structure/table/steel,
+/obj/item/duct_tape_roll,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/security/lower)
 "gTk" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -10033,6 +10232,13 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/gravsnow/lythios43c,
 /area/rift/surfacebase/outside/outside1)
+"hcE" = (
+/obj/machinery/vending/sovietsoda,
+/obj/structure/sign/double/barsign{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "hcL" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -10217,6 +10423,15 @@
 /obj/item/folder/blue,
 /turf/simulated/floor/tiled/techfloor,
 /area/server)
+"hhv" = (
+/obj/effect/debris/cleanable/ash,
+/obj/item/cigbutt/cigarbutt,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/security/lower)
+"hhC" = (
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "hhD" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -10458,6 +10673,12 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/rift/trade_shop)
+"hmK" = (
+/obj/structure/symbol/sa,
+/turf/simulated/wall/r_wall{
+	can_open = 1
+	},
+/area/security/security_cell_hallway)
 "hnh" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/ai_status_display{
@@ -10563,6 +10784,13 @@
 /obj/structure/railing,
 /turf/simulated/floor/outdoors/snow/noblend/lythios43c,
 /area/rift/surfacebase/outside/outside1)
+"hqO" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/light_construct/small,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "hqU" = (
 /obj/effect/floor_decal/industrial/loading,
 /obj/machinery/alarm{
@@ -10768,7 +10996,7 @@
 /area/maintenance/tool_storage)
 "hBl" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
-/turf/simulated/floor/tiled/monowhite,
+/turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "hBM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11012,6 +11240,12 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "hGN" = (
@@ -11169,9 +11403,7 @@
 /turf/simulated/floor/water/deep/indoors,
 /area/rift/station/public_garden)
 "hMb" = (
-/obj/machinery/door/firedoor/glass/hidden{
-	req_one_access = list(18,47)
-	},
+/obj/machinery/door/firedoor/glass/hidden,
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyisolation)
 "hMm" = (
@@ -11224,6 +11456,16 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"hNH" = (
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/obj/structure/sign/graffiti/pisoff{
+	pixel_y = 26
+	},
+/obj/effect/overlay/snow/floor/pointy,
+/turf/simulated/floor/snow/gravsnow,
+/area/maintenance/maint_bar)
 "hNW" = (
 /obj/effect/floor_decal/industrial/halfstair,
 /turf/simulated/floor/plating/lythios43c,
@@ -11233,6 +11475,10 @@
 /obj/item/storage/toolbox/emergency,
 /turf/simulated/floor/plating,
 /area/maintenance/research/lower)
+"hPe" = (
+/obj/random/junk,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/maintenance/maint_bar)
 "hPC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -11261,6 +11507,10 @@
 	},
 /turf/simulated/floor/outdoors/snow/lythios43c,
 /area/rift/surfacebase/outside/outside1)
+"hQd" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/security/lower)
 "hQy" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -11270,6 +11520,9 @@
 	},
 /obj/machinery/camera/network/medbay{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
@@ -11342,6 +11595,15 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/steel,
 /area/rnd/xenobiology/xenoflora/lab_atmos)
+"hTB" = (
+/obj/structure/bed/chair/comfy/red{
+	dir = 8
+	},
+/obj/structure/sign/poster{
+	pixel_x = 32
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/maintenance/maint_bar)
 "hTO" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -11397,6 +11659,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyisolation)
+"hWl" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "hWp" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -12225,6 +12493,13 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/tankstorage)
+"itT" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/light_construct/small{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "iue" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -12275,7 +12550,7 @@
 /area/maintenance/library)
 "ivG" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/monowhite,
+/turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "ivI" = (
 /obj/machinery/door/airlock/glass_external/public{
@@ -12425,6 +12700,14 @@
 /obj/item/cmo_disk_holder,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/cmo)
+"ixM" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = 30
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/maintenance/maint_bar)
 "iyk" = (
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/lino,
@@ -12441,6 +12724,12 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/surfaceeva/airlock/main)
+"iyD" = (
+/obj/machinery/vending/boozeomat{
+	req_access = null
+	},
+/turf/simulated/floor/reinforced,
+/area/maintenance/maint_bar)
 "iyI" = (
 /obj/structure/table/woodentable,
 /obj/item/flame/candle/candelabra/everburn,
@@ -12477,6 +12766,10 @@
 	},
 /turf/simulated/floor/carpet,
 /area/library/study)
+"iAE" = (
+/obj/structure/table,
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "iAL" = (
 /obj/structure/railing{
 	dir = 1
@@ -12810,11 +13103,10 @@
 	id = "main_ext_blast";
 	name = "Surface External Blast Door"
 	},
-/obj/effect/overlay/snow/floor,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled,
 /area/maintenance/evahallway)
 "iJU" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
@@ -12853,7 +13145,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/purple/border,
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "iKA" = (
 /obj/structure/sink/puddle,
@@ -12881,7 +13175,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/monowhite,
+/turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "iLH" = (
 /obj/machinery/light{
@@ -13001,7 +13295,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "iQT" = (
 /obj/machinery/door/airlock/glass_security{
@@ -13453,8 +13753,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/foyer)
 "jeG" = (
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
@@ -13545,12 +13845,10 @@
 /area/rnd/hallway)
 "jgE" = (
 /obj/structure/table/steel,
-/obj/item/storage/box/gloves,
-/obj/machinery/camera/network/security{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/red,
-/area/security/security_cell_hallway)
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/box/lights/bulbs,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/maintenance/maint_bar)
 "jgH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -13579,6 +13877,9 @@
 	},
 /turf/simulated/floor/outdoors/gravsnow/lythios43c,
 /area/rift/surfacebase/outside/outside1)
+"jhW" = (
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "jiI" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/tiled/techfloor,
@@ -13688,6 +13989,9 @@
 /obj/structure/sign/department/xenolab,
 /turf/simulated/wall,
 /area/rnd/outpost/xenobiology/outpost_decon)
+"jlF" = (
+/turf/simulated/floor/tiled/steel_dirty,
+/area/maintenance/maint_bar)
 "jmJ" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -13734,6 +14038,16 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/cargo_hallway)
 "jnS" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/hidden,
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "jnU" = (
@@ -13875,6 +14189,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/evahallway)
+"jxa" = (
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "jxb" = (
 /obj/machinery/door/airlock/glass_mining{
 	name = "Cargo Airlock";
@@ -14276,6 +14594,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/warehouse)
+"jKI" = (
+/obj/structure/closet/crate/bin{
+	anchored = 1
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "jLa" = (
 /obj/structure/stairs/spawner/north,
 /turf/simulated/floor/plating,
@@ -14338,6 +14662,12 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/tool_storage)
+"jNi" = (
+/obj/structure/table/woodentable,
+/obj/item/clothing/accessory/armband,
+/obj/item/material/twohanded/baseballbat/metal,
+/turf/simulated/floor/carpet/turcarpet,
+/area/maintenance/maint_bar)
 "jNR" = (
 /obj/machinery/disposal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14439,6 +14769,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"jQE" = (
+/obj/structure/table,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "jQK" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -14784,6 +15118,12 @@
 /area/rift/surfacebase/outside/outside1)
 "kah" = (
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/purple/border{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -15254,6 +15594,11 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"kod" = (
+/obj/structure/table/hardwoodtable,
+/obj/item/instrument/eguitar,
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "koh" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /obj/structure/cable/green{
@@ -15388,7 +15733,7 @@
 /obj/structure/metal_edge,
 /turf/simulated/floor/plating/lythios43c,
 /turf/simulated/floor/outdoors/snow/noblend/lythios43c,
-/area/rift/surfaceeva/aa/surface_south)
+/area/rift/surfacebase/outside/outside1)
 "ktI" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light,
@@ -15588,8 +15933,20 @@
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/foyer)
 "kyn" = (
-/turf/simulated/floor/tiled/monowhite,
-/area/medical/psych)
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/xenobiology/outpost_hallway)
 "kyD" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -15649,6 +16006,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/foyer)
+"kzX" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/security/lower)
 "kAb" = (
 /turf/simulated/wall/r_wall,
 /area/rift/trade_shop)
@@ -15795,6 +16155,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rift/trade_shop)
+"kFN" = (
+/obj/machinery/light_construct/small,
+/turf/simulated/floor/carpet/turcarpet,
+/area/maintenance/maint_bar)
 "kFR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -16128,6 +16492,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/tether/station/public_meeting_room)
+"kQw" = (
+/obj/machinery/vending/glukoz,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/maintenance/maint_bar)
 "kQH" = (
 /obj/structure/table/woodentable,
 /obj/item/book/bundle/custom_library/fiction,
@@ -16297,6 +16665,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
+"kVC" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/obj/machinery/light_construct/small,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "kVG" = (
 /obj/item/clothing/shoes/athletic,
 /turf/simulated/floor/tiled/monotile,
@@ -16811,6 +17186,13 @@
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/carpet/blucarpet,
 /area/lawoffice)
+"lje" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = 30
+	},
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "lkl" = (
 /obj/structure/bookcase/legal/combo,
 /turf/simulated/floor/wood,
@@ -16833,7 +17215,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monowhite,
+/turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "lkP" = (
 /obj/machinery/hologram/holopad,
@@ -16849,6 +17231,10 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/library)
+"llz" = (
+/obj/structure/bed/chair/comfy/black,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "llC" = (
 /turf/simulated/wall/r_wall,
 /area/prison/solitary)
@@ -16877,6 +17263,13 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
+"lnK" = (
+/obj/structure/table/rack/shelf,
+/obj/random/junk,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/security,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "lnP" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -17609,7 +18002,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/monowhite,
+/turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "lOY" = (
 /obj/machinery/vending,
@@ -17660,8 +18053,13 @@
 /turf/simulated/floor/outdoors/snow/noblend/lythios43c,
 /area/rift/surfacebase/outside/outside1)
 "lQh" = (
-/turf/simulated/wall,
-/area/security/prison)
+/obj/machinery/light_construct/small{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/random/junk,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/maintenance/maint_bar)
 "lQs" = (
 /obj/structure/table/woodentable,
 /obj/item/flashlight/lamp/green{
@@ -17877,9 +18275,17 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_breakroom)
 "mbH" = (
-/obj/effect/zone_divider,
-/turf/simulated/mineral/icerock/lythios43c,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/purple/border,
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/xenobiology/outpost_hallway)
 "mbJ" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/outdoors/grass/heavy/interior,
@@ -18155,9 +18561,6 @@
 /area/rnd/outpost/xenobiology/outpost_decon)
 "mis" = (
 /obj/structure/closet/secure_closet/medical2,
-/obj/effect/floor_decal/corner/beige{
-	dir = 6
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -18577,7 +18980,6 @@
 /area/medical/virology)
 "mrV" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/floor_decal/corner/beige/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "mst" = (
@@ -18956,12 +19358,24 @@
 /obj/structure/transit_tube/high_velocity,
 /turf/simulated/floor/tiled/white,
 /area/medical/virologytransitwest)
+"mDl" = (
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/maint_bar)
 "mDM" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "mDS" = (
 /obj/item/radio/intercom,
@@ -18973,6 +19387,12 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/funny/mimeoffice)
+"mFn" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/maintenance/maint_bar)
 "mFC" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
@@ -19343,7 +19763,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "mSE" = (
 /obj/item/mecha_parts/part/durand_left_leg,
@@ -19500,6 +19926,9 @@
 	},
 /turf/simulated/floor/wood,
 /area/lawoffice)
+"mXL" = (
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "mXO" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -20093,6 +20522,15 @@
 /obj/item/toy/character/alien,
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/game_room)
+"npr" = (
+/obj/structure/sign/poster{
+	pixel_x = -32
+	},
+/obj/structure/bed/chair/comfy/red{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/turcarpet,
+/area/maintenance/maint_bar)
 "npu" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 6
@@ -20230,6 +20668,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/security/lower)
+"ntO" = (
+/obj/structure/table/hardwoodtable,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = -30
+	},
+/turf/simulated/floor/reinforced,
+/area/maintenance/maint_bar)
 "ntZ" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "2-8"
@@ -20407,6 +20853,12 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/lawoffice)
+"nyh" = (
+/obj/structure/sign/poster{
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "nyp" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
@@ -20422,12 +20874,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tool_storage)
 "nyx" = (
-/obj/machinery/door/firedoor/glass/hidden{
-	req_one_access = list(18,47)
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/glass/hidden,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfaceone)
 "nyE" = (
@@ -20495,6 +20945,25 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rift/trade_shop)
+"nAb" = (
+/obj/structure/table/hardwoodtable,
+/obj/item/flashlight/lamp{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/paper_bin{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/maintenance/maint_bar)
 "nAi" = (
 /obj/structure/railing,
 /obj/machinery/embedded_controller/radio/airlock/phoron{
@@ -20766,6 +21235,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/janitor)
+"nHc" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "nHp" = (
 /obj/structure/railing{
 	dir = 4
@@ -20779,9 +21254,7 @@
 	pixel_x = -24
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/map_effect/portal/line/side_a{
-	dir = 4
-	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/tool_storage)
 "nHK" = (
@@ -20879,6 +21352,10 @@
 /obj/effect/floor_decal/corner/pink/border,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
+"nKU" = (
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/maintenance/maint_bar)
 "nLc" = (
 /obj/structure/bed/chair,
 /obj/machinery/firealarm{
@@ -21317,7 +21794,6 @@
 	id = "main_ext_blast";
 	name = "Surface External Blast Door"
 	},
-/obj/effect/overlay/snow/floor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -21327,7 +21803,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/maintenance/evahallway)
 "nXc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -21746,7 +22222,7 @@
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monowhite,
+/turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "ofF" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -22225,6 +22701,16 @@
 "otM" = (
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/surfaceone)
+"otX" = (
+/obj/machinery/chemical_dispenser/bar_soft/full,
+/obj/structure/table/woodentable,
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/obj/machinery/light_construct/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maint_bar)
 "oug" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -22368,6 +22854,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research/lower)
+"oAC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass/hidden{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/xenobiology/outpost_hallway)
 "oAV" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/large,
@@ -22650,7 +23151,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/evahallway)
 "oJs" = (
-/obj/machinery/media/jukebox,
+/obj/machinery/media/jukebox{
+	emagged = 1
+	},
 /obj/structure/railing,
 /obj/structure/railing{
 	dir = 8
@@ -22857,6 +23360,7 @@
 	dir = 4;
 	pixel_x = 26
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
 "oPD" = (
@@ -23089,7 +23593,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "oVa" = (
 /obj/machinery/door/firedoor/glass,
@@ -23686,6 +24190,11 @@
 /obj/structure/railing,
 /turf/simulated/floor/plating,
 /area/maintenance/research/lower)
+"pmJ" = (
+/obj/structure/table/hardwoodtable,
+/obj/item/gun/projectile/derringer,
+/turf/simulated/floor/carpet/bcarpet,
+/area/maintenance/maint_bar)
 "pmT" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -24078,7 +24587,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/monowhite,
+/turf/simulated/floor/tiled/white,
 /area/medical/psych)
 "pxL" = (
 /obj/structure/cable/green{
@@ -24267,6 +24776,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/cargo_hallway)
+"pDj" = (
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "pEF" = (
 /obj/machinery/vending/assist,
 /obj/effect/floor_decal/borderfloor{
@@ -24469,6 +24982,12 @@
 "pKq" = (
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/delivery)
+"pKE" = (
+/obj/structure/table/rack/shelf,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/steel,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/maintenance/maint_bar)
 "pKJ" = (
 /obj/machinery/vending/coffee{
 	dir = 8
@@ -24865,6 +25384,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/virologyaccess)
+"qdd" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
+"qdj" = (
+/obj/structure/table/woodentable,
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 1
+	},
+/obj/item/flashlight/lamp,
+/turf/simulated/floor/carpet/turcarpet,
+/area/maintenance/maint_bar)
 "qdk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -24903,6 +25436,12 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/tool_storage)
+"qdM" = (
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/snow/gravsnow,
+/area/rift/surfacebase/outside/outside1)
 "qeb" = (
 /obj/machinery/door/airlock{
 	name = "Showers and Decontamination"
@@ -25743,7 +26282,13 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "qFN" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -25771,6 +26316,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_eva)
+"qIO" = (
+/obj/effect/debris/cleanable/vomit{
+	icon_state = "vomit_3"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/security/lower)
 "qIZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -25781,7 +26332,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/purple/bordercorner,
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "qJb" = (
 /obj/structure/bed/chair/wood,
@@ -26048,6 +26601,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/structure/table/steel,
+/obj/item/storage/box/gloves,
 /turf/simulated/floor/tiled/monotile,
 /area/security/security_cell_hallway)
 "qSH" = (
@@ -26428,7 +26983,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid/lythios43c,
-/area/space)
+/area/rift/surfacebase/outside/outside1)
 "rha" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -26498,6 +27053,10 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/steel,
 /area/security/prison)
+"rkh" = (
+/obj/item/stool/padded,
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "rku" = (
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
@@ -26734,6 +27293,14 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/security/security_cell_hallway)
+"rtX" = (
+/obj/structure/table/hardwoodtable,
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/flora/pottedplant/smallcactus{
+	pixel_y = 10
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/maintenance/maint_bar)
 "ruk" = (
 /obj/machinery/light{
 	dir = 4
@@ -26953,6 +27520,16 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/foyer)
+"ryW" = (
+/obj/structure/closet/crate,
+/obj/item/circuitboard/atm,
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"rzY" = (
+/obj/structure/bed/double/padded,
+/obj/item/bedsheet/browndouble,
+/turf/simulated/floor/carpet/turcarpet,
+/area/maintenance/maint_bar)
 "rAj" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/vending/sovietsoda{
@@ -26986,6 +27563,15 @@
 /obj/machinery/atmospherics/component/binary/pump,
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/testingroom)
+"rAH" = (
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/obj/random/maintenance/security,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "rAW" = (
 /obj/item/radio{
 	pixel_x = 3;
@@ -27452,6 +28038,10 @@
 	},
 /turf/simulated/floor/lino,
 /area/security/detectives_office)
+"rPR" = (
+/obj/item/stool/padded,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "rQb" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/brown/bordercorner,
@@ -27662,6 +28252,12 @@
 	},
 /turf/simulated/floor/reinforced/lythios43c,
 /area/rift/surfacebase/outside/outside1)
+"rWI" = (
+/obj/machinery/media/jukebox{
+	emagged = 1
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "rXL" = (
 /obj/item/megaphone,
 /obj/structure/railing{
@@ -27717,7 +28313,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "rZS" = (
 /obj/structure/table/wooden_reinforced,
@@ -27869,6 +28471,13 @@
 	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
+"sfP" = (
+/obj/structure/bed/chair,
+/obj/item/handcuffs/cable/white,
+/obj/effect/debris/cleanable/blood,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/security/lower)
 "sgf" = (
 /obj/structure/flora/ausbushes,
 /obj/structure/window/wooden{
@@ -28155,9 +28764,6 @@
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/structure/window/basic{
 	dir = 1
-	},
-/obj/effect/floor_decal/corner/beige{
-	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
@@ -28577,6 +29183,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medical_restroom)
+"sAz" = (
+/obj/random/junk,
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "sBy" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
@@ -28682,19 +29292,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_main)
-"sFB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/rnd/outpost/xenobiology/outpost_hallway)
 "sFL" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 1
 	},
 /turf/simulated/open/lythios43c,
-/area/space)
+/area/rift/surfacebase/outside/outside1)
 "sFP" = (
 /obj/effect/overlay/snow/floor/pointy,
 /obj/effect/overlay/snow/floor/pointy{
@@ -28743,6 +29347,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/storage/tools)
+"sHk" = (
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/obj/structure/table,
+/turf/simulated/floor/plating,
+/area/maintenance/maint_bar)
 "sHu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
@@ -29034,12 +29644,11 @@
 /turf/simulated/floor/wood,
 /area/library)
 "sMS" = (
-/obj/machinery/door/blast/regular{
-	id = "viro_burn";
-	name = "Virology Burn Vent"
-	},
-/turf/simulated/floor/plating,
-/area/medical/virologypurge)
+/obj/structure/table/steel,
+/obj/item/soap/syndie,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/maintenance/maint_bar)
 "sNf" = (
 /obj/structure/bed/chair/wood{
 	dir = 4
@@ -29316,7 +29925,11 @@
 	dir = 8
 	},
 /turf/simulated/open/lythios43c,
-/area/space)
+/area/rift/surfacebase/outside/outside1)
+"sWx" = (
+/obj/structure/kitchenspike,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/security/lower)
 "sWF" = (
 /obj/effect/overlay/snow/floor/pointy,
 /obj/effect/overlay/snow/floor/pointy{
@@ -29920,6 +30533,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
+"toc" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/outdoors/snow/lythios43c,
+/area/rift/surfacebase/outside/outside1)
 "toy" = (
 /obj/machinery/camera/network/medbay{
 	dir = 1;
@@ -30386,6 +31003,12 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/medical/mentalhealth)
+"tDQ" = (
+/obj/structure/sign/poster{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/maintenance/maint_bar)
 "tDU" = (
 /obj/structure/table/hardwoodtable,
 /obj/machinery/light_construct/small{
@@ -30452,9 +31075,6 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/trade_shop)
 "tFN" = (
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/random/maintenance/clean,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
@@ -30603,7 +31223,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/monowhite,
+/turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "tJx" = (
 /obj/structure/railing,
@@ -30644,7 +31264,7 @@
 	dir = 4
 	},
 /turf/simulated/open/lythios43c,
-/area/space)
+/area/rift/surfacebase/outside/outside1)
 "tLR" = (
 /obj/structure/railing{
 	dir = 1
@@ -31021,7 +31641,9 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "tZl" = (
-/obj/machinery/vending/boozeomat,
+/obj/machinery/vending/boozeomat{
+	req_access = null
+	},
 /turf/simulated/floor/wood/broken,
 /area/maintenance/starboard)
 "tZo" = (
@@ -31561,6 +32183,12 @@
 /obj/effect/floor_decal/corner/red/bordercorner,
 /turf/simulated/floor/tiled/steel,
 /area/security/security_cell_hallway)
+"une" = (
+/obj/machinery/light_construct/small{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "unA" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass,
@@ -32529,6 +33157,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/security/checkpoint)
+"uSe" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/maintenance/maint_bar)
 "uSm" = (
 /obj/machinery/light{
 	dir = 8
@@ -33287,12 +33919,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/storage/tools)
 "vrL" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/flora/pottedplant/minitree,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "vrW" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -33457,9 +34086,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
 "vzD" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -33531,6 +34157,15 @@
 	},
 /turf/simulated/floor/outdoors/grass/heavy/interior,
 /area/medical/virologyisolation)
+"vBx" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/xenobiology/outpost_hallway)
 "vBD" = (
 /obj/structure/table/hardwoodtable,
 /obj/machinery/chemical_dispenser/bar_alc/full,
@@ -33549,6 +34184,11 @@
 /obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/entertainment)
+"vCn" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "vCB" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
@@ -33732,7 +34372,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/purple/border,
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "vKv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -33774,6 +34416,7 @@
 /area/security/prison)
 "vLK" = (
 /obj/structure/closet/crate,
+/obj/item/circuitboard/autolathe,
 /turf/simulated/floor/plating,
 /area/maintenance/library)
 "vLP" = (
@@ -34292,6 +34935,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/rift/surfaceeva/cargodock)
+"wca" = (
+/obj/structure/table/woodentable,
+/obj/item/material/ashtray/glass,
+/turf/simulated/floor/snow/gravsnow,
+/area/rift/surfacebase/outside/outside1)
 "wci" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -34448,6 +35096,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"weV" = (
+/obj/random/junk,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "wft" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -34456,9 +35108,6 @@
 /area/quartermaster/foyer)
 "wfK" = (
 /obj/machinery/scale,
-/obj/effect/floor_decal/corner/beige/full{
-	dir = 4
-	},
 /obj/machinery/camera/network/medbay{
 	dir = 8
 	},
@@ -34572,7 +35221,7 @@
 /turf/simulated/floor/wood,
 /area/library)
 "wkp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monowhite,
@@ -34589,7 +35238,9 @@
 /area/tether/surfacebase/medical/mentalhealth)
 "wkO" = (
 /obj/machinery/light,
-/obj/machinery/media/jukebox,
+/obj/machinery/media/jukebox{
+	emagged = 1
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_breakroom)
 "wlB" = (
@@ -34727,7 +35378,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "wrb" = (
 /obj/effect/floor_decal/borderfloor/corner{
@@ -35065,6 +35722,12 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
+"wAc" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/maintenance/maint_bar)
 "wAn" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 8
@@ -35532,6 +36195,7 @@
 	},
 /obj/structure/closet/firecloset,
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/tool_storage)
 "wMe" = (
@@ -35712,6 +36376,13 @@
 	can_open = 1
 	},
 /area/maintenance/evahallway)
+"wTT" = (
+/obj/structure/dancepole{
+	pixel_y = 12
+	},
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "wUd" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -35795,6 +36466,15 @@
 	},
 /turf/simulated/floor/lino,
 /area/tether/surfacebase/entertainment/backstage)
+"wXJ" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/maintenance/maint_bar)
 "wXQ" = (
 /obj/effect/overlay/snow/floor/pointy,
 /obj/structure/railing{
@@ -35817,6 +36497,11 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/outdoors/grass/heavy/interior,
 /area/rift/station/public_garden)
+"wZo" = (
+/obj/structure/bonfire,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/rift/surfacebase/outside/outside1)
 "xad" = (
 /obj/structure/table/woodentable,
 /obj/structure/mirror/long/right{
@@ -36029,6 +36714,11 @@
 /obj/vehicle_old/train/trolley,
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/warehouse)
+"xen" = (
+/obj/random/junk,
+/obj/structure/table,
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "xex" = (
 /obj/structure/table/woodentable,
 /obj/random/maintenance/clean,
@@ -36234,6 +36924,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"xlB" = (
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
+/obj/random/junk,
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "xlG" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/clowndouble,
@@ -36256,6 +36953,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_main)
+"xmm" = (
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor/reinforced,
+/area/maintenance/maint_bar)
 "xms" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -36505,6 +37209,13 @@
 /obj/structure/transit_tube/high_velocity,
 /turf/simulated/floor/outdoors/safeice/lythios43c/indoors,
 /area/rift/surfacebase/outside/outside1)
+"xxZ" = (
+/obj/structure/table/hardwoodtable,
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood/broken,
+/area/maintenance/maint_bar)
 "xyo" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
@@ -36523,7 +37234,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/monowhite,
 /area/medical/virologytransitwest)
 "xyV" = (
 /obj/effect/overlay/snow/floor/pointy,
@@ -36829,6 +37540,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_decon)
+"xKh" = (
+/obj/machinery/chemical_dispenser/bar_coffee/full,
+/obj/structure/table/woodentable,
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/reinforced,
+/area/maintenance/maint_bar)
 "xKD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36849,6 +37568,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/library)
+"xLN" = (
+/obj/effect/floor_decal/industrial/halfstair,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "xMn" = (
 /obj/machinery/door/airlock/medical{
 	id_tag = "mentaldoor";
@@ -37036,6 +37759,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/security/prison)
+"xQZ" = (
+/obj/effect/overlay/snow/floor/pointy,
+/turf/simulated/floor/snow/gravsnow,
+/area/rift/surfacebase/outside/outside1)
 "xRb" = (
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/civilian_hallway_mid)
@@ -37093,6 +37820,9 @@
 	},
 /turf/simulated/floor/outdoors/grass/heavy/interior,
 /area/rift/station/public_garden)
+"xSV" = (
+/turf/simulated/floor/snow/gravsnow,
+/area/rift/surfacebase/outside/outside1)
 "xTe" = (
 /turf/simulated/wall,
 /area/quartermaster/office)
@@ -37162,6 +37892,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"xUB" = (
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/wood,
+/area/maintenance/maint_bar)
 "xUH" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -37195,6 +37929,14 @@
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/evahallway)
+"xUN" = (
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/ladder,
+/turf/simulated/floor/tiled/dark,
+/area/rnd/outpost/xenobiology/outpost_stairs)
 "xUO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -37463,6 +38205,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel,
 /area/rift/stairwell/primary/surfaceone)
+"yeC" = (
+/obj/structure/table/steel,
+/obj/item/clothing/gloves/sterile/latex,
+/obj/item/surgical/hemostat,
+/obj/item/tool/screwdriver,
+/obj/item/tool/wirecutters,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/security/lower)
 "yeH" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -37638,14 +38388,18 @@
 /turf/simulated/floor/tiled/steel,
 /area/rift/stairwell/primary/surfaceone)
 "ymi" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/purple/border,
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 
 (1,1,1) = {"
@@ -44760,7 +45514,7 @@ eUx
 aJo
 jnS
 kah
-jnS
+aJo
 tYL
 hWJ
 mYX
@@ -44952,7 +45706,7 @@ uQi
 uKj
 qEl
 oUP
-gjm
+oAC
 gjm
 gjm
 cZa
@@ -44979,7 +45733,7 @@ dHs
 dFq
 gCy
 gCy
-fxS
+gCy
 xIm
 sGn
 vUA
@@ -45144,11 +45898,11 @@ klr
 jYx
 uQi
 uKj
-sFB
+wqA
 qIZ
-jnS
+eTW
 hGF
-jnS
+vBx
 tYL
 jaA
 lhN
@@ -45173,7 +45927,7 @@ dCb
 aAY
 jLP
 aQc
-nwZ
+xUN
 xIm
 sGn
 smV
@@ -45920,8 +46674,8 @@ lcN
 aBn
 tgg
 qqW
-sFB
-qIZ
+wqA
+iKr
 qqW
 lcN
 lcN
@@ -46308,8 +47062,8 @@ lcN
 aBn
 tgg
 uKj
-sFB
-qIZ
+wqA
+iKr
 uKj
 lcN
 lcN
@@ -46696,8 +47450,8 @@ lcN
 aBn
 tgg
 uKj
-sFB
-qIZ
+wqA
+iKr
 uKj
 lcN
 lcN
@@ -47084,8 +47838,8 @@ lcN
 aBn
 tgg
 qqW
-sFB
-qIZ
+wqA
+iKr
 qqW
 lcN
 lcN
@@ -47472,8 +48226,8 @@ lcN
 aBn
 tgg
 uKj
-sFB
-qIZ
+wqA
+iKr
 uKj
 lcN
 lcN
@@ -47860,8 +48614,8 @@ hgE
 kxc
 wdE
 uKj
-sFB
-qIZ
+wqA
+iKr
 uKj
 lcN
 lcN
@@ -48248,7 +49002,7 @@ hgE
 kxc
 aoF
 qqW
-dvH
+wqA
 ymi
 qqW
 lcN
@@ -48636,8 +49390,8 @@ wes
 dfH
 aoF
 uKj
-sFB
-qIZ
+fxS
+mbH
 uKj
 mfX
 mfX
@@ -48847,7 +49601,7 @@ evV
 evV
 evV
 hgE
-iFN
+hgE
 iFN
 iFN
 iFN
@@ -49024,12 +49778,12 @@ xUK
 wes
 pbf
 qqW
-sFB
-qIZ
+wqA
+iKr
 qqW
-egd
-egd
-egd
+sHD
+sHD
+sHD
 tLJ
 hgE
 hgE
@@ -49037,11 +49791,11 @@ kxc
 hgE
 hgE
 tLJ
-egd
-egd
-egd
-dcS
-dcS
+sHD
+sHD
+sHD
+hgE
+hgE
 hgE
 hgE
 hgE
@@ -49221,9 +49975,9 @@ qqW
 iQC
 iKr
 qqW
-egd
-egd
-dXh
+sHD
+sHD
+nKu
 bUK
 hgE
 hgE
@@ -49232,10 +49986,10 @@ hgE
 hgE
 bUK
 sFL
-egd
-egd
-dcS
-mbH
+sHD
+sHD
+hgE
+kxc
 ddt
 kxc
 kxc
@@ -49412,12 +50166,12 @@ cEL
 wes
 ugN
 qqW
-sFB
-qIZ
+wqA
+iKr
 qqW
-egd
-egd
-egd
+sHD
+sHD
+sHD
 sVG
 hgE
 hgE
@@ -49425,11 +50179,11 @@ hgE
 hgE
 hgE
 sVG
-egd
-egd
-egd
-dcS
-dcS
+sHD
+sHD
+sHD
+hgE
+hgE
 hgE
 rZY
 rZY
@@ -49606,8 +50360,8 @@ lNs
 yeX
 tTn
 qqW
-wqA
-iKr
+kyn
+ank
 qqW
 bWq
 rgY
@@ -49622,7 +50376,7 @@ hgE
 afW
 rgY
 ktw
-dcS
+hgE
 hgE
 hgE
 rZY
@@ -52051,7 +52805,7 @@ tyv
 tyv
 vEs
 ofx
-jXM
+dcS
 kdy
 dwP
 eIl
@@ -52438,9 +53192,9 @@ giH
 fMS
 cAV
 aXw
-jXM
+dcS
 iDw
-jXM
+dcS
 dwP
 sJS
 cwV
@@ -53404,7 +54158,7 @@ qOD
 toy
 twG
 oRV
-jXM
+dcS
 iNX
 sDY
 sDY
@@ -53792,7 +54546,7 @@ hgE
 hgE
 sDY
 kEZ
-nOt
+dXh
 bSG
 daz
 kfR
@@ -55756,8 +56510,8 @@ ygW
 iTF
 hFE
 hFE
-jgE
 hFE
+hmK
 hFE
 nqs
 eNh
@@ -55932,7 +56686,7 @@ qnQ
 jDX
 jDX
 rRV
-kyn
+pfT
 vjl
 sDY
 pZn
@@ -55950,9 +56704,9 @@ erN
 lHI
 ulY
 iTF
-hFE
-hFE
-pZn
+yeC
+hQd
+sWx
 nqs
 lCl
 cZd
@@ -56125,7 +56879,7 @@ fhl
 pwU
 dQi
 wkp
-wkp
+egd
 xMJ
 qYD
 sDY
@@ -56144,9 +56898,9 @@ erN
 erN
 mMk
 iTF
-pZn
-pZn
-pZn
+sfP
+qIO
+coC
 nqs
 wEf
 lSE
@@ -56338,9 +57092,9 @@ erN
 rrt
 gxu
 iTF
-pZn
-tdI
-tdI
+gSP
+hhv
+hQd
 nqs
 csy
 lSE
@@ -56532,9 +57286,9 @@ vyU
 iTF
 iTF
 iTF
-pZn
 tdI
-dMX
+tdI
+tdI
 nqs
 nqs
 eNr
@@ -56907,7 +57661,7 @@ upJ
 sDY
 pZn
 pZn
-lQh
+iTF
 mJO
 lHI
 erN
@@ -57101,7 +57855,7 @@ wtn
 sDY
 tdI
 pZn
-lQh
+iTF
 deX
 aBy
 rkg
@@ -57295,10 +58049,10 @@ sDY
 sDY
 tdI
 pZn
-lQh
-lQh
-lQh
-lQh
+iTF
+iTF
+iTF
+iTF
 iTF
 iTF
 iTF
@@ -57683,14 +58437,14 @@ hgE
 hgE
 tdI
 tdI
-tdI
-tdI
-tdI
-tdI
-tdI
-tdI
-tdI
-tdI
+kzX
+kzX
+kzX
+kzX
+kzX
+kzX
+kzX
+kzX
 tdI
 tdI
 snT
@@ -57877,14 +58631,14 @@ hgE
 hgE
 hgE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+dkv
+iyD
+xmm
+ntO
+rPR
+mXL
+qdd
+dkv
 hgE
 hgE
 hgE
@@ -57897,7 +58651,7 @@ oZF
 snT
 ipK
 awP
-vLK
+ryW
 snT
 awP
 oZF
@@ -58066,24 +58820,24 @@ lCp
 lCp
 lCp
 lCp
-lCp
 gzd
 gzd
 hgE
 hgE
 hgE
+dkv
+eFx
+eGb
+sHk
+rkh
+jhW
+jxa
+dkv
 hgE
 hgE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+qdM
+wca
 hgE
 snT
 awP
@@ -58259,28 +59013,28 @@ tmB
 wIY
 cBb
 vQN
-mAk
-sMS
+cyn
 gzd
 gzd
 gzd
-gzd
 hgE
 hgE
+dkv
+otX
+mDl
+ftg
+rkh
+bny
+hqO
+dkv
+hNH
+xSV
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-snT
-oZF
+xSV
+xSV
+xSV
+aVS
+awP
 oZF
 awP
 awP
@@ -58315,16 +59069,16 @@ pwf
 lDv
 eLp
 bmQ
-kEs
-uVN
+iNE
+dZn
 uiY
 dEP
 esW
 vzD
 vzD
-kEs
-kEs
-kEs
+iNE
+iNE
+iNE
 kEs
 lYg
 nFo
@@ -58453,25 +59207,25 @@ ouJ
 dwY
 mAk
 mAk
-mAk
-sMS
+cyn
 gzd
 gzd
 gzd
 hgE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+dkv
+xKh
+eGb
+ftg
+rPR
+jhW
+aSt
+cBk
+xQZ
+xSV
+xSV
+xSV
+xSV
 hgE
 snT
 awP
@@ -58511,9 +59265,9 @@ eLp
 tFN
 mKA
 mKA
-cyn
+iNE
 hdi
-vrL
+tXc
 kbe
 kbe
 kbe
@@ -58647,24 +59401,24 @@ wCv
 vDJ
 ocY
 efF
-mAk
-sMS
+cyn
 gzd
 gzd
-gzd
 hgE
 hgE
 hgE
+dkv
+hcE
+mXL
+jhW
+mXL
+mXL
+jhW
+dkv
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+xSV
+xSV
+xSV
 hgE
 hgE
 snT
@@ -58707,7 +59461,7 @@ tJC
 iNE
 cJA
 hdi
-dkv
+iNE
 kbe
 hgE
 hgE
@@ -58842,22 +59596,22 @@ lCp
 lCp
 lCp
 lCp
-lCp
 gzd
 gzd
 gzd
-gzd
 hgE
 hgE
+dkv
+rWI
+mXL
+mXL
+sAz
+jhW
+nHc
+dkv
 hgE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+xSV
 hgE
 hgE
 hgE
@@ -58901,7 +59655,7 @@ lHm
 lHm
 lHm
 hdi
-dkv
+iNE
 kbe
 hgE
 hgE
@@ -59039,19 +59793,19 @@ gzd
 gzd
 gzd
 gzd
+gzd
 hgE
+dkv
+jQE
+pDj
+xLN
+mXL
+llz
+iAE
+dkv
+bPE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+xSV
 hgE
 hgE
 hgE
@@ -59095,7 +59849,7 @@ xRb
 xNO
 lHm
 hdi
-vrL
+tXc
 kbe
 hgE
 hgE
@@ -59230,22 +59984,22 @@ paY
 fqa
 lCp
 gzd
+hgE
 gzd
 hgE
 hgE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+dkv
+gvI
+kod
+jQE
+mXL
+mXL
+hqO
+dkv
+iFN
+xSV
+iFN
 hgE
 hgE
 hgE
@@ -59289,7 +60043,7 @@ xRb
 xNO
 lHm
 hdi
-dkv
+iNE
 kbe
 hgE
 hgE
@@ -59429,18 +60183,18 @@ hgE
 hgE
 hgE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+dkv
+xxZ
+wTT
+jxa
+jhW
+jhW
+jKI
+dkv
+toc
+iFN
+iFN
+iFN
 hgE
 hgE
 snT
@@ -59483,7 +60237,7 @@ lHm
 lHm
 lHm
 hdi
-dkv
+iNE
 kbe
 hgE
 hgE
@@ -59620,21 +60374,21 @@ hgE
 hgE
 hgE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+dkv
+dkv
+dkv
+dkv
+itT
+xen
+pDj
+weV
+mXL
+kVC
+dkv
+toc
+iFN
+wZo
+iFN
 hgE
 hgE
 snT
@@ -59677,7 +60431,7 @@ rAo
 iNE
 iNE
 hdi
-dkv
+iNE
 kbe
 hgE
 hgE
@@ -59813,22 +60567,22 @@ hgE
 hgE
 hgE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+dkv
+dkv
+kQw
+uSe
+dkv
+jQE
+jxa
+xLN
+mXL
+llz
+jxa
+dkv
+toc
+iFN
+iFN
+iFN
 hgE
 hgE
 snT
@@ -59871,7 +60625,7 @@ fCX
 tJC
 iNE
 hdi
-dkv
+iNE
 kbe
 hgE
 hgE
@@ -60007,21 +60761,21 @@ hgE
 hgE
 hgE
 hgE
+dkv
+jgE
+jlF
+hPe
+nKU
+mXL
+jhW
+lje
+eDQ
+nyh
+hWl
+dkv
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+toc
+toc
 hgE
 hgE
 hgE
@@ -60065,7 +60819,7 @@ fCX
 iNE
 iNE
 hdi
-vrL
+tXc
 kbe
 hgE
 hgE
@@ -60201,18 +60955,18 @@ hgE
 hgE
 hgE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+dkv
+lQh
+mFn
+tDQ
+dkv
+cIt
+dkv
+dkv
+dkv
+dkv
+dkv
+dkv
 hgE
 hgE
 hgE
@@ -60259,7 +61013,7 @@ fCX
 tJC
 iNE
 hdi
-dkv
+iNE
 kbe
 hgE
 hgE
@@ -60395,18 +61149,18 @@ hgE
 hgE
 hgE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+dkv
+sMS
+dix
+pKE
+dkv
+weV
+mXL
+dkv
+xUB
+npr
+jNi
+dkv
 hgE
 hgE
 hgE
@@ -60453,7 +61207,7 @@ fCX
 tXc
 iNE
 hdi
-dkv
+iNE
 kbe
 hgE
 hgE
@@ -60589,18 +61343,18 @@ hgE
 hgE
 hgE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+dkv
+dkv
+dkv
+dkv
+dkv
+mXL
+jhW
+hhC
+xUB
+faL
+kFN
+dkv
 hgE
 hgE
 hgE
@@ -60647,7 +61401,7 @@ fCX
 iNE
 iNE
 vgZ
-dkv
+iNE
 kbe
 hgE
 hgE
@@ -60783,18 +61537,18 @@ hgE
 hgE
 hgE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+dkv
+vrL
+une
+weV
+mXL
+mXL
+jhW
+dkv
+vCn
+qdj
+rzY
+dkv
 hgE
 hgE
 hgE
@@ -60841,7 +61595,7 @@ fCX
 tXc
 iNE
 hdi
-ell
+dTX
 kbe
 kbe
 kbe
@@ -60977,18 +61731,18 @@ hgE
 hgE
 hgE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+dkv
+aCk
+wAc
+wXJ
+fRc
+jhW
+ajI
+dkv
+cBk
+dkv
+dkv
+dkv
 hgE
 hgE
 hgE
@@ -61171,18 +61925,18 @@ hgE
 hgE
 hgE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+dkv
+xlB
+nAb
+pmJ
+rtX
+sAz
+mXL
+dkv
+mXL
+sAz
+lnK
+dkv
 hgE
 hgE
 hgE
@@ -61365,18 +62119,18 @@ hgE
 hgE
 hgE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+dkv
+bah
+dSz
+hTB
+ixM
+jhW
+bah
+dkv
+bEb
+rAH
+dkv
+dkv
 hgE
 hgE
 hgE
@@ -61559,18 +62313,18 @@ hgE
 hgE
 hgE
 hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
-hgE
+dkv
+dkv
+dkv
+dkv
+dkv
+dkv
+dkv
+dkv
+dkv
+dkv
+dkv
+ght
 hgE
 hgE
 hgE

--- a/_maps/map_files/rift/rift-05-surface2.dmm
+++ b/_maps/map_files/rift/rift-05-surface2.dmm
@@ -16522,6 +16522,7 @@
 /obj/random/maintenance/security,
 /obj/random/maintenance/security,
 /obj/random/maintenance/clean,
+/obj/item/clothing/accessory/holster/hip,
 /turf/simulated/floor/plating,
 /area/maintenance/security/upper)
 "mDt" = (
@@ -25815,6 +25816,7 @@
 	pixel_y = 24
 	},
 /obj/random/maintenance/research,
+/obj/item/clothing/accessory/holster/armpit,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "ugf" = (

--- a/_maps/map_files/rift/rift-06-surface3.dmm
+++ b/_maps/map_files/rift/rift-06-surface3.dmm
@@ -3700,6 +3700,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/bridge_hallway)
 "gB" = (
@@ -15255,14 +15258,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/security/checkpoint2)
 "Db" = (
-/obj/machinery/door/firedoor/glass/hidden{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/glass/hidden{
+	dir = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/bridge_hallway)
 "Dc" = (
@@ -46835,11 +46839,11 @@ fq
 cH
 fq
 fq
-fq
-YF
+cH
+cH
 YF
 vS
-yK
+aA
 YF
 NJ
 LK
@@ -47028,12 +47032,12 @@ cH
 fq
 fq
 fq
-fq
+cH
+cH
 fq
 YF
 yK
 Ex
-yK
 cp
 aA
 LK
@@ -47223,11 +47227,11 @@ fq
 fq
 fq
 fq
+cH
 fq
 YF
 ek
 aA
-yK
 YF
 aA
 vu
@@ -47417,11 +47421,11 @@ fq
 fq
 fq
 fq
-fq
+cH
+cH
 YF
 eH
 lg
-yK
 YF
 vS
 aA
@@ -47612,7 +47616,7 @@ fq
 fq
 fq
 fq
-YF
+cH
 YF
 YF
 YF
@@ -49387,10 +49391,10 @@ Ch
 Xq
 Ch
 Mf
-Ea
+kE
 fX
 hi
-kE
+Ea
 Ea
 gx
 Os
@@ -49581,10 +49585,10 @@ ox
 CW
 ny
 Ug
-kt
+Db
 mI
 yn
-Db
+yn
 yn
 gA
 du
@@ -49775,10 +49779,10 @@ nJ
 eD
 ze
 uJ
-mb
-mb
-mb
 eY
+mb
+mb
+mb
 Ht
 BA
 JU

--- a/_maps/map_files/rift/rift-10-west_plains.dmm
+++ b/_maps/map_files/rift/rift-10-west_plains.dmm
@@ -3829,12 +3829,6 @@
 /obj/machinery/door/airlock/multi_tile/metal/mait,
 /turf/simulated/floor,
 /area/tether/outpost/solars_shed)
-"sM" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid/lythios43c/indoors,
-/area/rift/exterior/checkpoint/south)
 "sN" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -31089,7 +31083,7 @@ dQ
 dQ
 dQ
 dQ
-sM
+Ak
 hj
 hj
 hj


### PR DESCRIPTION
## About The Pull Request

Adds phoron glass around the SME core, makes some edits to various parts of the map. Adds a hip holster and an armpit holster to parts of the map. Adds a deep maint bar hidden in the ice, far more ruined than than the current maint bar.

## Why It's Good For The Game

Because some people like to have another maint bar for use when the original one is taken up by someone's scene. Also because holsters are no big deal, they do not start with guns and you can put stuff like stamps in them. And some people were complaining about venting hot air into the cold air in engineering when accessing the rad collectors late into the round, this should fix that.

## Changelog
:cl:
add: Deep maint bar
tweak: Map tweaks, engineering tweaks, ladder fixes.
/:cl:
