### PR TITLE
Change Crewkin Slowdown

### DIFF
--- a/code/modules/species/shadekin/shadekin_blackeyed.dm
+++ b/code/modules/species/shadekin/shadekin_blackeyed.dm
@@ -31,8 +31,8 @@
 	siemens_coefficient = 0 // Completely shockproof (this is no longer the case on virgo, feel free to change if it needs rebalancing)
 	darksight = 10 // Best darksight around
 
-	slowdown = 0.5 // As slow as unathi
-	item_slowdown_mod = 1.5 // They're not as fit as them, though, slowed down more by heavy gear.
+	slowdown = 0 // Originally 0.5 (As slow as unathi), lowered to 0 to be at human speed.
+	item_slowdown_mod = 2 // Originally 1.5. They're not as physically fits, slowed down more by heavy gear.
 
 	total_health = 75   // Fragile
 	brute_mod    = 1 // Originally 1.25, lowered to 1 because lower HP and increased damage is a bit heavy.


### PR DESCRIPTION
## About The Pull Request

Reduces the normal slowdown for Black-Eyed Shadekin to 0, bringing them to human level, and in turn increasing their item slowdown.

## Why It's Good For The Game

I failed to see why they were given that slowdown in the first place.

## Changelog
:cl:
balance: Lowered Black-Eyed Shadekin slowdown by 0.5, increased item slowdown by 0.5
/:cl:
