### PR TITLE
Adds oxygen tank to hos suit rack

### DIFF
--- a/_maps/map_files/rift/rift-05-surface2.dmm
+++ b/_maps/map_files/rift/rift-05-surface2.dmm
@@ -15232,6 +15232,9 @@
 	req_one_access = list(58)
 	},
 /obj/effect/floor_decal/borderfloorblack/full,
+/obj/item/tank/oxygen{
+	pixel_y = -4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
 "kXI" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Self-explanatory.

## Why It's Good For The Game

 The HOS shouldn't need to steal one from the security EVA prep.

## Changelog
:cl:
add: Added an oxygen tank to the head of security's voidsuit rack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
