### PR TITLE
makes brig timers use REALTIMEOFDAY 

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -82,7 +82,7 @@
 	if(machine_stat & (NOPOWER|BROKEN))
 		return FALSE
 
-	activation_time = REALTIMEOFDAy
+	activation_time = REALTIMEOFDAY
 	timing = TRUE
 
 	for(var/datum/weakref/door_ref as anything in doors)
@@ -144,7 +144,7 @@
 	return TRUE
 
 /obj/machinery/door_timer/proc/time_left(seconds = FALSE)
-	. = max(0, timer_duration - (activation_time ? (RELATIMEOFDAY - activation_time) : 0))
+	. = max(0, timer_duration - (activation_time ? (REALTIMEOFDAY - activation_time) : 0))
 	if(seconds)
 		. /= 10
 

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -72,7 +72,7 @@
 		return
 
 	if(timing)
-		if(world.time - activation_time >= timer_duration)
+		if(REALTIMEOFDAY - activation_time >= timer_duration)
 			timer_end() //Open doors, reset timer, clear status screen
 		update_icon()
 
@@ -82,7 +82,7 @@
 	if(machine_stat & (NOPOWER|BROKEN))
 		return FALSE
 
-	activation_time = world.time
+	activation_time = REALTIMEOFDAy
 	timing = TRUE
 
 	for(var/datum/weakref/door_ref as anything in doors)
@@ -144,7 +144,7 @@
 	return TRUE
 
 /obj/machinery/door_timer/proc/time_left(seconds = FALSE)
-	. = max(0, timer_duration - (activation_time ? (world.time - activation_time) : 0))
+	. = max(0, timer_duration - (activation_time ? (RELATIMEOFDAY - activation_time) : 0))
 	if(seconds)
 		. /= 10
 
@@ -153,7 +153,7 @@
 	. = new_time == timer_duration //return 1 on no change
 	timer_duration = new_time
 	if(timer_duration && activation_time && timing) // Setting it while active will reset the activation time
-		activation_time = world.time
+		activation_time = REALTIMEOFDAY
 
 /obj/machinery/door_timer/attack_ai(mob/user)
 	return src.attack_hand(user)
@@ -275,7 +275,7 @@
 			investigate_log("[key_name(usr)] set cell [id]'s timer to [preset_time/10] seconds", INVESTIGATE_RECORDS)
 			log_attack("set cell [id]'s timer to [preset_time/10] seconds")
 			if(timing)
-				activation_time = world.time
+				activation_time = REALTIMEOFDAY
 		else
 			. = FALSE
 


### PR DESCRIPTION
brig timers no longer respect lag basically

why: I was reminded by the corpregs page that lag is a thing

It really shouldn't be a thing for the youtube mechanic.