### PR TITLE
Fix species display in character directory

### DIFF
--- a/code/game/verbs/character_directory.dm
+++ b/code/game/verbs/character_directory.dm
@@ -47,6 +47,7 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 		// These are the three vars we're trying to find
 		// The approach differs based on the mob the client is controlling
 		var/name = null
+		var/species = null
 		var/ooc_notes = null
 		var/flavor_text = null
 		var/tag = C.prefs.directory_tag || "Unset"
@@ -60,12 +61,14 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 					if(!find_record("name", H.real_name, data_core.hidden_general))
 						continue
 			name = H.real_name
+			species = "[H.custom_species ? H.custom_species : H.species.name]"
 			ooc_notes = H.ooc_notes
 			flavor_text = H.flavor_texts["general"]
 
 		if(isAI(C.mob))
 			var/mob/living/silicon/ai/A = C.mob
-			name = "[A.name] (Artificial Intelligence)"
+			name = A.name
+			species = "Artificial Intelligence"
 			ooc_notes = A.ooc_notes
 			flavor_text = null // No flavor text for AIs :c
 
@@ -73,7 +76,8 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 			var/mob/living/silicon/robot/R = C.mob
 			if(R.scrambledcodes || (R.module && R.module.hide_on_manifest))
 				continue
-			name = "[R.name] ([R.modtype] [R.braintype])"
+			name = R.name
+			species = "[R.modtype] [R.braintype]"
 			ooc_notes = R.ooc_notes
 			flavor_text = R.flavor_text
 
@@ -84,6 +88,7 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 
 		directory_mobs.Add(list(list(
 			"name" = name,
+			"species" = species,
 			"ooc_notes" = ooc_notes,
 			"tag" = tag,
 			"erptag" = erptag,


### PR DESCRIPTION
## About The Pull Request

Somehow during the reorg some of the necessary bits that make species display properly in the chardir got eaten. This PR restores the necessary .dm-side code to make it work again.

## Why It's Good For The Game

Fixes a silly bug so there's no longer a useless blank column in the directory. Tested and works.

## Changelog

:cl:
fix: fixed species not displaying in character directory
/:cl: