### PR TITLE
Z-Mimic: Automatic Plane Mangling

### DIFF
--- a/code/__DEFINES/rendering/zmimic.dm
+++ b/code/__DEFINES/rendering/zmimic.dm
@@ -65,3 +65,22 @@ DEFINE_BITFIELD(mz_flags, list(
 #define ZMM_IGNORE         (1<<0) //! Do not copy this movable. Atoms with INVISIBILITY_ABSTRACT implicitly do not copy.
 #define ZMM_MANGLE_PLANES  (1<<1) //! Check this movable's overlays/underlays for explicit plane use and mangle for compatibility with Z-Mimic. If you're using emissive overlays, you probably should be using this flag. Expensive, only use if necessary.
 #define ZMM_LOOKAHEAD      (1<<2) //! Look one turf ahead and one turf back when considering z-turfs that might be seeing this atom. Cheap, but not free.
+#define ZMM_AUTOMANGLE_STD (1<<3) //! Behaves the same as ZMM_MANGLE_PLANES, but is automatically applied by SSoverlays. Do not manually use.
+#define ZMM_AUTOMANGLE_PRI (1<<4) //! Behaves the same as ZMM_MANGLE_PLANES, but is automatically applied by SSoverlays. Do not manually use.
+
+#define ZMM_AUTOMANGLE (ZMM_AUTOMANGLE_STD|ZMM_AUTOMANGLE_PRI)	// convenience
+
+DEFINE_BITFIELD(zmm_flags, list(
+	BITFIELD(ZMM_IGNORE),
+	BITFIELD(ZMM_MANGLE_PLANES),
+	BITFIELD(ZMM_LOOKAHEAD),
+	BITFIELD(ZMM_AUTOMANGLE_STD),
+	BITFIELD(ZMM_AUTOMANGLE_PRI)
+))
+
+/*
+On ZMM_AUTOMANGLE_*:
+	So, it's possible for both normal and priority overlays to contain mangle targets.
+	Tracking them separately means that the logic in SSoverlays can avoid additional iterations of overlays.
+	They're also separate from ZMM_MANGLE_PLANES so SSoverlays doesn't disable mangling on a manually flagged atom.
+*/

--- a/code/__DEFINES/rendering/zmimic.dm
+++ b/code/__DEFINES/rendering/zmimic.dm
@@ -3,8 +3,8 @@
 #define UPDATE_OO_IF_PRESENT CHECK_OO_EXISTENCE(bound_overlay); if (bound_overlay) { update_above(); }
 
 // I do not apologize.
-#define MOVABLE_IS_BELOW_ZTURF(M) (isturf(loc) && ((M:mz_flags & ZMM_LOOKAHEAD) ? ((get_step(M, M:dir)?:above?:mz_flags & MZ_MIMIC_BELOW) || (loc:above?:mz_flags & MZ_MIMIC_BELOW) || (get_step(M, GLOB.reverse_dir[M:dir])?:above?:mz_flags & MZ_MIMIC_BELOW)) : TURF_IS_MIMICKING(loc:above)))
-#define MOVABLE_IS_ON_ZTURF(M) (isturf(loc) && ((M:mz_flags & ZMM_LOOKAHEAD) ? ((get_step(M, M:dir)?:mz_flags & MZ_MIMIC_BELOW) || (loc:mz_flags & MZ_MIMIC_BELOW) || (get_step(M, GLOB.reverse_dir[M:dir])?:mz_flags & MZ_MIMIC_BELOW)) : TURF_IS_MIMICKING(loc:above)))
+#define MOVABLE_IS_BELOW_ZTURF(M) (isturf(loc) && ((M:zmm_flags & ZMM_LOOKAHEAD) ? ((get_step(M, M:dir)?:above?:mz_flags & MZ_MIMIC_BELOW) || (loc:above?:mz_flags & MZ_MIMIC_BELOW) || (get_step(M, GLOB.reverse_dir[M:dir])?:above?:mz_flags & MZ_MIMIC_BELOW)) : TURF_IS_MIMICKING(loc:above)))
+#define MOVABLE_IS_ON_ZTURF(M) (isturf(loc) && ((M:zmm_flags & ZMM_LOOKAHEAD) ? ((get_step(M, M:dir)?:mz_flags & MZ_MIMIC_BELOW) || (loc:mz_flags & MZ_MIMIC_BELOW) || (get_step(M, GLOB.reverse_dir[M:dir])?:mz_flags & MZ_MIMIC_BELOW)) : TURF_IS_MIMICKING(loc:above)))
 
 //# Turf Multi-Z flags.
 #define MZ_MIMIC_BELOW     (1<<0)  //! If this turf should mimic the turf on the Z below.

--- a/code/__DEFINES/rendering/zmimic.dm
+++ b/code/__DEFINES/rendering/zmimic.dm
@@ -62,19 +62,19 @@ DEFINE_BITFIELD(mz_flags, list(
 
 
 //# Movable mz_flags.
-#define ZMM_IGNORE         (1<<0) //! Do not copy this movable. Atoms with INVISIBILITY_ABSTRACT implicitly do not copy.
-#define ZMM_MANGLE_PLANES  (1<<1) //! Check this movable's overlays/underlays for explicit plane use and mangle for compatibility with Z-Mimic. If you're using emissive overlays, you probably should be using this flag. Expensive, only use if necessary.
-#define ZMM_LOOKAHEAD      (1<<2) //! Look one turf ahead and one turf back when considering z-turfs that might be seeing this atom. Cheap, but not free.
-#define ZMM_AUTOMANGLE_STD (1<<3) //! Behaves the same as ZMM_MANGLE_PLANES, but is automatically applied by SSoverlays. Do not manually use.
-#define ZMM_AUTOMANGLE_PRI (1<<4) //! Behaves the same as ZMM_MANGLE_PLANES, but is automatically applied by SSoverlays. Do not manually use.
+#define ZMM_IGNORE          (1<<0) //! Do not copy this movable. Atoms with INVISIBILITY_ABSTRACT implicitly do not copy.
+#define ZMM_MANGLE_PLANES   (1<<1) //! Check this movable's overlays/underlays for explicit plane use and mangle for compatibility with Z-Mimic. If you're using emissive overlays, you probably should be using this flag. Expensive, only use if necessary.
+#define ZMM_LOOKAHEAD       (1<<2) //! Look one turf ahead and one turf back when considering z-turfs that might be seeing this atom. Cheap, but not free.
+#define ZMM_AUTOMANGLE_NRML (1<<3) //! Behaves the same as ZMM_MANGLE_PLANES, but is automatically applied by SSoverlays. Do not manually use.
+#define ZMM_AUTOMANGLE_PRI  (1<<4) //! Behaves the same as ZMM_MANGLE_PLANES, but is automatically applied by SSoverlays. Do not manually use.
 
-#define ZMM_AUTOMANGLE (ZMM_AUTOMANGLE_STD|ZMM_AUTOMANGLE_PRI)	// convenience
+#define ZMM_AUTOMANGLE (ZMM_AUTOMANGLE_NRML|ZMM_AUTOMANGLE_PRI)	// convenience
 
 DEFINE_BITFIELD(zmm_flags, list(
 	BITFIELD(ZMM_IGNORE),
 	BITFIELD(ZMM_MANGLE_PLANES),
 	BITFIELD(ZMM_LOOKAHEAD),
-	BITFIELD(ZMM_AUTOMANGLE_STD),
+	BITFIELD(ZMM_AUTOMANGLE_NRML),
 	BITFIELD(ZMM_AUTOMANGLE_PRI)
 ))
 

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -233,7 +233,7 @@ SUBSYSTEM_DEF(overlays)
 // This one gets to be done the sane way because it shouldn't be as hot as the others.
 /atom/movable/cut_overlays(priority = FALSE)
 	..()
-	zmm_flags &= priority ? ~ZMM_AUTOMANGLE_PRI : ~ZMM_AUTOMANGLE_STD
+	zmm_flags &= priority ? ~ZMM_AUTOMANGLE_PRI : ~ZMM_AUTOMANGLE_NRML
 
 /// Remove one or more overlays from this atom.
 /atom/proc/cut_overlay(list/overlays, priority)
@@ -277,7 +277,7 @@ SUBSYSTEM_DEF(overlays)
 				found = TRUE
 				break
 		if (!found)
-			zmm_flags &= ~ZMM_AUTOMANGLE_STD
+			zmm_flags &= ~ZMM_AUTOMANGLE_NRML
 
 	// Likewise, but now for priority and AUTOMANGLE_PRI.
 	else if (priority && LAZYLEN(cached_priority))
@@ -293,7 +293,7 @@ SUBSYSTEM_DEF(overlays)
 
 	// None left, just unset the bit.
 	else
-		zmm_flags &= priority ? ~ZMM_AUTOMANGLE_PRI : ~ZMM_AUTOMANGLE_STD
+		zmm_flags &= priority ? ~ZMM_AUTOMANGLE_PRI : ~ZMM_AUTOMANGLE_NRML
 
 /// Add one or more overlays to this atom.
 /atom/proc/add_overlay(list/overlays, priority = FALSE)
@@ -307,7 +307,7 @@ SUBSYSTEM_DEF(overlays)
 	overlays = build_appearance_list(overlays)
 	if (SSoverlays.context_needs_automangle && is_movable)
 		// This is a movable flag.
-		src:zmm_flags |= priority ? ZMM_AUTOMANGLE_PRI : ZMM_AUTOMANGLE_STD
+		src:zmm_flags |= priority ? ZMM_AUTOMANGLE_PRI : ZMM_AUTOMANGLE_NRML
 
 	if (!overlays || (islist(overlays) && !overlays.len))
 		// No point trying to compile if we don't have any overlays.
@@ -340,7 +340,7 @@ SUBSYSTEM_DEF(overlays)
 			LAZYADD(priority_overlays, overlays)
 	else
 		if (!SSoverlays.context_needs_automangle && is_movable)
-			src:zmm_flags &= ~ZMM_AUTOMANGLE_STD
+			src:zmm_flags &= ~ZMM_AUTOMANGLE_NRML
 
 		LAZYCLEARLIST(our_overlays)
 		if (overlays)
@@ -362,7 +362,7 @@ SUBSYSTEM_DEF(overlays)
 			for (var/i in 1 to length(cached_other))
 				var/image/I = cached_other[i]
 				if (I.plane != FLOAT_PLANE)
-					src:zmm_flags |= ZMM_AUTOMANGLE_STD
+					src:zmm_flags |= ZMM_AUTOMANGLE_NRML
 					break
 
 		if(cut_old)

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -13,6 +13,10 @@ SUBSYSTEM_DEF(overlays)
 	var/list/overlay_icon_cache = list()
 	var/overlays_initialized = FALSE
 
+	// If the overlay set currently being considered contains a manglable overlay.
+	// This is only safe because SSoverlays can only ever consider one overlay list at a time with no interior sleeps. Professional on closed course, do not attempt.
+	var/context_needs_automangle
+
 /datum/controller/subsystem/overlays/stat_entry()
 	return ..() + " Ov:[processing.len - (idex - 1)]"
 
@@ -171,6 +175,9 @@ SUBSYSTEM_DEF(overlays)
 		target = appearance_bro.appearance; \
 	}
 
+// If the overlay has a planeset (e.g., emissive), mark for ZM mangle. This won't catch overlays on overlays, but the flag can just manually be set in that case.
+#define ZM_AUTOMANGLE(target) if ((target):plane != FLOAT_PLANE) { SSoverlays.context_needs_automangle = TRUE; }
+
 /atom/proc/build_appearance_list(atom/new_overlays)
 	var/static/image/appearance_bro = new
 	if (islist(new_overlays))
@@ -185,6 +192,21 @@ SUBSYSTEM_DEF(overlays)
 		return new_overlays
 	else
 		APPEARANCEIFY(new_overlays, .)
+
+// The same as the above, but with ZM_AUTOMANGLE.
+/atom/movable/build_appearance_list(atom/new_overlays)
+	var/static/image/appearance_bro = new
+	if (islist(new_overlays))
+		new_overlays = new_overlays:Copy()
+		listclearnulls(new_overlays)
+		for (var/i in 1 to length(new_overlays))
+			var/image/cached_overlay = new_overlays[i]
+			APPEARANCEIFY(cached_overlay, new_overlays[i])
+			ZM_AUTOMANGLE(new_overlays[i])
+		return new_overlays
+	else
+		APPEARANCEIFY(new_overlays, .)
+		ZM_AUTOMANGLE(.)
 
 #undef APPEARANCEIFY
 #define NOT_QUEUED_ALREADY (!(atom_flags & ATOM_OVERLAY_QUEUED))
@@ -208,11 +230,17 @@ SUBSYSTEM_DEF(overlays)
 	if(NOT_QUEUED_ALREADY && need_compile)
 		QUEUE_FOR_COMPILE
 
-/// Remove one or more overlays from this atom. This mutates passed lists.
+// This one gets to be done the sane way because it shouldn't be as hot as the others.
+/atom/movable/cut_overlays(priority = FALSE)
+	..()
+	zmm_flags &= priority ? ~ZMM_AUTOMANGLE_PRI : ~ZMM_AUTOMANGLE_STD
+
+/// Remove one or more overlays from this atom.
 /atom/proc/cut_overlay(list/overlays, priority)
 	if(!overlays)
 		return
 
+	SSoverlays.context_needs_automangle = FALSE
 	overlays = build_appearance_list(overlays)
 
 	var/list/cached_overlays = our_overlays	//sanic
@@ -220,19 +248,66 @@ SUBSYSTEM_DEF(overlays)
 	var/init_o_len = LAZYLEN(cached_overlays)
 	var/init_p_len = LAZYLEN(cached_priority)  //starter pokemon
 
-	LAZYREMOVE(cached_overlays, overlays)
+
 	if(priority)
 		LAZYREMOVE(cached_priority, overlays)
+	else
+		LAZYREMOVE(cached_overlays, overlays)
 
 	if(NOT_QUEUED_ALREADY && ((init_o_len != LAZYLEN(cached_priority)) || (init_p_len != LAZYLEN(cached_overlays))))
 		QUEUE_FOR_COMPILE
 
-/// Add one or more overlays to this atom. This mutates passed lists.
+// This one also gets to be done sanely because it shouldn't be too hot.
+/atom/movable/cut_overlay(list/overlays, priority)
+	..()
+	// If we removed an automangle-eligible overlay and have automangle enabled, reevaluate automangling.
+	if (!SSoverlays.context_needs_automangle || !(zmm_flags && ZMM_AUTOMANGLE))
+		return
+
+	var/list/cached_overlays = our_overlays
+	var/list/cached_priority = priority_overlays
+
+	// If we cut some non-priority overlays but some are still left, we need to scan for AUTOMANGLE_STD.
+	if (!priority && LAZYLEN(cached_overlays))
+		// need to scan overlays
+		var/found = FALSE
+		for (var/i in 1 to length(cached_overlays))
+			var/image/I = cached_overlays[i]
+			if (I.plane != FLOAT_PLANE)
+				found = TRUE
+				break
+		if (!found)
+			zmm_flags &= ~ZMM_AUTOMANGLE_STD
+
+	// Likewise, but now for priority and AUTOMANGLE_PRI.
+	else if (priority && LAZYLEN(cached_priority))
+		// need to scan priority overlays
+		var/found = FALSE
+		for (var/i in 1 to length(cached_priority))
+			var/image/I = cached_priority[i]
+			if (I.plane != FLOAT_PLANE)
+				found = TRUE
+				break
+		if (!found)
+			zmm_flags &= ~ZMM_AUTOMANGLE_PRI
+
+	// None left, just unset the bit.
+	else
+		zmm_flags &= priority ? ~ZMM_AUTOMANGLE_PRI : ~ZMM_AUTOMANGLE_STD
+
+/// Add one or more overlays to this atom.
 /atom/proc/add_overlay(list/overlays, priority = FALSE)
 	if(!overlays)
 		return
 
+	// the things I do for performance
+	var/is_movable = istype(src, /atom/movable)
+
+	SSoverlays.context_needs_automangle = FALSE
 	overlays = build_appearance_list(overlays)
+	if (SSoverlays.context_needs_automangle && is_movable)
+		// This is a movable flag.
+		src:zmm_flags |= priority ? ZMM_AUTOMANGLE_PRI : ZMM_AUTOMANGLE_STD
 
 	if (!overlays || (islist(overlays) && !overlays.len))
 		// No point trying to compile if we don't have any overlays.
@@ -251,13 +326,22 @@ SUBSYSTEM_DEF(overlays)
 	if (!overlays)
 		return
 
+	var/is_movable = istype(src, /atom/movable)
+
+	SSoverlays.context_needs_automangle = FALSE
 	overlays = build_appearance_list(overlays)
 
 	if (priority)
+		if (!SSoverlays.context_needs_automangle && is_movable)
+			src:zmm_flags &= ~ZMM_AUTOMANGLE_PRI
+
 		LAZYCLEARLIST(priority_overlays)
 		if (overlays)
 			LAZYADD(priority_overlays, overlays)
 	else
+		if (!SSoverlays.context_needs_automangle && is_movable)
+			src:zmm_flags &= ~ZMM_AUTOMANGLE_STD
+
 		LAZYCLEARLIST(our_overlays)
 		if (overlays)
 			LAZYADD(our_overlays, overlays)
@@ -274,6 +358,13 @@ SUBSYSTEM_DEF(overlays)
 
 	var/list/cached_other = other.our_overlays
 	if(cached_other)
+		if (istype(src, /atom/movable))
+			for (var/i in 1 to length(cached_other))
+				var/image/I = cached_other[i]
+				if (I.plane != FLOAT_PLANE)
+					src:zmm_flags |= ZMM_AUTOMANGLE_STD
+					break
+
 		if(cut_old)
 			our_overlays = cached_other.Copy()
 		else

--- a/code/controllers/subsystem/zmimic.dm
+++ b/code/controllers/subsystem/zmimic.dm
@@ -461,7 +461,7 @@ SUBSYSTEM_DEF(zmimic)
 		OO.queued = 0
 
 		// If an atom has explicit plane sets on its overlays/underlays, we need to replace the appearance so they can be mangled to work with our planing.
-		if (OO.zmm_flags & ZMM_MANGLE_PLANES)
+		if (OO.zmm_flags & (ZMM_MANGLE_PLANES | ZMM_AUTOMANGLE))
 			var/new_appearance = fixup_appearance_planes(OO.appearance)
 			if (new_appearance)
 				OO.appearance = new_appearance

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -10,7 +10,7 @@
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 10
 	power_channel = LIGHT
-	mz_flags = ZMM_MANGLE_PLANES
+	zmm_flags = ZMM_MANGLE_PLANES
 
 	var/on = TRUE
 	var/area/area = null

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -322,7 +322,7 @@
 	icon = 'icons/obj/mining.dmi'
 	amount = 10
 	max_amount = 10
-	mz_flags = ZMM_MANGLE_PLANES
+	zmm_flags = ZMM_MANGLE_PLANES
 
 	var/upright = 0
 	var/base_state

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -52,7 +52,7 @@
 	mob_swap_flags = ~HEAVY
 	mob_push_flags = ~HEAVY //trundle trundle
 
-	mz_flags = ZMM_MANGLE_PLANES
+	zmm_flags = ZMM_MANGLE_PLANES
 
 	// Wideborgs are offset, but their light shouldn't be. This disables offset because of how the math works (1 is less than 16).
 	light_offset_x = 1
@@ -875,9 +875,9 @@
 
 /mob/living/silicon/robot/updateicon()
 	if (wideborg)
-		mz_flags |= ZMM_LOOKAHEAD
+		zmm_flags |= ZMM_LOOKAHEAD
 	else
-		mz_flags &= ~ZMM_LOOKAHEAD
+		zmm_flags &= ~ZMM_LOOKAHEAD
 
 	cut_overlays()
 	if(stat == CONSCIOUS)

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -1,7 +1,8 @@
-/// The mimic (if any) that's *directly* copying us.
-/atom/movable/var/tmp/atom/movable/openspace/mimic/bound_overlay
-/// Movable-level Z-Mimic flags. This uses ZMM_* flags, not ZM_* flags.
-/atom/movable/var/mz_flags = NONE
+/atom/movable
+	/// The mimic (if any) that's *directly* copying us.
+	var/tmp/atom/movable/openspace/mimic/bound_overlay
+	/// Movable-level Z-Mimic flags. This uses ZMM_* flags, not ZM_* flags.
+	var/zmm_flags = NONE
 
 /atom/movable/forceMove(atom/dest)
 	. = ..(dest)
@@ -199,7 +200,7 @@
 /atom/movable/openspace/turf_proxy
 	plane = OPENTURF_MAX_PLANE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	mz_flags = ZMM_IGNORE  // Only one of these should ever be visible at a time, the mimic logic will handle that.
+	zmm_flags = ZMM_IGNORE  // Only one of these should ever be visible at a time, the mimic logic will handle that.
 
 /atom/movable/openspace/turf_proxy/attackby(obj/item/W, mob/user)
 	loc.attackby(W, user)

--- a/code/modules/multiz/zmimic/mimic_turf.dm
+++ b/code/modules/multiz/zmimic/mimic_turf.dm
@@ -88,6 +88,6 @@
 
 /turf/Entered(atom/movable/thing, turf/oldLoc)
 	. = ..()
-	if (thing.bound_overlay || (thing.mz_flags & ZMM_IGNORE) || thing.invisibility == INVISIBILITY_ABSTRACT || !TURF_IS_MIMICKING(above))
+	if (thing.bound_overlay || (thing.zmm_flags & ZMM_IGNORE) || thing.invisibility == INVISIBILITY_ABSTRACT || !TURF_IS_MIMICKING(above))
 		return
 	above.update_mimic()


### PR DESCRIPTION
This is somewhat experimental, but it should mostly eliminate the need to manually set the plane mangling flag on movables.

Also renames the movable level `mz_flags` to `zmm_flags` to fix VV.

~~WIP: I really don't like how many `istype(src, ...)` this code contains.~~