### PR TITLE
Z-Mimic: Fix runtime w/ upward movement + AO fix

### DIFF
--- a/code/___compile_options.dm
+++ b/code/___compile_options.dm
@@ -200,4 +200,4 @@
 
 //! Lighting
 
-#define AO_USE_LIGHTING_OPACITY
+// #define AO_USE_LIGHTING_OPACITY

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -21,7 +21,8 @@
 
 	if (bound_overlay)
 		bound_overlay.forceMove(get_step(src, UP))
-		if (bound_overlay.dir != dir)
+		// forceMove could've deleted our overlay
+		if (bound_overlay && bound_overlay.dir != dir)
 			bound_overlay.setDir(dir)
 
 	if (light_source_solo)


### PR DESCRIPTION
`AO_USE_LIGHTING_OPACITY` is incomplete and buggy, it shouldn't be enabled. Also includes a runtime fix that was supposed to be in the main PR.