### PR TITLE
Tweaks Wall Rendering & Fixes Damage Overlays

### DIFF
--- a/code/game/turfs/simulated/wall.dm
+++ b/code/game/turfs/simulated/wall.dm
@@ -33,10 +33,11 @@
 	// TODO: Remove this when falsewalls are implemented.
 	var/cached_wall_state
 
-	var/damage = 0
-	var/damage_overlay = 0
-	/// damage overlays are cached
-	var/static/list/damage_overlays = generate_wall_damage_overlays()
+	var/damage
+	var/tmp/image/damage_overlay
+	// Damage overlays are cached.
+	var/global/damage_overlays[16]
+
 	var/active
 	var/can_open = FALSE
 
@@ -148,7 +149,7 @@
 	for(var/obj/effect/plant/plant in range(src, 1))
 		if(!plant.floor) //shrooms drop to the floor
 			plant.floor = 1
-			plant.update_icon()
+			plant.update_appearance()
 			plant.pixel_x = 0
 			plant.pixel_y = 0
 		plant.update_neighbors()
@@ -205,7 +206,7 @@
 	if(damage >= cap)
 		dismantle_wall()
 	else
-		update_icon()
+		update_appearance()
 
 /turf/simulated/wall/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)//Doesn't fucking work because walls don't interact with air :(
 	burn(exposed_temperature)

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -343,7 +343,7 @@
 					construction_stage = 5
 					user.update_examine_panel(src)
 					to_chat(user, "<span class='notice'>You cut through the outer grille.</span>")
-					update_icon()
+					update_appearance()
 					return
 			if(5)
 				if (W.is_screwdriver())
@@ -353,7 +353,7 @@
 						return
 					construction_stage = 4
 					user.update_examine_panel(src)
-					update_icon()
+					update_appearance()
 					to_chat(user, "<span class='notice'>You unscrew the support lines.</span>")
 					return
 				else if (W.is_wirecutter())
@@ -361,7 +361,7 @@
 					user.update_examine_panel(src)
 					to_chat(user, "<span class='notice'>You mend the outer grille.</span>")
 					playsound(src, W.tool_sound, 100, 1)
-					update_icon()
+					update_appearance()
 					return
 			if(4)
 				var/cut_cover
@@ -395,7 +395,7 @@
 						return
 					construction_stage = 3
 					user.update_examine_panel(src)
-					update_icon()
+					update_appearance()
 					to_chat(user, "<span class='notice'>You press firmly on the cover, dislodging it.</span>")
 					return
 				else if (W.is_screwdriver())
@@ -405,7 +405,7 @@
 						return
 					construction_stage = 5
 					user.update_examine_panel(src)
-					update_icon()
+					update_appearance()
 					to_chat(user, "<span class='notice'>You screw down the support lines.</span>")
 					return
 			if(3)
@@ -416,7 +416,7 @@
 						return
 					construction_stage = 2
 					user.update_examine_panel(src)
-					update_icon()
+					update_appearance()
 					to_chat(user, "<span class='notice'>You pry off the cover.</span>")
 					return
 			if(2)
@@ -427,7 +427,7 @@
 						return
 					construction_stage = 1
 					user.update_examine_panel(src)
-					update_icon()
+					update_appearance()
 					to_chat(user, "<span class='notice'>You remove the bolts anchoring the support rods.</span>")
 					return
 			if(1)
@@ -451,7 +451,7 @@
 						return
 					construction_stage = 0
 					user.update_examine_panel(src)
-					update_icon()
+					update_appearance()
 					to_chat(user, "<span class='notice'>The slice through the support rods.</span>")
 					return
 			if(0)

--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -1,24 +1,23 @@
 /**
  * generates damage overlays
  */
-/proc/generate_wall_damage_overlays()
-	// arbitrary, hardcoded number for now: 16
-	var/amt = 16
-	var/alpha_inc = 256 / 16
-	var/list/generated = list()
-	generated.len = amt
-	. = generated
-	for(var/i in 1 to 16)
-		var/image/I = image(icon = 'icons/turf/walls/damage_masks.dmi', icon_state = "overlay_damage")
-		I.blend_mode = BLEND_MULTIPLY
-		I.alpha = (i * alpha_inc) - 1
-		generated[i] = I
+/turf/simulated/wall/proc/generate_wall_damage_overlays()
+	var/alpha_inc = 256 / damage_overlays.len
+
+	for(var/i = 1; i <= damage_overlays.len; i++)
+		var/image/img = image(icon = 'icons/turf/walls/damage_masks.dmi', icon_state = "overlay_damage")
+		img.blend_mode = BLEND_MULTIPLY
+		img.alpha = (i * alpha_inc) - 1
+		damage_overlays[i] = img
+
 
 /turf/simulated/wall/proc/get_wall_icon()
 	. = (istype(material) && material.icon_base) || 'icons/turf/walls/solid.dmi'
 
+
 /turf/simulated/wall/proc/apply_reinf_overlay()
 	. = istype(reinf_material)
+
 
 /turf/simulated/wall/update_appearance(updates)
 	. = ..()
@@ -27,11 +26,13 @@
 
 	color = material.icon_colour
 
+
 /turf/simulated/wall/update_icon()
 	. = ..()
 
 	if(icon == initial(icon))
 		icon = get_wall_icon()
+
 
 /turf/simulated/wall/update_icon_state()
 	. = ..()
@@ -44,8 +45,13 @@
 	else if(icon_state == "fwall_open")
 		icon_state = cached_wall_state
 
+
 /turf/simulated/wall/update_overlays()
 	. = ..()
+
+	if(!damage_overlays[1]) // Our list hasn't been populated yet.
+		generate_wall_damage_overlays()
+
 	if(!istype(reinf_material))
 		return
 
@@ -59,18 +65,22 @@
 	if (apply_reinf_overlay())
 		// Reinforcement Construction
 		if (construction_stage != null && construction_stage < 6)
-			var/mutable_appearance/appearance = mutable_appearance('icons/turf/walls/_construction_overlays.dmi', "reinf_construct-[construction_stage]", appearance_flags = RESET_COLOR)
+			var/image/appearance = image('icons/turf/walls/_construction_overlays.dmi', "reinf_construct-[construction_stage]")
+			appearance.appearance_flags = RESET_COLOR
 			appearance.color = reinf_material.icon_colour
 			. += appearance
 
 		// Directional Reinforcements.
 		else if(reinf_material.icon_reinf_directionals)
-			var/mutable_appearance/appearance = mutable_appearance(reinf_material.icon_base, icon_state, appearance_flags = RESET_COLOR)
+			var/image/appearance = image(reinf_material.icon_reinf, icon_state)
+			appearance.appearance_flags = RESET_COLOR
+			appearance.color = reinf_material.icon_colour
 			. += appearance
 
 		// Standard Reinforcements.
 		else
-			var/mutable_appearance/appearance = mutable_appearance(reinf_material.icon_reinf, "reinforced", appearance_flags = RESET_COLOR)
+			var/image/appearance = image(reinf_material.icon_reinf, "reinforced")
+			appearance.appearance_flags = RESET_COLOR
 			appearance.color = reinf_material.icon_colour
 			. += appearance
 
@@ -84,4 +94,5 @@
 		if (overlay > damage_overlays.len)
 			overlay = damage_overlays.len
 
-			. += mutable_appearance(damage_overlays[overlay])
+		damage_overlay = damage_overlays[overlay]
+		. += damage_overlay


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Now using images instead of mutable_appearance's.
Wall Damage overlays now works properly, and the cached list is now global.
Also fixes directional reinforcement overlays as they were using the base icon by mistake.