### PR TITLE
fixes beartraps not allowing unbuckle & nanoui runtime spam

### DIFF
--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -1,3 +1,4 @@
+// todo: rewrite this shitcode
 /obj/item/beartrap
 	name = "mechanical trap"
 	throw_speed = 2
@@ -10,6 +11,7 @@
 	w_class = ITEMSIZE_NORMAL
 	origin_tech = list(TECH_MATERIAL = 1)
 	matter = list(MAT_STEEL = 18750)
+	buckle_restrained_resist_time = 15 SECONDS
 	var/deployed = 0
 	var/camo_net = FALSE
 	var/stun_length = 0.25 SECONDS
@@ -80,7 +82,10 @@
 	if(!has_buckled_mobs())
 		anchored = FALSE
 
-/obj/item/beartrap/attack_hand(mob/user as mob)
+/obj/item/beartrap/attack_hand(mob/user)
+	// check unbuckle first
+	if(click_unbuckle_interaction(user))
+		return CLICKCHAIN_DO_NOT_PROPAGATE
 	if(deployed)
 		user.visible_message(
 			"<span class='danger'>[user] starts to disarm \the [src].</span>",
@@ -94,8 +99,10 @@
 				"<span class='danger'>[user] has disarmed \the [src].</span>",
 				"<span class='notice'>You have disarmed \the [src]!</span>"
 				)
-			deployed = 0
-			anchored = 0
+			deployed = FALSE
+			anchored = FALSE
+			// reset buckle allowed
+			buckle_allowed = FALSE
 			update_icon()
 	else
 		return ..()
@@ -123,10 +130,12 @@
 
 	//trap the victim in place
 	setDir(L.dir)
+	// allow it so they can do buckle interactions at all
+	buckle_allowed = TRUE
 	buckle_mob(L, BUCKLE_OP_FORCE)
 	L.Stun(stun_length)
 	to_chat(L, "<span class='danger'>The steel jaws of \the [src] bite into you, trapping you in place!</span>")
-	deployed = 0
+	deployed = FALSE
 
 /obj/item/beartrap/Crossed(atom/movable/AM as mob|obj)
 	if(AM.is_incorporeal())

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -12,7 +12,10 @@
 /mob/observer/dead/nano_default_can_use_topic(var/src_object)
 	if(can_admin_interact())
 		return UI_INTERACTIVE							// Admins are more equal
-	if(!client || get_dist(src_object, src)	> client.view)	// Preventing ghosts from having a million windows open by limiting to objects in range
+	if(!client)
+		return UI_CLOSE
+	// todo: in view range for zooming
+	if(get_dist(src, src_object) > min(CEILING(client.current_viewport_width / 2, 1), CEILING(client.current_viewport_height / 2, 1)))
 		return UI_CLOSE
 	return UI_UPDATE									// Ghosts can view updates
 


### PR DESCRIPTION
never in my life did i think someone would genuinely try to make an item be buckle-able 
we really either need to kill this dumb design pattern (items being used as structures)
or have better generic handling for items (this is what will happen on atom damage/attack hand refactor)
because this is fucking stupid

:cl:
fix: beartraps can be removed again
/:cl:
