### PR TITLE
Mining base changes

### DIFF
--- a/_maps/map_files/rift/rift-02-underground2.dmm
+++ b/_maps/map_files/rift/rift-02-underground2.dmm
@@ -10204,17 +10204,15 @@
 	},
 /area/quartermaster/belterdock/refinery)
 "Ap" = (
-/obj/item/clothing/suit/space/void/mining,
-/obj/item/clothing/head/helmet/space/void/mining,
 /obj/item/clothing/mask/breath,
 /obj/item/mining_scanner,
-/obj/item/clothing/shoes/magboots,
 /obj/item/tank/oxygen,
-/obj/item/suit_cooling_unit,
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /obj/structure/table/rack/shelf,
+/obj/item/clothing/mask/gas,
+/obj/item/storage/bag/ore,
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/belterdock/gear)
 "Ar" = (
@@ -12050,14 +12048,12 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/rift/asylum/cellblock)
 "KI" = (
-/obj/item/clothing/suit/space/void/mining,
-/obj/item/clothing/head/helmet/space/void/mining,
 /obj/item/clothing/mask/breath,
 /obj/item/mining_scanner,
-/obj/item/clothing/shoes/magboots,
 /obj/item/tank/oxygen,
-/obj/item/suit_cooling_unit,
 /obj/structure/table/rack/shelf,
+/obj/item/clothing/mask/gas,
+/obj/item/storage/bag/ore,
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/belterdock/gear)
 "KJ" = (

--- a/_maps/map_files/rift/rift-08-west_deep.dmm
+++ b/_maps/map_files/rift/rift-08-west_deep.dmm
@@ -786,6 +786,9 @@
 "sW" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
+/obj/item/binoculars{
+	pixel_y = 6
+	},
 /obj/item/binoculars,
 /turf/simulated/floor/tiled/techfloor,
 /area/quartermaster/belterdock)

--- a/_maps/map_files/rift/rift-09-west_caves.dmm
+++ b/_maps/map_files/rift/rift-09-west_caves.dmm
@@ -777,6 +777,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/gun/energy/kinetic_accelerator,
 /turf/simulated/floor/tiled/steel_grid,
 /area/outpost/mining_main/outpost)
 "oM" = (
@@ -1553,11 +1554,15 @@
 /turf/simulated/floor/tiled/steel_dirty/lythios43c/indoors,
 /area/rift/facility/interior/command)
 "Cv" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/item/clothing/suit/space/void/mining,
+/obj/item/clothing/head/helmet/space/void/mining,
+/obj/item/clothing/mask/breath,
+/obj/item/mining_scanner,
+/obj/item/clothing/shoes/magboots,
+/obj/item/tank/oxygen,
+/obj/item/suit_cooling_unit,
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/techmaint,
 /area/outpost/mining_main/outpost)
 "Cy" = (
 /obj/effect/floor_decal/industrial/warning/dust,
@@ -2096,6 +2101,7 @@
 "MR" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/gun/energy/kinetic_accelerator,
 /turf/simulated/floor/tiled/steel_grid,
 /area/outpost/mining_main/outpost)
 "Ne" = (
@@ -35387,7 +35393,7 @@ KA
 WJ
 Xl
 Uj
-XL
+Cv
 ga
 Qj
 VG


### PR DESCRIPTION
## About The Pull Request

Surt miners get a Mining Softsuit, Mining Voidsuits were moved to the Belt station.
Added Proto-Kinetic Accelerators to the Belt station.
Added 2nd Binoculars to the Belt station.

## Why It's Good For The Game

Some may call it a change of pace, some may call it balancing by removing the 50 armor voidsuit and bringing it to where people would actually need it.

## Changelog
:cl:
add: 2nd Binocular added to the Belter station
add: Added Proto-Kinetic Accelerators to the Belter station
tweak: Moved Mining Voidsuits to the Belter station
/:cl: