### PR TITLE
Luxury shelter pod glass fix

### DIFF
--- a/_maps/templates/shelters/shelter_2.dmm
+++ b/_maps/templates/shelters/shelter_2.dmm
@@ -90,7 +90,8 @@
 "n" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8;
-	layer = 2.6
+	layer = 2.6;
+	pixel_y = -8
 	},
 /obj/machinery/door/window/survival_pod{
 	dir = 1;
@@ -119,7 +120,7 @@
 "r" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8;
-	icon_state = "pwindow"
+	pixel_y = -8
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/survivalpod)
@@ -165,11 +166,6 @@
 	icon_state = "pwindow"
 	},
 /obj/machinery/holoplant,
-/obj/structure/window/reinforced/survival_pod{
-	density = 0;
-	dir = 5;
-	pixel_x = 8
-	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/survivalpod)
 "y" = (

--- a/_maps/templates/shelters/shelter_a.dmm
+++ b/_maps/templates/shelters/shelter_a.dmm
@@ -11,7 +11,8 @@
 "c" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8;
-	layer = 2.6
+	layer = 2.6;
+	pixel_y = -8
 	},
 /obj/machinery/door/window/survival_pod{
 	dir = 1;
@@ -185,7 +186,7 @@
 "o" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8;
-	icon_state = "pwindow"
+	pixel_y = -8
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/survivalpod)
@@ -233,11 +234,6 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1;
 	icon_state = "pwindow"
-	},
-/obj/structure/window/reinforced/survival_pod{
-	density = 0;
-	dir = 5;
-	pixel_x = 8
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/survivalpod)


### PR DESCRIPTION
## About The Pull Request

The Luxury Shelter Capsule has some very nise interior, including a cornerpiece glass. This blocks movement though and to use the pod, one has to destroy the glass.
This PR removes this cornerpiece glass and shifts the rest of the glass a bit to create a smooth corner again.

## Why It's Good For The Game

It's nice to not get blocked as you walk.

## Changelog
:cl:
del: Removed a cornerpiece glass which blocked movement.
/:cl: