### PR TITLE
nerfs haste

### DIFF
--- a/code/modules/mob/living/carbon/human/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/traits/positive.dm
@@ -1,8 +1,9 @@
 /datum/trait/positive/speed_fast
 	name = "Haste"
 	desc = "Allows you to move faster on average than baseline."
-	cost = 3
+	cost = 2
 	var_changes = list("slowdown" = -0.25)
+	excludes = list(/datum/trait/positive/hardy, /datum/trait/positive/hardy_plus)
 
 /datum/trait/positive/hardy
 	name = "Hardy"

--- a/code/modules/mob/living/carbon/human/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/traits/positive.dm
@@ -1,8 +1,8 @@
 /datum/trait/positive/speed_fast
 	name = "Haste"
 	desc = "Allows you to move faster on average than baseline."
-	cost = 4
-	var_changes = list("slowdown" = -0.5)
+	cost = 3
+	var_changes = list("slowdown" = -0.25)
 
 /datum/trait/positive/hardy
 	name = "Hardy"

--- a/code/modules/mob/living/carbon/human/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/traits/positive.dm
@@ -2,7 +2,7 @@
 	name = "Haste"
 	desc = "Allows you to move faster on average than baseline."
 	cost = 2
-	var_changes = list("slowdown" = -0.25)
+	var_changes = list("slowdown" = -0.2)
 	excludes = list(/datum/trait/positive/hardy, /datum/trait/positive/hardy_plus)
 
 /datum/trait/positive/hardy


### PR DESCRIPTION
getting +1.67 tiles/second movespeed should not be a trait at all
the rest of the traits will be dealt with as we roll out the new characteristics & modifications system over the next month or two.

in return, haste will have its point value dropped and also made mutually exclusive to hardy.