### PR TITLE
foam is no longer hard or weighty (basically, foam weapons are now actually nonlethal)

### DIFF
--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -1251,8 +1251,8 @@
 	ignition_point = T0C+232
 	melting_point = T0C+300
 	icon_colour = "#ff9900"
-	hardness = 1
-	weight = 1
+	hardness = 0
+	weight = 0
 	protectiveness = 0 // 0%
 	conductive = 0
 


### PR DESCRIPTION

## About The Pull Request

"we need it to be able to hit people"

ok then

- fix item attack code instead of add spikes to foam

## Why It's Good For The Game

non-lethal nerf wars

## Changelog

:cl:
tweak: foam weapons no longer do damage
/:cl:
