### PR TITLE
Add paperwork stuff to engineering

### DIFF
--- a/_maps/map_files/rift/rift-02-underground2.dmm
+++ b/_maps/map_files/rift/rift-02-underground2.dmm
@@ -9700,6 +9700,13 @@
 	pixel_y = 7
 	},
 /obj/item/pen/red,
+/obj/item/folder/yellow{
+	pixel_x = 9
+	},
+/obj/item/folder/yellow{
+	pixel_x = 9;
+	pixel_y = 5
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_monitoring)
 "IQ" = (
@@ -10419,8 +10426,8 @@
 "Mb" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/single_use/med_pouch/radiation{
-	pixel_y = -7;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = -7
 	},
 /obj/item/storage/single_use/med_pouch/trauma{
 	pixel_x = -7;
@@ -12856,6 +12863,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/wood,
 /area/engineering/break_room)
 "Xq" = (
@@ -13261,6 +13269,7 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/wood,
 /area/engineering/break_room)
 "Zj" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a couple folders to the table in the monitoring room, and a photocopier and shredder in the break room.

## Why It's Good For The Game

Having only one measly paper bin for paperwork is a little pathetic.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added some folders and paperwork equipment to the engineering department.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
