### PR TITLE
Mining Softsuit Armor and Suit Slot

### DIFF
--- a/code/modules/clothing/head/hood.dm
+++ b/code/modules/clothing/head/hood.dm
@@ -151,7 +151,7 @@
 	worn_render_flags = WORN_RENDER_SLOT_ONE_FOR_ALL
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.9
-	armor = list(melee = 50, bullet = 5, laser = 10, energy = 0, bomb = 35, bio = 50, rad = 65)
+	armor = list(melee = 50, bullet = 5, laser = 10, energy = 0, bomb = 55, bio = 50, rad = 65)
 
 // Eldritch suit
 /obj/item/clothing/head/hood/eldritch

--- a/code/modules/clothing/head/hood.dm
+++ b/code/modules/clothing/head/hood.dm
@@ -151,7 +151,7 @@
 	worn_render_flags = WORN_RENDER_SLOT_ONE_FOR_ALL
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.9
-	armor = list(melee = 50, bullet = 5, laser = 10, energy = 0, bomb = 35, bio = 50, rad = 65)
+	armor = list(melee = 50, bullet = 5, laser = 20, energy = 5, bomb = 55, bio = 100, rad = 65)
 
 // Eldritch suit
 /obj/item/clothing/head/hood/eldritch

--- a/code/modules/clothing/head/hood.dm
+++ b/code/modules/clothing/head/hood.dm
@@ -151,7 +151,7 @@
 	worn_render_flags = WORN_RENDER_SLOT_ONE_FOR_ALL
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.9
-	armor = list(melee = 50, bullet = 5, laser = 20, energy = 5, bomb = 55, bio = 100, rad = 65)
+	armor = list(melee = 50, bullet = 5, laser = 10, energy = 0, bomb = 35, bio = 50, rad = 65)
 
 // Eldritch suit
 /obj/item/clothing/head/hood/eldritch

--- a/code/modules/clothing/suits/hooded.dm
+++ b/code/modules/clothing/suits/hooded.dm
@@ -456,12 +456,12 @@
 	flags = PHORONGUARD
 	worn_render_flags = WORN_RENDER_SLOT_ONE_FOR_ALL
 	clothing_flags = THICKMATERIAL
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
-	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
+	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS
 	hoodtype = /obj/item/clothing/head/hood/miner
 	siemens_coefficient = 0.9
-	armor = list(melee = 50, bullet = 5, laser = 20, energy = 5, bomb = 55, bio = 100, rad = 65)
+	armor = list(melee = 50, bullet = 5, laser = 10, energy = 0, bomb = 35, bio = 50, rad = 65)
 	allowed = list(
 		/obj/item/flashlight,
 		/obj/item/material/knife,

--- a/code/modules/clothing/suits/hooded.dm
+++ b/code/modules/clothing/suits/hooded.dm
@@ -456,19 +456,23 @@
 	flags = PHORONGUARD
 	worn_render_flags = WORN_RENDER_SLOT_ONE_FOR_ALL
 	clothing_flags = THICKMATERIAL
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
-	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	hoodtype = /obj/item/clothing/head/hood/miner
 	siemens_coefficient = 0.9
-	armor = list(melee = 50, bullet = 5, laser = 10, energy = 0, bomb = 35, bio = 50, rad = 65)
+	armor = list(melee = 50, bullet = 5, laser = 20, energy = 5, bomb = 55, bio = 100, rad = 65)
 	allowed = list(
 		/obj/item/flashlight,
 		/obj/item/material/knife,
 		/obj/item/tank,
 		/obj/item/radio,
 		/obj/item/suit_cooling_unit,
-		/obj/item/pickaxe
+		/obj/item/pickaxe,
+		/obj/item/gun/energy/kinetic_accelerator,
+		/obj/item/kinetic_crusher,
+		/obj/item/resonator,
+		/obj/item/gun/magnetic/matfed
 		)
 
 //The Chippin' In Set -Cap

--- a/code/modules/clothing/suits/hooded.dm
+++ b/code/modules/clothing/suits/hooded.dm
@@ -456,12 +456,12 @@
 	flags = PHORONGUARD
 	worn_render_flags = WORN_RENDER_SLOT_ONE_FOR_ALL
 	clothing_flags = THICKMATERIAL
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
-	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS
+	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	hoodtype = /obj/item/clothing/head/hood/miner
 	siemens_coefficient = 0.9
-	armor = list(melee = 50, bullet = 5, laser = 10, energy = 0, bomb = 35, bio = 50, rad = 65)
+	armor = list(melee = 50, bullet = 5, laser = 10, energy = 0, bomb = 55, bio = 50, rad = 65)
 	allowed = list(
 		/obj/item/flashlight,
 		/obj/item/material/knife,


### PR DESCRIPTION
## About The Pull Request

After complaints from some miners, Blue told me to give the Mining Softsuit the same armor as the Voidsuit had.
In addition, I added some commonly used mining tools to the list of items the Mining Softsuit can carry in its suit storage.

## Why It's Good For The Game

It's really nice for the Mining Suit to be able to carry some Mining tools on its suit slot!
Regarding the armor changes, I'm sure those who complained have their reason, and we hope those complaints get addressed with these changes.

## Changelog
:cl:
tweak: Expanded the Mining Softsuit storage list for some mining tools
balance: Gave the Mining Softsuit the protection the Mining Voidsuit had
/:cl: