### PR TITLE
Reenables hairstyles

### DIFF
--- a/code/modules/sprite_accessories/hair/_hair.dm
+++ b/code/modules/sprite_accessories/hair/_hair.dm
@@ -607,6 +607,11 @@
 	id = "hair_parted_alt"
 	icon_state = "hair_partedalt"
 
+/datum/sprite_accessory/hair/pixie
+	name = "Pixie"
+	id = "hair_pixie"
+	icon_state = "hair_pixie"
+
 /datum/sprite_accessory/hair/pompadour
 	name = "Pompadour"
 	id = "hair_pompadour"
@@ -741,6 +746,12 @@
 	name = "Row Braid"
 	id = "hair_row_braid"
 	icon_state = "hair_rowbraid"
+	hair_flags = HAIR_TIEABLE
+
+/datum/sprite_accessory/hair/sabitsuki
+	name = "Sabitsuki"
+	id = "hair_sabitsuki"
+	icon_state = "hair_sabitsuki"
 	hair_flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/scully


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Reenables two hairstyles.
Sabitsuki
![image](https://user-images.githubusercontent.com/18533061/209005488-fe150fb8-c030-41a5-97ed-1091a3646ee9.png)
Pixie 
![image](https://user-images.githubusercontent.com/18533061/209005542-1dfde7ff-5419-4fc1-8213-b036c4199673.png)
## Why It's Good For The Game

Variety.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: sabitsuki & pixie hairstyle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
