### PR TITLE
Designated Marksman Rifle reloadable cell

### DIFF
--- a/code/modules/organs/external/species/shadekin.dm
+++ b/code/modules/organs/external/species/shadekin.dm
@@ -1,37 +1,37 @@
 //! Blackeyed limbs.
 
 /obj/item/organ/external/chest/crewkin
-	min_broken_damage = 20
+	min_broken_damage = 31 // Original 20, raised to 31 to be at 0.9 of default
 
 /obj/item/organ/external/groin/crewkin
-	min_broken_damage = 20
+	min_broken_damage = 31 // Original 20, raised to 31 to be at 0.9 of default
 
 /obj/item/organ/external/head/vr/crewkin
-	min_broken_damage = 15
+	min_broken_damage = 31 // Original 15, raised to 31 to be at 0.9 of default
 
 	eye_icons_vr = 'icons/mob/human_face_vr.dmi'
 	eye_icon_vr = "eyes_shadekin_station"
 
 /obj/item/organ/external/arm/crewkin
-	min_broken_damage = 15
+	min_broken_damage = 27 // Original 15, raised to 27 to be at 0.9 of default
 
 /obj/item/organ/external/arm/right/crewkin
-	min_broken_damage = 15
+	min_broken_damage = 27 // Original 15, raised to 27 to be at 0.9 of default
 
 /obj/item/organ/external/leg/crewkin
-	min_broken_damage = 15
+	min_broken_damage = 27 // Original 15, raised to 27 to be at 0.9 of default
 
 /obj/item/organ/external/leg/right/crewkin
-	min_broken_damage = 15
+	min_broken_damage = 27 // Original 15, raised to 27 to be at 0.9 of default
 
 /obj/item/organ/external/foot/crewkin
-	min_broken_damage = 7
+	min_broken_damage = 13 // Original 7, raised to 13 to be at 0.9 of default
 
 /obj/item/organ/external/foot/right/crewkin
-	min_broken_damage = 7
+	min_broken_damage = 13 // Original 7, raised to 13 to be at 0.9 of default
 
 /obj/item/organ/external/hand/crewkin
-	min_broken_damage = 7
+	min_broken_damage = 13 // Original 7, raised to 13 to be at 0.9 of default
 
 /obj/item/organ/external/hand/right/crewkin
-	min_broken_damage = 7
+	min_broken_damage = 13 // Original 7, raised to 13 to be at 0.9 of default

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -172,7 +172,6 @@
 	origin_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 5, TECH_POWER = 4)
 	projectile_type = /obj/item/projectile/beam/sniper
 	slot_flags = SLOT_BACK
-	battery_lock = 1
 	charge_cost = 600
 	fire_delay = 35
 	force = 10
@@ -196,6 +195,7 @@
 	pin = /obj/item/firing_pin/explorer
 	cell_type = /obj/item/cell/device/weapon/recharge/sniper
 	accuracy = 45 //Modifications include slightly better hip-firing furniture.
+	battery_lock = 1 //By making the normal Designated Sniper Rifle have a removable cell, we need to make sure this weapon can't have the self-recharging cell removed.
 	scoped_accuracy = 100
 	charge_cost = 600
 

--- a/code/modules/species/shadekin/shadekin_blackeyed.dm
+++ b/code/modules/species/shadekin/shadekin_blackeyed.dm
@@ -35,7 +35,7 @@
 	item_slowdown_mod = 1.5 // They're not as fit as them, though, slowed down more by heavy gear.
 
 	total_health = 75   // Fragile
-	brute_mod    = 1 // Originally 1.25, lowered to 1 in an attempt to make bone breaking less likely. Change raises damage needed for bones to break from 18 to 22.5
+	brute_mod    = 1 // Originally 1.25, lowered to 1 because lower HP and increased damage is a bit heavy.
 	burn_mod     = 1.25 // Furry
 
 	blood_volume  = 500 // Slightly less blood than human baseline.

--- a/code/modules/species/shadekin/shadekin_blackeyed.dm
+++ b/code/modules/species/shadekin/shadekin_blackeyed.dm
@@ -35,7 +35,7 @@
 	item_slowdown_mod = 1.5 // They're not as fit as them, though, slowed down more by heavy gear.
 
 	total_health = 75   // Fragile
-	brute_mod    = 1.25 // Frail
+	brute_mod    = 1 // Originally 1.25, lowered to 1 in an attempt to make bone breaking less likely. Change raises damage needed for bones to break from 18 to 22.5
 	burn_mod     = 1.25 // Furry
 
 	blood_volume  = 500 // Slightly less blood than human baseline.


### PR DESCRIPTION
## About The Pull Request

Changes it so the Cargo/Security DMR can have the cell changed for reloads, while keeping it so the Exploration DMR can not remove the cell.

## Why It's Good For The Game

I understand that not allowing the DMR to reload was a balancing choice. However, this was deemed negligable and we are going to make it reloadable and see what happens.

## Changelog
:cl:
balance: Made DMR Rifle cell be detachable.
/:cl:
