### PR TITLE
Fixes user-supplied sec/med records

### DIFF
--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -165,9 +165,9 @@
 					fields[++fields.len] = MED_FIELD("Blood Type", active2.fields["b_type"], "blood_type", FALSE)
 					fields[++fields.len] = MED_FIELD("DNA", active2.fields["b_dna"], "b_dna", TRUE)
 					fields[++fields.len] = MED_FIELD("Brain Type", active2.fields["brain_type"], "brain_type", TRUE)
-					fields[++fields.len] = MED_FIELD("Important Notes", active2.fields["notes"], "notes", TRUE)
 					if(!active2.fields["comments"] || !islist(active2.fields["comments"]))
 						active2.fields["comments"] = list()
+					medical["notes"] = active2.fields["notes"]
 					medical["comments"] = active2.fields["comments"]
 					medical["empty"] = 0
 				else
@@ -314,7 +314,6 @@
 					R.fields["alg_d"] = "No allergies have been detected in this patient."
 					R.fields["cdi"] = "None"
 					R.fields["cdi_d"] = "No diseases have been diagnosed at the moment."
-					R.fields["notes"] = "No notes."
 					data_core.medical += R
 					active2 = R
 					screen = MED_DATA_RECORD
@@ -443,7 +442,7 @@
 		<br>\nDetails: [active2.fields["alg_d"]]<br>\n
 		<br>\nCurrent Diseases: [active2.fields["cdi"]] (per disease info placed in log/comment section)
 		<br>\nDetails: [active2.fields["cdi_d"]]<br>\n
-		<br>\nImportant Notes:
+		<br>\nMedical Notes Summary:
 		<br>\n\t[active2.fields["notes"]]<br>\n
 		<br>\n
 		<center><b>Comments/Log</b></center><br>"}

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -174,9 +174,9 @@
 					fields[++fields.len] = FIELD("Details", active2.fields["mi_crim_d"], "mi_crim_d")
 					fields[++fields.len] = FIELD("Major Crimes", active2.fields["ma_crim"], "ma_crim")
 					fields[++fields.len] = FIELD("Details", active2.fields["ma_crim_d"], "ma_crim_d")
-					fields[++fields.len] = FIELD("Important Notes", active2.fields["notes"], "notes")
 					if(!active2.fields["comments"] || !islist(active2.fields["comments"]))
 						active2.fields["comments"] = list()
+					security["notes"] = active2.fields["notes"]
 					security["comments"] = active2.fields["comments"]
 					security["empty"] = FALSE
 				else
@@ -297,8 +297,6 @@
 					R.fields["mi_crim_d"]	= "No minor crime convictions."
 					R.fields["ma_crim"]		= "None"
 					R.fields["ma_crim_d"]	= "No major crime convictions."
-					R.fields["notes"]		= "No notes."
-					R.fields["notes"]		= "No notes."
 					data_core.security += R
 					active2 = R
 					screen = SEC_DATA_RECORD
@@ -439,7 +437,7 @@
 		<br>\nDetails: [active2.fields["mi_crim_d"]]<br>\n
 		<br>\nMajor Crimes: [active2.fields["ma_crim"]]
 		<br>\nDetails: [active2.fields["ma_crim_d"]]<br>\n
-		<br>\nImportant Notes:
+		<br>\nSecurity Notes Summary:
 		<br>\n\t[active2.fields["notes"]]<br>\n
 		<br>\n
 		<center><b>Comments/Log</b></center><br>"}

--- a/tgui/packages/tgui/interfaces/GeneralRecords.js
+++ b/tgui/packages/tgui/interfaces/GeneralRecords.js
@@ -202,7 +202,7 @@ const GeneralRecordsViewGeneral = (_properties, context) => {
             </LabeledList.Item>
           ))}
         </LabeledList>
-        <Section title="Employment/skills summary" level={2} preserveWhitespace>
+        <Section title="Employment/Skills Summary" level={2} preserveWhitespace>
           {general.skills || "No data found."}
         </Section>
         <Section title="Comments/Log" level={2}>

--- a/tgui/packages/tgui/interfaces/MedicalRecords.js
+++ b/tgui/packages/tgui/interfaces/MedicalRecords.js
@@ -303,6 +303,9 @@ const MedicalRecordsViewMedical = (_properties, context) => {
           </LabeledList.Item>
         ))}
       </LabeledList>
+      <Section title="Medical Notes Summary" level={2} preserveWhitespace>
+        {medical.notes || "No data found."}
+      </Section>
       <Section title="Comments/Log" level={2}>
         {medical.comments.length === 0 ? (
           <Box color="label">

--- a/tgui/packages/tgui/interfaces/SecurityRecords.js
+++ b/tgui/packages/tgui/interfaces/SecurityRecords.js
@@ -261,6 +261,9 @@ const SecurityRecordsViewSecurity = (_properties, context) => {
           </LabeledList.Item>
         ))}
       </LabeledList>
+      <Section title="Security Notes Summary" level={2} preserveWhitespace>
+        {security.notes || "No data found."}
+      </Section>
       <Section title="Comments/Log">
         {security.comments.length === 0 ? (
           <Box color="label">


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Security and medical records are now in their own "section" of the records console. They can no longer be edited and will now display line breaks, similar to employment records.

## Why It's Good For The Game

Wall of text trying to read through someone's medical record is no bueno.

## Changelog
:cl:
tweak: Security and medical records now display in their own section of the records console, display line breaks, and can no longer be edited mid-round.
spellcheck: Fixed capitalization for employment records.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
