### PR TITLE
Altevians are not canon, why didn't anybody replace them?

### DIFF
--- a/code/modules/busy_space/organizations.dm
+++ b/code/modules/busy_space/organizations.dm
@@ -2303,56 +2303,36 @@
 			"an active incident site"
 			)
 
-// Space Alien Rats.
-/datum/lore/organization/gov/altevian_hegemony
-	name = "The Altevian Hegemony"
-	short_name = "Altevian Hegemony"
-	acronym = "AH"
-	desc = "The Altevians are a space-faring race of rodents that resemble Earth-like rats. They do not have a place they call home in terms of a planet, and instead have massive multiple-kilometer-long colony-ships that are constantly on the move and typically keep operations outside of known populated systems to not eat the resources from others. Their primary focus is trade and slavage operations and can be expected to be seen around both densely populated and empty systems for their work."
-	history = ""
-	work = "salvage and trade operators"
-	headquarters = "AH-CV Migrant"
-	motto = ""
-	org_type = "government"
+//Cheeses
+/datum/lore/organization/gov/naramadi_ascendancy
+    name = "The Naramadi Ascendancy
+    short_name = "Naramadi Ascendancy"
+    acronym = "NA"
+    desc = "The Naramadi Ascendancy is a member-state of the Moghes Hegemony, though operating largely independant in matters of diplomacy and Trade, often sending Traders and Diplomats out to establish relations."
+    history = ""
+    work = "trade and diplmacy"
+    headquarters = "Verkihar Minor"
+    motto = ""
+    org_type = "government"
 
-	ship_prefixes = list("AH-DV" = "a diplomatic", "AH-EV" = "an exploration", "AH-FV" = "a fueling", "AH-FV" = "a cargo", "AH-SV" = "a research", "AH-TV" = "a colony-transporter", "AH-RV" = "an emergency response", "AH-RV" = "a response", "AH-MV" = "a medical")
-	ship_names = list(
-			"Platinum",
-			"Warson",
-			"Mane",
-			"Holland",
-			"Arauz",
-			"Diamond",
-			"Gold",
-			"Steam",
-			"Boiler",
-			"Slip",
-			"Lavender",
-			"Wheel",
-			"Stuntson",
-			"Desto",
-			"Palos",
-			"Matterson",
-			"Mill",
-			"Smoke",
-			"Squeakson",
-			"Rabion",
-			"Strikedown",
-			"Cluster",
-			"Ratling",
-			"Archaeologist",
-			"Beaker"
-			)
-	destination_names = list(
-			"the AH-CV Migrant flagship",
-			"one of our research colony-ships",
-			"the AH-CV Lotus",
-			"the AH-CV Anvil",
-			"the AH-CV Generations",
-			"the AH-CV Galley",
-			"the AH-CV Prosperity",
-			"the AH-CV Kitsap",
-			"the AH-CV Diamondback",
-			"one of our colony-ships",
-			"one of our production fleets"
-			)
+    ship_prefixes = list("NA-DV" = "a diplomatic", "NA-RV" = "a quick response", "NA-TV" = "a fueling", "NA-CV" = "a cargo", "NA-HV" = "a hunting")
+    ship_names = list(
+            "Seat of Power",
+            "Tools of Trade",
+            "Knowledge of Elders",
+            "Return what's taken",
+            "High and Mighty",
+            "Moral High Ground",
+            "Voice that speaks",
+            "Map that guides",
+            "Hand that strikes",
+            "Hand that feeds",
+            "Of Artificers aplenty",
+            )
+    destination_names = list(
+            "the Moghes Hegemony",
+            "the Vikara Combine",
+            "Verkihar Major",
+            "Onkhera Synthetic Solutions production site",
+            "a distress beacon"
+            )

--- a/code/modules/busy_space/organizations.dm
+++ b/code/modules/busy_space/organizations.dm
@@ -2305,7 +2305,7 @@
 
 //Cheeses
 /datum/lore/organization/gov/naramadi_ascendancy
-    name = "The Naramadi Ascendancy
+    name = "The Naramadi Ascendancy"
     short_name = "Naramadi Ascendancy"
     acronym = "NA"
     desc = "The Naramadi Ascendancy is a member-state of the Moghes Hegemony, though operating largely independant in matters of diplomacy and Trade, often sending Traders and Diplomats out to establish relations."
@@ -2320,7 +2320,7 @@
             "Seat of Power",
             "Tools of Trade",
             "Knowledge of Elders",
-            "Return what's taken",
+            "Return what is taken",
             "High and Mighty",
             "Moral High Ground",
             "Voice that speaks",

--- a/code/modules/busy_space/organizations.dm
+++ b/code/modules/busy_space/organizations.dm
@@ -2315,7 +2315,7 @@
     motto = ""
     org_type = "government"
 
-    ship_prefixes = list("NA-DV" = "a diplomatic", "NA-RV" = "a quick response", "NA-TV" = "a fueling", "NA-CV" = "a cargo", "NA-HV" = "a hunting")
+    ship_prefixes = list("NA-DV" = "a diplomatic", "NA-RV" = "a quick response", "NA-TV" = "a trade", "NA-CV" = "a cargo", "NA-HV" = "a hunting")
     ship_names = list(
             "Seat of Power",
             "Tools of Trade",


### PR DESCRIPTION
It should work.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces the Altevian Hegemony with Naramadi Ascendancy for now, as more Moghes Hegemony vessels are being written still

## Why It's Good For The Game

Altevians aren't canon and it's pissing me off that the game keeps referencing them

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Naramadi Ascendancy ship chatter
del: Mentions of the Altevian Hegemony
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
