### PR TITLE
Removes Cryopod from Surt POI

### DIFF
--- a/_maps/submaps/level_specific/lavaland/idleruins2.dmm
+++ b/_maps/submaps/level_specific/lavaland/idleruins2.dmm
@@ -158,12 +158,6 @@
 /obj/effect/debris/cleanable/molten_item,
 /turf/simulated/floor/plating/lavaland,
 /area/lavaland/idleruins)
-"Qv" = (
-/obj/structure/ghost_pod/manual/human{
-	dir = 8
-	},
-/turf/simulated/shuttle/floor/lavaland,
-/area/lavaland/idleruins)
 "Re" = (
 /turf/template_noop,
 /area/lavaland/idleruins)
@@ -395,7 +389,7 @@ or
 or
 or
 YZ
-Qv
+Sk
 Sk
 IO
 YZ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Removes the Cryopod from the one Surt POI that has one.**

## Why It's Good For The Game

1. _We shouldn't be stacking multiple ghostroles on one map. Especially not one with a clear design philosophy that runs counter to the concept._

## Changelog
:cl:
del: Removes the Cryopod from Surt.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
