### PR TITLE
Fix nightshift, add option to c&c console

### DIFF
--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -6,9 +6,11 @@ SUBSYSTEM_DEF(nightshift)
 	subsystem_flags = SS_NO_TICK_CHECK
 
 	var/nightshift_active = FALSE
-	var/nightshift_start_time = 702000		//7:30 PM, station time
-	var/nightshift_end_time = 270000		//7:30 AM, station time
+	var/nightshift_start_time = 19 HOURS + 30 MINUTES		//7:30 PM, station time
+	var/nightshift_end_time = 7 HOURS + 30 MINUTES		//7:30 AM, station time
 	var/nightshift_first_check = 30 SECONDS
+
+	var/overridden //Overridden by a C&C console.
 
 	var/high_security_mode = FALSE
 
@@ -20,7 +22,7 @@ SUBSYSTEM_DEF(nightshift)
 	return ..()
 
 /datum/controller/subsystem/nightshift/fire(resumed = FALSE)
-	if(world.time - SSticker.round_start_time < nightshift_first_check)
+	if(world.time - round_duration_in_ds < nightshift_first_check)
 		return
 	check_nightshift()
 
@@ -31,11 +33,11 @@ SUBSYSTEM_DEF(nightshift)
 	priority_announcement.Announce(message, new_title = "Automated Lighting System Announcement", new_sound = 'sound/misc/notice2.ogg', zlevel = announce_z)
 
 /datum/controller/subsystem/nightshift/proc/check_nightshift(check_canfire=FALSE) //This is called from elsewhere, like setting the alert levels
-	if(check_canfire && !can_fire)
+	if(overridden || (check_canfire && !can_fire))
 		return
 	var/emergency = GLOB.security_level > SEC_LEVEL_GREEN
 	var/announcing = TRUE
-	var/time = station_time()
+	var/time = station_time_in_ds
 	var/night_time = (time < nightshift_end_time) || (time > nightshift_start_time)
 	if(high_security_mode != emergency)
 		high_security_mode = emergency

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -29,6 +29,7 @@
 	var/const/STATE_ALERT_LEVEL = 8
 	var/const/STATE_CONFIRM_LEVEL = 9
 	var/const/STATE_CREWTRANSFER = 10
+	var/const/STATE_NIGHTSHIFT = 11
 
 	var/status_display_freq = "1435"
 	var/stat_msg1
@@ -164,6 +165,9 @@
 		if("status")
 			src.state = STATE_STATUSDISPLAY
 
+		if("nightshift")
+			src.state = STATE_NIGHTSHIFT
+
 		// Status display stuff
 		if("setstat")
 			switch(href_list["statdisp"])
@@ -254,6 +258,8 @@
 			src.aistate = STATE_MESSAGELIST
 		if("ai-status")
 			src.aistate = STATE_STATUSDISPLAY
+		if("ai-nightshift")
+			src.aistate = STATE_NIGHTSHIFT
 
 		if("securitylevel")
 			src.tmp_alertlevel = text2num( href_list["newalertlevel"] )
@@ -263,8 +269,22 @@
 		if("changeseclevel")
 			state = STATE_ALERT_LEVEL
 
-
-
+		if("setnightshift")
+			var/oldactive = SSnightshift.nightshift_active
+			var/newactive
+			switch(href_list["newsetting"])
+				if("auto")
+					SSnightshift.overridden = FALSE
+					newactive = oldactive
+				if("on")
+					SSnightshift.overridden = TRUE
+					newactive = TRUE
+				if("off")
+					SSnightshift.overridden = TRUE
+					newactive = FALSE
+			if(oldactive != newactive)
+				SSnightshift.update_nightshift(newactive)
+			src.state = STATE_DEFAULT
 	src.updateUsrDialog()
 
 /obj/machinery/computer/communications/emag_act(var/remaining_charges, var/mob/user)
@@ -318,6 +338,7 @@
 						dat += "<BR>\[ <A HREF='?src=\ref[src];operation=callshuttle'>Call Emergency Shuttle</A> \]"
 
 				dat += "<BR>\[ <A HREF='?src=\ref[src];operation=status'>Set Status Display</A> \]"
+				dat += "<BR>\[ <A HREF='?src=\ref[src];operation=nightshift'>Set Nightshift Setting</A> \]"
 			else
 				dat += "<BR>\[ <A HREF='?src=\ref[src];operation=login'>Log In</A> \]"
 			dat += "<BR>\[ <A HREF='?src=\ref[src];operation=messagelist'>Message List</A> \]"
@@ -358,6 +379,22 @@
 			dat += " <A HREF='?src=\ref[src];operation=setstat;statdisp=alert;alert=redalert'>Red Alert</A> |"
 			dat += " <A HREF='?src=\ref[src];operation=setstat;statdisp=alert;alert=lockdown'>Lockdown</A> |"
 			dat += " <A HREF='?src=\ref[src];operation=setstat;statdisp=alert;alert=biohazard'>Biohazard</A> \]<BR><HR>"
+		if(STATE_NIGHTSHIFT)
+			if(!SSnightshift.overridden)
+				dat += "Current Nightshift Setting: <b>Auto ([SSnightshift.nightshift_active ? "On" : "Off"])</b><BR>"
+				dat += "\[ <A HREF='?src=\ref[src];operation=setnightshift;newsetting=off'>Off</A> \]<BR>"
+				dat += "Auto<BR>"
+				dat += "\[ <A HREF='?src=\ref[src];operation=setnightshift;newsetting=on'>On</A> \]<BR>"
+			else if(SSnightshift.nightshift_active)
+				dat += "Current Nightshift Setting: <b>On</b><BR>"
+				dat += "\[ <A HREF='?src=\ref[src];operation=setnightshift;newsetting=off'>Off</A> \]<BR>"
+				dat += "\[ <A HREF='?src=\ref[src];operation=setnightshift;newsetting=auto'>Auto</A> \]<BR>"
+				dat += "On<BR>"
+			else
+				dat += "Current Nightshift Setting: <b>Off</b><BR>"
+				dat += "Off<BR>"
+				dat += "\[ <A HREF='?src=\ref[src];operation=setnightshift;newsetting=auto'>Auto</A> \]<BR>"
+				dat += "\[ <A HREF='?src=\ref[src];operation=setnightshift;newsetting=on'>On</A> \]<BR>"
 		if(STATE_ALERT_LEVEL)
 			dat += "Current alert level: [get_security_level()]<BR>"
 			if(GLOB.security_level == SEC_LEVEL_DELTA)
@@ -389,6 +426,7 @@
 			dat += "<BR>\[ <A HREF='?src=\ref[src];operation=ai-messagelist'>Message List</A> \]"
 			dat += "<BR>\[ <A HREF='?src=\ref[src];operation=ai-status'>Set Status Display</A> \]"
 			dat += "<BR>\[ <A HREF='?src=\ref[src];operation=toggleatc'>[ATC.squelched ? "Enable" : "Disable"] ATC Relay</A> \]"
+			dat += "<BR>\[ <A HREF='?src=\ref[src];operation=ai-nightshift'>Set Nightshift Setting</A> \]"
 		if(STATE_CALLSHUTTLE)
 			dat += "Are you sure you want to call the shuttle? \[ <A HREF='?src=\ref[src];operation=ai-callshuttle2'>OK</A> | <A HREF='?src=\ref[src];operation=ai-main'>Cancel</A> \]"
 		if(STATE_MESSAGELIST)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The nightshift subsystem now works -- it will automatically turn on nightshift lighting at 7:30 PM and beyond, and turn it off at 7:30 AM and beyond.

In addition, added a new option to the Command and Communications console to manually change the nightshift setting. You can override it to be on or off at all times, or switch it back to automatic mode.

Example video is too large for here, look in development-rp for "Nightshift example:" for an example of it.

## Why It's Good For The Game

Nightshift is a cool mechanic, but was broken before. This fixes it and also adds a way for command to manually change it station-wide instead of having to do it APC by APC.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed the nightshift subsystem; it will now automatically turn on at 19:30 (7:30 PM) and off at 7:30 AM.
add: Added an option in the Command and Communications console to manually turn the nightshift on, off, or to automatic mode (default).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
