### PR TITLE
Removes Holster Selection from Loadout

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/explorer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/explorer.dm
@@ -152,6 +152,7 @@
 		/obj/item/ammo_magazine/m57x28mm,
 		/obj/item/ammo_magazine/m57x28mm,
 		/obj/item/clothing/accessory/holster/machete,
+		/obj/item/clothing/accessory/holster/leg,
 		/obj/item/reagent_containers/food/snacks/liquidfood,
 		/obj/item/reagent_containers/food/snacks/liquidprotein,
 		/obj/item/card/mining_point_card/survey/gimmick,

--- a/code/modules/preferences/preference_setup/loadout/loadout_role_restricted.dm
+++ b/code/modules/preferences/preference_setup/loadout/loadout_role_restricted.dm
@@ -750,7 +750,7 @@
 /datum/gear/restricted/medical/suit/labcoat_blue
 	name = "Medical Labcoat - Blue"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/blue
-	
+
 /datum/gear/restricted/medical/suit/department_jacket
 	name = "Medical Department Jacket"
 	path = /obj/item/clothing/suit/storage/toggle/med_dep_jacket
@@ -1512,24 +1512,3 @@
 	name = "Hydroponics Winter Boots"
 	path = /obj/item/clothing/shoes/boots/winter/hydro
 	allowed_roles = list("Botanist")
-
-
-//*This clusterfuck of access combinations
-//*Now with Talon roles!
-/datum/gear/restricted/misc/accessory/holster
-	name = "(Command/Security/Exploration/Talon) Holster - Selection"
-	path = /obj/item/clothing/accessory/holster
-	cost = 3
-	allowed_roles = list(
-	"Facility Director", "Head of Personnel", "Chief Medical Officer", "Head of Security", "Research Director", "Chief Engineer", "Command Secretary",
-	"Security Officer", "Warden", "Head of Security", "Detective",
-	"Field Medic", "Explorer", "Pathfinder", "Pilot",
-	"Talon Captain", "Talon Doctor", "Talon Medic", "Talon Engineer", "Talon Pilot", "Talon Guard")
-
-/datum/gear/restricted/misc/accessory/holster/New()
-	..()
-	var/list/holsters = list()
-	for(var/holster in typesof(/obj/item/clothing/accessory/holster))
-		var/obj/item/clothing/accessory/holster_type = holster
-		holsters[initial(holster_type.name)] = holster_type
-	gear_tweaks += new/datum/gear_tweak/path(tim_sort(holsters, /proc/cmp_text_asc))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. *Removes Holster Selection from Loadout.*
2. *Adds a Holster to the Pathfinder's locker.*

## Why It's Good For The Game

1. _I have general issues with the existence of this listing to begin with. However, there is a bug in the nature of Selection that causes the machete scabbard to select its longest path, which in this case is a pre-loaded Durasteel machete. This fault, paired with my general dislike of this item being made available in the loadout, has led to this outcome._
2. _Consequently, I have given the Pathfinder a spare holster in their locker, as this was apparently the most frequent use of this loadout option. This is how we should address holster shortcomings - not by giving them out to anyone in a role restricted slot. I will accept further requests to put holsters in lockers within reason._

## Changelog
:cl:
add: Adds a holster to the PF's locker.
del: Removes Holsters from Loadout Selection.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
