### PR TITLE
(WIP) AR-B Employment Records

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -474,6 +474,8 @@
 		. += SPAN_BOLDNOTICE("Physical status: <a href='?src=\ref[src];medical=1'>\[[medical]\]</a>")
 		. += SPAN_BOLDNOTICE("Medical records: <a href='?src=\ref[src];medrecord=`'>\[View\]</a> <a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>")
 
+	if(hasHUD(user,"best"))
+		. += SPAN_BOLDNOTICE("Employment records: <a href='?src=\ref[src];emprecord=`'>\[View\]</a>")
 
 	if(print_flavor_text())
 		. += "[print_flavor_text()]"
@@ -594,6 +596,9 @@
 					return TRUE
 			if("medical")
 				if(omni.mode == "med" || omni.mode == "best")
+					return TRUE
+			if("best")
+				if(omni.mode == "best")
 					return TRUE
 
 	return FALSE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -555,6 +555,34 @@
 									var/mob/living/silicon/robot/U = usr
 									R.fields[text("com_[counter]")] = text("Made by [U.name] ([U.modtype] [U.braintype]) on [time2text(world.realtime, "DDD MMM DD hh:mm:ss")], [game_year]<BR>[t1]")
 
+	if (href_list["emprecord"])
+		if(hasHUD(usr,"best"))
+			var/perpname = "wot"
+			var/read = 0
+
+			var/obj/item/card/id/I = GetIdCard()
+			if(I)
+				perpname = I.registered_name
+			else
+				perpname = name
+			for (var/datum/data/record/E in data_core.general)
+				if (E.fields["name"] == perpname)
+					for (var/datum/data/record/R in data_core.general)
+						if (R.fields["id"] == E.fields["id"])
+							if(hasHUD(usr,"best"))
+								to_chat(usr, "<b>Name:</b> [R.fields["name"]]")
+								to_chat(usr, "<b>Assignment:</b> [R.fields["real_rank"]] ([R.fields["rank"]])")
+								to_chat(usr, "<b>Home System:</b> [R.fields["home_system"]]")
+								to_chat(usr, "<b>Citizenship:</b> [R.fields["citizenship"]]")
+								to_chat(usr, "<b>Primary Employer:</b> [R.fields["personal_faction"]]")
+								to_chat(usr, "<b>Religious Beliefs:</b> [R.fields["religion"]]")
+								to_chat(usr, "<b>Notes:</b> [R.fields["notes"]]")
+								to_chat(usr, "<a href='?src=\ref[src];emprecordComment=`'>\[View Comment Log\]</a>")
+								read = 1
+
+			if(!read)
+				to_chat(usr, "<font color='red'>Unable to locate a data core entry for this person.</font>")
+
 	if (href_list["lookitem"])
 		var/obj/item/I = locate(href_list["lookitem"])
 		if(get_dist(src, get_turf(I)) > 7)


### PR DESCRIPTION
## About The Pull Request

Ports a couple of bits of code that allow those wearing AR-B glasses (or otherwise somehow having the Command-tier HUD) to easily view the employment records of anyone they examine, similar to how you can easily view medical and security records. It outputs the character's name, assignment (and true assignment if they've been given a funny title), home system, citizenship, primary employer, religious beliefs, and any employment records the player may have provided as part of their character details.

There is a slight catch in that the changes made to records here mean I'm not sure how to hook up home system, citizenship, employer, and beliefs. I'm hoping someone can help me figure that one out. The PR is otherwise locally tested and should be ready to merge.

If possible I'd also like to add languages, but worst-case that can be left as part of the player-input records.

## Why It's Good For The Game

It exposes a range of character details that are normally harder to get to. Anyone using the relevant glasses or HUD will be able to look at someone and figure out what their deal is, what they know, what they can do, in character.

## Changelog

:cl:
add: AR-B glasses can now display employment records of anyone you examine (if they have a proper ID/etc.)
/:cl: