### PR TITLE
Fixes Wooden Gate Icon

### DIFF
--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -210,6 +210,15 @@
 	open = TRUE
 	density = TRUE
 
+/obj/structure/fence/door/wooden/update_door_status()
+	switch(open)
+		if(FALSE)
+			density = TRUE
+			icon_state = "door_wood-closed"
+		if(TRUE)
+			density = FALSE
+			icon_state = "door_wood-opened"
+
 #undef CUT_TIME
 #undef CLIMB_TIME
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Fixes Wooden Gate Icon.**

## Why It's Good For The Game

1. _The wooden gate was taking the wrong proc's icon states, leading to wooden gates turning into brown metal fences._

## Changelog
:cl:
fix: Fixes wooden gates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
