### PR TITLE
Touch-up on head of staff offices

### DIFF
--- a/_maps/map_files/rift/rift-02-underground2.dmm
+++ b/_maps/map_files/rift/rift-02-underground2.dmm
@@ -303,8 +303,8 @@
 	pixel_x = -3
 	},
 /obj/machinery/firealarm{
-	layer = 3.3;
 	dir = 4;
+	layer = 3.3;
 	pixel_x = 26
 	},
 /turf/simulated/floor/tiled,
@@ -732,14 +732,14 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/component/unary/outlet_injector{
+	dir = 4;
 	frequency = 1438;
 	id = "cooling_in";
 	name = "Coolant Injector";
 	pixel_y = 1;
 	power_rating = 30000;
 	use_power = 1;
-	volume_rate = 700;
-	dir = 4
+	volume_rate = 700
 	},
 /turf/simulated/floor/reinforced/nitrogen{
 	initial_gas_mix = "n2=82.1472;TEMP=293.15"
@@ -881,8 +881,8 @@
 	dir = 1
 	},
 /obj/machinery/requests_console/preset/engineering{
-	pixel_y = -30;
-	pixel_x = -31
+	pixel_x = -31;
+	pixel_y = -30
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_monitoring)
@@ -1109,10 +1109,10 @@
 	},
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /obj/machinery/button/remote/airlock{
-	pixel_x = -25;
-	pixel_y = 7;
 	id = "engine_access_hatch";
 	name = "Access Hatch bolts";
+	pixel_x = -25;
+	pixel_y = 7;
 	specialfunctions = 4
 	},
 /turf/simulated/floor,
@@ -2877,8 +2877,8 @@
 /area/maintenance/engineering/pumpstation)
 "iD" = (
 /obj/machinery/firealarm{
-	layer = 3.3;
 	dir = 4;
+	layer = 3.3;
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4211,12 +4211,12 @@
 	},
 /obj/machinery/button/remote/blast_door{
 	desc = "A remote control-switch for the engine control room blast doors.";
+	dir = 1;
 	id = "EngineEmitterPortWest";
 	name = "Engine Room Blast Doors";
 	pixel_y = -25;
 	req_access = null;
-	req_one_access = list(11,24);
-	dir = 1
+	req_one_access = list(11,24)
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor,
@@ -5172,9 +5172,9 @@
 	},
 /obj/machinery/door/airlock/hatch{
 	icon_state = "door_locked";
+	id_tag = "engine_access_hatch";
 	locked = 1;
-	req_access = list(11);
-	id_tag = "engine_access_hatch"
+	req_access = list(11)
 	},
 /turf/simulated/floor,
 /area/engineering/engine_core)
@@ -5527,10 +5527,10 @@
 /area/shuttle/cryo/station)
 "px" = (
 /obj/machinery/door/window/southleft{
+	dir = 4;
 	name = "Hardsuit Storage";
 	req_access = newlist();
-	req_one_access = list(11,24);
-	dir = 4
+	req_one_access = list(11,24)
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -8231,11 +8231,11 @@
 	},
 /obj/machinery/button/remote/airlock{
 	desc = "A remote control-switch for the engine core airlock hatch bolts.";
+	dir = 1;
 	id = "EngineVent";
 	name = "Engine Ejection Vent";
 	pixel_y = -32;
-	specialfunctions = 4;
-	dir = 1
+	specialfunctions = 4
 	},
 /obj/structure/window/basic{
 	dir = 1
@@ -8283,8 +8283,8 @@
 /area/maintenance/lower/atmos)
 "zj" = (
 /obj/machinery/firealarm{
-	layer = 3.3;
 	dir = 4;
+	layer = 3.3;
 	pixel_x = 26
 	},
 /turf/simulated/floor,
@@ -10576,9 +10576,9 @@
 /area/rift/surfacebase/underground/under2)
 "Iv" = (
 /obj/machinery/door/window/southright{
+	dir = 4;
 	name = "Hardsuit Storage";
-	req_one_access = list(11,24);
-	dir = 4
+	req_one_access = list(11,24)
 	},
 /obj/structure/table/rack{
 	dir = 8;
@@ -11235,9 +11235,9 @@
 /obj/item/tank/jetpack/carbondioxide,
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/southright{
+	dir = 8;
 	name = "Jetpack Storage";
-	req_one_access = list(11,24);
-	dir = 8
+	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_eva)
@@ -11553,8 +11553,8 @@
 	dir = 4
 	},
 /obj/machinery/firealarm{
-	layer = 3.3;
 	dir = 4;
+	layer = 3.3;
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
@@ -13582,9 +13582,16 @@
 	},
 /obj/item/pen/multi,
 /obj/item/folder/yellow_ce,
-/obj/item/stamp/ce,
+/obj/item/stamp/ce{
+	pixel_x = 8;
+	pixel_y = -3
+	},
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/item/stamp/denied{
+	pixel_x = 8;
+	pixel_y = 3
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/heads/chief)
@@ -13853,8 +13860,8 @@
 /area/crew_quarters/sleep/engi_wash)
 "Uz" = (
 /obj/machinery/firealarm{
-	layer = 3.3;
 	dir = 4;
+	layer = 3.3;
 	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/white,
@@ -13983,8 +13990,8 @@
 	pixel_x = 6
 	},
 /obj/item/megaphone{
-	pixel_y = 8;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/heads/chief)
@@ -14016,10 +14023,10 @@
 	dir = 1
 	},
 /obj/machinery/door/window/southleft{
+	dir = 8;
 	name = "Jetpack Storage";
 	req_access = newlist();
-	req_one_access = list(11,24);
-	dir = 8
+	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_eva)
@@ -15237,8 +15244,8 @@
 	dir = 4
 	},
 /obj/item/storage/box/lights/mixed{
-	pixel_y = -5;
-	pixel_x = -11
+	pixel_x = -11;
+	pixel_y = -5
 	},
 /obj/machinery/alarm{
 	dir = 1;

--- a/_maps/map_files/rift/rift-04-surface1.dmm
+++ b/_maps/map_files/rift/rift-04-surface1.dmm
@@ -4976,7 +4976,10 @@
 "dsb" = (
 /obj/structure/table/glass,
 /obj/item/folder/white_cmo,
-/obj/item/stamp/cmo,
+/obj/item/stamp/cmo{
+	pixel_x = -8;
+	pixel_y = -3
+	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -4988,6 +4991,10 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/item/stamp/denied{
+	pixel_x = -8;
+	pixel_y = 3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/cmo)

--- a/_maps/map_files/rift/rift-05-surface2.dmm
+++ b/_maps/map_files/rift/rift-05-surface2.dmm
@@ -2673,7 +2673,6 @@
 /turf/simulated/floor/tiled/steel,
 /area/rift/stairwell/primary/surfacetwo)
 "bSJ" = (
-/obj/item/retail_scanner/security,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -2687,6 +2686,9 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	pixel_x = -30
+	},
+/obj/item/paper_bin{
+	pixel_y = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -4925,7 +4927,14 @@
 /obj/item/pinpointer{
 	pixel_x = 14
 	},
-/obj/item/stamp/hos,
+/obj/item/stamp/hos{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/obj/item/stamp/denied{
+	pixel_x = -8;
+	pixel_y = 3
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
 "dGc" = (
@@ -4970,8 +4979,8 @@
 	dir = 1
 	},
 /mob/living/simple_mob/animal/passive/lizard{
-	name = "Beppy";
-	desc = "Beppy is the result of a series of funding cuts to the science division's budget. Beppy is not his original name, but it is the only name he has now. He was born a working man, quickly rising through the ranks to become a hotshot in the Nanotrasen science division, only to be stuck in an accident that irretrievably warped him along with his department to an unreachable part of subspace. Years of research and trial and error finally led the science team to return to the correct dimension, albeit all of their souls were transferred into Beppy's body, and his body was transfigured into that of a small green anole. The true moral of this story is that back in nineteen ninety eight the undertaker threw mankind off hell in a cell and plummeted sixteen feet through an announcers table."
+	desc = "Beppy is the result of a series of funding cuts to the science division's budget. Beppy is not his original name, but it is the only name he has now. He was born a working man, quickly rising through the ranks to become a hotshot in the Nanotrasen science division, only to be stuck in an accident that irretrievably warped him along with his department to an unreachable part of subspace. Years of research and trial and error finally led the science team to return to the correct dimension, albeit all of their souls were transferred into Beppy's body, and his body was transfigured into that of a small green anole. The true moral of this story is that back in nineteen ninety eight the undertaker threw mankind off hell in a cell and plummeted sixteen feet through an announcers table.";
+	name = "Beppy"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/pool)
@@ -9302,9 +9311,9 @@
 "gCx" = (
 /obj/structure/table/bench/wooden,
 /obj/machinery/button/windowtint{
-	pixel_y = 30;
 	id = "sauna";
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 30
 	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -14969,8 +14978,15 @@
 "kOp" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white_rd,
-/obj/item/stamp/rd,
+/obj/item/stamp/rd{
+	pixel_x = -8;
+	pixel_y = -3
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/stamp/denied{
+	pixel_x = -8;
+	pixel_y = 3
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/hor)
 "kPd" = (
@@ -17381,6 +17397,14 @@
 	pixel_x = -8;
 	pixel_y = 6;
 	req_access = list(3)
+	},
+/obj/item/stamp/denied{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/stamp/ward{
+	pixel_x = 8;
+	pixel_y = -3
 	},
 /turf/simulated/floor/carpet,
 /area/security/warden)
@@ -32507,10 +32531,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security/upper)
 "yem" = (
-/obj/item/stamp/ward,
-/obj/item/stamp/denied{
-	pixel_x = 5
-	},
 /obj/machinery/button/windowtint{
 	id = "warden_office";
 	pixel_x = -18;

--- a/_maps/map_files/rift/rift-06-surface3.dmm
+++ b/_maps/map_files/rift/rift-06-surface3.dmm
@@ -15643,7 +15643,14 @@
 "DM" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/folder/blue_captain,
-/obj/item/stamp/captain,
+/obj/item/stamp/captain{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/stamp/denied{
+	pixel_x = 8;
+	pixel_y = 3
+	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/captain)
 "DN" = (
@@ -17884,7 +17891,14 @@
 /area/crew_quarters/bar_backroom)
 "Ip" = (
 /obj/structure/table/reinforced,
-/obj/item/stamp/hop,
+/obj/item/stamp/hop{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/obj/item/stamp/denied{
+	pixel_x = -8;
+	pixel_y = 3
+	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "Iq" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds denied stamps to all head of staff offices (it's silly to have their head stamp but not a denied one) and pixel shifted them to look nicer.

Also added a paperwork bin to the warden's office, since he literally has paperwork equipment. It replaces the useless retail scanner that he has.

StrongDMM appears to like touching unrelated things. It shouldn't break anything.

## Why It's Good For The Game

Simple qol features for paperwork.

## Changelog
:cl:
add: Added denied rubber stamps to all head of staff offices.
add: Added a paper bin to the warden's office, replacing the retail scanner.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
