### PR TITLE
Small map fixes - Trader airlock, Surface airlock, Luxury shelter

### DIFF
--- a/_maps/map_files/rift/rift-04-surface1.dmm
+++ b/_maps/map_files/rift/rift-04-surface1.dmm
@@ -3456,6 +3456,12 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 5
 	},
+/obj/machinery/access_button/airlock_interior{
+	dir = 4;
+	master_tag = "central_airlock";
+	pixel_x = 8;
+	pixel_y = -26
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/surfaceeva/airlock/main)
 "cEL" = (
@@ -11890,6 +11896,12 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 9
 	},
+/obj/machinery/access_button/airlock_interior{
+	dir = 4;
+	master_tag = "central_airlock_two";
+	pixel_x = 8;
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/surfaceeva/airlock/main/secondary)
 "ijr" = (
@@ -13483,21 +13495,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/tool_storage)
-"jfd" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/overlay/snow/floor/grav_surround{
-	dir = 8
-	},
-/obj/machinery/access_button/airlock_exterior{
-	dir = 8;
-	master_tag = "central_airlock_two";
-	pixel_x = 24;
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/steel_grid/lythios43c,
-/area/rift/surfacebase/outside/outside1)
 "jfw" = (
 /obj/machinery/door/airlock/maintenance/engi{
 	name = "RTG Access";
@@ -23500,12 +23497,6 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/access_button/airlock_interior{
-	dir = 4;
-	master_tag = "central_airlock_two";
-	pixel_x = -24;
-	pixel_y = 26
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/surfaceeva)
 "pfy" = (
@@ -28381,6 +28372,12 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 5
 	},
+/obj/machinery/access_button/airlock_exterior{
+	dir = 8;
+	master_tag = "central_airlock";
+	pixel_x = -8;
+	pixel_y = -26
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/surfaceeva/airlock/main)
 "srP" = (
@@ -32394,21 +32391,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/xenoarch_storage)
-"uNc" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/overlay/snow/floor/grav_surround{
-	dir = 8
-	},
-/obj/machinery/access_button/airlock_exterior{
-	dir = 8;
-	master_tag = "central_airlock";
-	pixel_x = 24;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/steel_grid/lythios43c,
-/area/rift/surfacebase/outside/outside1)
 "uND" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -33848,12 +33830,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
-	},
-/obj/machinery/access_button/airlock_interior{
-	dir = 4;
-	master_tag = "central_airlock";
-	pixel_x = -24;
-	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/surfaceeva)
@@ -35966,6 +35942,12 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 9
+	},
+/obj/machinery/access_button/airlock_exterior{
+	dir = 8;
+	master_tag = "central_airlock_two";
+	pixel_x = -8;
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/surfaceeva/airlock/main/secondary)
@@ -48035,11 +48017,11 @@ hgE
 kxc
 mUL
 nbg
-uNc
+nbg
 cMO
 iFN
 mUL
-jfd
+nbg
 nbg
 cMO
 kxc

--- a/_maps/map_files/rift/rift-04-surface1.dmm
+++ b/_maps/map_files/rift/rift-04-surface1.dmm
@@ -5504,10 +5504,8 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/component/binary/passive_gate/on{
-	dir = 8;
-	pressure_resistance = 750;
-	target_pressure = 750
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/rift/trade_shop)
@@ -7939,8 +7937,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/library)
 "fIm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
+/obj/machinery/atmospherics/component/binary/passive_gate/on{
+	dir = 8;
+	pressure_resistance = 750;
+	target_pressure = 750
 	},
 /turf/simulated/floor/plating,
 /area/rift/trade_shop)

--- a/_maps/templates/shelters/shelter_2.dmm
+++ b/_maps/templates/shelters/shelter_2.dmm
@@ -101,8 +101,8 @@
 "o" = (
 /obj/structure/bed/chair/comfy/black,
 /obj/structure/window/reinforced/survival_pod{
-	icon_state = "pwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "pwindow"
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/survivalpod)
@@ -144,8 +144,8 @@
 	pixel_y = -2
 	},
 /obj/structure/window/reinforced/survival_pod{
-	icon_state = "pwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "pwindow"
 	},
 /obj/structure/table/steel{
 	pixel_y = -9
@@ -154,31 +154,28 @@
 /area/survivalpod)
 "u" = (
 /obj/machinery/door/window/survival_pod{
-	icon_state = "windoor";
-	dir = 1
+	dir = 1;
+	icon_state = "windoor"
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/survivalpod)
 "v" = (
 /obj/structure/window/reinforced/survival_pod{
-	icon_state = "pwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "pwindow"
 	},
 /obj/machinery/holoplant,
-/turf/simulated/floor/carpet/bcarpet,
-/area/survivalpod)
-"w" = (
 /obj/structure/window/reinforced/survival_pod{
 	density = 0;
-	dir = 9;
-	icon_state = "pwindow"
+	dir = 5;
+	pixel_x = 8
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/survivalpod)
 "y" = (
 /obj/structure/sink/kitchen{
-	icon_state = "sink_alt";
 	dir = 4;
+	icon_state = "sink_alt";
 	pixel_x = -13
 	},
 /turf/simulated/floor/carpet/bcarpet,
@@ -258,7 +255,7 @@ a
 h
 n
 r
-w
+A
 S
 a
 "}

--- a/_maps/templates/shelters/shelter_a.dmm
+++ b/_maps/templates/shelters/shelter_a.dmm
@@ -175,8 +175,8 @@
 /area/survivalpod)
 "n" = (
 /obj/structure/window/reinforced/survival_pod{
-	icon_state = "pwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "pwindow"
 	},
 /obj/structure/bed/padded,
 /obj/item/bedsheet/hop,
@@ -195,8 +195,8 @@
 	pixel_y = 6
 	},
 /obj/structure/sink/kitchen{
-	icon_state = "sink_alt";
 	dir = 4;
+	icon_state = "sink_alt";
 	pixel_x = -13
 	},
 /turf/simulated/shuttle/floor/voidcraft,
@@ -216,31 +216,28 @@
 /area/survivalpod)
 "s" = (
 /obj/structure/window/reinforced/survival_pod{
-	icon_state = "pwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "pwindow"
 	},
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/survivalpod)
 "t" = (
 /obj/machinery/door/window/survival_pod{
-	icon_state = "windoor";
-	dir = 1
+	dir = 1;
+	icon_state = "windoor"
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/survivalpod)
 "u" = (
 /obj/structure/window/reinforced/survival_pod{
-	icon_state = "pwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "pwindow"
 	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/survivalpod)
-"v" = (
 /obj/structure/window/reinforced/survival_pod{
 	density = 0;
-	dir = 9;
-	icon_state = "pwindow"
+	dir = 5;
+	pixel_x = 8
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/survivalpod)
@@ -330,7 +327,7 @@ a
 i
 c
 o
-v
+z
 A
 a
 "}


### PR DESCRIPTION
## About The Pull Request

Fixes some annoying things that people either didn't want to fix or didn't know about.
Fixes:
.) Trader airlock pipe system
.) Surface 1 airlock buttons
.) Luxury Shelter + Variant glass door blocking

## Why It's Good For The Game

Because it's nice to fix things.

## Changelog
:cl:
fix: Trader airlock pipe system
fix: Surface 1 airlock now has the buttons on the doors but pixelshifted onto the wall, allowing you to press the button. Same sytem we use for all other airlocks that I know about
fix: Luxury Shelter Capsule and alternative capsule corner glass removed. Sprite covers only the corner, but it blocks movement. Moved to same space as glass next to it and pixelshifted to look as if it was on the old position.
/:cl: