### PR TITLE
paper tags v2

### DIFF
--- a/code/modules/paperwork/paper/paper.dm
+++ b/code/modules/paperwork/paper/paper.dm
@@ -261,8 +261,6 @@
 	t = replacetext(t, "\[center\]", "<center>")
 	t = replacetext(t, "\[/center\]", "</center>")
 	t = replacetext(t, "\[br\]", "<BR>")
-	t = replacetext(t, "\[b\]", "<B>")
-	t = replacetext(t, "\[/b\]", "</B>")
 	t = replacetext(t, "\[i\]", "<I>")
 	t = replacetext(t, "\[/i\]", "</I>")
 	t = replacetext(t, "\[u\]", "<U>")

--- a/code/modules/paperwork/paper/tag.dm
+++ b/code/modules/paperwork/paper/tag.dm
@@ -1,17 +1,76 @@
-GLOBAL_LIST_INIT(paper_tags, paper_tags())
+GLOBAL_LIST_INIT(single_paper_tags, single_paper_tags())
+GLOBAL_LIST_INIT(paired_paper_tags, paired_paper_tags())
+GLOBAL_LIST(paired_paper_tag_lookup)
 
-/proc/paper_tags()
+/proc/single_paper_tags()
 	. = list()
-	for(var/path in subtypesof(/datum/paper_tag))
-		var/datum/paper_tag/T = path
+	for(var/path in subtypesof(/datum/paper_tag/single))
+		var/datum/paper_tag/single/T = path
 		if(initial(T.abstract_type) == path)
 			continue
 		. += new path
 
+/proc/paired_paper_tags()
+	. = list()
+	GLOB.paired_paper_tag_lookup = list()
+	for(var/path in subtypesof(/datum/paper_tag/paired))
+		var/datum/paper_tag/paired/T = path
+		if(initial(T.abstract_type) == path)
+			continue
+		T = new path
+		. += T
+		GLOB.paired_paper_tag_lookup[T.tagname] = T
+
 /obj/item/paper/proc/parse_tags(str, mob/user, obj/item/pen/T)
 	. = str
-	for(var/datum/paper_tag/tag as anything in GLOB.paper_tags)
+	//? parse single tags
+	for(var/datum/paper_tag/single/tag as anything in GLOB.single_paper_tags)
 		. = tag.transform_string(., user, src, T)
+	//? parse paired tag via regex (uh oh overhead maybe we'll rust it someday)
+	// simple parser for paired tags
+	var/static/regex/R = regex("(\\\[/?\[a-z\]+=?\[a-z\]*\\\])")
+	var/list/parsed = splittext_char(str, R)
+	var/parsed_length = length(parsed)
+	if(parsed_length == 1)
+		return parsed[1]
+	var/list/tags = list()
+	var/list/params = list()
+	for(var/i in 2 to parsed.len step 2)
+		var/raw = parsed[i]
+		var/closing = raw[2] == "/"
+		var/param_index = findtext_char(raw, "=")
+		var/found
+		var/param
+		// ignore param index if closing, don't put params in closing tags idiots
+		if(!closing && param_index)
+			found = copytext_char(raw, 2, param_index)
+			param = copytext_char(raw, param_index + 1, -1)
+		else
+			found = copytext_char(raw, closing? 3 : 2, -1)
+		var/datum/paper_tag/paired/PT = GLOB.paired_paper_tag_lookup[found]
+		if(!PT)
+			continue
+		if(closing)
+			var/first = tags.Find(found)
+			if(!first)
+				continue
+			param = params[first]
+			tags.Cut(first, first + 1)
+			params.Cut(first, first + 1)
+			parsed[i] = PT.replace_end(user, src, T, param)
+		else
+			tags += found
+			params += param
+			parsed[i] = PT.replace_start(user, src, T, param)
+	//? auto close any open tags
+	var/tags_length = length(tags)
+	for(var/i in tags_length to 1 step -1)
+		var/found = tags[i]
+		var/param = params[i]
+		var/datum/paper_tag/paired/PT = GLOB.paired_paper_tag_lookup[found]
+		parsed += PT.replace_auto_close(user, src, T, param)
+	return parsed.Join("")
+
 
 /**
  * datumized paper tag system ~silicons
@@ -31,13 +90,8 @@ GLOBAL_LIST_INIT(paper_tags, paper_tags())
 	var/abstract_type = /datum/paper_tag
 
 /**
- * user can be null
- * P can be null
- * T can be null
+ * simple macros
  */
-/datum/paper_tag/proc/transform_string(str, mob/user, obj/item/paper/P, obj/item/pen/T)
-	return str
-
 /datum/paper_tag/single
 	abstract_type = /datum/paper_tag/single
 	var/tagname
@@ -45,6 +99,14 @@ GLOBAL_LIST_INIT(paper_tags, paper_tags())
 
 /datum/paper_tag/single/New()
 	cached_replace_query = "\[[tagname]\]"
+
+/**
+ * user can be null
+ * P can be null
+ * T can be null
+ */
+/datum/paper_tag/single/proc/transform_string(str, mob/user, obj/item/paper/P, obj/item/pen/T)
+	return str
 
 /**
  * user can be null
@@ -76,3 +138,30 @@ GLOBAL_LIST_INIT(paper_tags, paper_tags())
 	return GLOB.using_map.station_name
 
 //? todo: [station_controller]
+
+/**
+ * paired paper tags
+ * supports a single parameter via =
+ */
+/datum/paper_tag/paired
+	abstract_type = /datum/paper_tag/paired
+	/// tag name; ending this tag should be a [/tagname].
+	var/tagname
+
+/datum/paper_tag/paired/proc/replace_start(mob/user, obj/item/paper/P, obj/item/pen/T, parameter)
+	return ""
+
+/datum/paper_tag/paired/proc/replace_end(mob/user, obj/item/paper/P, obj/item/pen/T, parameter)
+	return ""
+
+/datum/paper_tag/paired/proc/replace_auto_close(mob/user, obj/item/paper/P, obj/item/pen/T, parameter)
+	return replace_end(user, P, T, parameter)
+
+/datum/paper_tag/paired/bold
+	tagname = "b"
+
+/datum/paper_tag/paired/bold/replace_start(mob/user, obj/item/paper/P, obj/item/pen/T, parameter)
+	return "<b>"
+
+/datum/paper_tag/paired/bold/replace_end(mob/user, obj/item/paper/P, obj/item/pen/T, parameter)
+	return "</b>"

--- a/code/modules/preferences/preference_setup/background/species.dm
+++ b/code/modules/preferences/preference_setup/background/species.dm
@@ -11,9 +11,9 @@
 	. += "<center>"
 	. += "<b>Species</b><br>[CS.name] - \[[href_simple(prefs, "change", "CHANGE")]\]"
 	if(CS.species_spawn_flags & SPECIES_SPAWN_RESTRICTED)
-		. += "This is a [SPAN_RED("restricted")] species. You cannot join as this outside of special circumstances."
+		. += "<br>This is a [SPAN_RED("restricted")] species. You cannot join as this outside of special circumstances."
 	else if(CS.species_spawn_flags & SPECIES_SPAWN_WHITELISTED)
-		. += "This is a whitelisted species. You "
+		. += "<br>This is a whitelisted species. You "
 		if(config.check_alien_whitelist(ckey(CS.name), prefs.client_ckey))
 			. += SPAN_GREEN("do")
 		else


### PR DESCRIPTION
adds paired tags
we'll have language tags after, gamers ;)

:cl:
add: paper tags now auto-close. no more [b]ombing papers with mismatched tags.
refactor: paired paper tags; might be a bit expensive to parse, should rustg it later
/:cl: