### PR TITLE
[DNM] Adds language indicator preference

### DIFF
--- a/code/modules/language/animal.dm
+++ b/code/modules/language/animal.dm
@@ -10,6 +10,7 @@
 	machine_understands = 0
 	space_chance = 100
 	syllables = list("bark", "woof", "bowwow", "yap", "arf")
+	shorthand = "DOG"
 
 /datum/language/cat
 	id = LANGUAGE_ID_CAT
@@ -23,6 +24,7 @@
 	machine_understands = 0
 	space_chance = 100
 	syllables = list("meow", "mrowl", "purr", "meow", "meow", "meow")
+	shorthand = "CAT"
 
 /datum/language/mouse
 	id = LANGUAGE_ID_MOUSE
@@ -36,6 +38,7 @@
 	machine_understands = 0
 	space_chance = 100
 	syllables = list("squeak")	// , "gripes", "oi", "meow")
+	shorthand = "MSE"
 
 /datum/language/bird
 	id = LANGUAGE_ID_BIRD
@@ -49,3 +52,4 @@
 	machine_understands = 0
 	space_chance = 100
 	syllables = list("chirp", "squawk", "tweet")
+	shorthand = "BIRD"

--- a/code/modules/language/antagonist/xenomorph.dm
+++ b/code/modules/language/antagonist/xenomorph.dm
@@ -10,6 +10,7 @@
 	machine_understands = 0
 	language_flags = RESTRICTED
 	syllables = list("sss","sSs","SSS")
+	shorthand = "XENO"
 
 /datum/language/xenos
 	id = LANGUAGE_ID_XENOMORPH_HIVEMIND

--- a/code/modules/language/core.dm
+++ b/code/modules/language/core.dm
@@ -12,6 +12,7 @@
 "vol", "zum", "coo","zoo","bi","do","ooz","ite","og","re","si","ite","ish",
 "ar","at","on","ee","east","ma","da", "rim")
 	partial_understanding = list(LANGUAGE_SKRELLIAN = 30, LANGUAGE_SOL_COMMON = 30)
+	shorthand = "GC"
 
 /datum/language/machine
 	id = LANGUAGE_ID_EAL
@@ -25,6 +26,7 @@
 	language_flags = NO_STUTTER
 	syllables = list("beep","beep","beep","beep","beep","boop","boop","boop","bop","bop","dee","dee","doo","doo","hiss","hss","buzz","buzz","bzz","ksssh","keey","wurr","wahh","tzzz","shh","shk")
 	space_chance = 10
+	shorthand = "EAL"
 
 /datum/language/machine/get_random_name()
 	if(prob(70))
@@ -40,6 +42,7 @@
 	colour = "say_quote"
 	key = "s"
 	language_flags = SIGNLANG|NO_STUTTER|NONVERBAL
+	shorthand = "SIGN"
 
 /datum/language/sign/can_speak_special(var/mob/speaker)	// TODO: If ever we make external organs assist languages, convert this over to the new format
 	var/obj/item/organ/external/hand/hands = locate() in speaker //you can't sign without hands

--- a/code/modules/language/galactic.dm
+++ b/code/modules/language/galactic.dm
@@ -6,12 +6,14 @@
 	speech_verb = "enunciates"
 	colour = "say_quote"
 	key = "2"
+	shorthand = "TBND"
 	syllables = list(
 "fea","vea","vei","veh","vee","feh","fa","soa","su","sua","sou","se","seh","twa","twe","twi",
 "ahm","lea","lee","nae","nah","pa","pau","fae","fai","soh","mou","ahe","ll","ea","ai","thi",
 "hie","zei","zie","ize","ehy","uy","oya","dor","di","ja","ej","er","um","in","qu","is","re",
 "nt","ti","us","it","en","at","tu","te","ri","es","et","ra","ta","an","ni","li","on","or","se",
 "am","ae","ia","di","ue","em","ar","ui","st","si","de","ci","iu","ne","pe","co","os","ur","ru")
+
 
 // Criminal language.
 /datum/language/gutter
@@ -23,6 +25,7 @@
 	space_chance = 45
 	machine_understands = FALSE
 	partial_understanding = list(LANGUAGE_GALCOM = 10, LANGUAGE_TRADEBAND = 20, LANGUAGE_SOL_COMMON = 20)
+	shorthand = "GUT"
 	syllables = list (
 "gra","ba","ba","breh","bra","rah","dur","ra","ro","gro","go","ber","bar","geh","heh", "gra",
 "a", "ai", "an", "ang", "ao", "ba", "bai", "ban", "bang", "bao", "bei", "ben", "beng", "bi", "bian", "biao",

--- a/code/modules/language/language.dm
+++ b/code/modules/language/language.dm
@@ -49,6 +49,9 @@
 	var/list/partial_understanding
 	var/list/scramble_cache = list()
 
+	/// The shorthand name of this language, used for the indicators in chat. Should be only a handful of all-caps letters.
+	var/shorthand = "???"
+
 /datum/language/New()
 	if(isnull(id))
 		id = ckey(name)

--- a/code/modules/language/monkey.dm
+++ b/code/modules/language/monkey.dm
@@ -9,6 +9,7 @@
 	syllables = list("ook","eek")
 	language_flags = RESTRICTED
 	machine_understands = 0
+	shorthand = "MONK"
 
 /datum/language/skrell/monkey
 	id = LANGUAGE_ID_NEAERA
@@ -18,6 +19,7 @@
 	syllables = list("hiss","gronk")
 	language_flags = RESTRICTED
 	machine_understands = 0
+	shorthand = "NEA"
 
 /datum/language/unathi/monkey
 	id = LANGUAGE_ID_STOK
@@ -27,6 +29,7 @@
 	syllables = list("squick","croak")
 	language_flags = RESTRICTED
 	machine_understands = 0
+	shorthand = "STOK"
 
 /datum/language/tajaran/monkey
 	id = LANGUAGE_ID_FARWA
@@ -36,4 +39,5 @@
 	syllables = list("meow","mew")
 	language_flags = RESTRICTED
 	machine_understands = 0
+	shorthand = "FAR"
 

--- a/code/modules/language/species/adherent.dm
+++ b/code/modules/language/species/adherent.dm
@@ -14,3 +14,4 @@
 		"\[harmonic\]", "\[disharmonic\]", "\[choral\]"
 	)
 	space_chance = 0
+	shorthand = "ADH"

--- a/code/modules/language/species/akula.dm
+++ b/code/modules/language/species/akula.dm
@@ -10,3 +10,4 @@
 	key = "a"
 	space_chance = 80
 	syllables = list("ko'lakou","hiki","iloko'o","o'e","kekahi","olelo","keia","'ekahi","loaa","no'ka'mea","ia","ka'mea","ko'ino", "kela", "ma", "keia", "hai aku", "paani", "hopena", "heluhelu", "mai'o", "ke'awa", "a'hiki", "nui", "maanei", "ki'eki'e", "no'ke'aha'mai", "no'i", "malamalama", "keia'ano", "ka'hale", "pono", "ki'i", "holoholona", "wahi", "makuahine", "kokoke", "makuakāne", "kekahi", "lawe", "wahi", "mahope'iho'o", "ma'popo'eka")
+	shorthand = "AKU"

--- a/code/modules/language/species/alraune.dm
+++ b/code/modules/language/species/alraune.dm
@@ -11,3 +11,4 @@
 	key = "t" //Rustles susurrus crackles
 	syllables = list ("shh", "fssh", "rustle", "snap", "kssh", "sffh", "mssh", "creak",
 			"knock", "crk", "srhh", "rrssh", "sh", "hk", "fsh", "rss", "ks")
+	shorthand = "VERN"

--- a/code/modules/language/species/altevian.dm
+++ b/code/modules/language/species/altevian.dm
@@ -10,3 +10,4 @@
 	syllables = list ("sque", "uik", "squeak", "squee", "eak", "eek", "uek", "squik",
 			"squeek", "sq", "eek", "squeee", "ee", "ek", "ak", "ueak", "squea")
 	machine_understands = 1
+	shorthand = "SQ"

--- a/code/modules/language/species/birdsong.dm
+++ b/code/modules/language/species/birdsong.dm
@@ -6,5 +6,5 @@
 	colour = "birdsongc"
 	key = "7"
 	syllables = list ("cheep", "peep", "tweet")
-
+	shorthand = "BDSNG"
 // todo: wtf is this

--- a/code/modules/language/species/celestial.dm
+++ b/code/modules/language/species/celestial.dm
@@ -10,6 +10,7 @@
 	syllables = list("viepn","e","bag","docu","kar","xlaqf","raa","qwos","nen","ty","von","kytaf","xin","ty","ka","baak","hlafaifpyk","znu","agrith","na'ar","uah","plhu","six","fhler","bjel","scee","lleri",
 	"dttm","aggr","uujl","hjjifr","wwuthaav",)
 	machine_understands = FALSE
+	shorthand = "DEM"
 
 /datum/language/angel
 	id = LANGUAGE_ID_DAEDAL_AURIL
@@ -23,3 +24,4 @@
 	syllables = list("salve","sum","loqui","operatur","iusta","et","permittit","facere","effercio","pluribus","enim","hoc",
 	"mihi","wan","six","tartu")
 	machine_understands = FALSE
+	shorthand = "ANG"

--- a/code/modules/language/species/diona.dm
+++ b/code/modules/language/species/diona.dm
@@ -10,6 +10,7 @@
 	machine_understands = 0
 	language_flags = RESTRICTED
 	syllables = list("hs","zt","kr","st","sh")
+	shorthand = "DIO"
 
 /datum/language/diona_local/get_random_name()
 	var/new_name = "[pick(list("To Sleep Beneath","Wind Over","Embrace of","Dreams of","Witnessing","To Walk Beneath","Approaching the"))]"

--- a/code/modules/language/species/human.dm
+++ b/code/modules/language/species/human.dm
@@ -8,6 +8,7 @@
 	colour = "solcom"
 	key = "1"
 	//syllables are at the bottom of the file
+	shorthand = "SC"
 
 /datum/language/human/get_random_name(gender)
 	if (prob(80))
@@ -30,6 +31,7 @@
 		"ko", "ne", "en", "po", "ra", "li", "on", "byl", "cto", "eni", "ost", "ol", "ego",
 		"ver", "stv", "pro"
 	)
+	shorthand = "SLAV"
 
 //Syllable Lists
 /*

--- a/code/modules/language/species/moth.dm
+++ b/code/modules/language/species/moth.dm
@@ -37,6 +37,7 @@
 	space_chance = 35
 	machine_understands = FALSE
 	partial_understanding = list()
+	shorthand = "LUI"
 
 /datum/language/species/moth/get_random_name(gender, name_count = 2, syllable_count= 4 , syllable_divisor = 2)
 	var/list/names = GLOB.moth_lore_data["name"]

--- a/code/modules/language/species/naramadi.dm
+++ b/code/modules/language/species/naramadi.dm
@@ -7,3 +7,4 @@
 	colour = "sergal"
 	key = "T"
 	syllables = list ("grr", "gah", "woof", "arf", "arra", "rah", "wor", "sarg")
+	shorthand = "SAG"

--- a/code/modules/language/species/phoronoid.dm
+++ b/code/modules/language/species/phoronoid.dm
@@ -8,3 +8,4 @@
 	colour = "changeling"
 	key = "c"
 	syllables = list("clatter","tink","chink","clack","rattle","clink","clunk","dink","tonk","donk","plink,","plonk")
+	shorthand = "PHO"

--- a/code/modules/language/species/skrell.dm
+++ b/code/modules/language/species/skrell.dm
@@ -10,6 +10,7 @@
 	key = "k"
 	space_chance = 30
 	syllables = list("qr","qrr","xuq","qil","quum","xuqm","vol","xrim","zaoo","qu-uu","qix","qoo","zix")
+	shorthand = "SKRL"
 
 
 /datum/language/skrellfar
@@ -25,6 +26,7 @@
 	space_chance = 30
 	language_flags = WHITELISTED
 	syllables = list("qr","qrr","xuq","qil","quum","xuqm","vol","xrim","zaoo","qu-uu","qix","qoo","zix", "...", "oo", "q", "nq", "x", "xq", "ll", "...", "...", "...") //should sound like there's holes in it
+	shorthand = "SKRLFR"
 
 /datum/language/skrell/get_random_name(gender)
 	var/list/first_name = GLOB.skrell_first_names

--- a/code/modules/language/species/tajaran.dm
+++ b/code/modules/language/species/tajaran.dm
@@ -11,6 +11,7 @@
 	"mi","jri","dynh","manq","rhe","zar","rrhaz","kal","chur","eech","thaa","dra","jurl","mah","sanu","dra","ii'r",
 	"ka","aasi","far","wa","baq","ara","qara","zir","saam","mak","hrar","nja","rir","khan","jun","dar","rik","kah",
 	"hal","ket","jurl","mah","tul","cresh","azu","ragh","mro","mra","mrro","mrra")
+	shorthand = "TAJ"
 
 /datum/language/tajaran/get_random_name(var/gender)
 	var/new_name = ..(gender,1)
@@ -34,6 +35,7 @@
 	"ara","ka","zar","mah","ner","zir","mur","hai","raz","ni","ri","nar","njar","jir","ri","ahn","kha","sir",
 	"kar","yar","kzar","rha","hrar","err","fer","rir","rar","yarr","arr","ii'r","jar","kur","ran","rii","ii",
 	"nai","ou","kah","oa","ama","uuk","bel","chi","ayt","kay","kas","akor","tam","yir","enai")
+	shorthand = "AKH"
 
 /datum/language/tajsign
 	id = LANGUAGE_ID_TAJARAN_SIGN
@@ -44,6 +46,7 @@
 	colour = "tajaran"
 	key = "l"
 	language_flags = WHITELISTED | SIGNLANG | NO_STUTTER | NONVERBAL
+	shorthand = "TAJSIGN"
 
 /datum/language/tajsign/can_speak_special(var/mob/speaker)	// TODO: If ever we make external organs assist languages, convert this over to the new format
 	var/list/allowed_species = list(SPECIES_TAJ, SPECIES_TESHARI)	// Need a tail and ears and such to use this.

--- a/code/modules/language/species/teshari.dm
+++ b/code/modules/language/species/teshari.dm
@@ -13,6 +13,7 @@
 			"ce", "re", "me", "se", "ne", "te", "le", "she", "sche", "e", "e",
 			"ci", "ri", "mi", "si", "ni", "ti", "li", "shi", "schi", "i", "i"
 		)
+	shorthand = "SCH"
 
 /datum/language/teshari/get_random_name(gender)
 	return ..(gender, 2, 4, 1.5)

--- a/code/modules/language/species/unathi.dm
+++ b/code/modules/language/species/unathi.dm
@@ -17,6 +17,7 @@
  		"ra", "ar", "re", "er", "ri", "ir", "ro", "or", "ru", "ur", "rs", "sr",
  		"a",  "a",  "e",  "e",  "i",  "i",  "o",  "o",  "u",  "u",  "s",  "s"
 	)
+	shorthand = "ST"
 
 /datum/language/unathi/get_random_name()
 

--- a/code/modules/language/species/vasilissan.dm
+++ b/code/modules/language/species/vasilissan.dm
@@ -10,3 +10,4 @@
 	syllables = list("vaur","uyek","uyit","avek","sc'theth","k'ztak","teth","wre'ge","lii","dra'","zo'","ra'","kax'","zz","vh","ik","ak",
     "uhk","zir","sc'orth","sc'er","thc'yek","th'zirk","th'esk","k'ayek","ka'mil","sc'","ik'yir","yol","kig","k'zit","'","'","zrk","krg","isk'yet","na'k",
     "sc'azz","th'sc","nil","n'ahk","sc'yeth","aur'sk","iy'it","azzg","a'","i'","o'","u'","a","i","o","u","zz","kr","ak","nrk","tzzk","bz","xic'","k'lax'","histh")
+	shorthand = "VESP"

--- a/code/modules/language/species/vox.dm
+++ b/code/modules/language/species/vox.dm
@@ -11,6 +11,7 @@
 	syllables = list("ti","ti","ti","hi","hi","ki","ki","ki","ki","ya","ta","ha","ka","ya","chi","cha","kah", \
 	"SKRE","AHK","EHK","RAWK","KRA","AAA","EEE","KI","II","KRI","KA")
 	machine_understands = 0
+	shorthand = "VOX"
 
 /datum/language/vox/get_random_name()
 	return ..(FEMALE,1,6)

--- a/code/modules/language/species/vulpkanin.dm
+++ b/code/modules/language/species/vulpkanin.dm
@@ -11,3 +11,4 @@
 	"ist","ein","entch","zwichs","tut","mir","wo","bis","es","vor","nic","gro","lll","enem","zandt","tzch","noch", \
 	"hel","ischt","far","wa","baram","iereng","tech","lach","sam","mak","lich","gen","or","ag","eck","gec","stag","onn", \
 	"bin","ket","jarl","vulf","einech","cresthz","azunein","ghzth")
+	shorthand = "CAN"

--- a/code/modules/language/species/zaddat.dm
+++ b/code/modules/language/species/zaddat.dm
@@ -9,3 +9,4 @@
 	key = "z"
 	space_chance = 20
 	syllables = list("z", "dz", "i", "iv", "ti", "az", "hix", "xo", "av", "xo", "x", "za", "at", "vi")
+	shorthand = "ZAD"

--- a/code/modules/language/species/zorren.dm
+++ b/code/modules/language/species/zorren.dm
@@ -9,3 +9,4 @@
 	syllables = list (".a", "spa", "pan", "blaif", "stra", "!u", "!ei", "!am", "by", ".y", "gry", "zbly", "!y", "fl",
  	"sm", "rn", "cpi", "ku", "koi", "pr", "glau", "stu", "ved", "ki", "tsa", "xau", "jbu", "sny", "stro", "nu",
  	"uan", "ju", "!i", "ge", "luk", "an", "ar", "at", "es", "et", "bel", "ki", "jaa", "ch", "ki", "gh", "ll", "uu", "wat")
+	shorthand = "TERM"

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -65,6 +65,9 @@
 	else
 		var/message_to_send = null
 		if(language)
+			//Hivemind languages already say their names. Also, no indicator if you don't know the language.
+			if(client && !(language.language_flags & HIVEMIND) && say_understands(speaker, language) && client.is_preference_enabled(/datum/client_preference/language_indicator))
+				verb += " ([language.shorthand])"
 			message_to_send = "<span class='game say'><span class='name'>[speaker_name]</span>[alt_name] [track][language.format_message(message, verb)]</span>"
 		else
 			message_to_send = "<span class='game say'><span class='name'>[speaker_name]</span>[alt_name] [track][verb], <span class='message'><span class='body'>\"[message]\"</span></span></span>"
@@ -239,6 +242,8 @@
 
 	var/formatted
 	if(language)
+		if(client && !(language.language_flags & HIVEMIND) && say_understands(speaker, language) && client.is_preference_enabled(/datum/client_preference/language_indicator))
+			verb += " ([language.shorthand])"
 		formatted = "[language.format_message_radio(message, verb)][part_c]"
 	else
 		formatted = "[verb], <span class=\"body\">\"[message]\"</span>[part_c]"

--- a/code/modules/preferences/preference_setup/global/setting_datums.dm
+++ b/code/modules/preferences/preference_setup/global/setting_datums.dm
@@ -386,3 +386,9 @@ var/list/_client_preferences_by_type
 	key = "EXAMINE_LOOK"
 	enabled_description = "Show"
 	disabled_description = "Hide"
+
+/datum/client_preference/language_indicator
+	description = "Language Indicators"
+	key = "LANGUAGE_INDICATOR"
+	enabled_description = "Show"
+	disabled_description = "Hide"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### This PR is marked DNM because I don't know what each language's shorthand should be. The ones provided here are placeholders pending maintainer review.

Adds a language indicator preference. If you have it enabled and you know the language being spoken, a shorthand name of the language will pop up in the chat to let you know what language the person is speaking in. **This PR is based on https://github.com/Baystation12/Baystation12/pull/20721**.

Hivemind languages do not have these as their names are automatically given with each message. Likewise, machines that transmit without any language (such as station announcements or the ATC) do not have any indicator.

An example of a few languages:

![image](https://user-images.githubusercontent.com/25853190/204684618-d460acbd-3efd-4bbd-bbae-ccf81e75fff4.png)

## Why It's Good For The Game

It has been suggested in the past and can be helpful for people who don't know the languages by their colors.

## Changelog
:cl:
add: Added a new preference: Language Indicators. If enabled, a shorthand name of a language will be added whenever someone speaks that language, assuming you know it too.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
