### PR TITLE
Pasta's Crimmas Bar Patch [TM ONLY]

### DIFF
--- a/_maps/map_files/rift/rift-05-surface2.dmm
+++ b/_maps/map_files/rift/rift-05-surface2.dmm
@@ -9386,10 +9386,6 @@
 	pixel_x = -2;
 	pixel_y = -2
 	},
-/obj/item/storage/box/body_record_disk{
-	pixel_x = 6;
-	pixel_y = -4
-	},
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10

--- a/_maps/map_files/rift/rift-05-surface2.dmm
+++ b/_maps/map_files/rift/rift-05-surface2.dmm
@@ -214,12 +214,16 @@
 /turf/simulated/wall,
 /area/maintenance/locker)
 "alV" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/random/trash_pile,
-/turf/simulated/floor/plating,
-/area/maintenance/research/rnd)
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/coffee_shop)
 "alW" = (
 /turf/simulated/wall,
 /area/assembly/robotics)
@@ -1203,6 +1207,7 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
 "aTy" = (
@@ -1216,6 +1221,22 @@
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
+"aTY" = (
+/obj/structure/sign/christmas/lights{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights,
+/obj/structure/table/hardwoodtable,
+/obj/machinery/reagentgrinder{
+	pixel_y = 6;
+	pixel_x = 2
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "aUD" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -1494,6 +1515,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
+"bcw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "bcO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2135,6 +2166,20 @@
 /obj/effect/mist,
 /turf/simulated/floor/water/deep/pool,
 /area/crew_quarters/pool)
+"bvQ" = (
+/obj/machinery/door/airlock/freezer{
+	name = "Cafe Backroom";
+	req_access = list(28);
+	req_one_access = newlist()
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/coffee_shop)
 "bxf" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -2869,12 +2914,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/locker)
 "cee" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/closet/firecloset,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
-/area/maintenance/research/rnd)
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "cem" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3394,6 +3437,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
+"cxe" = (
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/coffee_shop)
 "cxh" = (
 /obj/machinery/photocopier,
 /obj/machinery/light{
@@ -3613,6 +3663,10 @@
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
@@ -3859,6 +3913,9 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "cQJ" = (
@@ -4248,6 +4305,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rift/trade_shop/loading)
+"dlo" = (
+/obj/machinery/chem_master/condimaster,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/coffee_shop)
 "dlX" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -4281,6 +4342,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
+"dmO" = (
+/obj/structure/sign/christmas/lights{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/structure/sign/christmas/lights{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/effect/floor_decal/spline/plain{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "dnh" = (
 /obj/machinery/door/firedoor/glass/hidden{
 	dir = 1
@@ -4291,9 +4369,9 @@
 	},
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
@@ -4718,6 +4796,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/research/rnd)
 "dBs" = (
@@ -5280,6 +5359,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
+"dSg" = (
+/obj/structure/sign/christmas/lights{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_range = 12
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/coffee_shop)
 "dSq" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloor{
@@ -6070,6 +6159,13 @@
 	name = "Station Intercom (General)";
 	pixel_x = 24
 	},
+/obj/machinery/light{
+	dir = 4;
+	use_power = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
 "eze" = (
@@ -6406,6 +6502,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
+"eJy" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/crew_quarters/coffee_shop)
 "eKx" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
@@ -6499,6 +6604,15 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
+"eQf" = (
+/obj/structure/table/hardwoodtable,
+/obj/item/material/kitchen/rollingpin,
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "eQx" = (
 /obj/structure/table/woodentable,
 /obj/machinery/microwave,
@@ -6904,6 +7018,16 @@
 /obj/structure/inflatable/door,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
+"fed" = (
+/obj/structure/catwalk,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/freezer{
+	name = "Cafe Backroom";
+	req_access = list(28);
+	req_one_access = newlist()
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/coffee_shop)
 "fef" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -7532,6 +7656,9 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "fzK" = (
@@ -8159,12 +8286,20 @@
 /turf/simulated/wall,
 /area/maintenance/dormitory)
 "fUs" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/sign/christmas/lights{
+	dir = 4
 	},
-/obj/structure/railing,
-/turf/simulated/floor/plating,
-/area/maintenance/research/rnd)
+/obj/machinery/light{
+	dir = 4;
+	use_power = 0
+	},
+/obj/machinery/vending/dinnerware,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "fUX" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/airlock/maintenance/common,
@@ -8896,6 +9031,16 @@
 /obj/structure/railing,
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
+"grL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "grW" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -9651,6 +9796,13 @@
 "gSp" = (
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/heads/hor)
+"gSs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "gTr" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -10525,8 +10677,12 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/showers)
 "hGr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
@@ -11496,6 +11652,10 @@
 /obj/item/toy/xmastree{
 	pixel_y = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
 "imL" = (
@@ -11548,14 +11708,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/robotics)
 "ipQ" = (
-/obj/machinery/light{
-	pixel_x = -16
-	},
-/obj/structure/bed/chair/wood{
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/coffee_shop)
 "ipW" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
@@ -11884,12 +12039,15 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/pool)
 "iAH" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/railing{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/research/rnd)
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "iBi" = (
 /obj/structure/table/rack/shelf,
 /obj/random/maintenance/security,
@@ -12663,15 +12821,9 @@
 /turf/simulated/floor/tiled/monowhite,
 /area/medical/morgue)
 "jdR" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
-/area/maintenance/research/rnd)
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "jeA" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -12793,6 +12945,16 @@
 	},
 /turf/simulated/floor/tiled/red,
 /area/security/observation)
+"jla" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "jlp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -13052,15 +13214,12 @@
 /turf/simulated/floor/plating,
 /area/rift/surfacebase/outside/outside2)
 "jsh" = (
-/obj/structure/railing{
+/obj/machinery/alarm{
+	pixel_x = 24;
 	dir = 8
 	},
-/obj/structure/table/rack,
-/obj/random/maintenance/research,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
-/area/maintenance/research/rnd)
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/coffee_shop)
 "jsy" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/evidence{
@@ -13423,6 +13582,14 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/security/lobby)
+"jNn" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/hallway/primary/surfacetwo)
 "jNu" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -13770,6 +13937,10 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "jZl" = (
@@ -14059,6 +14230,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/blue)
+"kiG" = (
+/obj/machinery/door/blast/shutters{
+	id = "cafe";
+	layer = 3.1;
+	name = "Cafe Shutters"
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "kiJ" = (
 /obj/machinery/button/remote/airlock{
 	id = "ReadingRoom2";
@@ -15496,6 +15677,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/breakroom)
+"lip" = (
+/obj/machinery/appliance/cooker/fryer,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/coffee_shop)
 "liB" = (
 /turf/simulated/open,
 /area/rift/trade_shop/loading)
@@ -16614,6 +16799,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel,
 /area/security/hallway)
+"lZg" = (
+/obj/structure/sign/christmas/lights,
+/obj/structure/table/hardwoodtable,
+/obj/machinery/chemical_dispenser/bar_coffee/full{
+	dir = 1;
+	pixel_y = 2;
+	pixel_x = 4
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "lZO" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -16876,6 +17073,23 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/security/hallway)
+"miF" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/structure/curtain/open/bed{
+	name = "brown curtain"
+	},
+/obj/machinery/door/firedoor/glass/hidden{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/hallway/primary/surfacetwo)
 "mjr" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -16926,15 +17140,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
 "mkA" = (
-/obj/structure/table/wooden_reinforced,
-/obj/item/reagent_containers/food/drinks/cup{
-	pixel_x = -14;
-	pixel_y = 5
-	},
-/obj/item/flame/candle/candelabra{
-	pixel_y = 8
-	},
-/obj/structure/sign/christmas/lights,
+/obj/item/stool/padded,
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
 "mlx" = (
@@ -17248,8 +17454,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
@@ -17474,6 +17680,16 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
+"mEZ" = (
+/obj/structure/sign/christmas/lights{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	use_power = 0
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/coffee_shop)
 "mFW" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -18658,6 +18874,45 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel,
 /area/medical/reception)
+"nCd" = (
+/obj/structure/sign/christmas/lights{
+	dir = 1
+	},
+/obj/structure/table/hardwoodtable,
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_y = 6;
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_y = 6;
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for shutters.";
+	id = "cafe";
+	name = "Cafe Shutters";
+	pixel_x = 8;
+	pixel_y = 24;
+	req_access = list();
+	req_one_access = list(25)
+	},
+/obj/structure/sign/christmas/lights{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "nCo" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -19335,6 +19590,9 @@
 "ocv" = (
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/robotics)
+"ocD" = (
+/turf/simulated/floor/tiled,
+/area/crew_quarters/coffee_shop)
 "odk" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -19886,10 +20144,19 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/Dorm_4)
 "oFi" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/structure/catwalk,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Cafe";
+	req_one_access = list(25)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/coffee_shop)
 "oFH" = (
 /obj/structure/cable/green{
@@ -21106,9 +21373,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/sleep)
 "pqG" = (
-/obj/structure/table/wooden_reinforced,
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/wood,
+/obj/machinery/appliance/cooker/oven,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/coffee_shop)
 "pqQ" = (
 /obj/effect/floor_decal/spline/plain{
@@ -23583,6 +23849,20 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/sleep)
+"rme" = (
+/obj/structure/sign/christmas/lights{
+	dir = 8
+	},
+/obj/structure/table/hardwoodtable,
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "rmi" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/lightgrey/bordercorner,
@@ -23641,9 +23921,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "rqV" = (
-/obj/structure/bed/chair/wood{
-	pixel_x = 16
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
 "rrL" = (
@@ -24161,6 +24441,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/Dorm_6)
+"rLV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/coffee_shop)
 "rMp" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -24801,6 +25088,15 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rift/station/public_garden/stairwell)
+"ssQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/coffee_shop)
 "stz" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -25183,6 +25479,19 @@
 	},
 /turf/simulated/open,
 /area/rift/station/public_garden/gantry)
+"sHQ" = (
+/obj/structure/sign/christmas/lights,
+/obj/machinery/light,
+/obj/structure/table/hardwoodtable,
+/obj/machinery/chemical_dispenser/bar_soft/full{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "sHY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26652,6 +26961,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel,
 /area/rnd/research/researchdivision)
+"tPY" = (
+/obj/machinery/door/blast/shutters{
+	id = "cafe";
+	layer = 3.1;
+	name = "Cafe Shutters"
+	},
+/obj/machinery/door/blast/shutters{
+	id = "cafe";
+	layer = 3.1;
+	name = "Cafe Shutters"
+	},
+/obj/item/stool/padded,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "tQp" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /obj/structure/cable/green{
@@ -27789,6 +28114,12 @@
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled,
 /area/security/briefing_room)
+"uNQ" = (
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/coffee_shop)
 "uNX" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
@@ -29470,6 +29801,12 @@
 /obj/effect/overlay/snow/floor,
 /turf/simulated/floor/lythios43c/indoors,
 /area/rift/surfacebase/outside/outside2)
+"vVo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "vVr" = (
 /obj/effect/floor_decal/rust,
 /obj/item/tool/screwdriver,
@@ -29905,6 +30242,16 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/lobby)
+"wjk" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "wjQ" = (
 /obj/structure/bed/chair/comfy/beige,
 /obj/machinery/firealarm{
@@ -30233,6 +30580,20 @@
 /obj/structure/table/rack/shelf/steel,
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/blue)
+"wvH" = (
+/obj/structure/sign/christmas/lights{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_x = 24;
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "wvJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -30312,6 +30673,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
+"wxt" = (
+/obj/structure/sign/christmas/lights{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "wxx" = (
 /obj/machinery/door/airlock/maintenance/sec{
 	req_one_access = null
@@ -31450,6 +31828,15 @@
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"xsb" = (
+/obj/effect/floor_decal/industrial/halfstair{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/coffee_shop)
 "xsA" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -31466,6 +31853,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"xsN" = (
+/obj/structure/table/hardwoodtable,
+/obj/item/material/knife/butch,
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "xsX" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
@@ -31576,6 +31972,9 @@
 /obj/machinery/camera/network/civilian{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "xxw" = (
@@ -31607,6 +32006,44 @@
 	},
 /turf/simulated/floor/tiled/red,
 /area/security/evidence_storage)
+"xyQ" = (
+/obj/structure/sign/christmas/lights{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table/hardwoodtable,
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_y = 18;
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_y = 8;
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_y = 8;
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_y = 18;
+	pixel_x = -4
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "xzS" = (
 /turf/simulated/wall,
 /area/maintenance/medbay)
@@ -31956,11 +32393,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/security/hallway)
 "xNq" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/research/rnd)
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/sugar,
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/coffee_shop)
 "xOs" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -32169,6 +32610,26 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/hor)
+"xUT" = (
+/obj/structure/sign/christmas/lights{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 24
+	},
+/obj/structure/table/hardwoodtable,
+/obj/machinery/microwave,
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/coffee_shop)
 "xVu" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -43256,12 +43717,12 @@ cwR
 uik
 uik
 uik
-cUW
-cUW
-cUW
-cUW
-cUW
-pBj
+uik
+uik
+uik
+uik
+uik
+uik
 pBj
 oLJ
 oLJ
@@ -43450,13 +43911,13 @@ sWY
 kHx
 jrj
 qGO
-hJs
-hJs
-hJs
-hJs
+nCd
+xyQ
+rme
+wxt
+aTY
+qGO
 cUW
-cUW
-pBj
 oLJ
 oLJ
 aUX
@@ -43641,15 +44102,15 @@ jfW
 uVO
 fSm
 viJ
-rqV
-pqG
+neF
+mkA
+kiG
+jdR
+jdR
+jdR
+jdR
+lZg
 qGO
-eBi
-eBi
-eBi
-hJs
-hJs
-cUW
 cUW
 oLJ
 ohX
@@ -43837,13 +44298,13 @@ cwF
 neF
 neF
 mkA
-qGO
+kiG
 cee
-nsG
-eBi
-eBi
-hJs
-hJs
+gSs
+eQf
+jdR
+sHQ
+qGO
 cUW
 cUW
 ohX
@@ -44030,15 +44491,15 @@ aTl
 imj
 tGt
 neF
-ipQ
-qGO
+mkA
+tPY
 jdR
-iiF
-iiF
-eBi
-eBi
-hJs
-hJs
+grL
+xsN
+jdR
+ipQ
+dSg
+lip
 cUW
 cUW
 cUW
@@ -44219,21 +44680,21 @@ hRG
 wPX
 qrc
 gsZ
-gsZ
+rLV
 mwh
 hGr
-viJ
-neF
+eJy
+rqV
 eyX
 oFi
-tyH
-tyH
-tyH
-nsG
-eBi
-eBi
-hJs
-hJs
+bcw
+wjk
+vVo
+jla
+ipQ
+ocD
+pqG
+tmJ
 cUW
 cUW
 pBj
@@ -44415,19 +44876,19 @@ kBf
 wHa
 jYd
 gql
-wHa
+xsb
 kvB
 sMm
 qGO
 qGO
-alV
+dmO
 fUs
-tyH
-iiF
-nsG
-eBi
-eBi
-hJs
+xUT
+iAH
+wvH
+mEZ
+dlo
+tmJ
 hJs
 cUW
 cUW
@@ -44609,18 +45070,18 @@ cUw
 tzd
 hyJ
 iga
-tzd
+miF
 xPt
 xPt
 xPt
 xPt
 xPt
 xPt
-tyH
-iiF
-iAH
-eBi
-eBi
+qGO
+bvQ
+qGO
+qGO
+qGO
 eBi
 hJs
 hJs
@@ -44810,10 +45271,10 @@ iji
 nZS
 phT
 phT
-tyH
-tyH
-tyH
-iSd
+cxe
+ssQ
+uNQ
+fed
 tyH
 eBi
 eBi
@@ -44997,7 +45458,7 @@ hPN
 bPt
 mcn
 egW
-bPt
+jNn
 xPt
 wgd
 vWe
@@ -45007,7 +45468,7 @@ xPt
 alV
 xNq
 jsh
-eBi
+qGO
 tyH
 tyH
 tyH
@@ -45198,10 +45659,10 @@ pbK
 xPt
 xPt
 xPt
-eBi
-eBi
-eBi
-eBi
+qGO
+qGO
+qGO
+qGO
 eBi
 iSd
 eBi

--- a/_maps/map_files/rift/rift-05-surface2.dmm
+++ b/_maps/map_files/rift/rift-05-surface2.dmm
@@ -22880,15 +22880,14 @@
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/item/reagent_containers/food/drinks/cup{
-	pixel_x = -7;
-	pixel_y = 4
-	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
 /obj/item/flame/candle/candelabra{
 	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/h_chocolate{
+	pixel_x = 9
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
@@ -26199,10 +26198,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/chemical_dispenser/bar_coffee/full{
-	dir = 4;
-	pixel_y = -16
-	},
 /obj/structure/table/hardwoodtable,
 /obj/machinery/light{
 	dir = 8
@@ -28504,12 +28499,11 @@
 /area/rift/station/public_garden/gantry)
 "uVO" = (
 /obj/structure/table/wooden_reinforced,
-/obj/item/reagent_containers/food/drinks/cup{
-	pixel_x = -12;
-	pixel_y = 4
-	},
 /obj/item/flame/candle/candelabra{
 	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/h_chocolate{
+	pixel_x = 9
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
@@ -32400,6 +32394,10 @@
 /obj/item/reagent_containers/food/condiment/sugar,
 /obj/item/reagent_containers/food/condiment/sugar,
 /obj/item/reagent_containers/food/condiment/sugar,
+/obj/machinery/light{
+	dir = 4;
+	use_power = 0
+	},
 /turf/simulated/floor/tiled/freezer/cold,
 /area/crew_quarters/coffee_shop)
 "xOs" = (
@@ -32645,28 +32643,16 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
-/obj/item/reagent_containers/food/drinks/cup{
-	pixel_y = 8;
-	pixel_x = 8
-	},
-/obj/item/reagent_containers/food/drinks/cup{
-	pixel_y = 8;
-	pixel_x = -8
-	},
-/obj/item/reagent_containers/food/drinks/cup{
-	pixel_y = 8
-	},
 /obj/structure/table/hardwoodtable,
 /obj/item/reagent_containers/glass/rag{
 	pixel_x = -6;
 	pixel_y = 2
 	},
-/obj/item/reagent_containers/food/drinks/cup{
-	pixel_x = 6;
-	pixel_y = -2
-	},
 /obj/structure/sign/christmas/lights{
 	dir = 8
+	},
+/obj/item/reagent_containers/food/drinks/h_chocolate{
+	pixel_x = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/coffee_shop)

--- a/_maps/map_files/rift/rift-05-surface2.dmm
+++ b/_maps/map_files/rift/rift-05-surface2.dmm
@@ -1156,29 +1156,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "aRq" = (
-/obj/structure/table/marble,
-/obj/item/reagent_containers/food/drinks/cup,
-/obj/item/reagent_containers/food/drinks/cup{
-	pixel_x = -8;
-	pixel_y = 8
+/obj/effect/floor_decal/corner/black/border/shifted{
+	dir = 6
 	},
-/obj/item/reagent_containers/food/drinks/cup{
-	pixel_y = 8
+/obj/effect/floor_decal/corner/black{
+	dir = 1
 	},
-/obj/item/reagent_containers/food/drinks/cup{
-	pixel_x = 8;
-	pixel_y = 8
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
 	},
-/obj/item/reagent_containers/food/drinks/cup{
-	pixel_x = -8
-	},
-/obj/item/reagent_containers/food/drinks/cup{
-	pixel_x = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/coffee_shop)
 "aRs" = (
 /obj/structure/toilet{
@@ -1212,9 +1199,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "aTl" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/structure/table/marble,
-/turf/simulated/floor/lino,
+/obj/structure/bed/chair/wood,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
 "aTy" = (
 /turf/simulated/floor/plating,
@@ -3351,7 +3340,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/security/lobby)
 "cwF" = (
-/obj/structure/table/wooden_reinforced,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
 "cwG" = (
@@ -3618,6 +3609,13 @@
 "cIj" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/medbay)
+"cIu" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/coffee_shop)
 "cIO" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
@@ -4350,7 +4348,12 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/medical/sleeper)
 "dqp" = (
-/turf/simulated/floor/lino,
+/obj/item/toy/plushie/coffee_fox{
+	name = "Cream";
+	pixel_x = 16;
+	pixel_y = 3
+	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "dqr" = (
 /obj/structure/cable/green{
@@ -5075,15 +5078,15 @@
 /turf/simulated/open,
 /area/rift/station/public_garden/gantry)
 "dJH" = (
-/obj/structure/table/wooden_reinforced,
-/obj/structure/flora/pottedplant/flower{
-	pixel_y = 14
-	},
 /obj/machinery/camera/network/civilian{
 	dir = 4
 	},
 /obj/machinery/computer/timeclock/premade/west,
-/turf/simulated/floor/wood,
+/obj/structure/bed/chair/sofa/brown/right,
+/obj/structure/sign/christmas/lights{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "dKq" = (
 /obj/structure/cable/green{
@@ -6886,59 +6889,16 @@
 /turf/simulated/floor/carpet/blue,
 /area/security/breakroom)
 "fdP" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
+/obj/structure/bed/chair/sofa/brown/right{
+	dir = 8
 	},
-/obj/structure/table/marble,
-/obj/item/reagent_containers/food/condiment/small/sugar{
-	pixel_x = -6;
-	pixel_y = 6
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
 	},
-/obj/item/reagent_containers/food/condiment/small/packet/coffee{
-	pixel_y = 9
+/obj/structure/sign/christmas/wreath{
+	dir = 8
 	},
-/obj/item/reagent_containers/food/condiment/small/packet/coffee{
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/condiment/small/packet/coffee{
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/condiment/small/packet/coffee,
-/obj/item/reagent_containers/food/condiment/small/packet/tea{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/condiment/small/packet/tea{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/condiment/small/packet/tea{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/condiment/small/packet/tea{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/food/condiment/small/packet/sugar{
-	pixel_x = 12;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/condiment/small/packet/sugar{
-	pixel_x = 12;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/condiment/small/packet/sugar{
-	pixel_x = 12;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/condiment/small/packet/sugar{
-	pixel_x = 12
-	},
-/obj/item/reagent_containers/glass/rag{
-	pixel_x = -10;
-	pixel_y = 6
-	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "fdT" = (
 /obj/structure/inflatable/door,
@@ -7759,15 +7719,17 @@
 /turf/simulated/wall,
 /area/security/range)
 "fHU" = (
-/obj/structure/bed/chair/wood{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 8
-	},
 /obj/structure/curtain/open/bed{
 	name = "brown curtain";
 	pixel_x = -32
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -15
+	},
+/obj/structure/sign/christmas/lights{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
@@ -7788,10 +7750,60 @@
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/sleep)
 "fIg" = (
+/obj/structure/table/hardwoodtable,
 /obj/effect/floor_decal/spline/plain{
-	dir = 10
+	dir = 5
 	},
-/turf/simulated/floor/lino,
+/obj/effect/floor_decal/spline/plain,
+/obj/item/reagent_containers/food/condiment/small/sugar{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/condiment/small/packet/coffee{
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/condiment/small/packet/coffee{
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/condiment/small/packet/coffee{
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/condiment/small/packet/coffee,
+/obj/item/reagent_containers/food/condiment/small/packet/tea{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/condiment/small/packet/tea{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/condiment/small/packet/tea{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/condiment/small/packet/tea{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/food/condiment/small/packet/sugar{
+	pixel_x = 12;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/condiment/small/packet/sugar{
+	pixel_x = 12;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/condiment/small/packet/sugar{
+	pixel_x = 12;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/condiment/small/packet/sugar{
+	pixel_x = 12
+	},
+/obj/item/reagent_containers/food/condiment/small/sugar{
+	pixel_x = -6;
+	pixel_y = -5
+	},
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/coffee_shop)
 "fIH" = (
 /obj/structure/railing,
@@ -8088,6 +8100,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"fSm" = (
+/obj/structure/bed/chair/sofa/brown/right{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/coffee_shop)
 "fSD" = (
 /obj/machinery/papershredder,
 /obj/effect/floor_decal/spline/plain{
@@ -8533,11 +8551,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "ghf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/coffee_shop)
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall,
+/area/medical/morgue)
 "ghA" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -8840,7 +8856,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "gqo" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -8927,7 +8943,7 @@
 /area/medical/surgeryprep)
 "gsZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "gts" = (
 /obj/structure/closet/secure_closet/medical3,
@@ -9369,6 +9385,10 @@
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = -2;
 	pixel_y = -2
+	},
+/obj/item/storage/box/body_record_disk{
+	pixel_x = 6;
+	pixel_y = -4
 	},
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/paleblue{
@@ -10097,10 +10117,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/heads/hor)
 "hoN" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/structure/table/marble,
-/obj/item/reagent_containers/food/drinks/cup,
-/turf/simulated/floor/lino,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "hpv" = (
 /obj/machinery/conveyor{
@@ -10512,8 +10529,10 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/showers)
 "hGr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "hGI" = (
 /obj/structure/table/steel,
@@ -10944,9 +10963,9 @@
 /area/rnd/research/researchdivision)
 "hRG" = (
 /obj/effect/floor_decal/spline/plain{
-	dir = 6
+	dir = 9
 	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/snow,
 /area/crew_quarters/coffee_shop)
 "hRU" = (
 /obj/effect/floor_decal/borderfloor{
@@ -11178,10 +11197,13 @@
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/hor)
 "ibd" = (
-/obj/structure/fireplace{
-	pixel_y = 14
+/obj/structure/sign/christmas/lights{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
+/obj/structure/sign/christmas/lights{
+	dir = 4
+	},
+/turf/simulated/floor/snow,
 /area/crew_quarters/coffee_shop)
 "ibv" = (
 /obj/effect/floor_decal/borderfloor/corner{
@@ -11467,6 +11489,19 @@
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/security/observation)
+"imj" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/item/toy/xmastree{
+	pixel_y = 6
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/coffee_shop)
 "imL" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 4
@@ -11517,8 +11552,13 @@
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/robotics)
 "ipQ" = (
-/obj/structure/table/wooden_reinforced,
-/obj/machinery/light,
+/obj/machinery/light{
+	pixel_x = -16
+	},
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
 "ipW" = (
@@ -12408,10 +12448,11 @@
 /area/security/armory/blue)
 "iVL" = (
 /obj/structure/railing,
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	dir = 8
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/sign/christmas/lights{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/snow,
 /area/crew_quarters/coffee_shop)
 "iWe" = (
 /turf/simulated/open,
@@ -12691,6 +12732,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rift/stairwell/primary/surfacetwo)
+"jfW" = (
+/obj/structure/bed/chair/sofa/brown/left,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/coffee_shop)
 "jgg" = (
 /obj/structure/railing{
 	dir = 4
@@ -12977,6 +13022,10 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/christmas/lights{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/coffee_shop)
 "jrD" = (
@@ -13721,8 +13770,11 @@
 	dir = 1
 	},
 /obj/structure/railing,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "jZl" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
@@ -14496,9 +14548,10 @@
 	dir = 8;
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 8
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
+/obj/fiftyspawner/log,
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
 "kvL" = (
@@ -14739,7 +14792,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "kBE" = (
 /obj/random/trash_pile,
@@ -14788,6 +14841,9 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	pixel_x = -30
+	},
+/obj/structure/sign/christmas/lights{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
@@ -15329,19 +15385,18 @@
 /turf/simulated/floor/tiled/steel,
 /area/rnd/research/researchdivision)
 "lcv" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 12
-	},
 /obj/item/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
 	pixel_x = 24
 	},
-/turf/simulated/floor/lino,
+/obj/structure/bed/chair/sofa/brown/left{
+	dir = 8
+	},
+/obj/structure/sign/christmas/wreath{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "lcJ" = (
 /obj/structure/bed/chair/comfy/black{
@@ -15459,55 +15514,23 @@
 /area/security/armory/red)
 "liI" = (
 /obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/accessory/armor/armguards{
+	pixel_y = 4
+	},
+/obj/item/clothing/accessory/armor/armguards,
+/obj/item/clothing/accessory/armor/armguards{
+	pixel_y = -4
+	},
+/obj/item/clothing/accessory/armor/armguards{
+	pixel_y = -9
+	},
+/obj/item/clothing/accessory/armor/armguards{
+	pixel_y = -9
+	},
+/obj/item/clothing/accessory/armor/armguards,
+/obj/item/clothing/accessory/armor/armguards,
+/obj/item/clothing/accessory/armor/armguards,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/clothing/accessory/armor/legguards{
-	pixel_x = 5
-	},
-/obj/item/clothing/accessory/armor/legguards{
-	pixel_x = -5
-	},
-/obj/item/clothing/accessory/armor/legguards{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/clothing/accessory/armor/legguards{
-	pixel_x = -5;
-	pixel_y = 8
-	},
-/obj/item/clothing/accessory/armor/legguards{
-	pixel_x = 5
-	},
-/obj/item/clothing/accessory/armor/legguards{
-	pixel_x = -5
-	},
-/obj/item/clothing/accessory/armor/legguards{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/clothing/accessory/armor/legguards{
-	pixel_x = -5;
-	pixel_y = 8
-	},
-/obj/item/clothing/accessory/armor/armguards{
-	pixel_y = -9
-	},
-/obj/item/clothing/accessory/armor/armguards{
-	pixel_y = -4
-	},
-/obj/item/clothing/accessory/armor/armguards,
-/obj/item/clothing/accessory/armor/armguards{
-	pixel_y = 4
-	},
-/obj/item/clothing/accessory/armor/armguards{
-	pixel_y = -9
-	},
-/obj/item/clothing/accessory/armor/armguards{
-	pixel_y = -4
-	},
-/obj/item/clothing/accessory/armor/armguards,
-/obj/item/clothing/accessory/armor/armguards{
-	pixel_y = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/blue)
 "ljf" = (
@@ -16908,7 +16931,14 @@
 /area/maintenance/dormitory)
 "mkA" = (
 /obj/structure/table/wooden_reinforced,
-/obj/item/reagent_containers/food/condiment/small/sugar,
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_x = -14;
+	pixel_y = 5
+	},
+/obj/item/flame/candle/candelabra{
+	pixel_y = 8
+	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
 "mlx" = (
@@ -17225,7 +17255,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "mxG" = (
 /obj/structure/symbol/sa,
@@ -17879,27 +17909,9 @@
 /area/security/security_lockerroom)
 "mZs" = (
 /obj/structure/table/rack/shelf/steel,
+/obj/item/gun/energy/phasegun/rifle,
+/obj/item/gun/energy/phasegun/rifle,
 /obj/effect/floor_decal/industrial/outline/red,
-/obj/item/gunbox/lethal{
-	pixel_y = 8
-	},
-/obj/item/gunbox/lethal{
-	pixel_y = 4
-	},
-/obj/item/gunbox/lethal,
-/obj/item/gunbox/lethal{
-	pixel_y = -4
-	},
-/obj/item/gunbox/lethal{
-	pixel_y = 8
-	},
-/obj/item/gunbox/lethal{
-	pixel_y = 4
-	},
-/obj/item/gunbox/lethal,
-/obj/item/gunbox/lethal{
-	pixel_y = -4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/red)
 "mZy" = (
@@ -18659,15 +18671,18 @@
 /turf/simulated/floor/tiled/steel,
 /area/rnd/lockers)
 "nCx" = (
-/obj/structure/bed/chair/wood,
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 1
-	},
 /obj/structure/curtain/open/bed{
 	name = "brown curtain";
 	pixel_x = -32
 	},
-/turf/simulated/floor/wood,
+/obj/structure/table/wooden_reinforced,
+/obj/item/toy/xmastree{
+	pixel_y = 6
+	},
+/obj/structure/sign/christmas/lights{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "nCO" = (
 /obj/machinery/vending/coffee{
@@ -19650,19 +19665,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/maintenance/medbay)
 "ovs" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
+/obj/structure/bed/chair/sofa/brown/left{
+	dir = 4
 	},
-/obj/structure/table/marble,
-/obj/item/toy/plushie/coffee_fox{
-	name = "Cream"
+/obj/structure/sign/christmas/wreath{
+	dir = 4
 	},
-/obj/machinery/button/holosign{
-	id = "cafe_sign";
-	pixel_x = -24;
-	pixel_y = -6
-	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "ovT" = (
 /obj/structure/grille,
@@ -19885,6 +19894,15 @@
 /obj/structure/catwalk,
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
+/area/crew_quarters/coffee_shop)
+"oFH" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
 "oFY" = (
 /obj/machinery/door/airlock/glass_security{
@@ -21092,9 +21110,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/sleep)
 "pqG" = (
-/obj/structure/bed/chair/wood{
-	dir = 4
-	},
+/obj/structure/table/wooden_reinforced,
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
 "pqQ" = (
@@ -21703,8 +21720,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "pRF" = (
-/obj/structure/table/wooden_reinforced,
-/obj/item/flame/candle,
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 1
 	},
@@ -21715,7 +21730,17 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/wood,
+/obj/structure/table/hardwoodtable,
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
+	},
+/obj/structure/sign/christmas/lights{
+	dir = 8
+	},
+/obj/item/storage/fancy/candle_box{
+	pixel_x = -3
+	},
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/coffee_shop)
 "pRI" = (
 /obj/effect/floor_decal/borderfloor{
@@ -22141,12 +22166,20 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "qjh" = (
-/obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/bar_coffee/full,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/fireplace{
+	pixel_y = 14;
+	pixel_x = 16
 	},
-/turf/simulated/floor/lino,
+/obj/effect/floor_decal/corner/black/border/shifted{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/black{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/coffee_shop)
 "qjk" = (
 /obj/effect/floor_decal/borderfloor/corner{
@@ -22283,24 +22316,14 @@
 "qpY" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/gunbox{
+/obj/item/gunbox/lethal{
 	pixel_y = 8
 	},
-/obj/item/gunbox{
+/obj/item/gunbox/lethal{
 	pixel_y = 4
 	},
-/obj/item/gunbox,
-/obj/item/gunbox{
-	pixel_y = -4
-	},
-/obj/item/gunbox{
-	pixel_y = 8
-	},
-/obj/item/gunbox{
-	pixel_y = 4
-	},
-/obj/item/gunbox,
-/obj/item/gunbox{
+/obj/item/gunbox/lethal,
+/obj/item/gunbox/lethal{
 	pixel_y = -4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -22342,11 +22365,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "qrc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "qrG" = (
 /obj/structure/table/rack/shelf/steel,
@@ -22585,6 +22610,26 @@
 /obj/structure/inflatable,
 /turf/simulated/floor/tiled/steel,
 /area/maintenance/medbay)
+"qAs" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/item/flame/candle/candelabra{
+	pixel_y = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/coffee_shop)
 "qAx" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -23045,27 +23090,27 @@
 /area/crew_quarters/sleep/Dorm_3)
 "qWZ" = (
 /obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/accessory/armor/legguards,
+/obj/item/clothing/accessory/armor/legguards,
+/obj/item/clothing/accessory/armor/legguards,
+/obj/item/clothing/accessory/armor/legguards{
+	pixel_x = 8
+	},
+/obj/item/clothing/accessory/armor/legguards{
+	pixel_x = -6
+	},
+/obj/item/clothing/accessory/armor/legguards{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/clothing/accessory/armor/legguards{
+	pixel_y = 8
+	},
+/obj/item/clothing/accessory/armor/legguards{
+	pixel_x = -5;
+	pixel_y = 8
+	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/gun/energy/taser{
-	pixel_y = -4
-	},
-/obj/item/gun/energy/taser{
-	pixel_y = -2
-	},
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser{
-	pixel_y = 2
-	},
-/obj/item/gun/energy/taser{
-	pixel_y = -4
-	},
-/obj/item/gun/energy/taser{
-	pixel_y = -2
-	},
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser{
-	pixel_y = 2
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/blue)
 "qXe" = (
@@ -23564,19 +23609,17 @@
 /turf/simulated/floor/tiled/steel,
 /area/rnd/research/researchdivision)
 "rnE" = (
-/obj/structure/table/wooden_reinforced,
-/obj/item/flame/candle,
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 8
-	},
 /obj/structure/curtain/open/bed{
 	name = "brown curtain";
 	pixel_x = -32
 	},
-/turf/simulated/floor/wood,
+/obj/structure/bed/chair/sofa/brown/left{
+	dir = 1
+	},
+/obj/structure/sign/christmas/lights{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "rnP" = (
 /obj/structure/catwalk,
@@ -23601,6 +23644,12 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"rqV" = (
+/obj/structure/bed/chair/wood{
+	pixel_x = 16
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/coffee_shop)
 "rrL" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -24263,6 +24312,10 @@
 /obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
+"rSZ" = (
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/wood,
+/area/crew_quarters/coffee_shop)
 "rTc" = (
 /obj/structure/railing{
 	dir = 1
@@ -25263,8 +25316,13 @@
 /area/security/breakroom)
 "sMm" = (
 /obj/structure/table/wooden_reinforced,
-/obj/structure/flora/pottedplant/stoutbush{
-	pixel_y = 12
+/obj/item/clothing/mask/smokable/cigarette{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/structure/flora/pottedplant/xmas{
+	pixel_y = 16;
+	pixel_x = 3
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
@@ -25470,6 +25528,19 @@
 /obj/effect/mist,
 /turf/simulated/floor/wood,
 /area/triumph/surfacebase/sauna)
+"sWY" = (
+/obj/structure/curtain/open/bed{
+	name = "brown curtain";
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/structure/sign/christmas/lights{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/coffee_shop)
 "sXG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -25813,7 +25884,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "tlj" = (
-/obj/structure/bed/chair/wood,
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 1
 	},
@@ -25824,7 +25894,21 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/chemical_dispenser/bar_coffee/full{
+	dir = 4;
+	pixel_y = -16
+	},
+/obj/structure/table/hardwoodtable,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/coffee_shop)
 "tln" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
@@ -27982,18 +28066,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/surfacetwo)
-"uSV" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/obj/structure/noticeboard{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/steel,
-/area/security/hallway)
 "uTa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -28103,6 +28175,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/rift/station/public_garden/gantry)
+"uVO" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_x = -12;
+	pixel_y = 4
+	},
+/obj/item/flame/candle/candelabra{
+	pixel_y = 8
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/coffee_shop)
 "uWd" = (
 /obj/machinery/shower{
 	pixel_y = 18
@@ -28458,7 +28541,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/security/security_lockerroom)
 "viJ" = (
-/obj/structure/bed/chair/comfy/beige{
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
 /turf/simulated/floor/wood,
@@ -29231,10 +29314,18 @@
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "vKQ" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
+/obj/structure/bed/chair/sofa/brown/right{
+	dir = 4
 	},
-/turf/simulated/floor/lino,
+/obj/machinery/button/holosign{
+	id = "cafe_sign";
+	pixel_x = -24;
+	pixel_y = -6
+	},
+/obj/structure/sign/christmas/wreath{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "vMk" = (
 /obj/effect/floor_decal/borderfloorwhite{
@@ -29578,14 +29669,10 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/clothing/suit/armor/pcarrier/medium/security{
 	pixel_x = 6;
-	pixel_y = -4
+	pixel_y = 4
 	},
 /obj/item/clothing/suit/armor/pcarrier/medium/security{
-	pixel_x = -3;
-	pixel_y = -4
-	},
-/obj/item/clothing/suit/armor/pcarrier/medium/security{
-	pixel_x = 6;
+	pixel_x = 1;
 	pixel_y = 4
 	},
 /obj/item/clothing/suit/armor/pcarrier/medium/security{
@@ -29597,16 +29684,12 @@
 	pixel_y = -4
 	},
 /obj/item/clothing/suit/armor/pcarrier/medium/security{
-	pixel_x = -3;
+	pixel_x = 1;
 	pixel_y = -4
 	},
 /obj/item/clothing/suit/armor/pcarrier/medium/security{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/clothing/suit/armor/pcarrier/medium/security{
 	pixel_x = -3;
-	pixel_y = 4
+	pixel_y = -4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/blue)
@@ -29921,7 +30004,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/rnd/workshop)
 "wlU" = (
-/obj/structure/bed/chair/wood,
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
 "wms" = (
@@ -30144,9 +30232,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/item/gun/energy/phasegun/pistol,
+/obj/item/gun/energy/phasegun/pistol,
 /obj/structure/table/rack/shelf/steel,
-/obj/item/gun/energy/phasegun/rifle,
-/obj/item/gun/energy/phasegun/rifle,
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/blue)
 "wvJ" = (
@@ -30527,7 +30615,7 @@
 /obj/effect/floor_decal/industrial/halfstair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
 "wHt" = (
 /obj/structure/sign/directions/evac{
@@ -30646,10 +30734,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "wPX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
 	},
-/turf/simulated/floor/wood,
+/obj/structure/flora/tree/pine/xmas/presents{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/turf/simulated/floor/snow,
 /area/crew_quarters/coffee_shop)
 "wQd" = (
 /obj/effect/floor_decal/rust,
@@ -32084,8 +32176,10 @@
 "xVu" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
-	pixel_y = 24
+	name = "north bump (cafe nightshift)";
+	pixel_y = 24;
+	pixel_x = -6;
+	nightshift_setting = 3
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -32094,7 +32188,30 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/wood,
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_y = 8;
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_y = 8;
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_y = 8
+	},
+/obj/structure/table/hardwoodtable,
+/obj/item/reagent_containers/glass/rag{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/drinks/cup{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/structure/sign/christmas/lights{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/coffee_shop)
 "xVD" = (
 /obj/effect/floor_decal/spline/plain{
@@ -43333,7 +43450,7 @@ fHU
 dJH
 nCx
 rnE
-fHU
+sWY
 kHx
 jrj
 qGO
@@ -43517,18 +43634,18 @@ tRT
 qXG
 vUk
 cHW
-nXX
+ghf
 ovs
 vKQ
 fIg
 neF
 uMP
-neF
-neF
-neF
-neF
-neF
-neF
+rSZ
+jfW
+uVO
+fSm
+viJ
+rqV
 pqG
 qGO
 eBi
@@ -43716,13 +43833,13 @@ qjh
 dqp
 hoN
 viJ
-uMP
-wlU
+oFH
+neF
 cwF
-tGt
+cwF
+cwF
 neF
 neF
-wlU
 mkA
 qGO
 cee
@@ -43907,16 +44024,16 @@ rNr
 cHW
 nXX
 aRq
-dqp
-aTl
+hoN
+hoN
 viJ
-uMP
+qAs
 wlU
-cwF
+cIu
+aTl
+imj
 tGt
 neF
-neF
-wlU
 ipQ
 qGO
 jdR
@@ -44109,7 +44226,7 @@ gsZ
 gsZ
 mwh
 hGr
-ghf
+viJ
 neF
 eyX
 oFi
@@ -50486,7 +50603,7 @@ whR
 aJX
 tyb
 whR
-uSV
+tiu
 uUo
 hUf
 gmC

--- a/_maps/map_files/rift/rift-06-surface3.dmm
+++ b/_maps/map_files/rift/rift-06-surface3.dmm
@@ -3478,7 +3478,7 @@
 /obj/structure/lattice,
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable{
-	icon_state = "32-4"
+	icon_state = "32-1"
 	},
 /turf/simulated/open,
 /area/maintenance/substation/surface_three)
@@ -5028,12 +5028,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/station/exploration)
-"jf" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/surface_three)
 "jg" = (
 /obj/structure/table/woodentable{
 	carpeted = 1
@@ -6240,11 +6234,11 @@
 	RCon_tag = "Substation - Surface Three";
 	cur_coils = 2
 	},
-/obj/structure/cable{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/surface_three)
@@ -9318,6 +9312,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/surface_three)
 "ru" = (
@@ -11167,10 +11164,6 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-8";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -39633,7 +39626,7 @@ nL
 Fm
 lu
 uW
-jf
+Lh
 Fm
 zR
 Ts

--- a/_maps/map_files/rift/rift-06-surface3.dmm
+++ b/_maps/map_files/rift/rift-06-surface3.dmm
@@ -3478,7 +3478,7 @@
 /obj/structure/lattice,
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable{
-	icon_state = "32-5"
+	icon_state = "32-4"
 	},
 /turf/simulated/open,
 /area/maintenance/substation/surface_three)
@@ -5029,11 +5029,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/station/exploration)
 "jf" = (
-/obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Surface - 3"
-	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/surface_three)
@@ -6239,8 +6236,15 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Substation - Surface Three";
+	cur_coils = 2
+	},
+/obj/structure/cable{
+	dir = 4
+	},
 /obj/structure/cable/green{
-	icon_state = "6-8"
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/surface_three)
@@ -9094,7 +9098,8 @@
 	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "32-2"
+	icon_state = "32-2";
+	dir = sssssssssssssssssssssssssssssddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
 	},
 /turf/simulated/open,
 /area/maintenance/engineering/pumpstation)
@@ -9309,6 +9314,12 @@
 /obj/spawner/window/reinforced/full/firelocks,
 /turf/simulated/floor/plating,
 /area/crew_quarters/bar)
+"rt" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/surface_three)
 "ru" = (
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Public External Airlock"
@@ -11152,8 +11163,15 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
 "uW" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
 /obj/structure/cable{
-	icon_state = "4-10"
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8";
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/surface_three)
@@ -21600,15 +21618,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/hydroponics)
 "PC" = (
-/obj/machinery/power/terminal,
 /obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-9"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/surface_three)
@@ -24599,13 +24610,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
 "Vi" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Surface Three";
-	cur_coils = 2
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
-/obj/structure/cable/green,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/surface_three)
@@ -25960,13 +25974,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/exploration/showers)
 "XE" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "Surface - 3"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/surface_three)
@@ -39429,7 +39438,7 @@ ZP
 KI
 Fm
 XE
-Lh
+rt
 ge
 Fm
 BM
@@ -39816,9 +39825,9 @@ Nw
 pH
 Xo
 Fm
-Lh
-PC
 Vi
+PC
+Lh
 Fm
 FF
 Ck

--- a/_maps/map_files/rift/rift-06-surface3.dmm
+++ b/_maps/map_files/rift/rift-06-surface3.dmm
@@ -21647,8 +21647,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "PG" = (

--- a/_maps/map_files/rift/rift-06-surface3.dmm
+++ b/_maps/map_files/rift/rift-06-surface3.dmm
@@ -226,8 +226,9 @@
 "at" = (
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/item/reagent_containers/food/drinks/shaker,
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/glass/rag,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
@@ -509,12 +510,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway2)
 "aS" = (
-/obj/landmark/spawnpoint/job/bartender,
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -15
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 16
 	},
-/turf/simulated/floor/lino,
+/obj/machinery/computer/arcade/orion_trail,
+/obj/structure/sign/christmas/lights{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "aT" = (
 /obj/machinery/door/airlock/vault/bolted{
@@ -548,11 +552,14 @@
 /turf/simulated/floor/tiled/freezer/cold,
 /area/crew_quarters/freezer)
 "aV" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/open/lythios43c,
+/area/rift/surfacebase/outside/outside3)
 "aW" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -947,11 +954,16 @@
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway2)
 "bA" = (
-/obj/machinery/chemical_dispenser/bar_soft/full{
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/table/marble,
-/turf/simulated/floor/lino,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bB" = (
 /obj/effect/floor_decal/borderfloor/corner,
@@ -1028,21 +1040,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
 "bH" = (
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/item/reagent_containers/food/condiment/small/saltshaker{
-	pixel_x = -3
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/condiment/small/peppermill{
-	pixel_x = 3
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/blast/shutters{
-	id = "kitchen_shutters";
-	name = "Kitchen Shutters"
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "bI" = (
 /obj/structure/metal_edge,
 /obj/structure/railing,
@@ -1115,7 +1120,9 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/captain)
 "bP" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/structure/flora/pottedplant/minitree{
 	pixel_y = 12
 	},
@@ -1308,7 +1315,15 @@
 	pixel_y = 24;
 	req_one_access = list(25)
 	},
-/turf/simulated/floor/lino,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/button/remote/blast_door{
+	id = "bar_window_shutters";
+	name = "Bar Window Shutter control";
+	pixel_x = 21;
+	pixel_y = 24;
+	req_one_access = list(25)
+	},
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "ci" = (
 /obj/structure/cable/green{
@@ -1907,6 +1922,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/bridge_hallway)
+"dt" = (
+/obj/structure/table/marble,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/metaglass{
+	pixel_y = 7;
+	pixel_x = -8
+	},
+/obj/item/flame/candle/candelabra{
+	pixel_y = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/crew_quarters/bar)
 "du" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -1987,9 +2022,10 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/bar/lower)
 "dB" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/machinery/reagentgrinder,
-/obj/item/reagent_containers/glass/rag,
 /obj/machinery/holoposter{
 	pixel_y = 32
 	},
@@ -2132,17 +2168,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/teleporter/departing)
 "dN" = (
-/obj/structure/table/marble,
-/obj/effect/floor_decal/spline/plain{
-	dir = 6
-	},
-/obj/item/flame/candle,
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	id = "bar_shutters";
-	name = "Bar Shutters"
-	},
-/turf/simulated/floor/lino,
+/obj/landmark/spawnpoint/job/bartender,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "dO" = (
 /obj/structure/cable/green{
@@ -2684,23 +2712,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/secondary/docking_hallway)
 "eJ" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized/full{
-	id = "booth_1"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/bar)
-"eK" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/table/marble,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/reagent_containers/glass/rag,
-/obj/item/storage/single_use/med_pouch/overdose,
-/obj/item/storage/single_use/med_pouch/toxin,
-/turf/simulated/floor/lino,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/item/trash/snack_bowl{
+	pixel_y = 6
+	},
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "eL" = (
 /obj/machinery/door/airlock/glass_research{
@@ -2746,9 +2766,6 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacethree)
 "eS" = (
@@ -2795,23 +2812,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/excursion/cockpit)
 "eW" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 1;
-	name = "Bar"
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel,
+/obj/spawner/window/full,
+/turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "eX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2900,6 +2902,17 @@
 /obj/structure/railing,
 /turf/simulated/floor/tiled/steel_grid/lythios43c,
 /area/rift/surfacebase/outside/outside3)
+"fg" = (
+/obj/item/stool/padded,
+/obj/effect/floor_decal/corner/beige/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "fh" = (
 /obj/structure/curtain/open,
 /turf/simulated/floor/plating,
@@ -3098,6 +3111,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
+"fz" = (
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "fA" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/machinery/light,
@@ -3227,8 +3249,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "fK" = (
-/obj/effect/floor_decal/spline/plain,
-/turf/simulated/floor/wood,
+/obj/item/material/ashtray/glass,
+/obj/structure/table/marble,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "fL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -3240,8 +3272,18 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/surfacethree)
+"fN" = (
+/obj/item/stool/padded,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "fO" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/structure/flora/pottedplant/minitree{
 	pixel_y = 12
 	},
@@ -3257,12 +3299,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
-/obj/structure/cable/green,
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/cafeteria)
 "fQ" = (
@@ -3382,12 +3421,23 @@
 /turf/simulated/wall,
 /area/rift/surfacebase/outside/outside3)
 "ga" = (
-/obj/item/stool/padded,
-/obj/landmark/spawnpoint/job/assistant,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/camera/network/civilian{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/requests_console{
+	department = "Bar";
+	departmentType = 2;
+	name = "Bar requests console";
+	pixel_x = -32
+	},
+/obj/structure/table/hardwoodtable,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/structure/sign/christmas/wreath{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "gb" = (
 /obj/effect/floor_decal/borderfloor{
@@ -3409,11 +3459,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacethree)
 "gc" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/structure/bed/chair/sofa/black/left,
-/turf/simulated/floor/carpet/turcarpet,
+/obj/structure/sign/christmas/wreath{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "gd" = (
 /obj/structure/catwalk,
@@ -3424,7 +3478,7 @@
 /obj/structure/lattice,
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable{
-	icon_state = "32-1"
+	icon_state = "32-5"
 	},
 /turf/simulated/open,
 /area/maintenance/substation/surface_three)
@@ -3762,19 +3816,8 @@
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/cafeteria)
 "gN" = (
-/obj/structure/table/wooden_reinforced,
-/obj/structure/flora/pottedplant/unusual{
-	pixel_y = 12
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
+/obj/structure/sign/poster,
+/turf/simulated/wall,
 /area/crew_quarters/bar)
 "gO" = (
 /obj/structure/railing{
@@ -3826,6 +3869,18 @@
 	},
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/cafeteria)
+"gS" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/structure/sign/kiddieplaque{
+	pixel_x = 16;
+	name = "\improper Forgotten Chicken plaque";
+	desc = "There\'s a picture of a chicken engraved here. Doesn\'t seem like anyone remembers what it's name was."
+	},
+/turf/simulated/floor/tiled/classd,
+/area/crew_quarters/bar)
 "gT" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3938,7 +3993,9 @@
 /turf/simulated/open/lythios43c,
 /area/rift/surfacebase/outside/outside3)
 "hg" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/item/clipboard,
 /obj/item/flashlight/lamp/green{
 	pixel_x = -5;
@@ -4062,14 +4119,16 @@
 /area/teleporter)
 "hs" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/door/airlock/freezer{
-	name = "Kitchen";
-	req_access = list(28)
+/obj/machinery/button/remote/blast_door{
+	id = "kitchen_shutters";
+	name = "Kitchen Shutter control";
+	pixel_x = -26;
+	pixel_y = 24
 	},
+/obj/effect/debris/cleanable/egg_smudge,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "ht" = (
@@ -4209,7 +4268,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/teleporter)
 "hH" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/wood,
 /area/bridge/bunker)
@@ -4234,21 +4295,23 @@
 /turf/simulated/floor/wood,
 /area/exploration/meeting)
 "hK" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/structure/disposalpipe/segment{
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/classd,
 /area/crew_quarters/bar)
 "hL" = (
+/obj/structure/table/hardwoodtable,
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/machinery/door/window/brigdoor/eastleft{
-	name = "Bar Access";
-	req_access = list(25)
+/obj/structure/sign/christmas/wreath{
+	dir = 4
 	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "hM" = (
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
@@ -4823,7 +4886,9 @@
 /area/maintenance/bar/lower)
 "iS" = (
 /obj/machinery/light,
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/item/storage/single_use/mre/random{
 	pixel_x = 2;
 	pixel_y = 2
@@ -4964,13 +5029,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/station/exploration)
 "jf" = (
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "Surface - 3"
+	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/surface_three)
 "jg" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/machinery/photocopier/faxmachine{
 	department = "Exploration"
 	},
@@ -5169,11 +5239,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway2)
 "jF" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/bed/chair/sofa/black/right,
-/turf/simulated/floor/carpet/turcarpet,
+/obj/item/stool/padded,
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "jG" = (
 /obj/structure/bed/chair{
@@ -5524,6 +5591,15 @@
 /obj/structure/inflatable,
 /turf/simulated/floor/plating,
 /area/rift/surfaceeva/aa/cliff_north)
+"kk" = (
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 4
+	},
+/obj/structure/window/basic{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/crew_quarters/bar)
 "kl" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -5636,6 +5712,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/bar)
 "ky" = (
@@ -5681,6 +5760,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
+"kC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "kD" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -5980,16 +6068,18 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/obj/effect/debris/cleanable/egg_smudge,
+/obj/structure/table/standard,
+/obj/machinery/reagentgrinder,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "le" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/window/reinforced/polarized/full{
-	id = "booth_1"
+/obj/structure/table/marble,
+/obj/item/material/ashtray/glass,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "lf" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -6012,7 +6102,9 @@
 /area/maintenance/commandmaint)
 "lh" = (
 /obj/effect/floor_decal/spline/plain,
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/item/clothing/suit/ianshirt,
 /obj/machinery/light{
 	dir = 4
@@ -6143,6 +6235,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/ai)
+"lu" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/surface_three)
 "lv" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -6295,6 +6396,13 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacethree)
+"lN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
 "lO" = (
 /obj/structure/railing,
 /obj/machinery/light/small{
@@ -6439,9 +6547,10 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "me" = (
@@ -6720,16 +6829,18 @@
 /turf/simulated/floor/tiled/steel,
 /area/hydroponics)
 "mG" = (
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacethree)
 "mH" = (
@@ -6818,11 +6929,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/commandmaint)
 "mO" = (
-/obj/structure/closet/crate,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/cargo,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
+/turf/simulated/open/lythios43c,
+/area/rift/surfacebase/outside/outside3)
 "mP" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -6981,9 +7093,10 @@
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/freezer)
 "nf" = (
-/obj/structure/table/marble,
-/obj/item/flame/candle,
-/turf/simulated/floor/carpet/turcarpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "ng" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7047,15 +7160,16 @@
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/general)
 "nm" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
+/obj/item/material/ashtray/glass,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "nn" = (
 /obj/effect/floor_decal/techfloor,
@@ -7313,40 +7427,34 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacethree)
 "nL" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/structure/bed/chair/sofa/black{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+/obj/machinery/holoposter{
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "nM" = (
 /obj/structure/table/reinforced,
@@ -7449,7 +7557,9 @@
 /obj/structure/flora/pottedplant/minitree{
 	pixel_y = 12
 	},
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
 	},
@@ -7460,11 +7570,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/bridge_hallway)
 "nX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/lino,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "nY" = (
 /obj/structure/cable/green{
@@ -7594,6 +7702,37 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/ai)
+"om" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/obj/item/reagent_containers/food/drinks/bottle/grenadine{
+	pixel_y = 14;
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/food/drinks/bottle/unathijuice{
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_y = 15;
+	pixel_x = 10
+	},
+/obj/structure/noticeboard{
+	pixel_x = -32
+	},
+/obj/item/reagent_containers/glass/rag{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/structure/sign/christmas/wreath{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
 "on" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
@@ -7613,26 +7752,39 @@
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/shuttle/emt/cockpit)
 "oq" = (
+/obj/structure/table/marble,
 /obj/effect/floor_decal/spline/plain{
-	dir = 1
+	dir = 10
 	},
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
+	},
+/obj/item/trash/plate{
+	pixel_y = 9;
+	pixel_x = 6
+	},
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/reagent_containers/food/drinks/metaglass{
+	pixel_y = 3;
+	pixel_x = -8
 	},
-/turf/simulated/floor/wood,
+/obj/item/flame/candle/candelabra{
+	pixel_y = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "or" = (
 /obj/structure/bed/chair/comfy/beige,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar_backroom)
 "os" = (
-/obj/structure/bed/chair/sofa/black/right{
+/obj/structure/bed/chair/sofa/black/left,
+/obj/structure/window/basic{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/turcarpet,
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "ot" = (
 /obj/machinery/holoposter{
@@ -7713,16 +7865,8 @@
 /turf/simulated/floor/wood,
 /area/exploration/meeting)
 "oA" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/open,
-/area/crew_quarters/bar)
+/turf/simulated/wall,
+/area/crew_quarters/bar_backroom)
 "oB" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
@@ -7730,7 +7874,7 @@
 "oC" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/chemical_dispenser/bar_coffee/full{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
@@ -7763,15 +7907,47 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/bridge/bunker)
 "oH" = (
-/obj/machinery/vending/boozeomat{
-	req_access = null
-	},
 /obj/machinery/button/holosign{
 	id = "bar_sign";
 	pixel_x = -6;
 	pixel_y = 24
 	},
-/turf/simulated/wall/r_wall,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/hardwoodtable,
+/obj/item/reagent_containers/food/drinks/bottle/small/beer{
+	pixel_x = -11;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/drinks/bottle/small/beer{
+	pixel_x = -11;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/food/drinks/bottle/small/beer{
+	pixel_x = -11;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/small/beer{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/drinks/bottle/small/beer{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/food/drinks/bottle/small/beer{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "oI" = (
 /obj/machinery/door/airlock/glass_external,
@@ -7995,6 +8171,21 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/teleporter/departing)
+"pc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/table/hardwoodtable,
+/obj/machinery/chemical_dispenser/bar_alc/full{
+	pixel_y = 12;
+	pixel_x = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
 "pd" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 4
@@ -8034,13 +8225,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/bridge_hallway)
 "ph" = (
-/obj/item/stool/padded,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Substation Access"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/surface_three)
 "pi" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -8195,6 +8387,22 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/grass,
 /area/hydroponics)
+"px" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "py" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/floor_decal/borderfloor/cee{
@@ -8270,17 +8478,16 @@
 /turf/simulated/floor/tiled/steel,
 /area/exploration/courser_dock)
 "pH" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/disposalpipe/junction{
+/obj/structure/bed/chair/sofa/black{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/sign/christmas/wreath{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "pI" = (
 /obj/structure/disposalpipe/sortjunction/flipped{
@@ -8354,16 +8561,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway)
 "pR" = (
-/obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/effect/debris/cleanable/flour,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/blast/shutters{
-	id = "kitchen_shutters";
-	name = "Kitchen Shutters"
-	},
-/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "pS" = (
@@ -8467,14 +8669,29 @@
 /turf/simulated/floor/plating/lythios43c,
 /area/rift/surfacebase/outside/outside3)
 "qd" = (
-/obj/item/stool/padded,
-/obj/landmark/spawnpoint/job/assistant,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/item/deskbell,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/door/blast/shutters{
+	id = "bar_shutters";
+	name = "Bar Shutters";
+	dir = 4
+	},
+/obj/structure/table/hardwoodtable,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/item/toy/xmastree{
+	pixel_y = 16
+	},
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "qe" = (
 /obj/effect/floor_decal/industrial/warning/full,
@@ -8563,15 +8780,9 @@
 /turf/simulated/mineral/icerock/lythios43c,
 /area/rift/surfacebase/outside/outside3)
 "qo" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/sign/nosmoking_1,
+/turf/simulated/wall,
+/area/crew_quarters/barrestroom)
 "qp" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 4
@@ -8706,6 +8917,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/bridge/bunker)
+"qD" = (
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/item/toy/xmastree{
+	pixel_x = -9
+	},
+/obj/structure/table/hardwoodtable,
+/obj/machinery/chemical_dispenser/bar_soft/full{
+	pixel_y = 12;
+	pixel_x = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
 "qE" = (
 /obj/structure/bed/chair/wood,
 /obj/structure/sign/hydro{
@@ -8906,6 +9132,9 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rift/surfaceeva/aa/cliff_north)
+"qY" = (
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
 "qZ" = (
 /obj/machinery/ai_slipper,
 /obj/structure/cable/cyan{
@@ -9072,24 +9301,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
 "rs" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/door/blast/shutters{
+	id = "bar_window_shutters";
+	name = "Bar Window Shutters";
 	dir = 4
 	},
-/obj/structure/curtain/open/bed{
-	name = "brown curtain"
-	},
+/obj/spawner/window/reinforced/full/firelocks,
 /turf/simulated/floor/plating,
-/area/crew_quarters/bar)
-"rt" = (
-/obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/bar_coffee/full,
-/turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "ru" = (
 /obj/machinery/door/airlock/glass_external/public{
@@ -9142,6 +9360,17 @@
 /obj/structure/railing,
 /turf/simulated/floor/reinforced/lythios43c,
 /area/rift/surfacebase/shuttle)
+"rz" = (
+/obj/structure/table/marble,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/item/material/ashtray/glass,
+/obj/structure/sign/christmas/wreath{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/crew_quarters/bar)
 "rA" = (
 /obj/machinery/door/airlock/voidcraft/vertical,
 /obj/map_helper/airlock/door/ext_door,
@@ -9347,12 +9576,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/ai)
 "rV" = (
-/obj/structure/table/marble,
-/obj/item/flame/candle,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8
+	dir = 4
 	},
-/turf/simulated/floor/carpet/turcarpet,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "rW" = (
 /obj/machinery/door/airlock/maintenance/int{
@@ -9406,7 +9642,6 @@
 "sc" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/standard,
-/obj/machinery/reagentgrinder,
 /obj/item/reagent_containers/dropper{
 	pixel_y = -12
 	},
@@ -9490,6 +9725,16 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacethree)
@@ -9647,7 +9892,9 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "sB" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/item/material/ashtray/glass,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -9678,7 +9925,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "sF" = (
@@ -9753,7 +9999,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "sM" = (
 /obj/effect/floor_decal/borderfloorblack,
@@ -9889,7 +10135,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/ai)
 "tb" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/item/paper_bin,
 /obj/item/storage/box/syringes,
 /obj/item/reagent_scanner{
@@ -10209,6 +10457,25 @@
 /obj/item/tool/crowbar,
 /turf/simulated/floor/tiled/techmaint,
 /area/rift/surfaceeva/aa/cliff_north)
+"tE" = (
+/obj/machinery/door/blast/shutters{
+	id = "bar_shutters";
+	name = "Bar Shutters";
+	dir = 4
+	},
+/obj/structure/table/hardwoodtable,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/drinks/metaglass{
+	pixel_y = 9;
+	pixel_x = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
 "tF" = (
 /obj/structure/symbol/sa,
 /turf/simulated/wall/r_wall{
@@ -10407,6 +10674,22 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/grass,
 /area/hydroponics)
+"tY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "tZ" = (
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Public External Airlock"
@@ -10461,6 +10744,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"ud" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "ue" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /turf/simulated/floor/tiled/monowhite,
@@ -10864,13 +11153,7 @@
 /area/shuttle/emt/general)
 "uW" = (
 /obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-10"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/surface_three)
@@ -10932,7 +11215,9 @@
 /turf/simulated/floor/outdoors/safeice/lythios43c/indoors,
 /area/rift/surfacebase/outside/outside3)
 "vd" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/machinery/photocopier,
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -11009,6 +11294,9 @@
 	},
 /obj/machinery/atm{
 	pixel_x = -32
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/cafeteria)
@@ -11137,13 +11425,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "vz" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
+/obj/random/trash_pile,
+/obj/structure/railing,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "vA" = (
@@ -11292,8 +11575,12 @@
 /turf/simulated/open/lythios43c,
 /area/rift/surfacebase/outside/outside3)
 "vO" = (
-/obj/structure/bed/chair/sofa/black/right,
-/turf/simulated/floor/carpet/turcarpet,
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "vP" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -11330,24 +11617,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/cargo)
 "vU" = (
-/obj/structure/table/marble,
-/obj/item/storage/pill_bottle/dice_nerd{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 1
 	},
-/obj/item/storage/pill_bottle/dice{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/deck/tarot{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/deck/cards{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/turf/simulated/floor/wood,
+/obj/structure/window/basic,
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "vV" = (
 /obj/machinery/shower{
@@ -11904,8 +12178,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/rift/stairwell/primary/surfacethree)
 "wR" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8;
+	light_range = 12
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -12005,13 +12281,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/excursion/cargo)
 "wZ" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 6
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/item/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 24
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/structure/sign/christmas/wreath{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -12106,7 +12383,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "xg" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/structure/flora/pottedplant/minitree{
 	pixel_y = 12
 	},
@@ -12191,7 +12470,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/excursion/cargo)
 "xo" = (
-/turf/simulated/floor/carpet/turcarpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "xp" = (
 /obj/structure/cable/green{
@@ -12433,16 +12718,16 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "xP" = (
-/obj/item/stool/padded,
-/obj/effect/floor_decal/corner/beige{
-	dir = 5
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/blast/shutters{
+	id = "kitchen_shutters";
+	name = "Kitchen Shutters"
+	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "xQ" = (
@@ -12539,8 +12824,21 @@
 /turf/simulated/floor,
 /area/shuttle/civvie/general)
 "xY" = (
-/obj/landmark/observer_spawn,
-/obj/machinery/hologram/holopad,
+/obj/structure/table/marble,
+/obj/item/reagent_containers/food/drinks/metaglass{
+	pixel_y = 11;
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/food/drinks/metaglass{
+	pixel_y = 11;
+	pixel_x = -3
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/item/reagent_containers/food/drinks/metaglass{
+	pixel_y = 11;
+	pixel_x = 15
+	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "xZ" = (
@@ -12568,11 +12866,15 @@
 /turf/simulated/floor/outdoors/safeice/lythios43c/indoors,
 /area/rift/surfacebase/outside/outside3)
 "yb" = (
-/obj/structure/bed/chair{
+/obj/machinery/computer/arcade/clawmachine,
+/obj/machinery/holoposter{
+	pixel_y = 32
+	},
+/obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
+/turf/simulated/floor/carpet/bcarpet,
+/area/crew_quarters/bar)
 "yc" = (
 /obj/structure/railing{
 	dir = 4
@@ -12618,14 +12920,8 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "yh" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 10
-	},
-/obj/structure/flora/pottedplant/minitree,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/tiled/classd,
 /area/crew_quarters/bar)
 "yi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12688,6 +12984,9 @@
 "ym" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -13093,12 +13392,20 @@
 /turf/simulated/floor,
 /area/shuttle/emt/general)
 "zh" = (
-/obj/structure/table/woodentable,
-/obj/random/maintenance/clean,
-/obj/random/cigarettes,
-/obj/item/flame/lighter/random,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/trunk,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	dir = 1
+	},
+/obj/structure/sign/christmas/lights{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/classd,
+/area/crew_quarters/bar)
 "zi" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/evidence{
@@ -13131,8 +13438,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/commandmaint)
 "zm" = (
-/obj/structure/flora/pottedplant/mysterious,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/classd,
 /area/crew_quarters/bar)
 "zn" = (
 /obj/structure/railing{
@@ -13177,27 +13487,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/cockpit)
-"zr" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/glass/hidden{
-	dir = 2
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals5,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/hallway/primary/surfacethree)
 "zs" = (
 /obj/machinery/computer/rcon{
 	dir = 8
@@ -13238,12 +13527,15 @@
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/shuttle/civvie/general)
 "zv" = (
-/obj/random/trash_pile,
-/obj/structure/railing{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "zx" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 1
@@ -13254,6 +13546,20 @@
 	},
 /turf/simulated/floor/carpet/tealcarpet,
 /area/shuttle/civvie/general)
+"zy" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/door/window/eastright{
+	req_access = list(25);
+	name = "Bar Access"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
 "zz" = (
 /obj/structure/bed/chair/office/dark,
 /obj/landmark/spawnpoint/job/pathfinder,
@@ -13329,13 +13635,8 @@
 /turf/simulated/floor/plating,
 /area/exploration/excursion_dock)
 "zG" = (
-/obj/effect/floor_decal/corner/beige{
-	dir = 5
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/smartfridge,
+/turf/simulated/wall,
 /area/crew_quarters/bar)
 "zH" = (
 /obj/machinery/light{
@@ -13343,6 +13644,18 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai_upload)
+"zI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
 "zJ" = (
 /turf/simulated/wall,
 /area/crew_quarters/kitchen)
@@ -13509,12 +13822,15 @@
 /area/bridge/bridge_hallway)
 "Aa" = (
 /obj/effect/floor_decal/spline/plain{
-	dir = 9
+	dir = 8
 	},
-/obj/machinery/button/windowtint{
-	id = "booth_1";
-	pixel_x = 26;
-	pixel_y = -8
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 24
+	},
+/obj/structure/sign/christmas/wreath{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -13608,18 +13924,13 @@
 /obj/machinery/camera/network/civilian{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = -30
-	},
 /obj/structure/ladder{
 	pixel_y = 8
 	},
 /obj/effect/floor_decal/spline/plain{
-	dir = 5
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "Ak" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -13719,6 +14030,14 @@
 /obj/machinery/camera/network/civilian{
 	dir = 8
 	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/cafeteria)
 "Aw" = (
@@ -13737,8 +14056,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/emt/general)
 "Ax" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -13933,20 +14258,12 @@
 /turf/simulated/floor/reinforced/lythios43c,
 /area/rift/surfacebase/outside/outside3)
 "AT" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/structure/lattice,
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/turf/simulated/open/lythios43c,
+/area/rift/surfacebase/outside/outside3)
 "AU" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -14130,14 +14447,20 @@
 /turf/simulated/floor/tiled/monotile,
 /area/rift/trade_shop/landing_pad)
 "Bn" = (
-/obj/structure/table/marble,
-/obj/effect/floor_decal/spline/plain,
 /obj/machinery/door/blast/shutters{
-	dir = 2;
 	id = "bar_shutters";
-	name = "Bar Shutters"
+	name = "Bar Shutters";
+	dir = 2
 	},
-/turf/simulated/floor/lino,
+/obj/structure/table/hardwoodtable,
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/item/flame/candle/candelabra{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "Bo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -14283,6 +14606,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
+"Bz" = (
+/obj/item/stool/padded{
+	pixel_y = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/crew_quarters/bar)
 "BA" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -14344,14 +14673,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/hydroponics)
 "BI" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/floor_decal/corner/beige/bordercorner,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
-/obj/structure/closet,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "BJ" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 8
@@ -14551,6 +14881,10 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai)
+"Cb" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "Cd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14579,16 +14913,9 @@
 /turf/simulated/open/lythios43c,
 /area/rift/surfacebase/outside/outside3)
 "Cg" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/spline/plain,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/sign/poster,
+/turf/simulated/wall,
+/area/crew_quarters/barrestroom)
 "Ch" = (
 /turf/simulated/wall,
 /area/bridge/bridge_hallway)
@@ -14924,6 +15251,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/courser_dock)
+"CU" = (
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
 "CV" = (
 /obj/structure/closet/walllocker/emerglocker{
 	pixel_x = -30
@@ -14964,7 +15295,9 @@
 /turf/simulated/floor/wood,
 /area/bridge/bunker)
 "CY" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/structure/flora/pottedplant/minitree{
 	pixel_y = 12
 	},
@@ -15028,6 +15361,14 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/excursion/cargo)
+"De" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/stool/padded,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "Df" = (
 /obj/machinery/power/smes/buildable/point_of_interest,
 /obj/structure/cable/cyan{
@@ -15207,12 +15548,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/excursion/general)
 "Dy" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
+/obj/structure/railing{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
+/turf/simulated/floor/outdoors/snow/lythios43c,
+/area/rift/surfacebase/outside/outside3)
 "Dz" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -15367,7 +15707,9 @@
 	pixel_x = 4;
 	pixel_y = 3
 	},
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
@@ -15495,12 +15837,8 @@
 /area/ai_upload)
 "Ee" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/camera/network/civilian,
 /obj/structure/cable/green{
 	icon_state = "2-8"
-	},
-/obj/structure/sink/kitchen{
-	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
@@ -15546,21 +15884,20 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/rift/turbolift/maint)
 "Ej" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/item/reagent_containers/food/condiment/small/saltshaker{
+	pixel_x = -3
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/item/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = 3
 	},
-/obj/structure/window/reinforced,
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
-	dir = 8
+/obj/machinery/door/blast/shutters{
+	id = "kitchen_shutters";
+	name = "Kitchen Shutters"
 	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/open,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "Ek" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
@@ -15582,14 +15919,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_cyborg_station)
 "El" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -15615,10 +15947,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/commandmaint)
-"Ep" = (
-/obj/machinery/status_display,
-/turf/simulated/wall,
-/area/crew_quarters/bar)
 "Eq" = (
 /turf/simulated/wall,
 /area/exploration/meeting)
@@ -15788,6 +16116,14 @@
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway)
+"EH" = (
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/vending/boozeomat{
+	layer = 2.8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
 "EI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15809,6 +16145,10 @@
 /obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
+"EK" = (
+/obj/structure/sign/poster/nanotrasen,
+/turf/simulated/wall,
+/area/crew_quarters/bar)
 "EL" = (
 /obj/machinery/door/airlock{
 	id_tag = "barbackdoor";
@@ -15996,15 +16336,21 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exploration/excursion_dock)
 "Fa" = (
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 1
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner{
-	dir = 1
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 1;
+	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacethree)
 "Fb" = (
@@ -16163,19 +16509,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/exploration)
-"Fr" = (
-/obj/structure/table/marble,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/item/material/ashtray/glass,
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	id = "bar_shutters";
-	name = "Bar Shutters"
-	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
 "Fs" = (
 /turf/simulated/wall/r_wall,
 /area/ai_cyborg_station)
@@ -16210,7 +16543,25 @@
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/captain)
 "Fw" = (
-/turf/simulated/floor/lino,
+/obj/structure/table/marble,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/obj/item/trash/plate{
+	pixel_y = 2;
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/food/drinks/metaglass{
+	pixel_y = 14;
+	pixel_x = 6
+	},
+/obj/structure/sign/christmas/wreath{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "Fx" = (
 /obj/machinery/alarm/alarms_hidden{
@@ -16439,7 +16790,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/commandmaint)
 "FV" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/item/storage/box/donkpockets{
 	pixel_x = 2;
 	pixel_y = 2
@@ -16701,6 +17054,20 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/tiled/freezer/cold,
 /area/crew_quarters/freezer)
+"Gy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "Gz" = (
 /obj/structure/railing,
 /obj/structure/lattice,
@@ -16713,9 +17080,16 @@
 /turf/simulated/floor/carpet/blue,
 /area/bridge/meeting_room)
 "GB" = (
-/obj/structure/table/marble,
-/obj/item/material/ashtray/glass,
-/turf/simulated/floor/carpet/turcarpet,
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "GC" = (
 /obj/effect/floor_decal/spline/plain,
@@ -16925,14 +17299,13 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "Hb" = (
-/obj/machinery/door/airlock/maintenance/engi{
-	name = "Substation Access"
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/surface_three)
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
 "Hc" = (
 /obj/machinery/computer/aifixer{
 	dir = 8
@@ -17316,14 +17689,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/commandmaint)
 "HQ" = (
+/obj/effect/floor_decal/corner/beige/border,
+/obj/item/stool/padded,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -17403,6 +17775,10 @@
 	},
 /obj/effect/floor_decal/corner/lightgrey/bordercorner{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacethree)
@@ -17740,20 +18116,26 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/bridge/bunker)
 "II" = (
-/obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/bar_alc/full{
+/obj/machinery/door/blast/shutters{
+	id = "bar_shutters";
+	name = "Bar Shutters";
+	dir = 2
+	},
+/obj/structure/table/hardwoodtable,
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/recharger,
+/obj/item/toy/xmastree{
+	pixel_y = 6;
+	pixel_x = 10
+	},
+/obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/obj/machinery/camera/network/civilian{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	department = "Bar";
-	departmentType = 2;
-	name = "Bar requests console";
-	pixel_x = -32
-	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "IJ" = (
 /obj/effect/floor_decal/spline/plain{
@@ -18058,7 +18440,6 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/obj/landmark/spawnpoint/job/bartender,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -18208,8 +18589,14 @@
 /turf/simulated/floor/tiled/steel,
 /area/hydroponics)
 "JC" = (
-/obj/item/stool/padded,
-/obj/machinery/light{
+/obj/machinery/door/airlock,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -18346,14 +18733,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/exploration/courser_dock)
 "JO" = (
-/obj/structure/railing{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/open/lythios43c,
-/area/rift/surfacebase/outside/outside3)
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
 "JP" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/borderfloorblack{
@@ -18408,7 +18793,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/hydroponics)
 "JU" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
 	},
@@ -18442,19 +18829,18 @@
 /turf/simulated/wall/r_wall,
 /area/bridge/bunker)
 "JY" = (
-/obj/machinery/recharger,
-/obj/structure/table/marble,
-/obj/effect/floor_decal/spline/plain,
-/obj/machinery/computer/security/telescreen{
-	pixel_x = -32;
-	pixel_y = -4
-	},
+/obj/item/material/ashtray/glass,
 /obj/machinery/door/blast/shutters{
-	dir = 2;
 	id = "bar_shutters";
-	name = "Bar Shutters"
+	name = "Bar Shutters";
+	dir = 2
 	},
-/turf/simulated/floor/lino,
+/obj/structure/table/hardwoodtable,
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "JZ" = (
 /obj/structure/table/reinforced,
@@ -18509,6 +18895,11 @@
 /obj/item/storage/box/glasses/meta,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
+"Kd" = (
+/obj/item/stool/padded,
+/obj/item/reagent_containers/food/snacks/monkeycube/wrapped,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
 "Ke" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -18528,17 +18919,11 @@
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "Kg" = (
-/obj/structure/table/marble,
-/obj/effect/floor_decal/spline/plain,
-/obj/item/material/ashtray/glass,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "bar_shutters";
-	name = "Bar Shutters"
+/obj/effect/floor_decal/industrial/halfstair{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/turf/simulated/floor/outdoors/snow/lythios43c,
+/area/rift/surfacebase/outside/outside3)
 "Kh" = (
 /obj/machinery/door/firedoor/glass/hidden{
 	dir = 8
@@ -18550,7 +18935,9 @@
 /turf/simulated/floor/outdoors/safeice/lythios43c/indoors,
 /area/rift/surfacebase/outside/outside3)
 "Kj" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/item/clothing/head/that{
 	pixel_x = 4;
 	pixel_y = 6
@@ -18636,6 +19023,15 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plating,
 /area/maintenance/station/exploration)
+"Ks" = (
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 4
+	},
+/obj/structure/window/basic{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/crew_quarters/bar)
 "Kt" = (
 /turf/simulated/floor/plating,
 /area/maintenance/station/exploration)
@@ -18670,16 +19066,26 @@
 /turf/simulated/floor/tiled/steel,
 /area/rift/stairwell/primary/surfacethree)
 "Ky" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/flora/pottedplant/tropical{
+	pixel_y = 10
+	},
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
+/obj/item/toy/figure/assistant{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/effect/floor_decal/spline/plain{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/sign/christmas/lights{
+	dir = 1
+	},
+/obj/structure/sign/christmas/lights{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/turcarpet,
+/turf/simulated/floor/tiled/classd,
 /area/crew_quarters/bar)
 "Kz" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -18781,20 +19187,20 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/bridge/bunker)
 "KI" = (
+/obj/structure/bed/chair/sofa/black/corner{
+	dir = 4
+	},
+/obj/structure/window/basic{
+	dir = 8
+	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+/obj/machinery/camera/network/civilian{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "KJ" = (
 /obj/effect/floor_decal/borderfloor{
@@ -18900,13 +19306,14 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "KS" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/turcarpet,
-/area/crew_quarters/bar)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/cafe,
+/area/crew_quarters/cafeteria)
 "KT" = (
 /obj/structure/symbol/sa,
 /turf/simulated/floor/plating,
@@ -19145,15 +19552,22 @@
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "Lx" = (
-/obj/machinery/door/airlock{
-	name = "Game Room"
-	},
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
+/obj/structure/flora/pottedplant/tropical{
+	pixel_y = 10
+	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "Ly" = (
 /obj/structure/grille,
@@ -19410,12 +19824,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"Ma" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "Mb" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 1
@@ -19544,6 +19952,32 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shuttle/courser/general)
+"Mm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"Mn" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/table/hardwoodtable,
+/obj/machinery/chemical_dispenser/bar_coffee/full{
+	dir = 8;
+	layer = 2.8;
+	pixel_x = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
 "Mo" = (
 /obj/structure/bed/chair/bay{
 	dir = 1
@@ -19604,27 +20038,24 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exploration/explorer_prep)
 "Ms" = (
-/obj/effect/floor_decal/corner/beige/full{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/obj/item/stool/padded,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
 "Mt" = (
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	nightshift_setting = 3
 	},
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
+/obj/machinery/media/jukebox,
 /obj/effect/floor_decal/spline/plain,
+/obj/structure/sign/christmas/wreath{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "Mu" = (
@@ -19684,13 +20115,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/spline/plain,
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "MA" = (
@@ -19762,14 +20191,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hop)
-"MH" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
 "MI" = (
 /obj/machinery/alarm/alarms_hidden{
 	dir = 1;
@@ -19877,9 +20298,6 @@
 /area/hallway/secondary/docking_hallway)
 "MX" = (
 /obj/item/stool/padded,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "MY" = (
@@ -19924,6 +20342,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/courser/general)
+"Nd" = (
+/obj/structure/table/rack/shelf,
+/obj/item/storage/box/mixedglasses{
+	pixel_x = -5
+	},
+/obj/item/storage/box/mixedglasses{
+	pixel_x = 5
+	},
+/obj/item/clothing/under/punpun,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
 "Ne" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -19942,13 +20371,13 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "Ng" = (
-/obj/item/stool/padded,
-/obj/effect/floor_decal/corner/beige{
-	dir = 5
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/door/blast/shutters{
+	id = "kitchen_shutters";
+	name = "Kitchen Shutters"
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "Nh" = (
@@ -19999,20 +20428,16 @@
 /turf/simulated/floor/tiled/steel,
 /area/exploration)
 "Nn" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "No" = (
 /obj/machinery/door/airlock/command{
@@ -20059,7 +20484,9 @@
 /turf/simulated/wall/r_wall,
 /area/bridge)
 "Nt" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/item/deck/cards,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -20102,33 +20529,22 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/courser_dock)
 "Nw" = (
-/obj/machinery/disposal,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 8
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/wood,
+/obj/structure/sign/christmas/wreath{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "Nx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 8;
-	name = "Kitchen";
-	sortType = "Kitchen"
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -20310,11 +20726,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "NU" = (
-/obj/machinery/holoposter{
-	pixel_x = 32
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/effect/floor_decal/corner/beige/bordercorner{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -20322,10 +20735,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "NW" = (
@@ -20570,6 +20983,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/exploration)
+"Oq" = (
+/obj/structure/disposalpipe/junction/yjunction,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "Or" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -20613,8 +21030,17 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ai)
 "Ox" = (
-/obj/structure/bed/chair/sofa/black/left,
-/turf/simulated/floor/carpet/turcarpet,
+/obj/structure/table/hardwoodtable,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/sign/christmas/wreath{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "Oy" = (
 /obj/structure/medical_stand/anesthetic,
@@ -20633,31 +21059,23 @@
 /turf/simulated/floor/tiled/steel,
 /area/exploration/explorer_prep)
 "Oz" = (
+/obj/effect/floor_decal/corner/beige/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/item/stool/padded,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "OA" = (
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Bar";
-	sortType = "Bar"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/sign/nosmoking_1,
+/turf/simulated/wall,
+/area/crew_quarters/bar_backroom)
 "OB" = (
 /obj/item/radio/intercom{
 	pixel_y = -24
@@ -20738,14 +21156,9 @@
 /turf/simulated/floor/plating,
 /area/shuttle/courser/cockpit)
 "OI" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/structure/railing,
 /turf/simulated/floor/plating,
-/area/maintenance/substation/surface_three)
+/area/maintenance/bar)
 "OJ" = (
 /obj/machinery/computer/robotics,
 /obj/structure/table/reinforced,
@@ -20879,12 +21292,6 @@
 /area/maintenance/ai)
 "OS" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/button/remote/blast_door{
-	id = "kitchen_shutters";
-	name = "Kitchen Shutter control";
-	pixel_x = -26;
-	pixel_y = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -21033,6 +21440,18 @@
 	},
 /turf/simulated/floor/tiled/freezer/cold,
 /area/crew_quarters/freezer)
+"Pj" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 20;
+	layer = 2.5;
+	pixel_x = 4
+	},
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
 "Pk" = (
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/turbolift/rsurface/level3)
@@ -21093,12 +21512,8 @@
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
 "Pr" = (
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/item/stool/padded,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "Ps" = (
@@ -21185,15 +21600,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/hydroponics)
 "PC" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Surface Three";
-	cur_coils = 2
+/obj/machinery/power/terminal,
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	icon_state = "0-9"
+	icon_state = "4-9"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/surface_three)
@@ -21225,15 +21640,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/commandmaint)
 "PF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/holosign/bar{
-	id = "bar_sign";
-	layer = 4.9;
-	pixel_y = -1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "PG" = (
 /obj/structure/bed/chair/wood,
@@ -21368,21 +21784,18 @@
 /turf/simulated/floor/plating,
 /area/bridge)
 "PQ" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/machinery/microwave,
 /turf/simulated/floor/wood,
 /area/exploration/meeting)
 "PR" = (
-/obj/structure/table/marble,
+/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/spline/plain{
-	dir = 4
+	dir = 8
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	id = "bar_shutters";
-	name = "Bar Shutters"
-	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "PS" = (
 /obj/machinery/pointdefense_control{
@@ -21514,19 +21927,21 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/bridge/bunker)
 "Qg" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "Qh" = (
@@ -21538,12 +21953,6 @@
 	},
 /turf/simulated/open/lythios43c,
 /area/rift/surfacebase/outside/outside3)
-"Qi" = (
-/obj/structure/cable/green{
-	icon_state = "1-6"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/surface_three)
 "Qj" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/flame/candle,
@@ -21566,6 +21975,20 @@
 	},
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
+"Ql" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/sign/christmas/lights{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/classd,
+/area/crew_quarters/bar)
 "Qm" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
@@ -21796,11 +22219,11 @@
 /turf/simulated/floor/carpet/blue,
 /area/bridge/meeting_room)
 "QH" = (
-/obj/structure/window/reinforced,
-/obj/structure/bed/chair/sofa/black/left{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/turcarpet,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "QI" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -21879,12 +22302,21 @@
 /turf/simulated/floor/plating,
 /area/rift/surfaceeva/aa/cliff_north)
 "QQ" = (
-/obj/item/stool/padded,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/door/blast/shutters{
+	id = "bar_shutters";
+	name = "Bar Shutters";
+	dir = 4
 	},
-/turf/simulated/floor/wood,
+/obj/structure/table/hardwoodtable,
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
+	},
+/obj/structure/flora/pottedplant/xmas{
+	pixel_y = 20;
+	pixel_x = -7;
+	layer = 3
+	},
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "QR" = (
 /obj/effect/floor_decal/borderfloor{
@@ -22002,6 +22434,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/courser/general)
+"QZ" = (
+/obj/structure/table/rack/shelf,
+/obj/item/storage/box/glass_extras/sticks{
+	pixel_x = -5
+	},
+/obj/item/storage/box/glass_extras/straws{
+	pixel_x = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
 "Ra" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -22039,15 +22481,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacethree)
 "Re" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "Rf" = (
@@ -22092,6 +22532,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/courser_dock)
+"Rk" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "Rl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -22190,6 +22635,15 @@
 /turf/simulated/floor/plating,
 /area/rift/surfaceeva/airlock/arrivals/secondary)
 "Rs" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/door/airlock/freezer{
+	name = "Kitchen";
+	req_access = list(28)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/glass,
 /obj/structure/sign/securearea{
 	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
 	icon_state = "monkey_painting";
@@ -22197,33 +22651,21 @@
 	pixel_x = -28;
 	pixel_y = 4
 	},
-/obj/effect/floor_decal/corner/beige/full{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "Rt" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
+/obj/structure/table/marble,
+/obj/item/material/ashtray/glass,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/open,
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "Ru" = (
 /turf/simulated/floor/bluegrid,
@@ -22272,6 +22714,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
+"Ry" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "Rz" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
@@ -22432,22 +22887,16 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "RN" = (
-/obj/structure/table/marble,
-/obj/item/storage/fancy/candle_box,
-/turf/simulated/floor/wood,
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 1
+	},
+/obj/structure/window/basic,
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "RO" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel,
+/obj/spawner/window/full,
+/obj/machinery/holosign/bar,
+/turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "RP" = (
 /obj/machinery/nuclearbomb{
@@ -22602,6 +23051,15 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/bar)
 "Se" = (
@@ -22621,7 +23079,9 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/classd,
 /area/crew_quarters/bar)
 "Sg" = (
 /obj/structure/plasticflaps/mining,
@@ -22958,10 +23418,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "SO" = (
-/obj/structure/bed/chair/sofa/black/left{
+/obj/structure/bed/chair/sofa/black/right,
+/obj/structure/window/basic{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/turcarpet,
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "SP" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -22986,7 +23447,7 @@
 /area/shuttle/excursion/cargo)
 "SR" = (
 /obj/machinery/smartfridge/drinks,
-/turf/simulated/wall,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "SS" = (
 /obj/structure/railing{
@@ -23173,11 +23634,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	dir = 1;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacethree)
@@ -23606,15 +24063,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
 "Uj" = (
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/door/blast/shutters{
-	id = "kitchen_shutters";
-	name = "Kitchen Shutters"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
 "Uk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -23628,14 +24081,8 @@
 /area/hydroponics)
 "Um" = (
 /obj/item/stool/padded,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -23884,6 +24331,16 @@
 /obj/structure/table/bench/steel,
 /turf/simulated/floor/plating,
 /area/maintenance/station/exploration)
+"UI" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/camera/network/civilian{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "UJ" = (
 /obj/machinery/photocopier,
 /obj/effect/floor_decal/corner/lightgrey{
@@ -23929,12 +24386,30 @@
 /turf/simulated/floor/plating,
 /area/maintenance/commandmaint)
 "UN" = (
-/obj/structure/railing,
-/obj/structure/railing{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/open/lythios43c,
-/area/rift/surfacebase/outside/outside3)
+/obj/structure/table/marble,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/item/trash/plate{
+	pixel_y = 10;
+	pixel_x = 7
+	},
+/obj/item/material/kitchen/utensil/fork/plastic{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/toy/xmastree{
+	pixel_y = 6;
+	pixel_x = -8
+	},
+/obj/structure/sign/christmas/wreath{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/crew_quarters/bar)
 "UO" = (
 /obj/structure/railing{
 	dir = 4
@@ -24002,7 +24477,9 @@
 /area/ai_upload)
 "UV" = (
 /obj/machinery/door/firedoor/glass,
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/machinery/door/window/westright{
 	dir = 1;
 	req_one_access = list(35,28)
@@ -24124,8 +24601,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
 "Vi" = (
-/obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Surface - 3"
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Substation - Surface Three";
+	cur_coils = 2
+	},
+/obj/structure/cable/green,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/surface_three)
@@ -24254,17 +24736,36 @@
 /turf/simulated/floor/plating,
 /area/rift/trade_shop/landing_pad)
 "Vu" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"Vv" = (
+/obj/machinery/door/blast/shutters{
+	id = "bar_shutters";
+	name = "Bar Shutters";
+	dir = 2
+	},
+/obj/structure/table/hardwoodtable,
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/item/reagent_containers/food/drinks/metaglass{
+	pixel_y = 3;
+	pixel_x = -7
+	},
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "Vw" = (
 /turf/simulated/floor/reinforced/lythios43c,
@@ -24530,11 +25031,28 @@
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/cafeteria)
 "VW" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/structure/curtain/open/bed{
-	name = "brown curtain"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/table/marble,
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/christmas/wreath,
+/obj/item/storage/fancy/candle_box{
+	pixel_x = -5
+	},
+/obj/item/storage/fancy/candle_box{
+	pixel_x = 7
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -24811,6 +25329,15 @@
 /obj/machinery/light/flamp,
 /turf/simulated/floor/reinforced/lythios43c,
 /area/rift/surfacebase/shuttle)
+"WA" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/structure/sign/christmas/wreath{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "WB" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -24846,6 +25373,22 @@
 /obj/map_helper/airlock/door/int_door,
 /turf/simulated/floor/plating,
 /area/shuttle/courser/general)
+"WE" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "WF" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/borderfloorblack{
@@ -25183,7 +25726,9 @@
 /turf/simulated/floor/plating,
 /area/rift/surfacebase/outside/outside3)
 "Xl" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/machinery/photocopier/faxmachine{
 	department = "Pathfinder's Office"
 	},
@@ -25220,27 +25765,27 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rift/surfaceeva/aa/cliff_north)
 "Xo" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/bed/chair/sofa/black/corner{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/wood,
+/obj/structure/sign/christmas/wreath{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "Xp" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/floor_decal/spline/plain,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "Xq" = (
 /obj/structure/grille,
@@ -25416,6 +25961,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/showers)
+"XE" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/surface_three)
 "XF" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -25514,16 +26070,16 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "2-4"
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/carpet/turcarpet,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "XT" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -25576,6 +26132,12 @@
 /obj/structure/sign/warning/nosmoking_1,
 /turf/simulated/wall/r_wall,
 /area/exploration/courser_dock)
+"XY" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
 "XZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -25719,9 +26281,16 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "Yt" = (
-/obj/machinery/smartfridge,
-/turf/simulated/wall,
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "Yu" = (
 /obj/structure/bed/chair/bay/chair,
 /obj/structure/cable/green{
@@ -25832,10 +26401,6 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/structure/flora/pottedplant/tall,
-/obj/machinery/camera/network/civilian{
-	dir = 1
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "YI" = (
@@ -25859,10 +26424,6 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/captain)
-"YK" = (
-/obj/machinery/media/jukebox,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "YL" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -25979,13 +26540,13 @@
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/cafeteria)
 "YV" = (
-/obj/item/stool/padded,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "YW" = (
 /obj/machinery/computer/ship/engines{
@@ -26071,7 +26632,9 @@
 /obj/effect/floor_decal/corner/lightgrey/bordercorner2{
 	dir = 1
 	},
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/item/material/ashtray/glass,
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -26083,12 +26646,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacethree)
 "Zd" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing,
-/turf/simulated/open/lythios43c,
-/area/rift/surfacebase/outside/outside3)
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
 "Ze" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 8
@@ -26112,20 +26672,28 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exploration/courser_dock)
 "Zf" = (
-/obj/structure/window/reinforced,
 /obj/structure/bed/chair/sofa/black/right{
-	dir = 1
+	dir = 8
 	},
-/turf/simulated/floor/carpet/turcarpet,
+/obj/structure/window/basic{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "Zg" = (
 /obj/machinery/camera/network/civilian{
 	dir = 9
 	},
-/obj/structure/bed/chair/comfy/black{
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
+/obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/turcarpet,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "Zh" = (
 /obj/effect/floor_decal/industrial/halfstair,
@@ -26253,12 +26821,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/steel_grid,
 /area/exploration/excursion_dock)
-"Zv" = (
-/obj/effect/floor_decal/industrial/halfstair{
-	dir = 1
-	},
-/turf/simulated/floor/outdoors/snow/lythios43c,
-/area/rift/surfacebase/outside/outside3)
 "Zw" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -26317,6 +26879,7 @@
 /area/maintenance/commandmaint)
 "ZF" = (
 /obj/landmark/spawnpoint/overflow/station,
+/obj/landmark/observer_spawn,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/secondary/docking_hallway)
 "ZG" = (
@@ -26375,7 +26938,9 @@
 /area/bridge/bridge_hallway)
 "ZK" = (
 /obj/structure/flora/ausbushes/leafybush,
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/item/reagent_containers/glass/bucket/wood,
 /obj/machinery/button/windowtint/multitint{
 	pixel_x = 24
@@ -26422,16 +26987,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/office)
 "ZP" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/bed/chair/sofa/black{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "ZQ" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	carpeted = 1
+	},
 /obj/item/clothing/mask/smokable/cigarette/joint,
 /obj/item/clothing/mask/smokable/pipe/cobpipe,
 /obj/item/flame/lighter/random,
@@ -36320,6 +36887,7 @@ Oi
 Oi
 Oi
 Oi
+KW
 Oi
 Oi
 Oi
@@ -36328,24 +36896,23 @@ Oi
 Oi
 Oi
 Oi
-Oi
-Oi
-Oi
-Oi
-Oi
-Oi
-Oi
-Oi
-Oi
-Oi
-Oi
-Oi
-Oi
-Oi
-Oi
-Oi
-cH
-cH
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Dy
+Dy
 cH
 cH
 cH
@@ -36522,24 +37089,24 @@ Oi
 cH
 cH
 cH
-Oi
-Oi
-Oi
-Oi
-Oi
-Tq
-Tq
-Tq
-Tq
-Tq
-Tq
-Tq
-Tq
-Tq
-Oi
-Oi
-Oi
-cH
+KW
+CA
+CA
+CA
+CA
+CA
+CA
+CA
+CA
+CA
+CA
+CA
+CA
+CA
+CA
+CA
+CA
+Zh
 cH
 cH
 cH
@@ -36716,24 +37283,24 @@ cH
 cH
 cH
 cH
-cH
-cH
-cH
-Tq
-Zd
+Nk
+Kg
+Kg
+aV
+DY
+si
+DY
+si
+DY
+AT
+DY
+si
+DY
+si
+DY
+mO
 CA
-CA
-CA
-CA
-CA
-CA
-CA
-CA
-CA
-JO
-Tq
-Oi
-cH
+Zh
 cH
 cH
 cH
@@ -36913,21 +37480,21 @@ cH
 cH
 cH
 QK
-Zv
-CA
-CA
-Tj
-si
-DY
-si
-DY
-si
-UN
-CA
-CA
-Zh
-QK
-QK
+cO
+cO
+rs
+rs
+rs
+cO
+rs
+cO
+rs
+rs
+rs
+cO
+cH
+me
+me
 QK
 QK
 QK
@@ -37108,16 +37675,16 @@ Io
 Gi
 Gi
 cO
-cO
-rs
-rs
-rs
-cO
-rs
-cO
-rs
-rs
-rs
+om
+ga
+Ox
+hL
+II
+gc
+Mt
+rz
+UN
+Fw
 cO
 cO
 bx
@@ -37288,33 +37855,33 @@ cH
 cH
 cH
 cH
-cH
-cH
-cH
-cH
-cH
-cH
+rX
+rX
+rX
+rX
+rX
+rX
 Gi
 Gi
 at
 or
 Kj
 Rp
-Gi
+oA
 oH
-II
-bA
-eK
-MH
+Zd
+dN
+Zd
+Zd
 JY
-JC
-Mt
+Um
+Gd
 jF
-rV
-QH
+jF
+jF
 Aj
 cO
-bx
+Rk
 kB
 jM
 jM
@@ -37482,13 +38049,13 @@ cH
 cH
 cH
 cH
-cH
-cH
-cH
-cH
-cH
-cH
-Gi
+rX
+QZ
+aF
+Uj
+Ms
+Ms
+OA
 nx
 Tf
 Jp
@@ -37496,17 +38063,17 @@ nD
 Ar
 GV
 ch
-Fw
-aS
-Fw
-nX
-Kg
-ph
-Gd
-gc
-GB
-Zf
-Nn
+Zd
+Mn
+qD
+Zd
+Vv
+fN
+ym
+PR
+PR
+PR
+zv
 Rs
 hs
 OS
@@ -37676,33 +38243,33 @@ cH
 cH
 cH
 cH
-cH
-cH
-cH
-cH
-cH
-cH
-Gi
+rX
+Nd
+aF
+Kd
+Ms
+Ms
+oA
 dB
 tb
 XA
 DN
 Nu
-eS
-rt
-Fw
-Fw
-Fw
-Fw
+oA
+Pj
+Zd
+EH
+pc
+lN
 Bn
-ga
-ym
-Zm
-Zm
-Zm
-HQ
+MX
+Re
+Ks
+kk
+YH
+BI
 zG
-Yt
+Ck
 Ck
 xB
 lX
@@ -37870,34 +38437,34 @@ cH
 cH
 cH
 cH
-cH
-cH
-cH
 rX
-rX
-rX
-Gi
-Gi
-Gi
+vz
+aF
+NS
+NS
+NS
+oA
+oA
+oA
 EL
-Gi
-Gi
-cO
-SR
-hL
-PR
-Fr
-PR
+oA
+oA
+oA
+vO
+nX
+Hb
+JO
 dN
+JY
 MX
-ym
-Zm
-Zm
-Zm
+Re
+fK
+dt
+YH
 HQ
 Ng
-Uj
 Ck
+Rk
 YN
 iu
 Fu
@@ -38064,34 +38631,34 @@ cH
 cH
 cH
 cH
-cH
-cH
 rX
-rX
+NS
+CU
+NS
 eM
 ji
 Po
 Xp
-xo
+zI
 XS
-KS
+sL
 nm
 Lx
-sL
-KG
-YV
+Po
+SR
+zy
 qd
-Um
+tE
 QQ
-OA
-Cg
-jF
+MX
+Mz
+Zf
 GB
-QH
-AT
-Ng
-bH
-Ck
+YH
+fg
+Ej
+Ts
+xO
 KC
 dj
 LZ
@@ -38259,29 +38826,29 @@ WU
 WU
 WU
 WU
-cH
-rX
+aF
+aF
 Rc
 Rc
 Rc
 Dv
-fK
+XY
 xo
-Ky
-xo
-YH
-Po
-Ma
-Zm
-aV
-Zm
-El
-Pr
+qY
+qY
+qY
+bA
+eS
 xY
-Mz
-gc
+Oq
+De
+Pr
+Pr
+Ry
+rV
+Gy
 nf
-Zf
+Zm
 Oz
 xP
 pR
@@ -38453,32 +39020,32 @@ mW
 WU
 mW
 WU
-cH
-vz
+aF
+Rc
 Rc
 sj
-Zx
-Zx
-Zx
-Zx
-LX
-Zx
+aF
 Po
+Nn
+YV
 Po
-le
+EK
+Po
+JC
+Po
 VW
-Ep
-Zm
-Sf
+Yt
+PF
+KG
 Vu
-gN
-Nx
+Ax
+Po
 Qg
 md
 sE
 NU
-Ms
-zJ
+Po
+UI
 Ee
 mJ
 Wd
@@ -38647,26 +39214,26 @@ QW
 Fn
 pb
 AM
-cH
-vz
+OI
 Rc
-mO
 Zx
-xb
-nT
-kO
-Nq
-Is
+Zx
+Zx
+Zx
+LX
+Zx
 Po
-wZ
-xo
-Ax
-le
-YK
-Zm
-hK
-Ej
-ZP
+zh
+Ql
+Sf
+kC
+px
+fz
+QH
+Nx
+tY
+Cb
+wR
 El
 Nr
 Fm
@@ -38841,30 +39408,30 @@ dM
 po
 Wj
 WU
-cH
-vz
+OI
 Rc
-Dy
 Zx
-su
-RF
-su
-Qa
-su
+xb
+nT
+kO
+Nq
+Is
 Po
-vO
-nf
+aS
+Bz
+gS
+Zm
 SO
 le
 RN
-Zm
-hK
-oA
+ud
+Mm
+Ks
 ZP
 KI
 Fm
+XE
 Lh
-OI
 ge
 Fm
 BM
@@ -39035,29 +39602,29 @@ SU
 WU
 SU
 WU
-cH
-rX
+vz
 Rc
-yb
-Zx
-xh
-Zx
-GW
-Zx
-Sq
+Cg
+su
+RF
+su
+Qa
+su
 Po
-Ox
-GB
+yb
+Bz
+zm
+Zm
 os
 eJ
 vU
-Zm
-qo
+ud
+Mm
 Rt
 oq
 nL
-Hb
-Qi
+Fm
+lu
 uW
 jf
 Fm
@@ -39229,24 +39796,24 @@ MW
 nN
 MW
 gm
-cH
-rX
+OI
 Rc
-zh
 Zx
-Dn
+xh
 Zx
-MC
-Zx
-Qu
+GW
+qo
+Sq
 Po
+Ky
+hK
 yh
 Zg
 Aa
-le
-zm
-wR
-Re
+wZ
+WA
+bH
+WE
 Nw
 pH
 Xo
@@ -39423,30 +39990,30 @@ wX
 GE
 OG
 Eu
-cH
-vz
+aF
 Rc
-BI
 Zx
+Dn
 Zx
+MC
 Zx
-Zx
-Zx
-Zx
+Qu
 Po
 Po
+Po
+gN
 Po
 Po
 Po
 Po
 kx
 Sd
-PF
+Po
 RO
 eW
 Fm
 Fm
-Fm
+ph
 Fm
 Fm
 IG
@@ -39617,15 +40184,15 @@ ve
 xJ
 RS
 Eu
-cH
-vz
+OI
 Rc
-aF
-zv
-aF
-aF
-aF
-aF
+Zx
+Zx
+Zx
+Cg
+Zx
+Zx
+Zx
 Ya
 fG
 ex
@@ -39811,8 +40378,8 @@ Bi
 zK
 QL
 Eu
-cH
 vz
+Rc
 Rc
 Rc
 TT
@@ -39835,7 +40402,7 @@ Fk
 Vc
 fY
 fY
-fY
+KS
 he
 CH
 Kw
@@ -40005,8 +40572,8 @@ JL
 FQ
 wm
 gm
-cH
-rX
+aF
+aF
 ax
 sI
 eN
@@ -43125,7 +43692,7 @@ vj
 xl
 xl
 xl
-zr
+zX
 ty
 YT
 ty

--- a/_maps/map_files/rift/rift-06-surface3.dmm
+++ b/_maps/map_files/rift/rift-06-surface3.dmm
@@ -9099,7 +9099,7 @@
 	},
 /obj/structure/cable{
 	icon_state = "32-2";
-	dir = sssssssssssssssssssssssssssssddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+	dir = 6
 	},
 /turf/simulated/open,
 /area/maintenance/engineering/pumpstation)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes some quality of life adjustments to the Crimmas themed bar
Changes were only made to surface 3, but considering the nature of the PR this is based off of I decided to include both crimmas-themed files
Map files pulled and adjusted from PR #4806 

## Why It's Good For The Game

Cuts out the extra dispensers and moves the disposal so it isn't in the way. Also shifts the sink over so you don't have to walk into the corner to use it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: makes the bar a bit more accessable for bartenders
tweak: changes some layering
tweak: moved the bar's disposal unit so it's out of the way
del: removes the body design disk box that was causing errors/preventing compiling
del: removed extra dispensers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
