### PR TITLE
Reworks the unknown language popup

### DIFF
--- a/code/modules/mob/living/carbon/alien/say.dm
+++ b/code/modules/mob/living/carbon/alien/say.dm
@@ -17,6 +17,9 @@
 
 	speaking = parse_language(message)
 
+	if(speaking == -1)
+		return
+		
 	message = trim(message)
 
 	if(!message || stat)

--- a/code/modules/mob/living/carbon/brain/say.dm
+++ b/code/modules/mob/living/carbon/brain/say.dm
@@ -9,6 +9,8 @@
 		return //Certain objects can speak, like MMIs. Most others cannot. -Q
 	else
 		speaking = parse_language(message)
+		if(speaking == -1)
+			return
 		if(speaking)
 			message = copytext(message, 2+length(speaking.key))
 		verb = "says"

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -187,6 +187,9 @@ var/list/channel_to_radio_key = new
 	if(!speaking)
 		speaking = parse_language(message)
 
+	if(speaking == -1)
+		return
+		
 	if(!speaking)
 		speaking = get_default_language()
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -152,11 +152,14 @@
 		if (can_speak(L))
 			return L
 		else
-			var/alert_result = alert(src, "You dont know the LANGUAGE you are about to speak, instead you will speak Babel. Do you want to?", "Unknown Language Alert","No","Yes")
-			if(alert_result == "Yes")
-				return SScharacters.resolve_language_name(LANGUAGE_GIBBERISH)
-			else
-				if(isliving(src))
-					var/mob/living/caller = src
-					return SScharacters.resolve_language_name(caller.default_language)
+			var/alert_result = alert(src, "You don't know that language. Would you rather speak your default language, gibberish, or nothing?", "Unknown Language Alert","Default Language","Gibberish", "Whoops I made a typo!")
+			switch(alert_result)
+				if("Default Language")
+					if(isliving(src))
+						var/mob/living/caller = src
+						return SScharacters.resolve_language_name(caller.default_language)
+				if("Gibberish")
+					return SScharacters.resolve_language_name(LANGUAGE_GIBBERISH)
+				if("Whoops I made a typo!")
+					return -1
 	return null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reworks the unknown language popup (which appears if you put in a prefix that doesn't match a language that you know) to clarify what has gone wrong and what your options are. Also adds an option to say nothing in case you made a typo. (This is pretty hacky in the code, but it should work?).

![image](https://user-images.githubusercontent.com/25853190/204688088-718e3d17-ee35-4ccb-b02b-a63841c26a39.png)


## Why It's Good For The Game

Being forced to say something in the wrong language is bad.

## Changelog
:cl:
tweak: Reworked the alert that pops up if you try speaking a language you don't know, and added an option to say nothing at all in case you made a typo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
