### PR TITLE
Maintainer Request Bundle - Decontamination showers, ore processing for mining outpost, and more

### DIFF
--- a/_maps/map_files/rift/rift-01-underground3.dmm
+++ b/_maps/map_files/rift/rift-01-underground3.dmm
@@ -1,4 +1,20 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"at" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/structure/curtain/open/shower,
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/mining_airlock)
 "aW" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/outdoors/safeice/lythios43c/indoors,
@@ -357,6 +373,26 @@
 "vr" = (
 /turf/simulated/floor/plating,
 /area/quartermaster/mining_airlock)
+"vD" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/structure/curtain/open/shower,
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/sign/signnew/radiation{
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/mining_airlock)
 "wH" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/snow/lythios43c,
@@ -472,6 +508,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/mining_airlock)
+"AF" = (
+/obj/machinery/washing_machine,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/mining_airlock)
 "AN" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -551,6 +591,9 @@
 	},
 /turf/simulated/floor/outdoors/snow/lythios43c/indoors,
 /area/rift/surfacebase/underground/under1)
+"Iw" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/mining_airlock)
 "Ji" = (
 /obj/machinery/atmospherics/component/binary/passive_gate/on{
 	dir = 8;
@@ -631,7 +674,7 @@
 	},
 /obj/structure/sign/signnew/radiation{
 	pixel_x = -32;
-	pixel_y = 32
+	pixel_y = -32
 	},
 /obj/structure/sign/warning{
 	pixel_x = -32
@@ -667,9 +710,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/mining_airlock)
 "Qt" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/glass,
+/obj/spawner/window/reinforced/full/firelocks,
 /turf/simulated/floor/plating,
 /area/quartermaster/mining_airlock)
 "QE" = (
@@ -19375,9 +19416,9 @@ PG
 jJ
 yh
 sc
+vD
 jJ
 Yr
-KS
 KS
 KS
 KS
@@ -19569,8 +19610,8 @@ JZ
 jJ
 yh
 bk
-Qt
-KS
+at
+jJ
 KS
 KS
 KS
@@ -19763,8 +19804,8 @@ RA
 Zn
 gi
 pj
-Qt
-KS
+Iw
+jJ
 KS
 KS
 KS
@@ -19957,8 +19998,8 @@ ux
 oE
 mv
 Ki
-Qt
-KS
+AF
+jJ
 KS
 KS
 KS
@@ -20151,9 +20192,9 @@ et
 jJ
 Qn
 Es
+AF
 jJ
 Yr
-KS
 KS
 KS
 dq
@@ -20345,8 +20386,8 @@ uH
 jJ
 jJ
 jJ
+jJ
 QE
-KS
 KS
 KS
 KS

--- a/_maps/map_files/rift/rift-02-underground2.dmm
+++ b/_maps/map_files/rift/rift-02-underground2.dmm
@@ -803,9 +803,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/engineering/locker_room)
 "ci" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor,
 /area/engineering/engine_airlock)
 "cj" = (
@@ -1283,6 +1281,13 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/greengrid/nitrogen,
 /area/engineering/engine_core)
+"dR" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/atmos/hallway)
 "dT" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/structure/cable{
@@ -5642,6 +5647,12 @@
 /obj/machinery/meter,
 /turf/simulated/floor,
 /area/engineering/engine_room)
+"qr" = (
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/engine_waste)
 "qt" = (
 /obj/machinery/door/airlock/engineering,
 /obj/structure/cable{
@@ -6246,8 +6257,8 @@
 /turf/simulated/floor,
 /area/engineering/engine_room)
 "sx" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
 	},
 /turf/simulated/floor,
 /area/engineering/engine_airlock)
@@ -6570,6 +6581,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"tQ" = (
+/obj/machinery/door/airlock/maintenance/engi,
+/turf/simulated/floor/plating,
+/area/engineering/engine_waste)
 "tR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -6949,6 +6964,9 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_smes)
+"vJ" = (
+/turf/simulated/wall,
+/area/engineering/engine_waste)
 "vK" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -7024,6 +7042,9 @@
 "wc" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/light,
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/atmos/hallway)
 "wh" = (
@@ -7741,6 +7762,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
+"zf" = (
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/maintenance/atmos)
 "zj" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -8084,6 +8109,12 @@
 /obj/structure/stairs/spawner/north,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/atmos/hallway)
+"Bk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/engine_waste)
 "Bl" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -8200,6 +8231,10 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/heads/chief)
+"BL" = (
+/obj/machinery/door/airlock/maintenance/engi,
+/turf/simulated/floor/plating,
+/area/engineering/break_room)
 "BM" = (
 /obj/structure/closet/crate,
 /obj/item/circuitboard/smes,
@@ -8486,7 +8521,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
 "Dj" = (
-/turf/simulated/floor,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain/open/shower/engineering,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_airlock)
 "Dk" = (
 /obj/machinery/power/port_gen/pacman{
@@ -8596,6 +8644,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
+"DH" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/engine_waste)
 "DK" = (
 /obj/structure/closet/crate,
 /obj/item/stack/material/phoron{
@@ -8648,8 +8700,9 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_monitoring)
 "DS" = (
-/turf/simulated/wall,
-/area/engineering/atmos)
+/obj/machinery/washing_machine,
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/engine_waste)
 "DV" = (
 /obj/structure/railing,
 /obj/effect/floor_decal/rust,
@@ -8911,6 +8964,10 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
 	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/atmos/hallway)
 "Fe" = (
@@ -9019,6 +9076,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
+"FB" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/engine_waste)
 "FC" = (
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plating,
@@ -9026,6 +9086,19 @@
 "FD" = (
 /turf/unsimulated/mineral/icerock/lythios43c,
 /area/rift/surfacebase/underground/under2)
+"FF" = (
+/obj/machinery/door/airlock/multi_tile/metal{
+	dir = 2;
+	name = "Radiation Prep - Cleanup"
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/atmos/hallway)
 "FG" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -9442,6 +9515,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/hallway)
+"HE" = (
+/obj/structure/closet/radiation,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/engine_waste)
 "HF" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -9573,7 +9651,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -9930,6 +10008,22 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/chief)
+"JS" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain/open/shower/engineering,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/engine_waste)
 "JT" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -10245,6 +10339,10 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled,
 /area/engineering/engine_eva)
+"Lu" = (
+/obj/structure/sign/signnew/radiation,
+/turf/simulated/wall,
+/area/engineering/atmos/hallway)
 "Lv" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/outdoors/snow/lythios43c,
@@ -10664,6 +10762,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/atmos)
+"MW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/atmos/hallway)
 "MX" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -10884,6 +10988,12 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/hallway)
+"NJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/engine_waste)
 "NL" = (
 /obj/structure/railing,
 /obj/effect/floor_decal/rust,
@@ -10930,6 +11040,10 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_room)
+"Ob" = (
+/obj/structure/closet/radiation,
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/engine_waste)
 "Oc" = (
 /obj/machinery/microwave,
 /obj/structure/table/reinforced,
@@ -11079,6 +11193,15 @@
 /obj/machinery/vending/sovietsoda,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
+"OT" = (
+/obj/item/geiger,
+/obj/item/geiger,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/engine_waste)
 "OU" = (
 /obj/machinery/space_heater,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -11232,6 +11355,18 @@
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
 "PD" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
 /obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller{
 	id_tag = "engine_room_airlock";
 	name = "Engine Room Airlock";
@@ -11243,12 +11378,8 @@
 	tag_interior_door = "engine_airlock_interior";
 	tag_interior_sensor = "eng_al_int_snsr"
 	},
-/obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
-	dir = 1;
-	frequency = 1379;
-	id_tag = "engine_airlock_pump"
-	},
-/turf/simulated/floor,
+/obj/structure/curtain/open/shower/engineering,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_airlock)
 "PF" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -11447,7 +11578,7 @@
 /area/engineering/break_room)
 "Qu" = (
 /obj/effect/floor_decal/borderfloor,
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -11646,6 +11777,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
+	frequency = 1379;
+	id_tag = "engine_airlock_pump"
+	},
 /turf/simulated/floor,
 /area/engineering/engine_airlock)
 "RC" = (
@@ -11820,6 +11955,12 @@
 /obj/effect/decal/remains/xeno,
 /turf/simulated/floor/outdoors/snow/lythios43c,
 /area/rift/surfacebase/underground/under2)
+"SC" = (
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/engine_waste)
 "SD" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet,
@@ -11834,8 +11975,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/atmos/hallway)
@@ -12627,11 +12768,11 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/atmos/hallway)
@@ -12684,6 +12825,12 @@
 /obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_monitoring)
+"Wx" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/atmos)
 "Wy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13310,8 +13457,8 @@
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/atmos/hallway)
@@ -30045,7 +30192,7 @@ FZ
 Jk
 KY
 Wp
-Qz
+dR
 aA
 ji
 Et
@@ -31208,10 +31355,10 @@ KE
 Hp
 Ir
 Ir
-Ir
-Ir
-Ir
-aa
+MW
+FF
+Lu
+vJ
 aa
 aa
 aa
@@ -31401,11 +31548,11 @@ LB
 eC
 vp
 Hp
-aa
-aa
-aa
-aa
-aa
+DS
+Bk
+NJ
+Ob
+vJ
 aa
 aa
 aa
@@ -31595,11 +31742,11 @@ qF
 RQ
 RQ
 Hp
-aa
-aa
-aa
-aa
-aa
+DS
+qr
+SC
+HE
+vJ
 aa
 aa
 aa
@@ -31789,11 +31936,11 @@ th
 Lw
 va
 Hp
-aa
-aa
-aa
-aa
-aa
+OT
+FB
+FB
+JS
+vJ
 aa
 aa
 aa
@@ -31983,11 +32130,11 @@ Hp
 Hp
 Hp
 Hp
-aa
-aa
-aa
-aa
-aa
+DH
+FB
+FB
+JS
+vJ
 aa
 aa
 aa
@@ -32167,21 +32314,21 @@ wG
 wG
 wG
 sW
-Rp
-zy
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Jb
+zf
+ks
+ks
+ks
+ks
+ks
+zf
+ks
+vJ
+vJ
+tQ
+vJ
+vJ
+vJ
 aa
 aa
 aa
@@ -32353,7 +32500,7 @@ Df
 SD
 hE
 Ko
-zy
+BL
 sW
 wG
 MN
@@ -32362,20 +32509,20 @@ Yx
 Xf
 Jb
 Jb
+ks
+ks
+ks
+ks
+ks
+ks
+Wx
+ks
+ks
+ks
+ks
+ks
+Uv
 zy
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -32547,7 +32694,7 @@ gp
 MJ
 gp
 DB
-zy
+DB
 wG
 Jc
 zy
@@ -32557,19 +32704,19 @@ zy
 zy
 aH
 zy
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+zy
+zy
+zy
+zy
+zy
+zy
+ks
+Jb
+ks
+ks
+ks
+FC
+zy
 aa
 aa
 aa
@@ -32737,10 +32884,10 @@ eh
 ep
 iJ
 Lj
-DS
-DS
-DS
-DS
+DB
+DB
+DB
+DB
 wG
 wG
 zy
@@ -32756,14 +32903,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+zy
+ks
+ks
+ks
+ks
+ks
+ks
+zy
 aa
 aa
 aa
@@ -32931,10 +33078,10 @@ Lj
 Lj
 Lj
 Lj
-DS
-DS
-DS
-DS
+DB
+DB
+DB
+DB
 wG
 MV
 zy
@@ -32950,14 +33097,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+zy
+ks
+ks
+ks
+ks
+ks
+Jb
+zy
 aa
 aa
 aa
@@ -33144,14 +33291,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+zy
+Jb
+kk
+ks
+Wx
+ks
+ks
+zy
 aa
 aa
 aa
@@ -33338,14 +33485,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+zy
+zy
+zy
+zy
+zy
+zy
+zy
+zy
 aa
 aa
 aa

--- a/_maps/map_files/rift/rift-08-west_deep.dmm
+++ b/_maps/map_files/rift/rift-08-west_deep.dmm
@@ -108,6 +108,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rift/facility/interior/temple)
+"aV" = (
+/turf/simulated/floor/tiled/monotile,
+/area/outpost/mining_main/refinery)
 "aZ" = (
 /obj/machinery/airlock_sensor/phoron{
 	pixel_x = 30;
@@ -119,6 +122,10 @@
 	},
 /obj/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/camera/network/mining{
+	c_tag = "OPM - Mining Production Room";
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -146,12 +153,24 @@
 /obj/structure/girder,
 /turf/simulated/floor/lythios43c/indoors,
 /area/rift/exterior/bunker/bottom)
-"bu" = (
-/obj/machinery/light/small{
-	dir = 8
+"bn" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techfloor,
+/area/quartermaster/belterdock)
+"bp" = (
+/obj/machinery/mineral/input,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "miningops_outpost"
 	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
+"bu" = (
 /obj/structure/cable/green{
 	icon_state = "1-6"
+	},
+/obj/machinery/door/airlock/multi_tile/metal/mait{
+	name = "Maintenance Access"
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/outpost/maintenance/north)
@@ -177,6 +196,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/outpost/maintenance/north)
+"bN" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "miningops_outpost"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
 "bR" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/power/apc{
@@ -300,6 +329,19 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/gateway)
+"dg" = (
+/obj/machinery/camera/network/mining{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock)
+"dq" = (
+/obj/machinery/mineral/output,
+/obj/machinery/conveyor{
+	id = "miningops_outpost"
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
 "ds" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -459,6 +501,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/machinery/camera/network/mining,
 /turf/simulated/floor/tiled/steel_grid,
 /area/outpost/mining_main/outpost/near_gateway)
 "fi" = (
@@ -477,6 +520,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/outpost/maintenance/north)
+"fm" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile,
+/area/outpost/mining_main/refinery)
 "fp" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 8
@@ -619,10 +666,26 @@
 /obj/structure/stairs/spawner/north,
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/outpost/near_gateway)
+"hg" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/outpost/maintenance/north)
 "hi" = (
 /obj/structure/barricade/cutout/fluke,
 /turf/simulated/floor/lythios43c/indoors,
 /area/rift/exterior/bunker/bottom)
+"hv" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
 "hC" = (
 /obj/effect/trap/pop_up/thrower{
 	id = "LF_DL_PS"
@@ -701,6 +764,14 @@
 "hW" = (
 /turf/simulated/floor/tiled/steel_dirty/lythios43c/indoors,
 /area/rift/exterior/bunker/bottom)
+"hX" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/camera/network/mining{
+	c_tag = "OPM - Mining Production Room";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
 "hZ" = (
 /obj/effect/debris/cleanable/blood/writing{
 	dir = 8;
@@ -1053,13 +1124,11 @@
 "kB" = (
 /obj/effect/floor_decal/techfloor/orange,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/machinery/camera/network/research_outpost{
 	dir = 1;
 	network = list("Research Outpost","Command")
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
 /area/gateway)
 "kC" = (
@@ -1101,6 +1170,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/outpost/mining_main/outpost/recreation)
+"kN" = (
+/obj/machinery/mineral/unloading_machine,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
 "kP" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 8
@@ -1329,6 +1402,13 @@
 /obj/item/pen,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/rift/facility/interior/janitorial)
+"mF" = (
+/obj/machinery/power/apc/direction_bump/south,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/outpost/mining_main/refinery)
 "mI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 8
@@ -1443,6 +1523,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/gateway)
+"ns" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/gateway)
 "nu" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/outpost/maintenance/north)
@@ -1494,6 +1583,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
+/obj/machinery/camera/network/mining{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/quartermaster/belterdock)
 "nK" = (
@@ -1632,6 +1724,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/camera/network/mining{
+	dir = 4
+	},
 /turf/simulated/shuttle/floor/voidcraft,
 /area/shuttle/belter)
 "pf" = (
@@ -1703,6 +1798,10 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/gateway)
+"pu" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
 "pC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1773,6 +1872,10 @@
 	},
 /turf/simulated/floor/lythios43c,
 /area/rift/facility/interior/undergound2)
+"qp" = (
+/obj/spawner/window/full/firelocks,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
 "qq" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 8
@@ -1912,6 +2015,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
+"rw" = (
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled/monotile,
+/area/outpost/mining_main/refinery)
 "rB" = (
 /turf/simulated/floor/tiled/monotile,
 /area/outpost/mining_main/outpost/recreation)
@@ -1985,6 +2092,10 @@
 /obj/item/bedsheet,
 /turf/simulated/floor/tiled/steel/lythios43c,
 /area/rift/facility/interior/prison)
+"sf" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/outpost/mining_main/outpost/recreation)
 "so" = (
 /turf/simulated/mineral/icerock/lythios43c,
 /area/rift/surfacebase/outside/west_deep)
@@ -2044,18 +2155,38 @@
 	},
 /turf/simulated/floor/tiled/steel/lythios43c,
 /area/rift/facility/interior/prison)
+"sZ" = (
+/obj/effect/floor_decal/industrial/loading{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
 "td" = (
 /obj/structure/cable/green{
 	icon_state = "4-9"
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/outpost/maintenance/north)
+"tf" = (
+/turf/simulated/wall,
+/area/gateway)
 "ti" = (
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/outpost/maintenance)
+"tj" = (
+/obj/structure/closet/crate,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/outpost/mining_main/refinery)
+"to" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/outpost/maintenance/north)
 "tq" = (
 /obj/random/landmine,
 /obj/machinery/light/small{
@@ -2154,6 +2285,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/gateway)
+"uf" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "miningops_outpost"
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
 "uj" = (
 /obj/effect/floor_decal/corner/white/diagonal{
 	dir = 4
@@ -2219,12 +2357,8 @@
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/outpost/airlock/three)
 "uJ" = (
-/obj/effect/floor_decal/techfloor/orange,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/gateway)
+/turf/simulated/wall,
+/area/outpost/mining_main/refinery)
 "uL" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/mining_main/outpost)
@@ -2308,8 +2442,9 @@
 /area/quartermaster/belterdock)
 "vA" = (
 /obj/effect/floor_decal/techfloor/orange,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/gateway)
@@ -2325,6 +2460,12 @@
 "vJ" = (
 /turf/simulated/wall,
 /area/rift/facility/interior/janitorial)
+"vX" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
 "wb" = (
 /turf/simulated/floor/outdoors/safeice/lythios43c,
 /area/rift/exterior/bunker/bottom)
@@ -2393,6 +2534,15 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/shuttle/floor/voidcraft,
 /area/shuttle/belter)
+"wQ" = (
+/obj/machinery/conveyor{
+	id = "miningops_outpost"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
 "wS" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -2439,6 +2589,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
+/obj/machinery/camera/network/mining,
 /turf/simulated/floor/wood,
 /area/outpost/mining_main/outpost/recreation)
 "xo" = (
@@ -2473,6 +2624,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/gateway/prep_room)
+"xJ" = (
+/obj/machinery/atmospherics/component/unary/vent_pump/on,
+/turf/simulated/floor/tiled,
+/area/gateway)
 "xK" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
@@ -2511,6 +2666,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rift/facility/interior/temple)
+"xZ" = (
+/obj/machinery/mineral/mint,
+/turf/simulated/floor/tiled/monotile,
+/area/outpost/mining_main/refinery)
+"yk" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/gateway/prep_room)
 "yn" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 6
@@ -2676,6 +2839,25 @@
 "zr" = (
 /turf/simulated/floor/outdoors/rocks/caves,
 /area/rift/surfacebase/outside/west_deep)
+"zv" = (
+/obj/machinery/mineral/input,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "miningops_outpost"
+	},
+/obj/structure/sign/warning/moving_parts{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
+"zz" = (
+/obj/machinery/mineral/output,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "miningops_outpost"
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
 "zA" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Gateway Civilian Prep";
@@ -2841,6 +3023,10 @@
 /obj/effect/floor_decal/corner/beige/bordercorner,
 /turf/simulated/floor/tiled/steel_dirty/lythios43c/indoors,
 /area/rift/facility/interior/undergound2)
+"Bm" = (
+/obj/effect/floor_decal/industrial/loading,
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
 "Bu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_grid,
@@ -2962,6 +3148,9 @@
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/machinery/camera/network/mining{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/outpost/mining_main/outpost/airlock/three)
 "Cu" = (
@@ -3026,6 +3215,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/outpost/maintenance/north)
+"CM" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain/open/shower,
+/turf/simulated/floor/tiled/white,
+/area/gateway)
 "CN" = (
 /turf/simulated/floor/carpet/bcarpet,
 /area/rift/facility/interior/temple)
@@ -3092,6 +3297,12 @@
 "Di" = (
 /obj/effect/floor_decal/techfloor/orange,
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/gateway)
 "Dk" = (
@@ -3125,6 +3336,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/outpost/underground)
+"DB" = (
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled,
+/area/gateway)
 "DC" = (
 /obj/machinery/gateway{
 	dir = 4
@@ -3140,6 +3355,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/outpost/mining_main/outpost/recreation)
+"DX" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/outpost/maintenance/north)
 "DY" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -3163,6 +3384,17 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty/lythios43c/indoors,
 /area/rift/facility/interior/undergound2)
+"Ei" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "miningops_outpost";
+	name = "Mining Ops conveyor switch";
+	pixel_x = 10;
+	pixel_y = 5;
+	req_access = list(48);
+	req_one_access = list(48)
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
 "Ej" = (
 /obj/structure/cable/green{
 	icon_state = "6-8"
@@ -3267,6 +3499,16 @@
 "EY" = (
 /turf/simulated/floor/plating,
 /area/rnd/outpost/maintenance)
+"EZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/camera/network/research_outpost{
+	dir = 4;
+	network = list("Research Outpost","Command")
+	},
+/turf/simulated/floor/tiled,
+/area/gateway)
 "Fg" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -3311,6 +3553,10 @@
 /obj/random/crystal,
 /turf/simulated/mineral/floor/ignore_cavegen/has_air,
 /area/rift/surfacebase/outside/west_deep)
+"Fz" = (
+/obj/machinery/mineral/processing_unit_console,
+/turf/simulated/wall,
+/area/outpost/mining_main/refinery)
 "FC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3319,6 +3565,12 @@
 "FI" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/gateway)
@@ -3344,6 +3596,9 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/outpost/underground)
+"Gf" = (
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
 "Gl" = (
 /turf/simulated/wall/solidrock,
 /area/rift/surfacebase/outside/west_deep)
@@ -3566,6 +3821,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techfloor,
 /area/gateway)
 "Is" = (
@@ -3583,6 +3839,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/outpost/substation)
+"IC" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/simulated/floor/tiled/monotile,
+/area/outpost/mining_main/refinery)
 "IE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -3619,6 +3879,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
+"IZ" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/outpost/mining_main/outpost/near_gateway)
 "Jd" = (
 /obj/random/outcrop,
 /turf/simulated/mineral/floor/icerock/lythios43c/indoors/ignore_cavegen,
@@ -3645,12 +3909,11 @@
 /turf/simulated/floor/outdoors/rocks/lythios43c/indoors,
 /area/rift/surfacebase/outside/west_deep)
 "Jo" = (
-/obj/machinery/power/apc/direction_bump/west,
-/obj/structure/cable/green{
-	icon_state = "0-6"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/outpost/mining_main/outpost/airlock/three)
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
 "Jq" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3785,6 +4048,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/outpost/maintenance/north)
+"Kl" = (
+/obj/machinery/camera/network/mining{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile,
+/area/outpost/mining_main/refinery)
 "Kn" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor/plating,
@@ -3995,6 +4265,20 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/outpost/mining_main/outpost/airlock/three)
+"Mp" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2;
+	req_one_access = list(48);
+	name = "Material Processing"
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/outpost/mining_main/refinery)
 "MD" = (
 /obj/item/radio/intercom{
 	pixel_y = -24
@@ -4030,6 +4314,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
+/obj/machinery/power/apc/direction_bump/south,
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/outpost/mining_main/outpost/airlock/three)
 "Na" = (
@@ -4039,6 +4327,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
+/area/gateway)
+"Nc" = (
+/turf/simulated/floor/tiled,
 /area/gateway)
 "Ne" = (
 /obj/machinery/door/firedoor/multi_tile,
@@ -4150,6 +4441,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/quartermaster/belterdock)
+"Of" = (
+/obj/structure/sign/warning/moving_parts{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/outpost/mining_main/refinery)
 "Ok" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -4173,6 +4470,15 @@
 /obj/effect/floor_decal/techfloor/orange/corner,
 /turf/simulated/floor/tiled/techfloor/grid/lythios43c/indoors,
 /area/rift/facility/interior/undergound2)
+"Ou" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/multi_tile/metal/mait{
+	name = "Maintenance Access"
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/outpost/maintenance/north)
 "Ow" = (
 /obj/machinery/suit_cycler/mining{
 	req_access = null
@@ -4249,19 +4555,22 @@
 	},
 /turf/simulated/floor/wood,
 /area/outpost/mining_main/outpost/recreation)
+"Ph" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/outpost/maintenance/north)
 "Pj" = (
 /obj/item/paper/crumpled,
 /turf/simulated/floor/tiled/dark,
 /area/rift/facility/interior/temple)
 "Pq" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
 /obj/structure/cable/green{
 	icon_state = "0-6"
 	},
+/obj/machinery/power/apc/direction_bump/west,
 /turf/simulated/floor/tiled/techfloor,
 /area/quartermaster/belterdock)
 "Pz" = (
@@ -4276,6 +4585,10 @@
 "PJ" = (
 /turf/simulated/floor/tiled/steel_dirty,
 /area/rift/facility/interior/undergound2)
+"PL" = (
+/obj/machinery/mineral/processing_unit,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
 "PM" = (
 /obj/effect/floor_decal/industrial/halfstair,
 /turf/simulated/floor/tiled/dark,
@@ -4449,6 +4762,10 @@
 	},
 /turf/simulated/open,
 /area/rift/surfacebase/outside/west_deep)
+"Sg" = (
+/obj/spawner/window/full/firelocks,
+/turf/simulated/floor/plating,
+/area/gateway)
 "Si" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/outpost/substation)
@@ -4763,6 +5080,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/outpost/maintenance)
+"UZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/gateway)
 "Vd" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4783,6 +5107,14 @@
 /obj/structure/barricade/cutout,
 /turf/simulated/floor/tiled/steel_dirty/lythios43c/indoors,
 /area/rift/exterior/bunker/bottom)
+"Vy" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "miningops_outpost"
+	},
+/obj/structure/plasticflaps/mining,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
 "Vz" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -4859,6 +5191,22 @@
 /obj/effect/overlay/snow/floor,
 /turf/simulated/floor/lythios43c/indoors,
 /area/rift/facility/interior/undergound2)
+"Wd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/camera/network/mining{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/quartermaster/belterdock)
+"Wg" = (
+/obj/machinery/washing_machine,
+/turf/simulated/floor/tiled,
+/area/gateway)
 "Wj" = (
 /obj/machinery/crystal/lava,
 /turf/simulated/floor/water/indoors,
@@ -4981,6 +5329,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
+"WY" = (
+/obj/machinery/conveyor{
+	id = "miningops_outpost"
+	},
+/obj/structure/plasticflaps,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
 "Xb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/green{
@@ -4997,6 +5352,19 @@
 "Xl" = (
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/rift/facility/interior/elevator)
+"Xu" = (
+/obj/machinery/door/airlock/glass_science{
+	req_one_access = null;
+	name = "Decontamination"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/gateway)
 "Xy" = (
 /obj/machinery/porta_turret/stationary{
 	health = 200
@@ -5080,6 +5448,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/outpost/underground)
+"Yj" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/outpost/mining_main/refinery)
 "Ym" = (
 /turf/simulated/floor/bluegrid,
 /area/gateway/prep_room)
@@ -5213,10 +5587,10 @@
 	dir = 6
 	},
 /obj/structure/cable/green{
-	icon_state = "2-9"
+	icon_state = "2-5"
 	},
 /obj/structure/cable/green{
-	icon_state = "2-5"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/outpost/mining_main/outpost/airlock/three)
@@ -32322,17 +32696,17 @@ WW
 WW
 WW
 WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
 WW
 WW
 WW
@@ -32516,17 +32890,17 @@ WW
 WW
 WW
 WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-so
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+XQ
 so
 so
 so
@@ -32707,20 +33081,20 @@ WW
 WW
 WW
 WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-so
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+XQ
 so
 so
 so
@@ -32901,22 +33275,22 @@ WW
 WW
 WW
 WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-so
-so
-so
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
 so
 so
 XQ
@@ -32941,11 +33315,11 @@ so
 so
 so
 so
-so
-so
-XQ
-XQ
-XQ
+tf
+tf
+tf
+tf
+tf
 XQ
 XQ
 XQ
@@ -33086,31 +33460,31 @@ WW
 WW
 WW
 WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-so
-so
-so
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+uJ
+uJ
+uJ
+uJ
+uJ
+uJ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
 so
 XQ
 XQ
@@ -33135,11 +33509,11 @@ so
 so
 so
 so
-so
-so
-XQ
-XQ
-XQ
+tf
+CM
+DB
+EZ
+tf
 XQ
 XQ
 XQ
@@ -33280,31 +33654,31 @@ WW
 WW
 WW
 WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-so
-so
-so
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+MI
+uJ
+uf
+sZ
+Yj
+Kl
+uJ
+uJ
+XQ
+XQ
+XQ
+XQ
+XQ
 so
 XQ
 XQ
@@ -33329,11 +33703,11 @@ so
 so
 so
 so
-XQ
-XQ
-XQ
-XQ
-XQ
+tf
+CM
+Nc
+UZ
+tf
 XQ
 XQ
 XQ
@@ -33474,30 +33848,30 @@ so
 so
 so
 so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+uJ
+zv
+sZ
+hv
+aV
+IC
+uJ
+uJ
+XQ
+XQ
+XQ
 XQ
 XQ
 XQ
@@ -33523,11 +33897,11 @@ XQ
 XQ
 XQ
 XQ
-XQ
-XQ
-XQ
-XQ
-XQ
+tf
+Wg
+xJ
+ns
+tf
 XQ
 XQ
 XQ
@@ -33668,30 +34042,30 @@ ky
 so
 so
 so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+uJ
+kN
+qp
+vX
+aV
+aV
+fm
+uJ
+uJ
+XQ
+XQ
 XQ
 XQ
 Ga
@@ -33719,8 +34093,8 @@ kt
 kt
 kt
 kt
-kt
-kt
+Sg
+Xu
 kt
 XQ
 XQ
@@ -33862,30 +34236,30 @@ ky
 ky
 so
 so
-so
 XQ
 XQ
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
 XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+XQ
+uJ
+zz
+qp
+Gf
+Gf
+aV
+aV
+xZ
+uJ
+uJ
+so
 XQ
 ge
 ky
@@ -34066,19 +34440,19 @@ XQ
 XQ
 XQ
 XQ
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
+XQ
+XQ
+XQ
+uJ
+Vy
+Fz
+Gf
+pu
+Gf
+aV
+aV
+tj
+uJ
 XQ
 XQ
 Bz
@@ -34260,19 +34634,19 @@ XQ
 XQ
 XQ
 XQ
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
-so
+XQ
+XQ
+XQ
+uJ
+bN
+qp
+Ei
+Gf
+Gf
+Gf
+aV
+rw
+uJ
 XQ
 XQ
 XQ
@@ -34455,18 +34829,18 @@ XQ
 XQ
 XQ
 XQ
-XQ
-XQ
-XQ
-XQ
-XQ
-XQ
 so
 XQ
-XQ
-XQ
-XQ
-XQ
+uJ
+bp
+qp
+qp
+qp
+Jo
+Jo
+aV
+Of
+uJ
 XQ
 XQ
 XQ
@@ -34496,7 +34870,7 @@ ue
 bi
 lY
 pI
-uJ
+BS
 JM
 Gc
 VV
@@ -34651,16 +35025,16 @@ XQ
 XQ
 XQ
 XQ
-XQ
-XQ
-XQ
-XQ
-XQ
-XQ
-XQ
-XQ
-XQ
-XQ
+uJ
+PL
+dq
+wQ
+WY
+Bm
+hX
+aV
+mF
+uJ
 XQ
 XQ
 XQ
@@ -34847,14 +35221,14 @@ Yr
 Yr
 Yr
 Yr
-Nw
-Nw
-Nw
-Nw
-Nw
-Nw
-Nw
-Nw
+uJ
+uJ
+uJ
+uJ
+uJ
+aV
+Mp
+uJ
 Nw
 Nw
 Nw
@@ -35045,12 +35419,12 @@ Jq
 Jq
 tK
 Jq
-Jq
-Jq
-Jq
+Ou
+Ph
+hg
 bu
 nu
-nu
+DX
 Nw
 XQ
 XQ
@@ -35240,8 +35614,8 @@ nu
 nu
 nu
 nu
-nu
-nu
+to
+to
 nu
 td
 nu
@@ -35434,8 +35808,8 @@ HH
 HH
 HH
 HH
-HH
-HH
+XN
+XN
 Nw
 wn
 nu
@@ -35628,7 +36002,7 @@ HH
 ia
 Cv
 HH
-Jo
+XN
 yD
 Nw
 Ej
@@ -36429,7 +36803,7 @@ FC
 lf
 lf
 ls
-PQ
+IZ
 PQ
 cG
 lh
@@ -36437,7 +36811,7 @@ CV
 et
 TF
 Da
-TF
+yk
 TF
 qA
 yK
@@ -37176,8 +37550,8 @@ oF
 Ij
 vI
 Cl
-Cl
-nz
+bn
+Wd
 rn
 hM
 kK
@@ -37948,7 +38322,7 @@ cK
 dP
 uZ
 uu
-Ij
+dg
 rn
 rn
 RO
@@ -37957,7 +38331,7 @@ rn
 rn
 jZ
 jm
-iY
+sf
 iY
 rb
 St

--- a/_maps/map_files/rift/rift-09-west_caves.dmm
+++ b/_maps/map_files/rift/rift-09-west_caves.dmm
@@ -89,6 +89,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/machinery/camera/network/mining{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/outpost/mining_main/outpost/substation)
 "be" = (
@@ -611,6 +614,15 @@
 	},
 /turf/simulated/open/lythios43c/indoors,
 /area/rift/surfacebase/outside/west_caves)
+"gY" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/clothing/shoes/black,
+/obj/machinery/camera/network/mining{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/outpost/mining_main/outpost/storage)
 "hd" = (
 /obj/structure/transit_tube/high_velocity{
 	icon_state = "N-S-Pass"
@@ -1887,6 +1899,9 @@
 /obj/structure/transit_tube/high_velocity{
 	icon_state = "S-NE"
 	},
+/obj/machinery/camera/network/mining{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/outpost/mining_main/outpost)
 "wg" = (
@@ -2730,6 +2745,9 @@
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/outpost)
 "Et" = (
+/obj/machinery/camera/network/mining{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/outpost/maintenance)
 "EB" = (
@@ -2876,8 +2894,15 @@
 	on = 1;
 	scrub_id = "mining_outpost1_airlock_scrubber"
 	},
+/obj/machinery/camera/network/mining{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/outpost/airlock/three)
+"Gg" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/outpost)
 "Gm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/green{
@@ -3643,6 +3668,9 @@
 	dir = 8
 	},
 /obj/structure/table/steel_reinforced,
+/obj/machinery/camera/network/mining{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/outpost)
 "Qa" = (
@@ -3883,6 +3911,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid/lythios43c/indoors,
 /area/rift/facility/interior/command)
+"SC" = (
+/obj/machinery/camera/network/mining{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/lythios43c,
+/area/outpost/mining_main/outpost)
 "SK" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -4552,6 +4586,16 @@
 	},
 /turf/simulated/floor/lythios43c/indoors,
 /area/rift/surfacebase/outside/west_caves)
+"Zo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/network/mining{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/outpost/mining_main/outpost/washrooms)
 "Zp" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -35344,7 +35388,7 @@ Jl
 PB
 TR
 QQ
-ui
+SC
 gq
 gq
 GF
@@ -35920,7 +35964,7 @@ Ku
 ga
 rM
 gU
-iO
+Gg
 gU
 iO
 Qa
@@ -37084,7 +37128,7 @@ Sv
 PO
 tB
 KA
-KA
+gY
 WJ
 Xl
 Uj
@@ -37097,7 +37141,7 @@ vV
 FC
 jw
 uJ
-oM
+Zo
 oM
 Xz
 UH

--- a/_maps/map_files/rift/rift-10-west_plains.dmm
+++ b/_maps/map_files/rift/rift-10-west_plains.dmm
@@ -932,6 +932,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/machinery/camera/network/mining{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/outpost/mining_main/outpost/airlock/one)
 "eA" = (
@@ -2991,6 +2994,7 @@
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/outpost/airlock/one)
 "ok" = (
+/obj/structure/closet/firecloset,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -26
@@ -3738,6 +3742,9 @@
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
+/obj/machinery/camera/network/mining{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/outpost/airlock/one)
 "rJ" = (
@@ -4261,11 +4268,20 @@
 /turf/simulated/floor/outdoors/snow/lythios43c,
 /area/rift/surfacebase/outside/west)
 "ub" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain/open/shower,
+/turf/simulated/floor/tiled/white,
 /area/rnd/outpost/anomaly_lab)
 "ug" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
@@ -4936,6 +4952,10 @@
 /obj/structure/window/reinforced{
 	dir = 8;
 	health = 1e+006
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/anomaly_lab)
@@ -5757,6 +5777,10 @@
 /obj/item/paper_bin,
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/anomaly_lab)
@@ -8058,6 +8082,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 1
 	},
+/obj/structure/sign/signnew/radiation{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/outpost/anomaly_lab)
 "MB" = (
@@ -9161,6 +9188,11 @@
 	},
 /turf/simulated/floor/reinforced/lythios43c,
 /area/rift/facility/exterior)
+"Ry" = (
+/obj/machinery/light/flamp/noshade,
+/obj/machinery/camera/network/mining,
+/turf/simulated/floor/plating/lythios43c,
+/area/rift/surfacebase/outside/west)
 "Rz" = (
 /obj/structure/sandbag,
 /turf/simulated/floor/tiled/steel_dirty/lythios43c,
@@ -38054,7 +38086,7 @@ qx
 iw
 nI
 YU
-ok
+ub
 Et
 sv
 sv
@@ -39218,7 +39250,7 @@ st
 bJ
 mj
 YU
-Uj
+ok
 Et
 sv
 sv
@@ -43999,7 +44031,7 @@ ex
 vp
 vp
 mr
-bL
+Ry
 sv
 sv
 sv

--- a/_maps/map_levels/192x192/lavaland.dmm
+++ b/_maps/map_levels/192x192/lavaland.dmm
@@ -38,16 +38,12 @@
 /turf/simulated/floor/outdoors/lavaland,
 /area/lavaland/central/explored)
 "ci" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "wind_orange"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/camera/network/mining{
+	dir = 8
 	},
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor{
-	req_one_access = list(48)
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "cj" = (
 /turf/simulated/floor/tiled/dark/lavaland,
@@ -75,6 +71,9 @@
 	},
 /obj/structure/closet/firecloset,
 /obj/structure/closet/firecloset,
+/obj/machinery/camera/network/mining{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "db" = (
@@ -436,6 +435,9 @@
 	dir = 1;
 	target_pressure = 15000
 	},
+/obj/machinery/camera/network/mining{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "ki" = (
@@ -558,6 +560,9 @@
 	power_rating = 20000
 	},
 /obj/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/camera/network/mining{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "mm" = (
@@ -576,15 +581,8 @@
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "mq" = (
-/obj/machinery/door/firedoor{
-	req_one_access = list(48)
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced/full,
-/turf/simulated/floor/plating,
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "mr" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -912,6 +910,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/camera/network/mining{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "qU" = (
@@ -974,13 +975,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -28
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/high/south_bump,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "sx" = (
@@ -994,14 +992,30 @@
 	},
 /turf/simulated/floor/outdoors/lava/lavaland,
 /area/lavaland/central/explored)
-"sJ" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor{
+"sH" = (
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	frequency = 1384;
+	id_tag = "mining_outpost";
+	pixel_y = 25;
 	req_one_access = list(48)
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced/full,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
+/area/lavaland/central/base/common)
+"sJ" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 8
+	},
+/obj/structure/curtain/open/shower/engineering,
+/turf/simulated/floor/tiled/white,
 /area/lavaland/central/base/common)
 "sN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -1048,6 +1062,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 1
 	},
+/obj/machinery/camera/network/mining{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "sV" = (
@@ -1071,16 +1088,9 @@
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "te" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor{
-	req_one_access = list(48)
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced/full,
-/turf/simulated/floor/plating,
-/area/lavaland/central/base/common)
+/obj/structure/sign/warning/lava,
+/turf/simulated/wall/r_wall,
+/area/lavaland/central/explored)
 "tn" = (
 /obj/structure/sink{
 	dir = 8;
@@ -1149,6 +1159,10 @@
 /obj/machinery/vending/coffee,
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/machinery/camera/network/mining{
+	c_tag = "OPM - Mining Production Room";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
@@ -1435,6 +1449,9 @@
 /area/lavaland/central/base/common)
 "zt" = (
 /obj/machinery/vending/fitness,
+/obj/machinery/camera/network/mining{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "zv" = (
@@ -1451,6 +1468,9 @@
 	},
 /mob/living/simple_mob/animal/passive/mouse/gray{
 	name = "Jerry"
+	},
+/obj/machinery/camera/network/mining{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/lavaland/central/base/common)
@@ -1529,14 +1549,7 @@
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "BY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor{
-	req_one_access = list(48)
-	},
+/obj/spawner/window/reinforced/full/firelocks,
 /obj/structure/curtain/black,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
@@ -1595,6 +1608,10 @@
 "DG" = (
 /turf/simulated/floor/outdoors/lava/lavaland,
 /area/lavaland/central/explored)
+"DW" = (
+/obj/structure/sign/warning/lava,
+/turf/simulated/wall/r_wall,
+/area/lavaland/central/base/common)
 "Em" = (
 /obj/machinery/door/firedoor/multi_tile{
 	req_one_access = list(48)
@@ -1730,15 +1747,11 @@
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "Il" = (
-/obj/machinery/door/firedoor{
-	req_one_access = list(48)
+/obj/machinery/camera/network/mining{
+	dir = 4
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced/full,
-/turf/simulated/floor/plating,
+/obj/machinery/washing_machine,
+/turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "Iq" = (
 /obj/machinery/light/small{
@@ -1836,6 +1849,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
+"KZ" = (
+/obj/machinery/mech_recharger,
+/obj/machinery/camera/network/mining{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/lavaland/central/base/common)
 "La" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -1923,15 +1943,13 @@
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "NH" = (
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+/obj/machinery/airlock_sensor{
+	dir = 1;
 	frequency = 1384;
 	id_tag = "mining_outpost";
-	pixel_y = 25;
-	req_one_access = list(48)
+	pixel_y = -25
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
+/obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "NN" = (
@@ -1951,15 +1969,7 @@
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "NW" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "wind_blue"
-	},
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor{
-	req_one_access = list(48)
-	},
+/obj/spawner/window/reinforced/full/firelocks,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "Ob" = (
@@ -2176,21 +2186,9 @@
 /turf/simulated/mineral/triumph/lavaland,
 /area/lavaland/central/unexplored)
 "Sa" = (
-/obj/machinery/airlock_sensor{
-	dir = 1;
-	frequency = 1384;
-	id_tag = "mining_outpost";
-	pixel_y = -25
+/obj/machinery/camera/network/mining{
+	dir = 1
 	},
-/obj/map_helper/airlock/sensor/chamber_sensor,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
-	dir = 1;
-	frequency = 1384;
-	id_tag = "mining_outpost";
-	power_rating = 20000
-	},
-/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "Sm" = (
@@ -2356,6 +2354,9 @@
 /area/lavaland/central/base/common)
 "Vw" = (
 /obj/structure/flora/pottedplant/subterranean,
+/obj/machinery/camera/network/mining{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "VA" = (
@@ -2391,8 +2392,6 @@
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "VT" = (
-/obj/structure/table/rack,
-/obj/item/storage/bag/ore,
 /obj/structure/sign/warning{
 	desc = "Warning: The PMD has confirmed multiple Memetic Hazards in this area. Please wear the appropriate protection.";
 	name = "\improper MEMETIC HAZARD";
@@ -2401,17 +2400,23 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/item/gun/energy/kinetic_accelerator,
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "VX" = (
-/obj/machinery/door/firedoor{
-	req_one_access = list(48)
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced/full,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain/open/shower/engineering,
+/turf/simulated/floor/tiled/white,
 /area/lavaland/central/base/common)
 "VY" = (
 /obj/machinery/light/small{
@@ -2484,15 +2489,11 @@
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "Wv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor{
-	req_one_access = list(48)
-	},
-/turf/simulated/floor/plating,
+/obj/item/geiger,
+/obj/item/geiger,
+/obj/item/geiger,
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "Wy" = (
 /obj/structure/flora/pottedplant/smalltree{
@@ -8889,11 +8890,11 @@ DG
 gy
 gy
 AO
-Wv
-Wv
+NW
+NW
 AO
 AO
-ci
+NW
 AO
 MX
 MX
@@ -9862,7 +9863,7 @@ db
 ew
 YJ
 eM
-VX
+NW
 MX
 MX
 MX
@@ -10056,7 +10057,7 @@ ew
 ew
 Zh
 VC
-VX
+NW
 MX
 MX
 MX
@@ -10250,7 +10251,7 @@ ew
 ew
 Zw
 Cg
-VX
+NW
 MX
 MX
 MX
@@ -10444,7 +10445,7 @@ db
 ew
 YJ
 ut
-VX
+NW
 MX
 MX
 MX
@@ -11016,7 +11017,7 @@ AO
 AO
 AO
 Bp
-ew
+Sa
 db
 FI
 db
@@ -11804,7 +11805,7 @@ zE
 oX
 YS
 ew
-sJ
+NW
 MX
 MX
 gy
@@ -11973,7 +11974,7 @@ Cq
 WX
 Ki
 AO
-AO
+DW
 QA
 lF
 AO
@@ -11998,7 +11999,7 @@ vX
 bH
 uh
 ew
-VX
+NW
 MX
 gy
 gy
@@ -12192,7 +12193,7 @@ ce
 KG
 Ro
 ew
-sJ
+NW
 gy
 gy
 MX
@@ -12382,7 +12383,7 @@ ew
 Vw
 AO
 WZ
-QR
+ci
 xh
 VD
 SL
@@ -12573,7 +12574,7 @@ db
 HA
 Mw
 ew
-VA
+ew
 AO
 AO
 AO
@@ -12769,8 +12770,8 @@ Mw
 ew
 VT
 AO
-AO
-xf
+KZ
+ew
 tU
 xV
 AO
@@ -12951,9 +12952,9 @@ MX
 MX
 MX
 AO
-te
-te
-mq
+NW
+NW
+NW
 AO
 gy
 gy
@@ -12963,8 +12964,8 @@ MV
 RE
 AO
 AO
-AO
 xf
+ew
 Pv
 Ob
 AO
@@ -13151,17 +13152,17 @@ gy
 gy
 gy
 gy
-gy
+NW
 Il
 ND
 RJ
 VX
-gy
-Il
+AO
 Kj
+ew
 ub
 Iy
-VX
+NW
 gy
 gy
 MX
@@ -13345,17 +13346,17 @@ gy
 MX
 MX
 gy
-gy
 AO
+sH
+ND
+Sm
 NH
-Sa
 AO
-gy
-AO
-te
-te
+Wv
+VA
+VA
 mq
-AO
+NW
 MX
 gy
 MX
@@ -13539,17 +13540,17 @@ MX
 MX
 MX
 MX
-gy
-Il
+NW
+PZ
 NN
 Sm
-VX
-gy
-gy
-gy
-gy
-gy
-MX
+sJ
+AO
+AO
+AO
+NW
+NW
+AO
 MX
 MX
 MX
@@ -13733,12 +13734,12 @@ MX
 MX
 MX
 MX
-gy
+AO
 AO
 NV
 Ss
 AO
-gy
+AO
 gy
 gy
 gy
@@ -14127,7 +14128,7 @@ gy
 gy
 gy
 gy
-MX
+te
 MX
 MX
 MX


### PR DESCRIPTION
## About The Pull Request

Adds in Decontamination showers at the science outpost, engineering, lower part of the station's mining elevator, and lava land mining base. Adds in ore processing on mining outpost. Adds in cameras to mining outpost and lava land mining base.

![image](https://user-images.githubusercontent.com/10539415/206328549-7d12952f-30a4-4c94-84c7-278ca9766792.png)
![image](https://user-images.githubusercontent.com/10539415/206328612-e99fc63c-01a9-4544-b89f-27553f069fbc.png)
![image](https://user-images.githubusercontent.com/10539415/206328631-c358afa5-567a-4f63-ba7a-3a924012ff1f.png)
![image](https://user-images.githubusercontent.com/10539415/206329278-3ec582ec-f616-4b27-be83-aeaad4baba7d.png)
![image](https://user-images.githubusercontent.com/10539415/206328683-f7d3c219-da33-40b0-86ea-c81d4e10f42d.png)
![image](https://user-images.githubusercontent.com/10539415/206328503-85e24c4f-1036-4ae6-887a-e5d6eddb9fea.png)
![image](https://user-images.githubusercontent.com/10539415/206328756-cceb993e-9ea1-41e5-8a1a-c305eb1d2efa.png)

## Why It's Good For The Game
Prep for radiation rework (showers and washing machines for decontaminations). Ore processing as per Silicon's request. Mining network cameras because outpost should have cameras.

## Changelog

:cl:
add: Cameras to outpost, showers in various places, ore processing on mining outpost
/:cl:
