### PR TITLE
defaults flooring can paint to true

### DIFF
--- a/code/game/turfs/simulated/flooring/_flooring.dm
+++ b/code/game/turfs/simulated/flooring/_flooring.dm
@@ -41,7 +41,7 @@ var/list/flooring_types
 
 	var/descriptor = "tiles"
 	var/flags
-	var/can_paint
+	var/can_paint = TRUE
 	var/list/footstep_sounds = list() // key=species name, value = list of soundss
 	var/is_plating = FALSE
 	var/list/flooring_cache = list() // Cached overlays for our edges and corners and junk


### PR DESCRIPTION
ok i'm not even going to go into how decal painters need to be more available + get a QOL update + how decals are shit on the codebase, but:

why it's good for the codebase;
in theory, you only want floors paintable, because you know, why would you paint wood-
oh wait, the mappers put decals. on wood.
and now you have to remove it as a player.
oof.

yeah, at this point, might as well allow by default. you can remove it from flooring when needed.

:cl:
add: most flooring can be painted now
/:cl: