### PR TITLE
Cyborg init refactor + other tweaks/fixes

### DIFF
--- a/citadel.dme
+++ b/citadel.dme
@@ -3095,6 +3095,7 @@
 #include "code\modules\mob\living\silicon\robot\drone\swarm_abilities.dm"
 #include "code\modules\mob\living\silicon\robot\drone\swarm_items.dm"
 #include "code\modules\mob\living\silicon\robot\drone\~defines.dm"
+#include "code\modules\mob\living\silicon\robot\robot_modules\_robot_modules_defs.dm"
 #include "code\modules\mob\living\silicon\robot\robot_modules\event.dm"
 #include "code\modules\mob\living\silicon\robot\robot_modules\event_vr.dm"
 #include "code\modules\mob\living\silicon\robot\robot_modules\station.dm"

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -130,7 +130,7 @@
 
 	if(isrobot(target))
 		var/mob/living/silicon/robot/R = target
-		if(R.module.type == /obj/item/robot_module/robot/quad_jani) // You can now feed the trash borg yay.
+		if(R.module.type == /obj/item/robot_module/robot/quad/jani) // You can now feed the trash borg yay.
 			if(!user.attempt_insert_item_for_installation(src, R.vore_selected))
 				return
 			playsound(R,'sound/items/eatfood.ogg', rand(10,50), 1)

--- a/code/global.dm
+++ b/code/global.dm
@@ -82,9 +82,23 @@ var/global/list/alphabet_uppercase = list("A","B","C","D","E","F","G","H","I","J
 
 // Used by robots and robot preferences.
 var/list/robot_module_types = list(
-	"Standard", "Engineering", "Medical",
-	"Miner",    "Janitor",     "Service",
-	"Clerical", "Security",    "Research"
+	"Standard",
+	"Engineering",
+	"Medical",
+	"Miner",
+	"Janitor",
+	"Service",
+	"Clerical",
+	"Security",
+	"Research",
+	"Quadruped",
+	"MediQuad",
+	"SecuriQuad",
+	"JaniQuad",
+	"SciQuad",
+	"EngiQuad",
+	"Mining Quad",
+	"Service Quad"
 )
 
 // Some scary sounds.
@@ -114,19 +128,6 @@ var/max_explosion_range = 14
 //Keyed list for caching icons so you don't need to make them for records, IDs, etc all separately.
 //Could be useful for AI impersonation or something at some point?
 var/static/list/cached_character_icons = list()
-
-//! ## VR FILE MERGE ## !//
-
-/hook/startup/proc/modules_vr()
-	robot_module_types += "Quadruped"
-	robot_module_types += "MediQuad"
-	robot_module_types += "SecuriQuad"
-	robot_module_types += "JaniQuad"
-	robot_module_types += "SciQuad"
-	robot_module_types += "EngiQuad"
-	robot_module_types += "Mining Quad"
-	robot_module_types += "Service Quad"
-	return 1
 
 var/list/shell_module_types = list(
 	"Standard", "Service", "Clerical"

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -208,47 +208,47 @@
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(user.client && (target in user.client.screen))
-		to_chat(user, "<span class='warning'>You need to take \the [target.name] off before cleaning it!</span>")
+		to_chat(user, "<span class='warning'>You need to take [target] off before cleaning it!</span>")
 	if(istype(target, /obj/structure/sink) || istype(target, /obj/structure/toilet)) //Dog vibes.
-		user.visible_message("[user] begins to lap up water from [target.name].", "<span class='notice'>You begin to lap up water from [target.name].</span>")
-		if(do_after (user, 50))
+		user.visible_message("[user] begins to lap up water from [target].", "<span class='notice'>You begin to lap up water from [target].</span>")
+		if(do_after(user, 50, target = target))
 			water.add_charge(500)
 	else if(water.energy < 5)
 		to_chat(user, "<span class='notice'>Your mouth feels dry. You should drink some water.</span>") //fixed annoying grammar and needless space
 		return
 	else if(istype(target,/obj/effect/debris/cleanable))
-		user.visible_message("[user] begins to lick off \the [target.name].", "<span class='notice'>You begin to lick off \the [target.name]...</span>")
-		if(do_after (user, 50))
-			to_chat(user, "<span class='notice'>You finish licking off \the [target.name].</span>")
+		user.visible_message("[user] begins to lick off [target].", "<span class='notice'>You begin to lick off [target]...</span>")
+		if(do_after(user, 50, target = target))
+			to_chat(user, "<span class='notice'>You finish licking off [target].</span>")
 			water.use_charge(5)
 			qdel(target)
 			var/mob/living/silicon/robot/R = user
 			R.cell.charge += 50
 	else if(istype(target,/obj/item))
 		if(istype(target,/obj/item/trash))
-			user.visible_message("[user] nibbles away at \the [target.name].", "<span class='notice'>You begin to nibble away at \the [target.name]...</span>")
-			if(do_after (user, 50))
-				user.visible_message("[user] finishes eating \the [target.name].", "<span class='notice'>You finish eating \the [target.name].</span>")
-				to_chat(user, "<span class='notice'>You finish off \the [target.name].</span>")
+			user.visible_message("[user] nibbles away at [target].", "<span class='notice'>You begin to nibble away at [target]...</span>")
+			if(do_after(user, 50, target = target))
+				user.visible_message("[user] finishes eating [target].", "<span class='notice'>You finish eating [target].</span>")
+				to_chat(user, "<span class='notice'>You finish off [target].</span>")
 				qdel(target)
 				var/mob/living/silicon/robot/R = user
 				R.cell.charge += 250
 				water.use_charge(5)
 			return
 		if(istype(target,/obj/item/cell))
-			user.visible_message("[user] begins cramming \the [target.name] down its throat.", "<span class='notice'>You begin cramming \the [target.name] down your throat...</span>")
-			if(do_after (user, 50))
-				user.visible_message("[user] finishes gulping down \the [target.name].", "<span class='notice'>You finish swallowing \the [target.name].</span>")
-				to_chat(user, "<span class='notice'>You finish off \the [target.name], and gain some charge!</span>")
+			user.visible_message("[user] begins cramming [target] down its throat.", "<span class='notice'>You begin cramming \the [target.name] down your throat...</span>")
+			if(do_after(user, 50, target = target))
+				user.visible_message("[user] finishes gulping down [target].", "<span class='notice'>You finish swallowing [target].</span>")
+				to_chat(user, "<span class='notice'>You finish off [target], and gain some charge!</span>")
 				var/mob/living/silicon/robot/R = user
 				var/obj/item/cell/C = target
 				R.cell.charge += C.maxcharge / 3
 				water.use_charge(5)
 				qdel(target)
 			return
-		user.visible_message("[user] begins to lick \the [target.name] clean...", "<span class='notice'>You begin to lick \the [target.name] clean...</span>")
-		if(do_after (user, 50))
-			to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
+		user.visible_message("[user] begins to lick [target] clean...", "<span class='notice'>You begin to lick [target] clean...</span>")
+		if(do_after(user, 50, target = target))
+			to_chat(user, "<span class='notice'>You clean [target].</span>")
 			water.use_charge(5)
 			var/obj/effect/debris/cleanable/C = locate() in target
 			qdel(C)
@@ -267,16 +267,16 @@
 			playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 			R.cell.charge -= 666
 		else
-			user.visible_message("<span class='notice'>\the [user] affectionally licks all over \the [target]'s face!</span>", "<span class='notice'>You affectionally lick all over \the [target]'s face!</span>")
+			user.visible_message("<span class='notice'>\The [user] affectionally licks all over [target]'s face!</span>", "<span class='notice'>You affectionally lick all over [target]'s face!</span>")
 			playsound(src.loc, 'sound/effects/attackblob.ogg', 50, 1)
 			water.use_charge(5)
 			var/mob/living/carbon/human/H = target
 			if(H.species.lightweight == 1)
 				H.Weaken(3)
 	else
-		user.visible_message("[user] begins to lick \the [target.name] clean...", "<span class='notice'>You begin to lick \the [target.name] clean...</span>")
-		if(do_after (user, 50))
-			to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
+		user.visible_message("[user] begins to lick [target] clean...", "<span class='notice'>You begin to lick [target] clean...</span>")
+		if(do_after(user, 50, target = target))
+			to_chat(user, "<span class='notice'>You clean [target].</span>")
 			var/obj/effect/debris/cleanable/C = locate() in target
 			qdel(C)
 			target.clean_blood()

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -8,6 +8,17 @@
 	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
 		act = copytext(act,1,length(act))
 
+	var/atom/movable/emote_target
+	if (param)
+		for (var/atom/movable/viewed in view())
+			if (!istype(viewed, /obj) && !ismob(viewed))
+				continue
+			if (viewed.invisibility > see_invisible || viewed.atom_flags & ATOM_ABSTRACT || !length(viewed.name))
+				continue
+			if (findtext(viewed.name, param) == 1)	// Prefix only.
+				emote_target = viewed
+				break
+
 	switch(act)
 		if ("me")
 			if (src.client)
@@ -26,33 +37,15 @@
 
 		if ("salute")
 			if (!src.buckled)
-				var/M = null
-				if (param)
-					for (var/mob/A in view(null, null))
-						if (param == A.name)
-							M = A
-							break
-				if (!M)
-					param = null
-
-				if (param)
-					message = "salutes to [param]."
+				if (emote_target)
+					message = "salutes to [emote_target]."
 				else
 					message = "salutes."
 			m_type = 1
 		if ("bow")
 			if (!src.buckled)
-				var/M = null
-				if (param)
-					for (var/mob/A in view(null, null))
-						if (param == A.name)
-							M = A
-							break
-				if (!M)
-					param = null
-
-				if (param)
-					message = "bows to [param]."
+				if (emote_target)
+					message = "bows to [emote_target]."
 				else
 					message = "bows."
 			m_type = 1
@@ -88,98 +81,43 @@
 			m_type = 1
 
 		if ("glare")
-			var/M = null
-			if (param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-			if (!M)
-				param = null
-
-			if (param)
-				message = "glares at [param]."
+			if (emote_target)
+				message = "glares at [emote_target]."
 			else
 				message = "glares."
 
 		if ("stare")
-			var/M = null
-			if (param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-			if (!M)
-				param = null
-
-			if (param)
-				message = "stares at [param]."
+			if (emote_target)
+				message = "stares at [emote_target]."
 			else
 				message = "stares."
 
 		if ("look")
-			var/M = null
-			if (param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-
-			if (!M)
-				param = null
-
-			if (param)
-				message = "looks at [param]."
+			if (emote_target)
+				message = "looks at [emote_target]."
 			else
 				message = "looks."
 			m_type = 1
 
 		if("beep")
-			var/M = null
-			if(param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-			if(!M)
-				param = null
-
-			if (param)
-				message = "beeps at [param]."
+			if (emote_target)
+				message = "beeps at [emote_target]."
 			else
 				message = "beeps."
 			playsound(src.loc, 'sound/machines/twobeep.ogg', 50, 0)
 			m_type = 1
 
 		if("ping")
-			var/M = null
-			if(param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-			if(!M)
-				param = null
-
-			if (param)
-				message = "pings at [param]."
+			if (emote_target)
+				message = "pings at [emote_target]."
 			else
 				message = "pings."
 			playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
 			m_type = 1
 
 		if("buzz")
-			var/M = null
-			if(param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-			if(!M)
-				param = null
-
-			if (param)
-				message = "buzzes at [param]."
+			if (emote_target)
+				message = "buzzes at [emote_target]."
 			else
 				message = "buzzes."
 			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
@@ -196,139 +134,55 @@
 			spin(15, 1)
 
 		if("yes", "ye")
-			var/M = null
-			if(param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-			if(!M)
-				param = null
-
-			if (param)
-				message = "emits an affirmative blip at [param]."
+			if (emote_target)
+				message = "emits an affirmative blip at [emote_target]."
 			else
 				message = "emits an affirmative blip."
 			playsound(src, 'sound/machines/synth_yes.ogg', 50, 0)
 			m_type = 1
 
 		if("no")
-			var/M = null
-			if(param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-			if(!M)
-				param = null
-
-			if (param)
-				message = "emits a negative blip at [param]."
+			if (emote_target)
+				message = "emits a negative blip at [emote_target]."
 			else
 				message = "emits a negative blip."
 			playsound(src.loc, 'sound/machines/synth_no.ogg', 50, 0)
 			m_type = 1
 
 		if("scary")
-			var/M = null
-			if(param)
-				for (var/mob/A in view(null, null))
-					if(param == A.name)
-						M = A
-						break
-			if(!M)
-				param = null
-
-			if (param)
-				message = "emits a disconcerting tone at [param]."
+			if (emote_target)
+				message = "emits a disconcerting tone at [emote_target]."
 			else
 				message = "emits a disconcerting tone."
 			playsound(src.loc, 'sound/machines/synth_scary.ogg', 50, 0)
 			m_type = 1
 
 		if("dwoop")
-			var/M = null
-			if(param)
-				for (var/mob/A in view(null, null))
-					if(param == A.name)
-						M = A
-						break
-			if(!M)
-				param = null
-
-			if (param)
-				message = "chirps happily at [param]."
+			if (emote_target)
+				message = "chirps happily at [emote_target]."
 			else
 				message = "chirps happily."
 			playsound(src.loc, 'sound/machines/dwoop.ogg', 50, 0)
 			m_type = 1
 
 		if("startup")
-			var/M = null
-			if(param)
-				for (var/mob/A in view(null, null))
-					if(param == A.name)
-						M = A
-						break
-			if(!M)
-				param = null
-
-			if (param)
-				message = "chimes to life."
-			else
-				message = "chimes to life."
-			playsound(src.loc, 'sound/machines/synth_startup.ogg')
+			message = "chimes to life."
+			playsound(src.loc, 'sound/machines/synth_startup.ogg', 50)
 			m_type = 1
 
 		if("shutdown")
-			var/M = null
-			if(param)
-				for (var/mob/A in view(null, null))
-					if(param == A.name)
-						M = A
-						break
-			if(!M)
-				param = null
-
-			if(param)
-				message = "emits a nostalgic tone as they fall silent."
-			else
-				message = "emits a nostalgic tone as they fall silent."
-			playsound(src.loc, 'sound/machines/synth_shutdown.ogg')
+			message = "emits a nostalgic tone as they fall silent."
+			playsound(src.loc, 'sound/machines/synth_shutdown.ogg', 50)
 			m_type = 1
 
 		if("error")
-			var/M = null
-			if(param)
-				for (var/mob/A in view(null, null))
-					if(param == A.name)
-						M = A
-						break
-			if(!M)
-				param = null
-
-			if(param)
-				message = "experiences a system error."
-			else
-				message = "experiences a system error."
-			playsound(src.loc, 'sound/machines/synth_error.ogg')
+			message = "experiences a system error."
+			playsound(src.loc, 'sound/machines/synth_error.ogg', 50)
 			m_type = 1
 
 		if("die")
-			var/M = null
-			if(param)
-				for (var/mob/A in view(null, null))
-					if(param == A.name)
-						M = A
-						break
-			if(!M)
-				param = null
-
-			if(param)
-				message = "crumples, their chassis colder and more lifeless than usual."
-			else
-				message = "crumples, their chassis colder and more lifeless than usual."
-			playsound(src.loc, 'sound/machines/synth_gameover.ogg')
+			message = "crumples, their chassis colder and more lifeless than usual."
+			playsound(src.loc, 'sound/machines/synth_gameover.ogg', 50)
 			m_type = 1
 
 		if("flip")
@@ -358,12 +212,16 @@
 
 		if("bark")
 			if (module.is_quad)
-				message = "lets out a bark."
+				if (emote_target)
+					message = "barks at [emote_target]."
+				else
+					message = "barks."
 
-				playsound(loc, 'sound/voice/bark2.ogg', 50, 1, -1)
+				playsound(loc, 'sound/voice/bark2.ogg', 50, 1)
 				m_type = 2
 			else
 				to_chat(src, "You're not a dog!")
+
 		if("arfe")
 			if (module.is_quad)
 				message = "lets out an A R F E."
@@ -374,22 +232,12 @@
 				to_chat(src, "You're not a dog!")
 
 		if("gonk")
-			var/M = null
-			if(param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-			if(!M)
-				param = null
-
-			if (param)
-				message = "gonks at [param]."
+			if (emote_target)
+				message = "gonks at [emote_target]."
 			else
 				message = "gonks."
 			playsound(src.loc, 'sound/machines/gonk.ogg', 50, 0)
 			m_type = 1
-
 
 		if ("help")
 			to_chat(src, "salute, bow-(none)/mob, clap, flap, aflap, twitch, twitch_s, nod, deathgasp, glare-(none)/mob, stare-(none)/mob, look, beep, ping, \nbuzz, law, halt, yes, no")

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -211,7 +211,7 @@
 				to_chat(src, "You are not security.")
 
 		if("bark")
-			if (module.is_quad)
+			if (module.is_dog())
 				if (emote_target)
 					message = "barks at [emote_target]."
 				else
@@ -223,7 +223,7 @@
 				to_chat(src, "You're not a dog!")
 
 		if("arfe")
-			if (module.is_quad)
+			if (module.is_dog())
 				message = "lets out an A R F E."
 
 				playsound(loc, 'sound/voice/arfe.ogg', 50, 1, -1)

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -339,7 +339,7 @@
 				m_type = 1
 
 		if("law")
-			if (istype(module,/obj/item/robot_module/robot/security) || istype(module,/obj/item/robot_module/robot/quad_sec))
+			if (module.is_the_law)
 				message = "shows its legal authorization barcode."
 
 				playsound(src.loc, 'sound/voice/biamthelaw.ogg', 50, 0)
@@ -348,7 +348,7 @@
 				to_chat(src, "You are not THE LAW, pal.")
 
 		if("halt")
-			if (istype(module,/obj/item/robot_module/robot/security) || istype(module,/obj/item/robot_module/robot/quad_sec))
+			if (module.is_the_law)
 				message = "<B>'s</B> speakers skreech, \"Halt! Security!\"."
 
 				playsound(src.loc, 'sound/voice/halt.ogg', 50, 0)
@@ -357,7 +357,7 @@
 				to_chat(src, "You are not security.")
 
 		if("bark")
-			if (istype(module,/obj/item/robot_module/robot/quad_sec) || istype(module,/obj/item/robot_module/robot/quad_medi) || istype(module,/obj/item/robot_module/robot/quad_jani) || istype(module,/obj/item/robot_module/robot/ert) || istype(module,/obj/item/robot_module/robot/quad_sci) || istype(module,/obj/item/robot_module/robot/quad_engi) || istype(module,/obj/item/robot_module/robot/clerical/quad_serv) || istype(module,/obj/item/robot_module/robot/quad_basic) || istype(module,/obj/item/robot_module/robot/quad_miner))
+			if (module.is_quad)
 				message = "lets out a bark."
 
 				playsound(loc, 'sound/voice/bark2.ogg', 50, 1, -1)
@@ -365,7 +365,7 @@
 			else
 				to_chat(src, "You're not a dog!")
 		if("arfe")
-			if (istype(module,/obj/item/robot_module/robot/quad_sec) || istype(module,/obj/item/robot_module/robot/quad_medi) || istype(module,/obj/item/robot_module/robot/quad_jani) || istype(module,/obj/item/robot_module/robot/ert) || istype(module,/obj/item/robot_module/robot/quad_sci) || istype(module,/obj/item/robot_module/robot/quad_engi) || istype(module,/obj/item/robot_module/robot/clerical/quad_serv) || istype(module,/obj/item/robot_module/robot/quad_basic) || istype(module,/obj/item/robot_module/robot/quad_miner))
+			if (module.is_quad)
 				message = "lets out an A R F E."
 
 				playsound(loc, 'sound/voice/arfe.ogg', 50, 1, -1)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -780,13 +780,22 @@
 	return
 
 /mob/living/silicon/robot/proc/module_reset()
+	shown_robot_modules = FALSE
+	if (client)
+		hud_used.update_robot_modules_display()
 	transform_with_anim()
 	uneq_all()
 	modtype = initial(modtype)
 	hands.icon_state = initial(hands.icon_state)
 
+	lights_on = FALSE
+	radio.set_light(0)
+
 	notify_ai(ROBOT_NOTIFICATION_MODULE_RESET, module.name)
 	module.Reset(src)
+
+	choose_icon(0, set_module_sprites(list("Default" = "robot")))
+
 	qdel(module)
 	module = null
 	updatename("Default")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -882,6 +882,10 @@
 			return 1
 	return 0
 
+/mob/living/silicon/robot/update_canmove()
+	. = ..()
+	updateicon()
+
 /mob/living/silicon/robot/updateicon()
 	if (wideborg)
 		mz_flags |= ZMM_LOOKAHEAD

--- a/code/modules/mob/living/silicon/robot/robot_modules/_robot_modules_defs.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/_robot_modules_defs.dm
@@ -11,3 +11,11 @@
 
 #define MATTER_SYNTH_WITH_NAME(K,T,N,V...) .[K] = new /datum/matter_synth/##T { name = N } (V)
 #define MATTER_SYNTH(K,T,V...) .[K] = new /datum/matter_synth/##T (V)
+#define CYBORG_STACK(T,K) do { var/obj/item/stack/S = new /obj/item/stack/##T(src); S.synths = __cyborg_stack_map(K); . += S } while (FALSE)
+
+/obj/item/robot_module/proc/__cyborg_stack_map(list/targets)
+	if (!islist(targets))
+		targets = list(targets)
+	. = list()
+	for (var/item in targets)
+		. += synths_by_kind[item]

--- a/code/modules/mob/living/silicon/robot/robot_modules/_robot_modules_defs.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/_robot_modules_defs.dm
@@ -1,0 +1,13 @@
+#define MATSYN_WATER "water"
+#define MATSYN_NANITES "nanites"
+#define MATSYN_WIRE "wire"
+#define MATSYN_NANOPASTE "nanopaste"
+#define MATSYN_METAL "metal"
+#define MATSYN_GLASS "glass"
+#define MATSYN_DRUGS "medicine"
+#define MATSYN_WOOD "wood"
+#define MATSYN_PLASTIC "plastic"
+#define MATSYN_PLASTEEL "plasteel"
+
+#define MATTER_SYNTH_WITH_NAME(K,T,N,V...) .[K] = new /datum/matter_synth/##T { name = N } (V)
+#define MATTER_SYNTH(K,T,V...) .[K] = new /datum/matter_synth/##T (V)

--- a/code/modules/mob/living/silicon/robot/robot_modules/event.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/event.dm
@@ -5,76 +5,86 @@
 	name = "lost robot module"
 	hide_on_manifest = 1
 	sprites = list(
-					"Drone" = "drone-lost"
-				)
+		"Drone" = "drone-lost"
+	)
 
-/obj/item/robot_module/robot/lost/Initialize(mapload)
+/obj/item/robot_module/robot/lost/get_modules()
 	. = ..()
-	// Sec
-	modules += new /obj/item/melee/baton/shocker/robot(src)
-	modules += new /obj/item/handcuffs/cyborg(src)
-	modules += new /obj/item/borg/combat/shield(src)
+	. |= list(
+		// Sec
+		/obj/item/melee/baton/shocker/robot,
+		/obj/item/handcuffs/cyborg,
+		/obj/item/borg/combat/shield,
 
-	// Med
-	modules += new /obj/item/healthanalyzer(src)
-	modules += new /obj/item/reagent_containers/borghypo/lost(src)
+		// Med
+		/obj/item/healthanalyzer,
+		/obj/item/reagent_containers/borghypo/lost,
 
-	// Engi
-	modules += new /obj/item/weldingtool/electric/mounted(src)
-	modules += new /obj/item/tool/screwdriver/cyborg(src)
-	modules += new /obj/item/tool/wrench/cyborg(src)
-	modules += new /obj/item/tool/wirecutters/cyborg(src)
-	modules += new /obj/item/multitool(src)
+		// Engi
+		/obj/item/weldingtool/electric/mounted,
+		/obj/item/tool/screwdriver/cyborg,
+		/obj/item/tool/wrench/cyborg,
+		/obj/item/tool/wirecutters/cyborg,
+		/obj/item/multitool,
 
-	// Sci
-	modules += new /obj/item/robotanalyzer(src)
+		// Sci
+		/obj/item/robotanalyzer
+	)
 
+/obj/item/robot_module/robot/lost/get_synths(mob/living/silicon/robot/R)
+	. = ..()
+	MATTER_SYNTH(MATSYN_WIRE, wire)
+
+/obj/item/robot_module/robot/lost/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
 	// Potato
 	emag = new /obj/item/gun/energy/retro/mounted(src)
 
-	var/datum/matter_synth/wire = new /datum/matter_synth/wire()
-	synths += wire
-
 	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
-	C.synths = list(wire)
-	modules += C
+	C.synths = list(synths_by_kind[MATSYN_WIRE])
+	. += C
 
 /obj/item/robot_module/robot/gravekeeper
 	name = "gravekeeper robot module"
 	hide_on_manifest = 1
 	sprites = list(
-					"Drone" = "drone-gravekeeper",
-					"Sleek" = "sleek-gravekeeper"
-				)
+		"Drone" = "drone-gravekeeper",
+		"Sleek" = "sleek-gravekeeper"
+	)
 
-/obj/item/robot_module/robot/gravekeeper/Initialize(mapload)
+/obj/item/robot_module/robot/gravekeeper/get_modules()
 	. = ..()
-	// For fending off animals and looters
-	modules += new /obj/item/melee/baton/shocker/robot(src)
-	modules += new /obj/item/borg/combat/shield(src)
+	. |= list(
+		// For fending off animals and looters
+		/obj/item/melee/baton/shocker/robot,
+		/obj/item/borg/combat/shield,
 
-	// For repairing gravemarkers
-	modules += new /obj/item/weldingtool/electric/mounted(src)
-	modules += new /obj/item/tool/screwdriver/cyborg(src)
-	modules += new /obj/item/tool/wrench/cyborg(src)
+		// For repairing gravemarkers
+		/obj/item/weldingtool/electric/mounted,
+		/obj/item/tool/screwdriver/cyborg,
+		/obj/item/tool/wrench/cyborg,
 
-	// For growing flowers
-	modules += new /obj/item/material/minihoe(src)
-	modules += new /obj/item/material/knife/machete/hatchet(src)
-	modules += new /obj/item/analyzer/plant_analyzer(src)
-	modules += new /obj/item/storage/bag/plants(src)
-	modules += new /obj/item/robot_harvester(src)
+		// For growing flowers
+		/obj/item/material/minihoe,
+		/obj/item/material/knife/machete/hatchet,
+		/obj/item/analyzer/plant_analyzer,
+		/obj/item/storage/bag/plants,
+		/obj/item/robot_harvester,
 
-	// For digging and beautifying graves
-	modules += new /obj/item/shovel(src)
-	modules += new /obj/item/gripper/gravekeeper(src)
+		// For digging and beautifying graves
+		/obj/item/shovel,
+		/obj/item/gripper/gravekeeper
+	)
 
+/obj/item/robot_module/robot/gravekeeper/get_synths(mob/living/silicon/robot/R)
+	. = ..()
+	MATTER_SYNTH(MATSYN_WOOD, wood, 25000)
+
+/obj/item/robot_module/robot/gravekeeper/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
 	// For really persistent looters
 	emag = new /obj/item/gun/energy/retro/mounted(src)
 
-	var/datum/matter_synth/wood = new /datum/matter_synth/wood(25000)
-	synths += wood
-
 	var/obj/item/stack/material/cyborg/wood/W = new (src)
-	W.synths = list(wood)
-	modules += W
+	W.synths = list(synths_by_kind[MATSYN_WOOD])
+	. += W

--- a/code/modules/mob/living/silicon/robot/robot_modules/event_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/event_vr.dm
@@ -1,60 +1,42 @@
-/obj/item/robot_module/robot/stray
+/obj/item/robot_module/robot/quad/stray
 	name = "stray robot module"
 	hide_on_manifest = 1
 	sprites = list(
-					"Stray" = "stray"
-				)
+		"Stray" = "stray"
+	)
+	can_shred = TRUE
 
-/obj/item/robot_module/robot/stray/Initialize(mapload)
+/obj/item/robot_module/robot/quad/stray/get_modules()
 	. = ..()
-	var/mob/living/silicon/robot/R = loc
-	// General
-	src.modules += new /obj/item/dogborg/boop_module(src)
+	. |= list(
+		// Sec
+		/obj/item/handcuffs/cyborg,
+		/obj/item/dogborg/jaws/big,
+		/obj/item/melee/baton/robot,
+		/obj/item/dogborg/pounce,
 
-	// Sec
-	src.modules += new /obj/item/handcuffs/cyborg(src)
-	src.modules += new /obj/item/dogborg/jaws/big(src)
-	src.modules += new /obj/item/melee/baton/robot(src)
-	src.modules += new /obj/item/dogborg/pounce(src)
+		// Med
+		/obj/item/healthanalyzer,
+		/obj/item/shockpaddles/robot/hound,
+		/obj/item/dogborg/mirrortool,
 
-	// Med
-	src.modules += new /obj/item/healthanalyzer(src)
-	src.modules += new /obj/item/shockpaddles/robot/hound(src)
-	src.modules += new /obj/item/dogborg/mirrortool(src)
+		// Engi
+		/obj/item/weldingtool/electric/mounted,
+		/obj/item/tool/screwdriver/cyborg,
+		/obj/item/tool/wrench/cyborg,
+		/obj/item/tool/wirecutters/cyborg,
+		/obj/item/multitool
+	)
 
-	// Engi
-	src.modules += new /obj/item/weldingtool/electric/mounted(src)
-	src.modules += new /obj/item/tool/screwdriver/cyborg(src)
-	src.modules += new /obj/item/tool/wrench/cyborg(src)
-	src.modules += new /obj/item/tool/wirecutters/cyborg(src)
-	src.modules += new /obj/item/multitool(src)
-
+/obj/item/robot_module/robot/quad/stray/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
 	// Boof
 	src.emag 	 = new /obj/item/gun/energy/retro/mounted(src)
 
-	var/datum/matter_synth/water = new /datum/matter_synth(500) //Starts full and has a max of 500
-	water.name = "Water reserves"
-	water.recharge_rate = 0
-	R.water_res = water
-	synths += water
-
 	var/obj/item/reagent_containers/borghypo/hound/lost/H = new /obj/item/reagent_containers/borghypo/hound/lost(src)
-	H.water = water
-	src.modules += H
-
-	var/obj/item/dogborg/tongue/T = new /obj/item/dogborg/tongue(src)
-	T.water = water
-	src.modules += T
+	H.water = synths_by_kind[MATSYN_WATER]
+	. += H
 
 	var/obj/item/dogborg/sleeper/B = new /obj/item/dogborg/sleeper(src)
-	B.water = water
-	src.modules += B
-
-	R.icon = 'icons/mob/robots_wide.dmi'
-	R.set_base_pixel_x(-16)
-	R.dogborg = TRUE
-	R.wideborg = TRUE
-	R.icon_dimension_x = 64
-	add_verb(R, /mob/living/silicon/robot/proc/ex_reserve_refill)
-	add_verb(R, /mob/living/proc/shred_limb)
-	add_verb(R, /mob/living/silicon/robot/proc/rest_style)
+	B.water = synths_by_kind[MATSYN_WATER]
+	. += B

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -246,12 +246,12 @@ GLOBAL_LIST_INIT(robot_modules, list(
 	R.dogborg = TRUE
 	R.wideborg = TRUE
 	R.icon_dimension_x = 64
-	add_obj_verb(R, list(
+	add_verb(R, list(
 		/mob/living/silicon/robot/proc/ex_reserve_refill,
 		/mob/living/silicon/robot/proc/rest_style
 	))
 	if (can_shred)
-		add_obj_verb(R, /mob/living/proc/shred_limb)
+		add_verb(R, /mob/living/proc/shred_limb)
 
 /obj/item/robot_module/robot/quad/Reset(mob/living/silicon/robot/R)
 	. = ..()
@@ -260,7 +260,7 @@ GLOBAL_LIST_INIT(robot_modules, list(
 	R.pixel_y = initial(R.pixel_y)
 	R.icon = initial(R.icon)
 	R.base_pixel_x = initial(R.pixel_x)
-	remove_obj_verb(R, list(
+	remove_verb(R, list(
 		/mob/living/silicon/robot/proc/ex_reserve_refill,
 		/mob/living/proc/shred_limb,
 		/mob/living/silicon/robot/proc/rest_style

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -10,15 +10,15 @@ GLOBAL_LIST_INIT(robot_modules, list(
 	"Engineering"	= /obj/item/robot_module/robot/engineering/general,
 //	"Construction"	= /obj/item/robot_module/robot/engineering/construction,
 	"Janitor" 		= /obj/item/robot_module/robot/janitor,
-	"Quadruped"		= /obj/item/robot_module/robot/quad_basic,
-	"MediQuad"		= /obj/item/robot_module/robot/quad_medi,
-	"SecuriQuad"	= /obj/item/robot_module/robot/quad_sec,
-	"JaniQuad"		= /obj/item/robot_module/robot/quad_jani,
-	"SciQuad"		= /obj/item/robot_module/robot/quad_sci,
-	"EngiQuad"		= /obj/item/robot_module/robot/quad_engi,
-	"Mining Quad"	= /obj/item/robot_module/robot/quad_miner,
-	"Service Quad"	= /obj/item/robot_module/robot/clerical/quad_serv,
-	"ERT"			= /obj/item/robot_module/robot/ert
+	"Quadruped"		= /obj/item/robot_module/robot/quad/basic,
+	"MediQuad"		= /obj/item/robot_module/robot/quad/medi,
+	"SecuriQuad"	= /obj/item/robot_module/robot/quad/sec,
+	"JaniQuad"		= /obj/item/robot_module/robot/quad/jani,
+	"SciQuad"		= /obj/item/robot_module/robot/quad/sci,
+	"EngiQuad"		= /obj/item/robot_module/robot/quad/engi,
+	"Mining Quad"	= /obj/item/robot_module/robot/quad/miner,
+	"Service Quad"	= /obj/item/robot_module/robot/quad/serv,
+	"ERT"			= /obj/item/robot_module/robot/quad/ert
 	))
 
 /obj/item/robot_module
@@ -33,6 +33,12 @@ GLOBAL_LIST_INIT(robot_modules, list(
 	var/sprites = list()
 	var/can_be_pushed = 1
 	var/no_slip = 0
+	/// Enables some dogborg mechanics and icon behaviors.
+	var/is_quad = FALSE
+	/// Affects emotes.
+	var/is_the_law = FALSE
+	/// Enables a verb.
+	var/can_shred = FALSE
 
 	var/languages = list(
 		LANGUAGE_AKHANI = 0,
@@ -56,6 +62,7 @@ GLOBAL_LIST_INIT(robot_modules, list(
 
 	var/list/modules = list()
 	var/list/datum/matter_synth/synths = list()
+	var/list/synths_by_kind = list()
 	var/obj/item/emag = null
 	var/obj/item/borg/upgrade/jetpack = null
 	var/obj/item/borg/upgrade/advhealth = null
@@ -82,8 +89,22 @@ GLOBAL_LIST_INIT(robot_modules, list(
 		R.radio.recalculateChannels()
 
 	R.set_module_sprites(sprites)
+
+	handle_custom_item(R)
+
 	// TODO: REFACTOR CYBORGS THEY ARE ALL SHITCODE
 	INVOKE_ASYNC(R, /mob/living/silicon/robot/proc/choose_icon, R.module_sprites.len + 1, R.module_sprites)
+
+	// Setup synths, modules, and modules with custom init code.
+	synths_by_kind = get_synths(R)
+	for (var/key in synths_by_kind)
+		synths += synths_by_kind[key]
+
+	for (var/entry in get_modules())
+		modules += new entry(src)
+
+	for (var/thing in handle_special_module_init(R))
+		modules += thing
 
 	for(var/obj/item/I in modules)
 		ADD_TRAIT(I, TRAIT_ITEM_NODROP, CYBORG_MODULE_TRAIT)
@@ -96,7 +117,23 @@ GLOBAL_LIST_INIT(robot_modules, list(
 
 	if(R.radio)
 		R.radio.recalculateChannels()
-	R.choose_icon(0, R.set_module_sprites(list("Default" = "robot")))
+
+/// Get a list of all matter synths available to this module. Executes before handle_special_module_init.
+/obj/item/robot_module/proc/get_synths(mob/living/silicon/robot/R)
+	. = list()
+
+/// Get a list of typepaths that should be put into the modules list.
+/obj/item/robot_module/proc/get_modules()
+	SHOULD_CALL_PARENT(TRUE)
+	return list()
+
+// This is for modules that need special handling, not just being added to the modules list.
+/obj/item/robot_module/proc/handle_special_module_init(mob/living/silicon/robot/R)
+	SHOULD_CALL_PARENT(TRUE)
+	. = list()
+
+/obj/item/robot_module/proc/handle_custom_item(mob/living/silicon/robot/R)
+	return
 
 /obj/item/robot_module/Destroy()
 	for(var/module in modules)
@@ -105,6 +142,7 @@ GLOBAL_LIST_INIT(robot_modules, list(
 		qdel(synth)
 	modules.Cut()
 	synths.Cut()
+	synths_by_kind = null
 	qdel(emag)
 	qdel(jetpack)
 	emag = null
@@ -181,23 +219,89 @@ GLOBAL_LIST_INIT(robot_modules, list(
 	if(!can_be_pushed)
 		R.status_flags |= CANPUSH
 
-// Cyborgs (non-drones), default loadout. This will be given to every module.
-/obj/item/robot_module/robot/Initialize(mapload)
+/obj/item/robot_module/robot/get_modules()
 	. = ..()
-	src.modules += new /obj/item/flash/robot(src)
-	src.modules += new /obj/item/tool/crowbar/cyborg(src)
-	src.modules += new /obj/item/extinguisher(src)
-	src.modules += new /obj/item/gps/robot(src)
-	vr_new() // For modules in robot_modules_vr.dm //TODO: Integrate
+	// Common items that all modules have.
+	. |= list(
+		/obj/item/flash/robot,
+		/obj/item/tool/crowbar/cyborg,
+		/obj/item/extinguisher,
+		/obj/item/gps/robot
+	)
 
-//Just add a new proc with the robot_module type if you wish to run some other vore code
-/obj/item/robot_module/proc/vr_new() // Any Global modules, just add them before the return (This will also affect all the borgs in this file)
-	return
+/obj/item/robot_module/robot/quad
+	is_quad = TRUE
 
-// /obj/item/robot_module/robot/medical/surgeon/vr_new() //Surgeon Bot
-// 	src.modules += new /obj/item/sleevemate(src) //Lets them scan people.
-// 	. = ..() //Any Global vore modules will come from here
+/obj/item/robot_module/robot/quad/Initialize()
+	. = ..()
+	var/mob/living/silicon/robot/R = loc
+	ASSERT(istype(R))
 
-// /obj/item/robot_module/robot/medical/crisis/vr_new() //Crisis Bot
-// 	src.modules += new /obj/item/sleevemate(src) //Lets them scan people.
-// 	. = ..() //Any Global vore modules will come from here
+	R.icon = 'icons/mob/robots_wide.dmi'
+	R.set_base_pixel_x(-16)
+	R.dogborg = TRUE
+	R.wideborg = TRUE
+	R.icon_dimension_x = 64
+	add_obj_verb(R, list(
+		/mob/living/silicon/robot/proc/ex_reserve_refill,
+		/mob/living/silicon/robot/proc/rest_style
+	))
+	if (can_shred)
+		add_obj_verb(R, /mob/living/proc/shred_limb)
+
+/obj/item/robot_module/robot/quad/Reset(mob/living/silicon/robot/R)
+	. = ..()
+	// Reset a bunch of wideborg specific things.
+	R.pixel_x = initial(R.pixel_x)
+	R.pixel_y = initial(R.pixel_y)
+	R.icon = initial(R.icon)
+	R.base_pixel_x = initial(R.pixel_x)
+	remove_obj_verb(R, list(
+		/mob/living/silicon/robot/proc/ex_reserve_refill,
+		/mob/living/proc/shred_limb,
+		/mob/living/silicon/robot/proc/rest_style
+	))
+	R.scrubbing = FALSE
+	R.dogborg = FALSE
+	R.wideborg = FALSE
+
+/obj/item/robot_module/robot/quad/get_modules()
+	. = ..()
+	. |= list(
+		/obj/item/dogborg/boop_module //Boop people on the nose.
+	)
+
+/obj/item/robot_module/robot/quad/get_synths(mob/living/silicon/robot/R)
+	. = ..()
+	var/datum/matter_synth/water = new /datum/matter_synth(500)
+	water.name = "Water reserves"
+	water.recharge_rate = 0
+	R.water_res = water
+	.[MATSYN_WATER] = water
+
+/obj/item/robot_module/robot/quad/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
+
+	var/obj/item/dogborg/tongue/T = new /obj/item/dogborg/tongue(src)
+	T.water = synths_by_kind[MATSYN_WATER]
+	. += T
+
+// Custom sprite stuff.
+
+/obj/item/robot_module/robot/quad/engi/handle_custom_item(mob/living/silicon/robot/R)
+	. = ..()
+	if (R.client?.ckey == "nezuli")
+		sprites += "Alina"
+		sprites["Alina"] = "alina-eng"
+
+/obj/item/robot_module/robot/quad/medi/handle_custom_item(mob/living/silicon/robot/R)
+	. = ..()
+	if (R.client?.ckey == "nezuli")
+		sprites += "Alina"
+		sprites["Alina"] = "alina-med"
+
+/obj/item/robot_module/robot/quad/sec/handle_custom_item(mob/living/silicon/robot/R)
+	. = ..()
+	if (R.client?.ckey == "nezuli")
+		sprites += "Alina"
+		sprites["Alina"] = "alina-sec"

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -88,9 +88,9 @@ GLOBAL_LIST_INIT(robot_modules, list(
 			channels = R.mainframe.aiRadio.channels
 		R.radio.recalculateChannels()
 
-	R.set_module_sprites(sprites)
-
 	handle_custom_item(R)
+
+	R.set_module_sprites(sprites)
 
 	// TODO: REFACTOR CYBORGS THEY ARE ALL SHITCODE
 	INVOKE_ASYNC(R, /mob/living/silicon/robot/proc/choose_icon, R.module_sprites.len + 1, R.module_sprites)

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -33,8 +33,6 @@ GLOBAL_LIST_INIT(robot_modules, list(
 	var/sprites = list()
 	var/can_be_pushed = 1
 	var/no_slip = 0
-	/// Enables some dogborg mechanics and icon behaviors.
-	var/is_quad = FALSE
 	/// Affects emotes.
 	var/is_the_law = FALSE
 	/// Enables a verb.
@@ -234,7 +232,6 @@ GLOBAL_LIST_INIT(robot_modules, list(
 	)
 
 /obj/item/robot_module/robot/quad
-	is_quad = TRUE
 
 /obj/item/robot_module/robot/quad/Initialize()
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -219,6 +219,10 @@ GLOBAL_LIST_INIT(robot_modules, list(
 	if(!can_be_pushed)
 		R.status_flags |= CANPUSH
 
+/// This is different from the dogborg or wideborg vars -- this is specifically if the module is a *dog* - if it should be able to do dog things like bark.
+/obj/item/robot_module/proc/is_dog()
+	return FALSE
+
 /obj/item/robot_module/robot/get_modules()
 	. = ..()
 	// Common items that all modules have.
@@ -286,22 +290,25 @@ GLOBAL_LIST_INIT(robot_modules, list(
 	T.water = synths_by_kind[MATSYN_WATER]
 	. += T
 
-// Custom sprite stuff.
+/obj/item/robot_module/robot/quad/is_dog()
+	var/mob/living/silicon/robot/R = loc
+	ASSERT(istype(R))
+	// This is the only non-canid dogborg type right now.
+	return R.icontype != "F3-LINE"
+
+// Custom sprite stuff. There's a dedicated system for this, not sure why this is done separately.
 
 /obj/item/robot_module/robot/quad/engi/handle_custom_item(mob/living/silicon/robot/R)
 	. = ..()
 	if (R.client?.ckey == "nezuli")
-		sprites += "Alina"
 		sprites["Alina"] = "alina-eng"
 
 /obj/item/robot_module/robot/quad/medi/handle_custom_item(mob/living/silicon/robot/R)
 	. = ..()
 	if (R.client?.ckey == "nezuli")
-		sprites += "Alina"
 		sprites["Alina"] = "alina-med"
 
 /obj/item/robot_module/robot/quad/sec/handle_custom_item(mob/living/silicon/robot/R)
 	. = ..()
 	if (R.client?.ckey == "nezuli")
-		sprites += "Alina"
 		sprites["Alina"] = "alina-sec"

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/cargo.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/cargo.dm
@@ -3,87 +3,85 @@
 	channels = list("Supply" = 1)
 	networks = list(NETWORK_MINE)
 	sprites = list(
-					"NM-USE NanoTrasen" = "robotMine",
-					"Cabeiri" = "eyebot-miner",
-					"Haruka" = "marinaMN",
-					"Telemachus" = "toiletbotminer",
-					"WTOperator" = "sleekminer",
-					"XI-GUS" = "spidermining",
-					"XI-ALP" = "heavyMiner",
-					"Basic" = "Miner_old",
-					"Advanced Droid" = "droid-miner",
-					"Treadhead" = "Miner",
-					"Drone" = "drone-miner",
-					"Misato" = "tall2miner",
-					"L3P1-D0T" = "Glitterfly-Miner",
-					"Miss M" = "miss-miner",
-					"Carffin" = "coffin-Service",
-					"Coffing" = "coffin-Mining",
-					"Handy" = "handy-miner",
-					"Acheron" = "mechoid-Miner",
-					"Shellguard Noble" = "Noble-DIG",
-					"ZOOM-BA" = "zoomba-miner",
-					"W02M" = "worm-miner"
-				)
+		"NM-USE NanoTrasen" = "robotMine",
+		"Cabeiri" = "eyebot-miner",
+		"Haruka" = "marinaMN",
+		"Telemachus" = "toiletbotminer",
+		"WTOperator" = "sleekminer",
+		"XI-GUS" = "spidermining",
+		"XI-ALP" = "heavyMiner",
+		"Basic" = "Miner_old",
+		"Advanced Droid" = "droid-miner",
+		"Treadhead" = "Miner",
+		"Drone" = "drone-miner",
+		"Misato" = "tall2miner",
+		"L3P1-D0T" = "Glitterfly-Miner",
+		"Miss M" = "miss-miner",
+		"Carffin" = "coffin-Service",
+		"Coffing" = "coffin-Mining",
+		"Handy" = "handy-miner",
+		"Acheron" = "mechoid-Miner",
+		"Shellguard Noble" = "Noble-DIG",
+		"ZOOM-BA" = "zoomba-miner",
+		"W02M" = "worm-miner"
+	)
 
-/obj/item/robot_module/robot/miner/Initialize(mapload)
+/obj/item/robot_module/robot/miner/get_modules()
 	. = ..()
-	src.modules += new /obj/item/borg/sight/material(src)
-	src.modules += new /obj/item/tool/wrench/cyborg(src)
-	src.modules += new /obj/item/tool/screwdriver/cyborg(src)
-	src.modules += new /obj/item/storage/bag/ore(src)
-	src.modules += new /obj/item/pickaxe/borgdrill(src)
-	src.modules += new /obj/item/storage/bag/sheetsnatcher/borg(src)
-	src.modules += new /obj/item/gripper/miner(src)
-	src.modules += new /obj/item/mining_scanner(src)
-	src.emag = new /obj/item/pickaxe/plasmacutter(src)
-	src.emag = new /obj/item/pickaxe/diamonddrill(src)
-	src.emag = new /obj/item/melee/disruptor/borg(src)
+	. |= list(
+		/obj/item/borg/sight/material,
+		/obj/item/tool/wrench/cyborg,
+		/obj/item/tool/screwdriver/cyborg,
+		/obj/item/storage/bag/ore,
+		/obj/item/pickaxe/borgdrill,
+		/obj/item/storage/bag/sheetsnatcher/borg,
+		/obj/item/gripper/miner,
+		/obj/item/mining_scanner
+	)
 
-/obj/item/robot_module/robot/quad_miner
+/obj/item/robot_module/robot/miner/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
+
+	// TODO: Only one emag module is supported right now.
+	src.emag = new /obj/item/pickaxe/plasmacutter(src)
+	// src.emag = new /obj/item/pickaxe/diamonddrill(src)
+	// src.emag = new /obj/item/melee/disruptor/borg(src)
+
+/obj/item/robot_module/robot/quad/miner
 	name = "Mining Quadruped module"
 	sprites = list(
-					"F3-LINE" = "FELI-Mining",
-					"K-MINE" = "kmine",
-					"Cargo Hound" = "cargohound",
-					"Cargo Hound Dark" = "cargohounddark"
-					)
+		"F3-LINE" = "FELI-Mining",
+		"K-MINE" = "kmine",
+		"Cargo Hound" = "cargohound",
+		"Cargo Hound Dark" = "cargohounddark"
+	)
 	channels = list("Supply" = 1)
 	can_be_pushed = 0
 
-// In a nutshell, basicly service/butler robot but in dog form.
-/obj/item/robot_module/robot/quad_miner/Initialize(mapload)
+/obj/item/robot_module/robot/quad/miner/get_modules()
 	. = ..()
-	var/mob/living/silicon/robot/R = loc
-	src.modules += new /obj/item/borg/sight/material(src)
-	src.modules += new /obj/item/tool/wrench/cyborg(src)
-	src.modules += new /obj/item/tool/screwdriver/cyborg(src)
-	src.modules += new /obj/item/storage/bag/ore(src)
-	src.modules += new /obj/item/pickaxe/borgdrill(src)
-	src.modules += new /obj/item/storage/bag/sheetsnatcher/borg(src)
-	src.modules += new /obj/item/gripper/miner(src)
-	src.modules += new /obj/item/mining_scanner(src)
-	src.modules += new /obj/item/dogborg/jaws/small(src)
-	src.modules += new /obj/item/dogborg/boop_module(src)
+	. |= list(
+		/obj/item/borg/sight/material,
+		/obj/item/tool/wrench/cyborg,
+		/obj/item/tool/screwdriver/cyborg,
+		/obj/item/storage/bag/ore,
+		/obj/item/pickaxe/borgdrill,
+		/obj/item/storage/bag/sheetsnatcher/borg,
+		/obj/item/gripper/miner,
+		/obj/item/mining_scanner,
+		/obj/item/dogborg/jaws/small
+	)
+
+// In a nutshell, basically service/butler robot but in dog form.
+/obj/item/robot_module/robot/quad/miner/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
+
+	// TODO: Only one emag module is supported right now.
 	src.emag = new /obj/item/pickaxe/plasmacutter(src)
-	src.emag = new /obj/item/pickaxe/diamonddrill(src)
-	src.emag = new /obj/item/melee/disruptor/borg(src)
+	// src.emag = new /obj/item/pickaxe/diamonddrill(src)
+	// src.emag = new /obj/item/melee/disruptor/borg(src)
 
-	var/datum/matter_synth/water = new /datum/matter_synth(500) // buffy fix, was 0
-	water.name = "Water reserves"
-	water.recharge_rate = 0
-	water.max_energy = 1000
-	R.water_res = water
-	synths += water
-
-	var/obj/item/dogborg/tongue/T = new /obj/item/dogborg/tongue(src)
-	T.water = water
-	src.modules += T
-
-	R.icon = 'icons/mob/robots_wide.dmi'
-	R.set_base_pixel_x(-16)
-	R.dogborg = TRUE
-	R.wideborg = TRUE
-	R.icon_dimension_x = 64
-	add_verb(R, /mob/living/silicon/robot/proc/ex_reserve_refill)
-	add_verb(R, /mob/living/silicon/robot/proc/rest_style)
+/obj/item/robot_module/robot/quad/miner/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
+	// These get a larger water synth.
+	synths_by_kind[MATSYN_WATER]:max_energy = 1000

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/drone.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/drone.dm
@@ -54,44 +54,15 @@
 	MD.plastic = synths_by_kind[MATSYN_PLASTIC]
 	. += MD
 
-	var/obj/item/stack/material/cyborg/steel/M = new (src)
-	M.synths = list(synths_by_kind[MATSYN_METAL])
-	. += M
-
-	var/obj/item/stack/material/cyborg/glass/G = new (src)
-	G.synths = list(synths_by_kind[MATSYN_GLASS])
-	. += G
-
-	var/obj/item/stack/rods/cyborg/rods = new /obj/item/stack/rods/cyborg(src)
-	rods.synths = list(synths_by_kind[MATSYN_METAL])
-	. += rods
-
-	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
-	C.synths = list(synths_by_kind[MATSYN_WIRE])
-	. += C
-
-	var/obj/item/stack/tile/floor/cyborg/S = new /obj/item/stack/tile/floor/cyborg(src)
-	S.synths = list(synths_by_kind[MATSYN_METAL])
-	. += S
-
-	var/obj/item/stack/material/cyborg/glass/reinforced/RG = new (src)
-	RG.synths = list(
-		synths_by_kind[MATSYN_METAL],
-		synths_by_kind[MATSYN_GLASS]
-	)
-	. += RG
-
-	var/obj/item/stack/tile/wood/cyborg/WT = new /obj/item/stack/tile/wood/cyborg(src)
-	WT.synths = list(synths_by_kind[MATSYN_WOOD])
-	. += WT
-
-	var/obj/item/stack/material/cyborg/wood/W = new (src)
-	W.synths = list(synths_by_kind[MATSYN_WOOD])
-	. += W
-
-	var/obj/item/stack/material/cyborg/plastic/P = new (src)
-	P.synths = list(synths_by_kind[MATSYN_PLASTIC])
-	. += P
+	CYBORG_STACK(material/cyborg/steel, MATSYN_METAL)
+	CYBORG_STACK(material/cyborg/glass, MATSYN_GLASS)
+	CYBORG_STACK(rods/cyborg          , MATSYN_METAL)
+	CYBORG_STACK(cable_coil/cyborg    , MATSYN_WIRE)
+	CYBORG_STACK(tile/floor/cyborg    , MATSYN_METAL)
+	CYBORG_STACK(material/cyborg/glass/reinforced, list(MATSYN_METAL, MATSYN_GLASS))
+	CYBORG_STACK(tile/wood/cyborg     , MATSYN_WOOD)
+	CYBORG_STACK(material/cyborg/wood , MATSYN_WOOD)
+	CYBORG_STACK(material/cyborg/plastic, MATSYN_PLASTIC)
 
 /obj/item/robot_module/drone/construction
 	name = "construction drone module"

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/drone.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/drone.dm
@@ -6,88 +6,92 @@
 	no_slip = 1
 	networks = list(NETWORK_ENGINEERING)
 
-/obj/item/robot_module/drone/Initialize(mapload)
+/obj/item/robot_module/drone/get_modules()
 	. = ..()
-	var/mob/living/silicon/robot/robot = loc
-	src.modules += new /obj/item/borg/sight/meson(src)
-	src.modules += new /obj/item/weldingtool/electric/mounted/cyborg(src)
-	src.modules += new /obj/item/tool/screwdriver/cyborg(src)
-	src.modules += new /obj/item/tool/wrench/cyborg(src)
-	src.modules += new /obj/item/tool/crowbar/cyborg(src)
-	src.modules += new /obj/item/tool/wirecutters/cyborg(src)
-	src.modules += new /obj/item/multitool(src)
-	src.modules += new /obj/item/lightreplacer(src)
-	src.modules += new /obj/item/gripper(src)
-	src.modules += new /obj/item/mop(src)
-	src.modules += new /obj/item/gripper/no_use/loader(src)
-	src.modules += new /obj/item/extinguisher(src)
-	src.modules += new /obj/item/pipe_painter(src)
-	src.modules += new /obj/item/floor_painter(src)
-	src.modules += new /obj/item/t_scanner(src)
-	src.modules += new /obj/item/analyzer(src)
-	src.modules += new /obj/item/inflatable_dispenser/robot(src)
-	src.modules += new /obj/item/barrier_tape_roll/engineering(src)
-	src.modules += new /obj/item/pipe_dispenser(src)
+	. |= list(
+		/obj/item/borg/sight/meson,
+		/obj/item/weldingtool/electric/mounted/cyborg,
+		/obj/item/tool/screwdriver/cyborg,
+		/obj/item/tool/wrench/cyborg,
+		/obj/item/tool/crowbar/cyborg,
+		/obj/item/tool/wirecutters/cyborg,
+		/obj/item/multitool,
+		/obj/item/lightreplacer,
+		/obj/item/gripper,
+		/obj/item/mop,
+		/obj/item/gripper/no_use/loader,
+		/obj/item/extinguisher,
+		/obj/item/pipe_painter,
+		/obj/item/floor_painter,
+		/obj/item/t_scanner,
+		/obj/item/analyzer,
+		/obj/item/inflatable_dispenser/robot,
+		/obj/item/barrier_tape_roll/engineering,
+		/obj/item/pipe_dispenser
+	)
 
-	robot.internals = new/obj/item/tank/jetpack/carbondioxide(src)
-	src.modules += robot.internals
+/obj/item/robot_module/drone/get_synths(mob/living/silicon/robot/R)
+	. = ..()
+	MATTER_SYNTH(MATSYN_METAL, metal, 25000)
+	MATTER_SYNTH(MATSYN_GLASS, glass, 25000)
+	MATTER_SYNTH(MATSYN_WOOD, wood, 25000)
+	MATTER_SYNTH(MATSYN_PLASTIC, plastic, 25000)
+	MATTER_SYNTH(MATSYN_WIRE, wire, 30)
+
+/obj/item/robot_module/drone/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
+
+	R.internals = new/obj/item/tank/jetpack/carbondioxide(src)
+	. += R.internals
 
 	src.emag = new /obj/item/pickaxe/plasmacutter(src)
 	src.emag.name = "Plasma Cutter"
 
-	var/datum/matter_synth/metal = new /datum/matter_synth/metal(25000)
-	var/datum/matter_synth/glass = new /datum/matter_synth/glass(25000)
-	var/datum/matter_synth/wood = new /datum/matter_synth/wood(25000)
-	var/datum/matter_synth/plastic = new /datum/matter_synth/plastic(25000)
-	var/datum/matter_synth/wire = new /datum/matter_synth/wire(30)
-	synths += metal
-	synths += glass
-	synths += wood
-	synths += plastic
-	synths += wire
-
 	var/obj/item/matter_decompiler/MD = new /obj/item/matter_decompiler(src)
-	MD.metal = metal
-	MD.glass = glass
-	MD.wood = wood
-	MD.plastic = plastic
-	src.modules += MD
+	MD.metal = synths_by_kind[MATSYN_METAL]
+	MD.glass = synths_by_kind[MATSYN_GLASS]
+	MD.wood = synths_by_kind[MATSYN_WOOD]
+	MD.plastic = synths_by_kind[MATSYN_PLASTIC]
+	. += MD
 
 	var/obj/item/stack/material/cyborg/steel/M = new (src)
-	M.synths = list(metal)
-	src.modules += M
+	M.synths = list(synths_by_kind[MATSYN_METAL])
+	. += M
 
 	var/obj/item/stack/material/cyborg/glass/G = new (src)
-	G.synths = list(glass)
-	src.modules += G
+	G.synths = list(synths_by_kind[MATSYN_GLASS])
+	. += G
 
-	var/obj/item/stack/rods/cyborg/R = new /obj/item/stack/rods/cyborg(src)
-	R.synths = list(metal)
-	src.modules += R
+	var/obj/item/stack/rods/cyborg/rods = new /obj/item/stack/rods/cyborg(src)
+	rods.synths = list(synths_by_kind[MATSYN_METAL])
+	. += rods
 
 	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
-	C.synths = list(wire)
-	src.modules += C
+	C.synths = list(synths_by_kind[MATSYN_WIRE])
+	. += C
 
 	var/obj/item/stack/tile/floor/cyborg/S = new /obj/item/stack/tile/floor/cyborg(src)
-	S.synths = list(metal)
-	src.modules += S
+	S.synths = list(synths_by_kind[MATSYN_METAL])
+	. += S
 
 	var/obj/item/stack/material/cyborg/glass/reinforced/RG = new (src)
-	RG.synths = list(metal, glass)
-	src.modules += RG
+	RG.synths = list(
+		synths_by_kind[MATSYN_METAL],
+		synths_by_kind[MATSYN_GLASS]
+	)
+	. += RG
 
 	var/obj/item/stack/tile/wood/cyborg/WT = new /obj/item/stack/tile/wood/cyborg(src)
-	WT.synths = list(wood)
-	src.modules += WT
+	WT.synths = list(synths_by_kind[MATSYN_WOOD])
+	. += WT
 
 	var/obj/item/stack/material/cyborg/wood/W = new (src)
-	W.synths = list(wood)
-	src.modules += W
+	W.synths = list(synths_by_kind[MATSYN_WOOD])
+	. += W
 
 	var/obj/item/stack/material/cyborg/plastic/P = new (src)
-	P.synths = list(plastic)
-	src.modules += P
+	P.synths = list(synths_by_kind[MATSYN_PLASTIC])
+	. += P
 
 /obj/item/robot_module/drone/construction
 	name = "construction drone module"
@@ -95,9 +99,9 @@
 	channels = list("Engineering" = 1)
 	languages = list()
 
-/obj/item/robot_module/drone/construction/Initialize(mapload)
+/obj/item/robot_module/drone/construction/get_modules()
 	. = ..()
-	src.modules += new /obj/item/rcd/electric/mounted/borg/lesser(src)
+	. |= /obj/item/rcd/electric/mounted/borg/lesser
 
 /obj/item/robot_module/drone/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	var/obj/item/lightreplacer/LR = locate() in src.modules
@@ -110,13 +114,18 @@
 	channels = list("Supply" = 1)
 	networks = list(NETWORK_MINE)
 
-/obj/item/robot_module/drone/mining/Initialize(mapload)
+/obj/item/robot_module/drone/mining/get_modules()
 	. = ..()
-	src.modules += new /obj/item/borg/sight/material(src)
-	src.modules += new /obj/item/pickaxe/borgdrill(src)
-	src.modules += new /obj/item/gun/energy/kinetic_accelerator/cyborg(src)
-	src.modules += new /obj/item/storage/bag/ore(src)
-	src.modules += new /obj/item/storage/bag/sheetsnatcher/borg(src)
+	. |= list(
+		/obj/item/borg/sight/material,
+		/obj/item/pickaxe/borgdrill,
+		/obj/item/gun/energy/kinetic_accelerator/cyborg,
+		/obj/item/storage/bag/ore,
+		/obj/item/storage/bag/sheetsnatcher/borg
+	)
+
+/obj/item/robot_module/drone/mining/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
 	src.emag = new /obj/item/pickaxe/diamonddrill(src)
 
 /obj/item/robot_module/drone/construction/matriarch

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/engineering.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/engineering.dm
@@ -205,7 +205,6 @@
 		/obj/item/inflatable_dispenser/robot,
 		/obj/item/pickaxe/plasmacutter,
 		/obj/item/dogborg/jaws/small,
-		/obj/item/dogborg/boop_module,
 		/obj/item/geiger_counter,
 		/obj/item/pipe_painter,
 		/obj/item/floor_painter,

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/engineering.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/engineering.dm
@@ -117,61 +117,21 @@
 
 	src.emag = new /obj/item/melee/baton/robot/arm(src)
 
-	var/datum/matter_synth/metal = synths_by_kind[MATSYN_METAL]
-	var/datum/matter_synth/glass = synths_by_kind[MATSYN_GLASS]
-	var/datum/matter_synth/plasteel = synths_by_kind[MATSYN_PLASTEEL]
-	var/datum/matter_synth/wood = synths_by_kind[MATSYN_WOOD]
-	var/datum/matter_synth/plastic = synths_by_kind[MATSYN_PLASTIC]
-
 	var/obj/item/matter_decompiler/MD = new /obj/item/matter_decompiler(src)
-	MD.metal = metal
-	MD.glass = glass
+	MD.metal = synths_by_kind[MATSYN_METAL]
+	MD.glass = synths_by_kind[MATSYN_GLASS]
 	src.modules += MD
 
-	var/obj/item/stack/material/cyborg/steel/M = new (src)
-	M.synths = list(metal)
-	. += M
-
-	var/obj/item/stack/material/cyborg/glass/G = new (src)
-	G.synths = list(glass)
-	. += G
-
-	var/obj/item/stack/rods/cyborg/rods = new /obj/item/stack/rods/cyborg(src)
-	rods.synths = list(metal)
-	. += R
-
-	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
-	C.synths = list(synths_by_kind[MATSYN_WIRE])
-	. += C
-
-	var/obj/item/stack/material/cyborg/plasteel/PS = new (src)
-	PS.synths = list(plasteel)
-	. += PS
-
-	var/obj/item/stack/tile/floor/cyborg/S = new /obj/item/stack/tile/floor/cyborg(src)
-	S.synths = list(metal)
-	. += S
-
-	var/obj/item/stack/tile/roofing/cyborg/CT = new /obj/item/stack/tile/roofing/cyborg(src)
-	CT.synths = list(metal)
-	. += CT
-
-	var/obj/item/stack/material/cyborg/glass/reinforced/RG = new (src)
-	RG.synths = list(metal, glass)
-	. += RG
-
-	var/obj/item/stack/tile/wood/cyborg/WT = new /obj/item/stack/tile/wood/cyborg(src)
-	WT.synths = list(wood)
-	. += WT
-
-	var/obj/item/stack/material/cyborg/wood/W = new (src)
-	W.synths = list(wood)
-	. += W
-
-	var/obj/item/stack/material/cyborg/plastic/PL = new (src)
-	PL.synths = list(plastic)
-	. += PL
-
+	CYBORG_STACK(material/cyborg/steel, MATSYN_METAL)
+	CYBORG_STACK(material/cyborg/glass, MATSYN_GLASS)
+	CYBORG_STACK(rods/cyborg          , MATSYN_METAL)
+	CYBORG_STACK(cable_coil/cyborg    , MATSYN_WIRE)
+	CYBORG_STACK(tile/floor/cyborg    , MATSYN_METAL)
+	CYBORG_STACK(tile/roofing/cyborg  , MATSYN_METAL)
+	CYBORG_STACK(material/cyborg/glass/reinforced, list(MATSYN_METAL, MATSYN_GLASS))
+	CYBORG_STACK(tile/wood/cyborg     , MATSYN_WOOD)
+	CYBORG_STACK(material/cyborg/wood , MATSYN_WOOD)
+	CYBORG_STACK(material/cyborg/plastic, MATSYN_PLASTIC)
 
 /obj/item/robot_module/robot/quad/engi
 	name = "EngiQuad module"
@@ -229,61 +189,25 @@
 
 	src.emag = new /obj/item/dogborg/pounce(src)
 
-	var/datum/matter_synth/metal = synths_by_kind[MATSYN_METAL]
-	var/datum/matter_synth/glass = synths_by_kind[MATSYN_GLASS]
-	var/datum/matter_synth/wood = synths_by_kind[MATSYN_WOOD]
-	var/datum/matter_synth/plastic = synths_by_kind[MATSYN_PLASTIC]
-	// var/datum/matter_synth/plasteel = synths_by_kind[MATSYN_PLASTEEL]
-	var/datum/matter_synth/wire = synths_by_kind[MATSYN_WIRE]
-
 	var/obj/item/lightreplacer/dogborg/LR = new /obj/item/lightreplacer/dogborg(src)
-	LR.glass = glass
+	LR.glass = synths_by_kind[MATSYN_GLASS]
 	. += LR
 
 	var/obj/item/dogborg/sleeper/compactor/decompiler/MD = new /obj/item/dogborg/sleeper/compactor/decompiler(src)
-	MD.metal = metal
-	MD.glass = glass
-	MD.wood = wood
-	MD.plastic = plastic
+	MD.metal = synths_by_kind[MATSYN_METAL]
+	MD.glass = synths_by_kind[MATSYN_GLASS]
+	MD.wood = synths_by_kind[MATSYN_WOOD]
+	MD.plastic = synths_by_kind[MATSYN_PLASTIC]
 	MD.water = synths_by_kind[MATSYN_WATER]
 	. += MD
 
-	var/obj/item/stack/material/cyborg/steel/M = new (src)
-	M.synths = list(metal)
-	. += M
-
-	var/obj/item/stack/material/cyborg/glass/G = new (src)
-	G.synths = list(glass)
-	. += G
-
-	var/obj/item/stack/rods/cyborg/RD = new /obj/item/stack/rods/cyborg(src)
-	RD.synths = list(metal)
-	. += RD
-
-	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
-	C.synths = list(wire)
-	. += C
-
-	var/obj/item/stack/tile/floor/cyborg/S = new /obj/item/stack/tile/floor/cyborg(src)
-	S.synths = list(metal)
-	. += S
-
-	var/obj/item/stack/tile/roofing/cyborg/CT = new /obj/item/stack/tile/roofing/cyborg(src)
-	CT.synths = list(metal)
-	. += CT
-
-	var/obj/item/stack/material/cyborg/glass/reinforced/RG = new (src)
-	RG.synths = list(metal, glass)
-	. += RG
-
-	var/obj/item/stack/tile/wood/cyborg/WT = new /obj/item/stack/tile/wood/cyborg(src)
-	WT.synths = list(wood)
-	. += WT
-
-	var/obj/item/stack/material/cyborg/wood/W = new (src)
-	W.synths = list(wood)
-	. += W
-
-	var/obj/item/stack/material/cyborg/plastic/PL = new (src)
-	PL.synths = list(plastic)
-	. += PL
+	CYBORG_STACK(material/cyborg/steel, MATSYN_METAL)
+	CYBORG_STACK(material/cyborg/glass, MATSYN_GLASS)
+	CYBORG_STACK(rods/cyborg          , MATSYN_METAL)
+	CYBORG_STACK(cable_coil/cyborg    , MATSYN_WIRE)
+	CYBORG_STACK(tile/floor/cyborg    , MATSYN_METAL)
+	CYBORG_STACK(tile/roofing/cyborg  , MATSYN_METAL)
+	CYBORG_STACK(material/cyborg/glass/reinforced, list(MATSYN_METAL, MATSYN_GLASS))
+	CYBORG_STACK(tile/wood/cyborg     , MATSYN_WOOD)
+	CYBORG_STACK(material/cyborg/wood , MATSYN_WOOD)
+	CYBORG_STACK(material/cyborg/plastic, MATSYN_PLASTIC)

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/engineering.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/engineering.dm
@@ -4,32 +4,32 @@
 	networks = list(NETWORK_ENGINEERING)
 	subsystems = list(/mob/living/silicon/proc/subsystem_power_monitor)
 	sprites = list(
-					"M-USE NanoTrasen" = "robotEngi",
-					"Cabeiri" = "eyebot-engineering",
-					"Haruka" = "marinaENG",
-					"Usagi" = "tallyellow",
-					"Telemachus" = "toiletbotengineering",
-					"WTOperator" = "sleekce",
-					"XI-GUS" = "spidereng",
-					"XI-ALP" = "heavyEng",
-					"Basic" = "Engineering",
-					"Antique" = "engineerrobot",
-					"Landmate" = "landmate",
-					"Landmate - Treaded" = "engiborg+tread",
-					"Drone" = "drone-engineer",
-					"Treadwell" = "treadwell",
-					"Handy" = "handy-engineer",
-					"Misato" = "tall2engineer",
-					"L3P1-D0T" = "Glitterfly-Engineering",
-					"Miss M" = "miss-engineer",
-					"Coffstruction" = "coffin-Construction",
-					"Coffgineer" = "coffin-Engineering",
-					"X-88" = "xeightyeight-engineering",
-					"Acheron" = "mechoid-Engineering",
-					"Shellguard Noble" = "Noble-ENG",
-					"ZOOM-BA" = "zoomba-engineering",
-					"W02M" = "worm-engineering"
-					)
+		"M-USE NanoTrasen" = "robotEngi",
+		"Cabeiri" = "eyebot-engineering",
+		"Haruka" = "marinaENG",
+		"Usagi" = "tallyellow",
+		"Telemachus" = "toiletbotengineering",
+		"WTOperator" = "sleekce",
+		"XI-GUS" = "spidereng",
+		"XI-ALP" = "heavyEng",
+		"Basic" = "Engineering",
+		"Antique" = "engineerrobot",
+		"Landmate" = "landmate",
+		"Landmate - Treaded" = "engiborg+tread",
+		"Drone" = "drone-engineer",
+		"Treadwell" = "treadwell",
+		"Handy" = "handy-engineer",
+		"Misato" = "tall2engineer",
+		"L3P1-D0T" = "Glitterfly-Engineering",
+		"Miss M" = "miss-engineer",
+		"Coffstruction" = "coffin-Construction",
+		"Coffgineer" = "coffin-Engineering",
+		"X-88" = "xeightyeight-engineering",
+		"Acheron" = "mechoid-Engineering",
+		"Shellguard Noble" = "Noble-ENG",
+		"ZOOM-BA" = "zoomba-engineering",
+		"W02M" = "worm-engineering"
+	)
 
 /obj/item/robot_module/robot/engineering/construction
 	name = "construction robot module"
@@ -78,43 +78,50 @@
 	src.modules += RG
 */
 
-/obj/item/robot_module/robot/engineering/general/Initialize(mapload)
+/obj/item/robot_module/robot/engineering/general/get_modules()
 	. = ..()
-	src.modules += new /obj/item/borg/sight/meson(src)
-	src.modules += new /obj/item/weldingtool/electric/mounted/cyborg(src)
-	src.modules += new /obj/item/tool/screwdriver/cyborg(src)
-	src.modules += new /obj/item/tool/wrench/cyborg(src)
-	src.modules += new /obj/item/tool/wirecutters/cyborg(src)
-	src.modules += new /obj/item/multitool(src)
-	src.modules += new /obj/item/t_scanner(src)
-	src.modules += new /obj/item/analyzer(src)
-	src.modules += new /obj/item/barrier_tape_roll/engineering(src)
-	src.modules += new /obj/item/gripper(src)
-	src.modules += new /obj/item/gripper/circuit(src)
-	src.modules += new /obj/item/lightreplacer(src)
-	src.modules += new /obj/item/pipe_painter(src)
-	src.modules += new /obj/item/floor_painter(src)
-	src.modules += new /obj/item/inflatable_dispenser/robot(src)
+	. |= list(
+		/obj/item/borg/sight/meson,
+		/obj/item/weldingtool/electric/mounted/cyborg,
+		/obj/item/tool/screwdriver/cyborg,
+		/obj/item/tool/wrench/cyborg,
+		/obj/item/tool/wirecutters/cyborg,
+		/obj/item/multitool,
+		/obj/item/t_scanner,
+		/obj/item/analyzer,
+		/obj/item/barrier_tape_roll/engineering,
+		/obj/item/gripper,
+		/obj/item/gripper/circuit,
+		/obj/item/lightreplacer,
+		/obj/item/pipe_painter,
+		/obj/item/floor_painter,
+		/obj/item/inflatable_dispenser/robot,
+		/obj/item/geiger_counter/cyborg,
+		/obj/item/rcd/electric/mounted/borg,
+		/obj/item/pickaxe/plasmacutter,
+		/obj/item/gripper/no_use/loader,
+		/obj/item/pipe_dispenser
+	)
+
+/obj/item/robot_module/robot/engineering/general/get_synths(mob/living/silicon/robot/R)
+	. = ..()
+	MATTER_SYNTH(MATSYN_METAL, metal, 40000)
+	MATTER_SYNTH(MATSYN_GLASS, glass, 40000)
+	MATTER_SYNTH(MATSYN_PLASTEEL, plasteel, 20000)
+	MATTER_SYNTH(MATSYN_WOOD, wood, 40000)
+	MATTER_SYNTH(MATSYN_PLASTIC, plastic, 40000)
+	MATTER_SYNTH(MATSYN_WIRE, wire)
+
+/obj/item/robot_module/robot/engineering/general/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
+
 	src.emag = new /obj/item/melee/baton/robot/arm(src)
-	src.modules += new /obj/item/geiger_counter/cyborg(src)
-	src.modules += new /obj/item/rcd/electric/mounted/borg(src)
-	src.modules += new /obj/item/pickaxe/plasmacutter(src)
-	src.modules += new /obj/item/gripper/no_use/loader(src)
-	src.modules += new /obj/item/pipe_dispenser(src)
 
-	var/datum/matter_synth/metal = new /datum/matter_synth/metal(40000)
-	var/datum/matter_synth/glass = new /datum/matter_synth/glass(40000)
-	var/datum/matter_synth/plasteel = new /datum/matter_synth/plasteel(20000)
-	var/datum/matter_synth/wood = new /datum/matter_synth/wood(40000)
-	var/datum/matter_synth/plastic = new /datum/matter_synth/plastic(40000)
-
-	var/datum/matter_synth/wire = new /datum/matter_synth/wire()
-	synths += metal
-	synths += glass
-	synths += plasteel
-	synths += wood
-	synths += plastic
-	synths += wire
+	var/datum/matter_synth/metal = synths_by_kind[MATSYN_METAL]
+	var/datum/matter_synth/glass = synths_by_kind[MATSYN_GLASS]
+	var/datum/matter_synth/plasteel = synths_by_kind[MATSYN_PLASTEEL]
+	var/datum/matter_synth/wood = synths_by_kind[MATSYN_WOOD]
+	var/datum/matter_synth/plastic = synths_by_kind[MATSYN_PLASTIC]
 
 	var/obj/item/matter_decompiler/MD = new /obj/item/matter_decompiler(src)
 	MD.metal = metal
@@ -123,184 +130,161 @@
 
 	var/obj/item/stack/material/cyborg/steel/M = new (src)
 	M.synths = list(metal)
-	src.modules += M
+	. += M
 
 	var/obj/item/stack/material/cyborg/glass/G = new (src)
 	G.synths = list(glass)
-	src.modules += G
+	. += G
 
-	var/obj/item/stack/rods/cyborg/R = new /obj/item/stack/rods/cyborg(src)
-	R.synths = list(metal)
-	src.modules += R
+	var/obj/item/stack/rods/cyborg/rods = new /obj/item/stack/rods/cyborg(src)
+	rods.synths = list(metal)
+	. += R
 
 	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
-	C.synths = list(wire)
-	src.modules += C
+	C.synths = list(synths_by_kind[MATSYN_WIRE])
+	. += C
 
 	var/obj/item/stack/material/cyborg/plasteel/PS = new (src)
 	PS.synths = list(plasteel)
-	src.modules += PS
+	. += PS
 
 	var/obj/item/stack/tile/floor/cyborg/S = new /obj/item/stack/tile/floor/cyborg(src)
 	S.synths = list(metal)
-	src.modules += S
+	. += S
 
 	var/obj/item/stack/tile/roofing/cyborg/CT = new /obj/item/stack/tile/roofing/cyborg(src)
 	CT.synths = list(metal)
-	src.modules += CT
+	. += CT
 
 	var/obj/item/stack/material/cyborg/glass/reinforced/RG = new (src)
 	RG.synths = list(metal, glass)
-	src.modules += RG
+	. += RG
 
 	var/obj/item/stack/tile/wood/cyborg/WT = new /obj/item/stack/tile/wood/cyborg(src)
 	WT.synths = list(wood)
-	src.modules += WT
+	. += WT
 
 	var/obj/item/stack/material/cyborg/wood/W = new (src)
 	W.synths = list(wood)
-	src.modules += W
+	. += W
 
 	var/obj/item/stack/material/cyborg/plastic/PL = new (src)
 	PL.synths = list(plastic)
-	src.modules += PL
+	. += PL
 
 
-/obj/item/robot_module/robot/quad_engi
+/obj/item/robot_module/robot/quad/engi
 	name = "EngiQuad module"
 	sprites = list(
-					"Pupdozer" = "pupdozer",
-					"V2 Engidog" = "thottbot",
-					"Borgi" = "borgi-eng",
-					"Engineering Hound" = "engihound",
-					"Engineering Hound Dark" = "engihounddark",
-					"F3-LINE" = "FELI-Engineer"
-					)
+		"Pupdozer" = "pupdozer",
+		"V2 Engidog" = "thottbot",
+		"Borgi" = "borgi-eng",
+		"Engineering Hound" = "engihound",
+		"Engineering Hound Dark" = "engihounddark",
+		"F3-LINE" = "FELI-Engineer"
+	)
 	channels = list("Engineering" = 1)
 	networks = list(NETWORK_ENGINEERING)
 	subsystems = list(/mob/living/silicon/proc/subsystem_power_monitor)
 	can_be_pushed = 0
+	can_shred = TRUE
 
-/obj/item/robot_module/robot/quad_engi/Initialize(mapload)
+/obj/item/robot_module/robot/quad/engi/get_modules()
 	. = ..()
-	var/mob/living/silicon/robot/R = loc
-	src.modules += new /obj/item/borg/sight/meson(src)
-	src.modules += new /obj/item/weldingtool/electric/mounted/cyborg(src)
-	src.modules += new /obj/item/tool/screwdriver/cyborg(src)
-	src.modules += new /obj/item/tool/wrench/cyborg(src)
-	src.modules += new /obj/item/tool/wirecutters/cyborg(src)
-	src.modules += new /obj/item/multitool(src)
-	src.modules += new /obj/item/t_scanner(src)
-	src.modules += new /obj/item/rcd/electric/mounted/borg(src)
-	src.modules += new /obj/item/analyzer(src)
-	src.modules += new /obj/item/barrier_tape_roll/engineering(src)
-	src.modules += new /obj/item/inflatable_dispenser/robot(src)
-	src.modules += new /obj/item/pickaxe/plasmacutter(src)
-	src.modules += new /obj/item/dogborg/jaws/small(src)
-	src.modules += new /obj/item/dogborg/boop_module(src)
-	src.modules += new /obj/item/geiger_counter(src)
-	src.modules += new /obj/item/pipe_painter(src)
-	src.modules += new /obj/item/floor_painter(src)
-	src.modules += new /obj/item/gripper(src)
-	src.modules += new /obj/item/gripper/no_use/loader(src)
-	src.modules += new /obj/item/pipe_dispenser(src)
-	src.modules += new /obj/item/gripper/circuit(src)
-	src.emag 	 = new /obj/item/dogborg/pounce(src)
+	. |= list(
+		/obj/item/borg/sight/meson,
+		/obj/item/weldingtool/electric/mounted/cyborg,
+		/obj/item/tool/screwdriver/cyborg,
+		/obj/item/tool/wrench/cyborg,
+		/obj/item/tool/wirecutters/cyborg,
+		/obj/item/multitool,
+		/obj/item/t_scanner,
+		/obj/item/rcd/electric/mounted/borg,
+		/obj/item/analyzer,
+		/obj/item/barrier_tape_roll/engineering,
+		/obj/item/inflatable_dispenser/robot,
+		/obj/item/pickaxe/plasmacutter,
+		/obj/item/dogborg/jaws/small,
+		/obj/item/dogborg/boop_module,
+		/obj/item/geiger_counter,
+		/obj/item/pipe_painter,
+		/obj/item/floor_painter,
+		/obj/item/gripper,
+		/obj/item/gripper/no_use/loader,
+		/obj/item/pipe_dispenser,
+		/obj/item/gripper/circuit
+	)
 
+/obj/item/robot_module/robot/quad/engi/get_synths(mob/living/silicon/robot/R)
+	. = ..()
 	//Painfully slow charger regen but high capacity. Also starts with low amount.
-	var/datum/matter_synth/metal = new /datum/matter_synth/metal(40000)
-	metal.name = "Steel reserves"
-	var/datum/matter_synth/glass = new /datum/matter_synth/glass(40000)
-	glass.name = "Glass reserves"
-	var/datum/matter_synth/wood = new /datum/matter_synth/wood(40000)
-	wood.name = "Wood reserves"
-	var/datum/matter_synth/plastic = new /datum/matter_synth/plastic(40000)
-	plastic.name = "Plastic reserves"
-	var/datum/matter_synth/plasteel = new /datum/matter_synth/plasteel(20000)
-	plasteel.name = "Plasteel reserves"
+	MATTER_SYNTH_WITH_NAME(MATSYN_METAL   , metal   , "Steel reserves"   , 40000)
+	MATTER_SYNTH_WITH_NAME(MATSYN_GLASS   , glass   , "Glass reserves"   , 40000)
+	MATTER_SYNTH_WITH_NAME(MATSYN_WOOD    , wood    , "Wood reserves"    , 40000)
+	MATTER_SYNTH_WITH_NAME(MATSYN_PLASTIC , plastic , "Plastic reserves" , 40000)
+	MATTER_SYNTH_WITH_NAME(MATSYN_PLASTEEL, plasteel, "Plasteel reserves", 20000)
+	MATTER_SYNTH(MATSYN_WIRE, wire)
 
-	var/datum/matter_synth/water = new /datum/matter_synth(500)
-	water.name = "Water reserves"
-	water.recharge_rate = 0
-	R.water_res = water
+/obj/item/robot_module/robot/quad/engi/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
 
-	var/datum/matter_synth/wire = new /datum/matter_synth/wire()
-	synths += metal
-	synths += glass
-	synths += plasteel
-	synths += wood
-	synths += plastic
-	synths += wire
-	synths += water
+	src.emag = new /obj/item/dogborg/pounce(src)
 
-	var/obj/item/dogborg/tongue/T = new /obj/item/dogborg/tongue(src)
-	T.water = water
-	src.modules += T
+	var/datum/matter_synth/metal = synths_by_kind[MATSYN_METAL]
+	var/datum/matter_synth/glass = synths_by_kind[MATSYN_GLASS]
+	var/datum/matter_synth/wood = synths_by_kind[MATSYN_WOOD]
+	var/datum/matter_synth/plastic = synths_by_kind[MATSYN_PLASTIC]
+	// var/datum/matter_synth/plasteel = synths_by_kind[MATSYN_PLASTEEL]
+	var/datum/matter_synth/wire = synths_by_kind[MATSYN_WIRE]
 
 	var/obj/item/lightreplacer/dogborg/LR = new /obj/item/lightreplacer/dogborg(src)
 	LR.glass = glass
-	src.modules += LR
+	. += LR
 
 	var/obj/item/dogborg/sleeper/compactor/decompiler/MD = new /obj/item/dogborg/sleeper/compactor/decompiler(src)
 	MD.metal = metal
 	MD.glass = glass
 	MD.wood = wood
 	MD.plastic = plastic
-	MD.water = water
-	src.modules += MD
+	MD.water = synths_by_kind[MATSYN_WATER]
+	. += MD
 
 	var/obj/item/stack/material/cyborg/steel/M = new (src)
 	M.synths = list(metal)
-	src.modules += M
+	. += M
 
 	var/obj/item/stack/material/cyborg/glass/G = new (src)
 	G.synths = list(glass)
-	src.modules += G
+	. += G
 
 	var/obj/item/stack/rods/cyborg/RD = new /obj/item/stack/rods/cyborg(src)
 	RD.synths = list(metal)
-	src.modules += RD
+	. += RD
 
 	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
 	C.synths = list(wire)
-	src.modules += C
+	. += C
 
 	var/obj/item/stack/tile/floor/cyborg/S = new /obj/item/stack/tile/floor/cyborg(src)
 	S.synths = list(metal)
-	src.modules += S
+	. += S
 
 	var/obj/item/stack/tile/roofing/cyborg/CT = new /obj/item/stack/tile/roofing/cyborg(src)
 	CT.synths = list(metal)
-	src.modules += CT
+	. += CT
 
 	var/obj/item/stack/material/cyborg/glass/reinforced/RG = new (src)
 	RG.synths = list(metal, glass)
-	src.modules += RG
+	. += RG
 
 	var/obj/item/stack/tile/wood/cyborg/WT = new /obj/item/stack/tile/wood/cyborg(src)
 	WT.synths = list(wood)
-	src.modules += WT
+	. += WT
 
 	var/obj/item/stack/material/cyborg/wood/W = new (src)
 	W.synths = list(wood)
-	src.modules += W
+	. += W
 
 	var/obj/item/stack/material/cyborg/plastic/PL = new (src)
 	PL.synths = list(plastic)
-	src.modules += PL
-
-	R.icon = 'icons/mob/robots_wide.dmi'
-	R.set_base_pixel_x(-16)
-	R.dogborg = TRUE
-	R.wideborg = TRUE
-	R.icon_dimension_x = 64
-	add_verb(R, /mob/living/silicon/robot/proc/ex_reserve_refill)
-	add_verb(R, /mob/living/proc/shred_limb)
-	add_verb(R, /mob/living/silicon/robot/proc/rest_style)
-
-	if(R.client && (R.client.ckey in list("nezuli")))
-		sprites += "Alina"
-		sprites["Alina"] = "alina-eng"
-		. = ..()
-
-
+	. += PL

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/medical.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/medical.dm
@@ -8,77 +8,86 @@
 /obj/item/robot_module/robot/medical/surgeon
 	name = "medical robot module"
 	sprites = list(
-					"M-USE NanoTrasen" = "robotMedi",
-					"Cabeiri" = "eyebot-medical",
-					"Haruka" = "marinaMD",
-					"Minako" = "arachne",
-					"Usagi" = "tallwhite",
-					"Telemachus" = "toiletbotsurgeon",
-					"WTOperator" = "sleekcmo",
-					"XI-ALP" = "heavyMed",
-					"Basic" = "Medibot",
-					"Advanced Droid" = "droid-medical",
-					"Needles" = "medicalrobot",
-					"Drone" = "drone-surgery",
-					"Handy" = "handy-med",
-					"Insekt" = "insekt-Med",
-					"Misato" = "tall2medical",
-					"L3P1-D0T" = "Glitterfly-Surgeon",
-					"Miss M" = "miss-medical",
-					"Coffical" = "coffin-Medical",
-					"Coffcue" = "coffin-Rescue",
-					"X-88" = "xeightyeight-medical",
-					"Acheron" = "mechoid-Medical",
-					"Shellguard Noble" = "Noble-MED",
-					"ZOOM-BA" = "zoomba-medical",
-					"W02M" = "worm-crisis"
-					)
+		"M-USE NanoTrasen" = "robotMedi",
+		"Cabeiri" = "eyebot-medical",
+		"Haruka" = "marinaMD",
+		"Minako" = "arachne",
+		"Usagi" = "tallwhite",
+		"Telemachus" = "toiletbotsurgeon",
+		"WTOperator" = "sleekcmo",
+		"XI-ALP" = "heavyMed",
+		"Basic" = "Medibot",
+		"Advanced Droid" = "droid-medical",
+		"Needles" = "medicalrobot",
+		"Drone" = "drone-surgery",
+		"Handy" = "handy-med",
+		"Insekt" = "insekt-Med",
+		"Misato" = "tall2medical",
+		"L3P1-D0T" = "Glitterfly-Surgeon",
+		"Miss M" = "miss-medical",
+		"Coffical" = "coffin-Medical",
+		"Coffcue" = "coffin-Rescue",
+		"X-88" = "xeightyeight-medical",
+		"Acheron" = "mechoid-Medical",
+		"Shellguard Noble" = "Noble-MED",
+		"ZOOM-BA" = "zoomba-medical",
+		"W02M" = "worm-crisis"
+	)
 
-/obj/item/robot_module/robot/medical/surgeon/Initialize(mapload)
+/obj/item/robot_module/robot/medical/surgeon/get_modules()
 	. = ..()
-	src.modules += new /obj/item/healthanalyzer(src)
-	src.modules += new /obj/item/reagent_containers/borghypo/surgeon(src)
-	src.modules += new /obj/item/autopsy_scanner(src)
-	src.modules += new /obj/item/reagent_scanner/adv(src)
-	src.modules += new /obj/item/roller_holder(src)
-	src.modules += new /obj/item/reagent_containers/glass/beaker/large(src)
-	src.modules += new /obj/item/surgical/scalpel/cyborg(src)
-	src.modules += new /obj/item/surgical/hemostat/cyborg(src)
-	src.modules += new /obj/item/surgical/retractor/cyborg(src)
-	src.modules += new /obj/item/surgical/cautery/cyborg(src)
-	src.modules += new /obj/item/surgical/bonegel/cyborg(src)
-	src.modules += new /obj/item/surgical/FixOVein/cyborg(src)
-	src.modules += new /obj/item/surgical/bonesetter/cyborg(src)
-	src.modules += new /obj/item/surgical/circular_saw/cyborg(src)
-	src.modules += new /obj/item/surgical/surgicaldrill/cyborg(src)
-	src.modules += new /obj/item/gripper/no_use/organ(src)
-	src.modules += new /obj/item/gripper/medical(src)
-	src.modules += new /obj/item/shockpaddles/robot(src)
-	src.modules += new /obj/item/reagent_containers/dropper(src) // Allows surgeon borg to fix necrosis
-	src.modules += new /obj/item/reagent_containers/syringe(src)
-	src.modules += new /obj/item/dogborg/mirrortool(src)
+	. |= list(
+		/obj/item/healthanalyzer,
+		/obj/item/reagent_containers/borghypo/surgeon,
+		/obj/item/autopsy_scanner,
+		/obj/item/reagent_scanner/adv,
+		/obj/item/roller_holder,
+		/obj/item/reagent_containers/glass/beaker/large,
+		/obj/item/surgical/scalpel/cyborg,
+		/obj/item/surgical/hemostat/cyborg,
+		/obj/item/surgical/retractor/cyborg,
+		/obj/item/surgical/cautery/cyborg,
+		/obj/item/surgical/bonegel/cyborg,
+		/obj/item/surgical/FixOVein/cyborg,
+		/obj/item/surgical/bonesetter/cyborg,
+		/obj/item/surgical/circular_saw/cyborg,
+		/obj/item/surgical/surgicaldrill/cyborg,
+		/obj/item/gripper/no_use/organ,
+		/obj/item/gripper/medical,
+		/obj/item/shockpaddles/robot,
+		/obj/item/reagent_containers/dropper, // Allows surgeon borg to fix necrosis
+		/obj/item/reagent_containers/syringe,
+		/obj/item/dogborg/mirrortool
+	)
+
+/obj/item/robot_module/robot/medical/surgeon/get_synths(mob/living/silicon/robot/R)
+	. = ..()
+	MATTER_SYNTH(MATSYN_DRUGS, medicine, 15000)
+
+/obj/item/robot_module/robot/medical/surgeon/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
+
 	src.emag = new /obj/item/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent("pacid", 250)
 	src.emag.name = "Polyacid spray"
 
-	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(15000)
-	synths += medicine
-
 	var/obj/item/stack/medical/advanced/ointment/O = new /obj/item/stack/medical/advanced/ointment(src)
-	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
-	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
 	O.uses_charge = 1
 	O.charge_costs = list(1000)
-	O.synths = list(medicine)
+	O.synths = list(synths_by_kind[MATSYN_DRUGS])
+	. += O
+
+	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	N.uses_charge = 1
 	N.charge_costs = list(1000)
-	N.synths = list(medicine)
+	N.synths = list(synths_by_kind[MATSYN_DRUGS])
+	. += N
+
+	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
 	B.uses_charge = 1
 	B.charge_costs = list(1000)
-	B.synths = list(medicine)
-	src.modules += O
-	src.modules += N
-	src.modules += B
+	B.synths = list(synths_by_kind[MATSYN_DRUGS])
+	. += B
 
 /obj/item/robot_module/robot/medical/surgeon/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 
@@ -97,97 +106,80 @@
 
 //Crisis module removed - 5/2/2021
 
-/obj/item/robot_module/robot/quad_medi
+/obj/item/robot_module/robot/quad/medi
 	name = "MediQuad module"
 	channels = list("Medical" = 1)
 	networks = list(NETWORK_MEDICAL)
 	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor)
 	can_be_pushed = 0
+	can_shred = TRUE
 	sprites = list(
-					"Medical Hound" = "medihound",
-					"Dark Medical Hound" = "medihounddark",
-					"Mediborg model V-2" = "vale",
-					"Borgi" = "borgi-medi",
-					"F3-LINE" = "FELI-Medical"
-					)
+		"Medical Hound" = "medihound",
+		"Dark Medical Hound" = "medihounddark",
+		"Mediborg model V-2" = "vale",
+		"Borgi" = "borgi-medi",
+		"F3-LINE" = "FELI-Medical"
+	)
 
-/obj/item/robot_module/robot/quad_medi/Initialize(mapload)
+/obj/item/robot_module/robot/quad/medi/get_modules()
 	. = ..()
-	var/mob/living/silicon/robot/R = loc
-	src.modules += new /obj/item/dogborg/jaws/small(src) //In case a patient is being attacked by carp.
-	src.modules += new /obj/item/dogborg/boop_module(src) //Boop the crew.
-	src.modules += new /obj/item/healthanalyzer(src) // See who's hurt specificially.
-	src.modules += new /obj/item/autopsy_scanner(src)
-	src.modules += new /obj/item/roller_holder(src) // Sometimes you just can't buckle someone to yourself because of taurcode. this is for those times.
-	src.modules += new /obj/item/reagent_scanner/adv(src)
-	src.modules += new /obj/item/reagent_containers/syringe(src) //In case the chemist is nice!
-	src.modules += new /obj/item/reagent_containers/glass/beaker/large(src)//For holding the chemicals when the chemist is nice
-	// src.modules += new /obj/item/sleevemate(src) //Lets them scan people.
-	src.modules += new /obj/item/shockpaddles/robot/hound(src) //Paws of life
+	. |= list(
+		/obj/item/dogborg/jaws/small, //In case a patient is being attacked by carp.
+		/obj/item/healthanalyzer, // See who's hurt specificially.
+		/obj/item/autopsy_scanner,
+		/obj/item/roller_holder, // Sometimes you just can't buckle someone to yourself because of taurcode. this is for those times.
+		/obj/item/reagent_scanner/adv,
+		/obj/item/reagent_containers/syringe, //In case the chemist is nice!
+		/obj/item/reagent_containers/glass/beaker/large,//For holding the chemicals when the chemist is nice
+		// /obj/item/sleevemate, //Lets them scan people.
+		/obj/item/shockpaddles/robot/hound, //Paws of life
+		//New surgery tools + grippers
+		/obj/item/surgical/scalpel/cyborg,
+		/obj/item/surgical/hemostat/cyborg,
+		/obj/item/surgical/retractor/cyborg,
+		/obj/item/surgical/cautery/cyborg,
+		/obj/item/surgical/bonegel/cyborg,
+		/obj/item/surgical/FixOVein/cyborg,
+		/obj/item/surgical/bonesetter/cyborg,
+		/obj/item/surgical/circular_saw/cyborg,
+		/obj/item/surgical/surgicaldrill/cyborg,
+		/obj/item/gripper/no_use/organ,
+		/obj/item/gripper/medical,
+		/obj/item/dogborg/mirrortool
+	)
+
+/obj/item/robot_module/robot/quad/medi/get_synths(mob/living/silicon/robot/R)
+	. = ..()
+	MATTER_SYNTH(MATSYN_DRUGS, medicine, 15000)
+
+/obj/item/robot_module/robot/quad/medi/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
 	src.emag 	 = new /obj/item/dogborg/pounce(src) //Pounce
 
-	//New surgery tools + grippers
-	src.modules += new /obj/item/surgical/scalpel/cyborg(src)
-	src.modules += new /obj/item/surgical/hemostat/cyborg(src)
-	src.modules += new /obj/item/surgical/retractor/cyborg(src)
-	src.modules += new /obj/item/surgical/cautery/cyborg(src)
-	src.modules += new /obj/item/surgical/bonegel/cyborg(src)
-	src.modules += new /obj/item/surgical/FixOVein/cyborg(src)
-	src.modules += new /obj/item/surgical/bonesetter/cyborg(src)
-	src.modules += new /obj/item/surgical/circular_saw/cyborg(src)
-	src.modules += new /obj/item/surgical/surgicaldrill/cyborg(src)
-	src.modules += new /obj/item/gripper/no_use/organ(src)
-	src.modules += new /obj/item/gripper/medical(src)
-	src.modules += new /obj/item/dogborg/mirrortool(src)
-
-
-	var/datum/matter_synth/water = new /datum/matter_synth(500)
-	water.name = "Water reserves"
-	water.recharge_rate = 0
-	R.water_res = water
-	synths += water
-
 	var/obj/item/reagent_containers/borghypo/hound/H = new /obj/item/reagent_containers/borghypo/hound(src)
-	H.water = water
-	src.modules += H
-
-	var/obj/item/dogborg/tongue/T = new /obj/item/dogborg/tongue(src)
-	T.water = water
-	src.modules += T
+	H.water = synths_by_kind[MATSYN_WATER]
+	. += H
 
 	var/obj/item/dogborg/sleeper/B = new /obj/item/dogborg/sleeper(src) //So they can nom people and heal them
-	B.water = water
+	B.water = synths_by_kind[MATSYN_WATER]
 	src.modules += B
 
-	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(15000) // BEGIN CITADEL CHANGES - adds trauma kits to medihounds
-	synths += medicine
+	var/medicine = synths_by_kind[MATSYN_DRUGS]
+
 	var/obj/item/stack/nanopaste/P = new /obj/item/stack/nanopaste(src)
-	var/obj/item/stack/medical/advanced/ointment/K = new /obj/item/stack/medical/advanced/ointment(src)
-	var/obj/item/stack/medical/advanced/bruise_pack/L = new /obj/item/stack/medical/advanced/bruise_pack(src)
 	P.uses_charge = 1
 	P.charge_costs = list(1000)
 	P.synths = list(medicine)
+	. += P
+
+	var/obj/item/stack/medical/advanced/ointment/K = new /obj/item/stack/medical/advanced/ointment(src)
 	K.uses_charge = 1
 	K.charge_costs = list(1000)
 	K.synths = list(medicine)
+	. += K
+
+	var/obj/item/stack/medical/advanced/bruise_pack/L = new /obj/item/stack/medical/advanced/bruise_pack(src)
 	L.uses_charge = 1
 	L.charge_costs = list(1000)
 	L.synths = list(medicine)
-	src.modules += K
-	src.modules += L
-	src.modules += P
-	// END CITADEL CHANGES
-
-	R.icon = 'icons/mob/robots_wide.dmi'
-	R.set_base_pixel_x(-16)
-	R.dogborg = TRUE
-	R.wideborg = TRUE
-	R.icon_dimension_x = 64
-	add_verb(R, /mob/living/silicon/robot/proc/ex_reserve_refill)
-	add_verb(R, /mob/living/proc/shred_limb)
-	add_verb(R, /mob/living/silicon/robot/proc/rest_style)
-
-	if(R.client && (R.client.ckey in list("nezuli")))
-		sprites += "Alina"
-		sprites["Alina"] = "alina-med"
-		. = ..()
+	. += L

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/misc.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/misc.dm
@@ -1,72 +1,62 @@
 /obj/item/robot_module/robot/standard
 	name = "standard robot module"
 	sprites = list(
-					"M-USE NanoTrasen" = "robot",
-					"Cabeiri" = "eyebot-standard",
-					"Haruka" = "marinaSD",
-					"Usagi" = "tallflower",
-					"Telemachus" = "toiletbot",
-					"WTOperator" = "sleekstandard",
-					"WTOmni" = "omoikane",
-					"XI-GUS" = "spider",
-					"XI-ALP" = "heavyStandard",
-					"Basic" = "robot_old",
-					"Android" = "droid",
-					"Drone" = "drone-standard",
-					"Insekt" = "insekt-Default",
-					"Misato" = "tall2standard",
-					"L3P1-D0T" = "Glitterfly-Standard",
-					"Convict" = "servitor",
-					"Miss M" = "miss-standard",
-					"Coffin" = "coffin-Standard",
-					"X-88" = "xeightyeight-standard",
-					"Handy" = "handy-standard",
-					"Acheron" = "mechoid-Standard",
-					"Shellguard Noble" = "Noble-STD",
-					"ZOOM-BA" = "zoomba-standard",
-					"W02M" = "worm-standard"
-					)
+		"M-USE NanoTrasen" = "robot",
+		"Cabeiri" = "eyebot-standard",
+		"Haruka" = "marinaSD",
+		"Usagi" = "tallflower",
+		"Telemachus" = "toiletbot",
+		"WTOperator" = "sleekstandard",
+		"WTOmni" = "omoikane",
+		"XI-GUS" = "spider",
+		"XI-ALP" = "heavyStandard",
+		"Basic" = "robot_old",
+		"Android" = "droid",
+		"Drone" = "drone-standard",
+		"Insekt" = "insekt-Default",
+		"Misato" = "tall2standard",
+		"L3P1-D0T" = "Glitterfly-Standard",
+		"Convict" = "servitor",
+		"Miss M" = "miss-standard",
+		"Coffin" = "coffin-Standard",
+		"X-88" = "xeightyeight-standard",
+		"Handy" = "handy-standard",
+		"Acheron" = "mechoid-Standard",
+		"Shellguard Noble" = "Noble-STD",
+		"ZOOM-BA" = "zoomba-standard",
+		"W02M" = "worm-standard"
+	)
 
-
-/obj/item/robot_module/robot/standard/Initialize(mapload)
+/obj/item/robot_module/robot/standard/get_modules()
 	. = ..()
-	src.modules += new /obj/item/melee/baton/loaded(src)
-	src.modules += new /obj/item/tool/wrench/cyborg(src)
-	src.modules += new /obj/item/healthanalyzer(src)
+	. |= list(
+		/obj/item/melee/baton/loaded,
+		/obj/item/tool/wrench/cyborg,
+		/obj/item/healthanalyzer
+	)
+
+/obj/item/robot_module/robot/standard/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
 	src.emag = new /obj/item/melee/energy/sword(src)
 
-/obj/item/robot_module/robot/quad_basic
+/obj/item/robot_module/robot/quad/basic
 	name = "Standard Quadruped module"
 	sprites = list(
-					"F3-LINE" = "FELI-Standard"
-					)
+		"F3-LINE" = "FELI-Standard"
+	)
 	can_be_pushed = 0
 
-/obj/item/robot_module/robot/quad_basic/Initialize(mapload)
+/obj/item/robot_module/robot/quad/basic/get_modules()
 	. = ..()
-	var/mob/living/silicon/robot/R = loc
-	src.modules += new /obj/item/melee/baton/loaded(src)
-	src.modules += new /obj/item/tool/wrench/cyborg(src)
-	src.modules += new /obj/item/healthanalyzer(src)
-	src.modules += new /obj/item/dogborg/jaws/small(src)
-	src.modules += new /obj/item/dogborg/boop_module(src)
+	. |= list(
+		/obj/item/melee/baton/loaded,
+		/obj/item/tool/wrench/cyborg,
+		/obj/item/healthanalyzer,
+		/obj/item/dogborg/jaws/small
+	)
+
+/obj/item/robot_module/robot/quad/basic/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
+	// These get a larger water synth.
+	synths_by_kind[MATSYN_WATER]:max_energy = 1000
 	src.emag = new /obj/item/melee/energy/sword(src)
-
-	var/datum/matter_synth/water = new /datum/matter_synth(500) // buffy fix, was 0
-	water.name = "Water reserves"
-	water.recharge_rate = 0
-	water.max_energy = 1000
-	R.water_res = water
-	synths += water
-
-	var/obj/item/dogborg/tongue/T = new /obj/item/dogborg/tongue(src)
-	T.water = water
-	src.modules += T
-
-	R.icon = 'icons/mob/robots_wide.dmi'
-	R.set_base_pixel_x(-16)
-	R.dogborg = TRUE
-	R.wideborg = TRUE
-	R.icon_dimension_x = 64
-	add_verb(R, /mob/living/silicon/robot/proc/ex_reserve_refill)
-	add_verb(R, /mob/living/silicon/robot/proc/rest_style)

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
@@ -97,7 +97,6 @@
 	. |= list(
 		/obj/item/portable_destructive_analyzer,
 		/obj/item/dogborg/jaws/small,
-		/obj/item/dogborg/boop_module,
 		/obj/item/gripper/research,
 		/obj/item/gripper/circuit,
 		/obj/item/gripper/no_use/organ/robotics,

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
@@ -54,18 +54,13 @@
 	. = ..()
 	src.emag = new /obj/item/borg/combat/shield(src)
 
-	var/datum/matter_synth/nanite = synths_by_kind[MATSYN_NANITES]
-	var/datum/matter_synth/wire = synths_by_kind[MATSYN_WIRE]						//Added to allow repairs, would rather add cable now than be asked to add it later,
-
 	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	N.uses_charge = 1
 	N.charge_costs = list(1000)
-	N.synths = list(nanite)
+	N.synths = list(synths_by_kind[MATSYN_NANITES])
 	src.modules += N
 
-	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)	//Cable code, taken from engiborg,
-	C.synths = list(wire)
-	src.modules += C
+	CYBORG_STACK(cable_coil/cyborg, list(MATSYN_WIRE))
 
 /obj/item/robot_module/robot/research/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 
@@ -136,8 +131,6 @@
 	B.water = synths_by_kind[MATSYN_WATER]
 	. += B
 
-	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
-	C.synths = list(synths_by_kind[MATSYN_WIRE])
-	. += C
+	CYBORG_STACK(cable_coil/cyborg, list(MATSYN_WIRE))
 
 	src.emag = new /obj/item/borg/combat/shield(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
@@ -84,7 +84,6 @@
 	)
 	channels = list("Science" = 1)
 	can_be_pushed = 0
-	is_quad = TRUE
 	can_shred = TRUE
 
 /obj/item/robot_module/robot/quad/sci/get_modules()

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/science.dm
@@ -2,52 +2,60 @@
 	name = "research module"
 	channels = list("Science" = 1)
 	sprites = list(
-					"L'Ouef" = "peaceborg",
-					"Cabeiri" = "eyebot-science",
-					"Haruka" = "marinaSCI",
-					"WTDove" = "whitespider",
-					"WTOperator" = "sleekscience",
-					"Droid" = "droid-science",
-					"Drone" = "drone-science",
-					"Handy" = "handy-science",
-					"Insekt" = "insekt-Sci",
-					"L3P1-D0T" = "Glitterfly-Research",
-					"Coffsearch" = "coffin-Research",
-					"X-88" = "xeightyeight-science",
-					"Acheron" = "mechoid-Science",
-					"ZOOM-BA" = "zoomba-research",
-					"W02M" = "worm-engineering"
-					)
+		"L'Ouef" = "peaceborg",
+		"Cabeiri" = "eyebot-science",
+		"Haruka" = "marinaSCI",
+		"WTDove" = "whitespider",
+		"WTOperator" = "sleekscience",
+		"Droid" = "droid-science",
+		"Drone" = "drone-science",
+		"Handy" = "handy-science",
+		"Insekt" = "insekt-Sci",
+		"L3P1-D0T" = "Glitterfly-Research",
+		"Coffsearch" = "coffin-Research",
+		"X-88" = "xeightyeight-science",
+		"Acheron" = "mechoid-Science",
+		"ZOOM-BA" = "zoomba-research",
+		"W02M" = "worm-engineering"
+	)
 
-/obj/item/robot_module/robot/research/Initialize(mapload)
+/obj/item/robot_module/robot/research/get_synths()
 	. = ..()
-	src.modules += new /obj/item/portable_destructive_analyzer(src)
-	src.modules += new /obj/item/gripper/research(src)
-	src.modules += new /obj/item/gripper/circuit(src)
-	src.modules += new /obj/item/gripper/no_use/organ/robotics(src)
-	src.modules += new /obj/item/gripper/no_use/mech(src)
-	src.modules += new /obj/item/gripper/no_use/loader(src)
-	src.modules += new /obj/item/robotanalyzer(src)
-	src.modules += new /obj/item/card/robot(src)
-	src.modules += new /obj/item/weldingtool/electric/mounted/cyborg(src)
-	src.modules += new /obj/item/tool/screwdriver/cyborg(src)
-	src.modules += new /obj/item/tool/wrench/cyborg(src)
-	src.modules += new /obj/item/tool/wirecutters/cyborg(src)
-	src.modules += new /obj/item/multitool(src)
-	src.modules += new /obj/item/surgical/scalpel/cyborg(src)
-	src.modules += new /obj/item/surgical/circular_saw/cyborg(src)
-	src.modules += new /obj/item/reagent_containers/syringe(src)
-	src.modules += new /obj/item/reagent_containers/glass/beaker/large(src)
-	src.modules += new /obj/item/storage/part_replacer(src)
-	src.modules += new /obj/item/shockpaddles/robot/jumper(src)
-	src.modules += new /obj/item/melee/baton/slime/robot(src)
-	src.modules += new /obj/item/gun/energy/taser/xeno/robot(src)
+	MATTER_SYNTH(MATSYN_NANITES, nanite, 10000)
+	MATTER_SYNTH(MATSYN_WIRE, wire)
+
+/obj/item/robot_module/robot/research/get_modules()
+	. = ..()
+	. |= list(
+		/obj/item/portable_destructive_analyzer,
+		/obj/item/gripper/research,
+		/obj/item/gripper/circuit,
+		/obj/item/gripper/no_use/organ/robotics,
+		/obj/item/gripper/no_use/mech,
+		/obj/item/gripper/no_use/loader,
+		/obj/item/robotanalyzer,
+		/obj/item/card/robot,
+		/obj/item/weldingtool/electric/mounted/cyborg,
+		/obj/item/tool/screwdriver/cyborg,
+		/obj/item/tool/wrench/cyborg,
+		/obj/item/tool/wirecutters/cyborg,
+		/obj/item/multitool,
+		/obj/item/surgical/scalpel/cyborg,
+		/obj/item/surgical/circular_saw/cyborg,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/reagent_containers/glass/beaker/large,
+		/obj/item/storage/part_replacer,
+		/obj/item/shockpaddles/robot/jumper,
+		/obj/item/melee/baton/slime/robot,
+		/obj/item/gun/energy/taser/xeno/robot
+	)
+
+/obj/item/robot_module/robot/research/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
 	src.emag = new /obj/item/borg/combat/shield(src)
 
-	var/datum/matter_synth/nanite = new /datum/matter_synth/nanite(10000)
-	synths += nanite
-	var/datum/matter_synth/wire = new /datum/matter_synth/wire()						//Added to allow repairs, would rather add cable now than be asked to add it later,
-	synths += wire																		//Cable code, taken from engiborg,
+	var/datum/matter_synth/nanite = synths_by_kind[MATSYN_NANITES]
+	var/datum/matter_synth/wire = synths_by_kind[MATSYN_WIRE]						//Added to allow repairs, would rather add cable now than be asked to add it later,
 
 	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	N.uses_charge = 1
@@ -70,82 +78,67 @@
 
 	..()
 
-/obj/item/robot_module/robot/quad_sci
+/obj/item/robot_module/robot/quad/sci
 	name = "SciQuad Module"
 	sprites = list(
-					"Research Hound" = "science",
-					"Borgi" = "borgi-sci",
-					"F3-LINE" = "FELI-Research",
-					"Sci-9" = "scihound",
-					"Sci-9 Dark" = "scihounddark"
-					)
+		"Research Hound" = "science",
+		"Borgi" = "borgi-sci",
+		"F3-LINE" = "FELI-Research",
+		"Sci-9" = "scihound",
+		"Sci-9 Dark" = "scihounddark"
+	)
 	channels = list("Science" = 1)
 	can_be_pushed = 0
+	is_quad = TRUE
+	can_shred = TRUE
 
-/obj/item/robot_module/robot/quad_sci/Initialize(mapload)
+/obj/item/robot_module/robot/quad/sci/get_modules()
 	. = ..()
-	var/mob/living/silicon/robot/R = loc
-	src.modules += new /obj/item/portable_destructive_analyzer(src)
-	src.modules += new /obj/item/dogborg/jaws/small(src)
-	src.modules += new /obj/item/dogborg/boop_module(src)
-	src.modules += new /obj/item/gripper/research(src)
-	src.modules += new /obj/item/gripper/circuit(src)
-	src.modules += new /obj/item/gripper/no_use/organ/robotics(src)
-	src.modules += new /obj/item/gripper/no_use/mech(src)
-	src.modules += new /obj/item/gripper/no_use/loader(src)
-	src.modules += new /obj/item/tool/screwdriver/cyborg(src)
-	src.modules += new /obj/item/tool/wrench/cyborg(src)
-	src.modules += new /obj/item/robotanalyzer(src)
-	src.modules += new /obj/item/weldingtool/electric/mounted/cyborg(src)
-	src.modules += new /obj/item/multitool(src)
-	src.modules += new /obj/item/reagent_containers/glass/beaker/large(src)
-	src.modules += new /obj/item/reagent_containers/syringe(src)
-	src.modules += new /obj/item/storage/part_replacer(src)
-	src.modules += new /obj/item/card/robot(src)
-	src.modules += new /obj/item/shockpaddles/robot/jumper(src)
-	src.modules += new /obj/item/tool/wirecutters/cyborg(src)
-	src.modules += new /obj/item/melee/baton/slime/robot(src)
-	src.modules += new /obj/item/gun/energy/taser/xeno/robot(src)
-	src.modules += new /obj/item/surgical/scalpel/cyborg(src)
-	src.modules += new /obj/item/surgical/circular_saw/cyborg(src)
-	src.emag = new /obj/item/borg/combat/shield(src)
+	. |= list(
+		/obj/item/portable_destructive_analyzer,
+		/obj/item/dogborg/jaws/small,
+		/obj/item/dogborg/boop_module,
+		/obj/item/gripper/research,
+		/obj/item/gripper/circuit,
+		/obj/item/gripper/no_use/organ/robotics,
+		/obj/item/gripper/no_use/mech,
+		/obj/item/gripper/no_use/loader,
+		/obj/item/tool/screwdriver/cyborg,
+		/obj/item/tool/wrench/cyborg,
+		/obj/item/robotanalyzer,
+		/obj/item/weldingtool/electric/mounted/cyborg,
+		/obj/item/multitool,
+		/obj/item/reagent_containers/glass/beaker/large,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/storage/part_replacer,
+		/obj/item/card/robot,
+		/obj/item/shockpaddles/robot/jumper,
+		/obj/item/tool/wirecutters/cyborg,
+		/obj/item/melee/baton/slime/robot,
+		/obj/item/gun/energy/taser/xeno/robot,
+		/obj/item/surgical/scalpel/cyborg,
+		/obj/item/surgical/circular_saw/cyborg
+	)
 
-	var/datum/matter_synth/nanite = new /datum/matter_synth/nanite(10000)
-	synths += nanite
+/obj/item/robot_module/robot/quad/sci/get_synths()
+	. = ..()
+	MATTER_SYNTH(MATSYN_NANITES, nanite, 10000)
+	MATTER_SYNTH(MATSYN_WIRE, wire)
 
-	var/datum/matter_synth/water = new /datum/matter_synth(500)
-	water.name = "Water reserves"
-	water.recharge_rate = 0
-	R.water_res = water
-	synths += water
-
-	var/datum/matter_synth/wire = new /datum/matter_synth/wire()
-	synths += wire
-
+/obj/item/robot_module/robot/quad/sci/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
 	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	N.uses_charge = 1
 	N.charge_costs = list(1000)
-	N.synths = list(nanite)
-	src.modules += N
-
-	var/obj/item/dogborg/tongue/T = new /obj/item/dogborg/tongue(src)
-	T.water = water
-	src.modules += T
+	N.synths = list(synths_by_kind[MATSYN_NANOPASTE])
+	. += N
 
 	var/obj/item/dogborg/sleeper/compactor/analyzer/B = new /obj/item/dogborg/sleeper/compactor/analyzer(src)
-	B.water = water
-	src.modules += B
+	B.water = synths_by_kind[MATSYN_WATER]
+	. += B
 
 	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
-	C.synths = list(wire)
-	src.modules += C
+	C.synths = list(synths_by_kind[MATSYN_WIRE])
+	. += C
 
-	R.icon = 'icons/mob/robots_wide.dmi'
-	R.set_base_pixel_x(-16)
-	R.dogborg = TRUE
-	R.wideborg = TRUE
-	R.icon_dimension_x = 64
-	add_verb(R, /mob/living/silicon/robot/proc/ex_reserve_refill)
-	add_verb(R, /mob/living/proc/shred_limb)
-	add_verb(R, /mob/living/silicon/robot/proc/rest_style)
-
+	src.emag = new /obj/item/borg/combat/shield(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/security.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/security.dm
@@ -5,42 +5,48 @@
 	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor)
 	can_be_pushed = 0
 	supported_upgrades = list(/obj/item/borg/upgrade/tasercooler)
+	is_the_law = TRUE
 
 /obj/item/robot_module/robot/security/general
 	sprites = list(
-					"M-USE NanoTrasen" = "robotSecy",
-					"Cabeiri" = "eyebot-security",
-					"Cerberus" = "bloodhound",
-					"Cerberus - Treaded" = "treadhound",
-					"Haruka" = "marinaSC",
-					"Usagi" = "tallred",
-					"Telemachus" = "toiletbotsecurity",
-					"WTOperator" = "sleeksecurity",
-					"XI-GUS" = "spidersec",
-					"XI-ALP" = "heavySec",
-					"Basic" = "secborg",
-					"Black Knight" = "securityrobot",
-					"Drone" = "drone-sec",
-					"Insekt" = "insekt-Sec",
-					"Misato" = "tall2security",
-					"L3P1-D0T" = "Glitterfly-Security",
-					"Miss M" = "miss-security",
-					"Coffcurity" = "coffin-Combat",
-					"Handy" = "handy-sec",
-					"Acheron" = "mechoid-Security",
-					"Shellguard Noble" = "Noble-SEC",
-					"ZOOM-BA" = "zoomba-security",
-					"W02M" = "worm-security"
-					)
+		"M-USE NanoTrasen" = "robotSecy",
+		"Cabeiri" = "eyebot-security",
+		"Cerberus" = "bloodhound",
+		"Cerberus - Treaded" = "treadhound",
+		"Haruka" = "marinaSC",
+		"Usagi" = "tallred",
+		"Telemachus" = "toiletbotsecurity",
+		"WTOperator" = "sleeksecurity",
+		"XI-GUS" = "spidersec",
+		"XI-ALP" = "heavySec",
+		"Basic" = "secborg",
+		"Black Knight" = "securityrobot",
+		"Drone" = "drone-sec",
+		"Insekt" = "insekt-Sec",
+		"Misato" = "tall2security",
+		"L3P1-D0T" = "Glitterfly-Security",
+		"Miss M" = "miss-security",
+		"Coffcurity" = "coffin-Combat",
+		"Handy" = "handy-sec",
+		"Acheron" = "mechoid-Security",
+		"Shellguard Noble" = "Noble-SEC",
+		"ZOOM-BA" = "zoomba-security",
+		"W02M" = "worm-security"
+	)
 
-/obj/item/robot_module/robot/security/general/Initialize(mapload)
+/obj/item/robot_module/robot/security/general/get_modules()
 	. = ..()
-	src.modules += new /obj/item/handcuffs/cyborg(src)
-	src.modules += new /obj/item/melee/baton/robot(src)
-	src.modules += new /obj/item/gun/energy/taser/mounted/cyborg(src)
-	src.modules += new /obj/item/barrier_tape_roll/police(src)
-	src.modules += new /obj/item/reagent_containers/spray/pepper(src)
-	src.modules += new /obj/item/gripper/security(src)
+	. |= list(
+		/obj/item/handcuffs/cyborg,
+		/obj/item/melee/baton/robot,
+		/obj/item/gun/energy/taser/mounted/cyborg,
+		/obj/item/barrier_tape_roll/police,
+		/obj/item/reagent_containers/spray/pepper,
+		/obj/item/gripper/security
+	)
+
+/obj/item/robot_module/robot/security/general/handle_special_module_init(mapload)
+	. = ..()
 	src.emag = new /obj/item/gun/energy/laser/mounted(src)
 
 /obj/item/robot_module/robot/security/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
@@ -62,82 +68,67 @@
 	name = "combat robot module"
 	hide_on_manifest = 1
 	sprites = list(
-					"Haruka" = "marinaCB",
-					"Cabeiri" = "eyebot-combat",
-					"Combat Android" = "droid-combat",
-					"Insekt" = "insekt-Combat",
-					"Acheron" = "mechoid-Combat",
-					"ZOOM-BA" = "zoomba-combat"
-					)
+		"Haruka" = "marinaCB",
+		"Cabeiri" = "eyebot-combat",
+		"Combat Android" = "droid-combat",
+		"Insekt" = "insekt-Combat",
+		"Acheron" = "mechoid-Combat",
+		"ZOOM-BA" = "zoomba-combat"
+	)
 
-/obj/item/robot_module/robot/security/combat/Initialize(mapload)
+/obj/item/robot_module/robot/security/combat/get_modules()
 	. = ..()
-	src.modules += new /obj/item/flash(src)
-	//src.modules += new /obj/item/borg/sight/thermal(src)
-	src.modules += new /obj/item/gun/energy/laser/mounted(src)
-	src.modules += new /obj/item/pickaxe/plasmacutter(src)
-	src.modules += new /obj/item/borg/combat/shield(src)
-	src.modules += new /obj/item/borg/combat/mobility(src)
+	. |= list(
+		/obj/item/flash,
+		// /obj/item/borg/sight/thermal,
+		/obj/item/gun/energy/laser/mounted,
+		/obj/item/pickaxe/plasmacutter,
+		/obj/item/borg/combat/shield,
+		/obj/item/borg/combat/mobility,
+	)
+
+/obj/item/robot_module/robot/security/combat/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
 	src.emag = new /obj/item/gun/energy/lasercannon/mounted(src)
 
-/obj/item/robot_module/robot/quad_sec
+/obj/item/robot_module/robot/quad/sec
 	name = "SecuriQuad module"
 	sprites = list(
-					"K9 hound" = "k9",
-					"K9 Alternative" = "k92",
-					"Secborg model V-2" = "secborg",
-					"Borgi" = "borgi-sec",
-					"Otieborg" = "oties",
-					"F3-LINE" = "FELI-Security"
-					)
+		"K9 hound" = "k9",
+		"K9 Alternative" = "k92",
+		"Secborg model V-2" = "secborg",
+		"Borgi" = "borgi-sec",
+		"Otieborg" = "oties",
+		"F3-LINE" = "FELI-Security"
+	)
 	channels = list("Security" = 1)
 	networks = list(NETWORK_SECURITY)
 	can_be_pushed = 0
-
-/obj/item/robot_module/robot/quad_sec/Initialize(mapload)
-	. = ..()
-	var/mob/living/silicon/robot/R = loc
-
+	is_quad = TRUE
+	is_the_law = TRUE
+	can_shred = TRUE
 	supported_upgrades = list(/obj/item/borg/upgrade/tasercooler)
 
-	src.modules += new /obj/item/handcuffs/cyborg(src) //You need cuffs to be a proper sec borg!
-	src.modules += new /obj/item/dogborg/jaws/big(src) //In case there's some kind of hostile mob.
-	src.modules += new /obj/item/melee/baton/robot(src) //Since the pounce module refused to work, they get a stunbaton instead.
-	src.modules += new /obj/item/dogborg/boop_module(src) //Boop people on the nose.
-	src.modules += new /obj/item/barrier_tape_roll/police(src) //Block out crime scenes.
-	src.modules += new /obj/item/gun/energy/taser/mounted/cyborg(src) //They /are/ a security borg, after all.
-	src.modules += new /obj/item/dogborg/pounce(src) //Pounce
-	src.emag 	 = new /obj/item/gun/energy/laser/mounted(src) //Emag. Not a big problem.
+/obj/item/robot_module/robot/quad/sec/get_modules()
+	. = ..()
+	. |= list(
+		/obj/item/handcuffs/cyborg, //You need cuffs to be a proper sec borg!
+		/obj/item/dogborg/jaws/big, //In case there's some kind of hostile mob.
+		/obj/item/melee/baton/robot, //Since the pounce module refused to work, they get a stunbaton instead.
+		/obj/item/barrier_tape_roll/police, //Block out crime scenes.
+		/obj/item/gun/energy/taser/mounted/cyborg, //They /are/ a security borg, after all.
+		/obj/item/dogborg/pounce //Pounce
+	)
 
-	var/datum/matter_synth/water = new /datum/matter_synth(500) //Starts full and has a max of 500
-	water.name = "Water reserves"
-	water.recharge_rate = 0
-	R.water_res = water
-	synths += water
-
-	var/obj/item/dogborg/tongue/T = new /obj/item/dogborg/tongue(src)
-	T.water = water
-	src.modules += T
+/obj/item/robot_module/robot/quad/sec/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
+	src.emag = new /obj/item/gun/energy/laser/mounted(src) //Emag. Not a big problem.
 
 	var/obj/item/dogborg/sleeper/K9/B = new /obj/item/dogborg/sleeper/K9(src) //Eat criminals. Bring them to the brig.
-	B.water = water
+	B.water = synths_by_kind[MATSYN_WATER]
 	src.modules += B
 
-	R.icon = 'icons/mob/robots_wide.dmi'
-	R.set_base_pixel_x(-16)
-	R.dogborg = TRUE
-	R.wideborg = TRUE
-	R.icon_dimension_x = 64
-	add_verb(R, /mob/living/silicon/robot/proc/ex_reserve_refill)
-	add_verb(R, /mob/living/proc/shred_limb)
-	add_verb(R, /mob/living/silicon/robot/proc/rest_style)
-
-	if(R.client && (R.client.ckey in list("nezuli")))
-		sprites += "Alina"
-		sprites["Alina"] = "alina-sec"
-		. = ..()
-
-/obj/item/robot_module/robot/quad_sec/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
+/obj/item/robot_module/robot/quad/sec/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	var/obj/item/flash/F = locate() in src.modules
 	if(F.broken)
 		F.broken = 0
@@ -155,47 +146,35 @@
 	if(B && B.bcell)
 		B.bcell.give(amount)*/
 
-/obj/item/robot_module/robot/ert
-	name = "Emergency Responce module"
+/obj/item/robot_module/robot/quad/ert
+	name = "Emergency Response module"
 	channels = list("Security" = 1)
 	networks = list(NETWORK_SECURITY)
 	can_be_pushed = 0
 	sprites = list(
-					"Standard" = "ert",
-					"Borgi" = "borgi",
-					"F3-LINE" = "FELI-Combat"
-					)
+		"Standard" = "ert",
+		"Borgi" = "borgi",
+		"F3-LINE" = "FELI-Combat"
+	)
 
-/obj/item/robot_module/robot/ert/Initialize(mapload)
+	can_shred = TRUE
+
+/obj/item/robot_module/robot/quad/ert/get_modules()
 	. = ..()
-	var/mob/living/silicon/robot/R = loc
-	src.modules += new /obj/item/handcuffs/cyborg(src)
-	src.modules += new /obj/item/dogborg/jaws/big(src)
-	src.modules += new /obj/item/melee/baton/robot(src)
-	src.modules += new /obj/item/barrier_tape_roll/police(src)
-	src.modules += new /obj/item/gun/energy/taser/mounted/cyborg/ertgun(src)
-	src.modules += new /obj/item/dogborg/swordtail(src)
-	src.emag     = new /obj/item/gun/energy/laser/mounted(src)
+	. |= list(
+		/obj/item/handcuffs/cyborg,
+		/obj/item/dogborg/jaws/big,
+		/obj/item/melee/baton/robot,
+		/obj/item/barrier_tape_roll/police,
+		/obj/item/gun/energy/taser/mounted/cyborg/ertgun,
+		/obj/item/dogborg/swordtail
+	)
 
-	var/datum/matter_synth/water = new /datum/matter_synth(500)
-	water.name = "Water reserves"
-	water.recharge_rate = 0
-	R.water_res = water
-	synths += water
+/obj/item/robot_module/robot/quad/ert/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
 
-	var/obj/item/dogborg/tongue/T = new /obj/item/dogborg/tongue(src)
-	T.water = water
-	src.modules += T
+	src.emag = new /obj/item/gun/energy/laser/mounted(src)
 
 	var/obj/item/dogborg/sleeper/K9/B = new /obj/item/dogborg/sleeper/K9(src)
-	B.water = water
-	src.modules += B
-
-	R.icon = 'icons/mob/64x64robot_vr.dmi'
-	R.set_base_pixel_x(-16)
-	R.dogborg = TRUE
-	R.wideborg = TRUE
-	R.icon_dimension_x = 64
-	add_verb(R, /mob/living/silicon/robot/proc/ex_reserve_refill)
-	add_verb(R, /mob/living/proc/shred_limb)
-	add_verb(R, /mob/living/silicon/robot/proc/rest_style)
+	B.water = synths_by_kind[MATSYN_WATER]
+	. += B

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/security.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/security.dm
@@ -104,7 +104,6 @@
 	channels = list("Security" = 1)
 	networks = list(NETWORK_SECURITY)
 	can_be_pushed = 0
-	is_quad = TRUE
 	is_the_law = TRUE
 	can_shred = TRUE
 	supported_upgrades = list(/obj/item/borg/upgrade/tasercooler)

--- a/code/modules/mob/living/silicon/robot/robot_modules/station/service.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/service.dm
@@ -2,35 +2,40 @@
 	name = "janitorial robot module"
 	channels = list("Service" = 1)
 	sprites = list(
-					"M-USE NanoTrasen" = "robotJani",
-					"Arachne" = "crawler",
-					"Cabeiri" = "eyebot-janitor",
-					"Haruka" = "marinaJN",
-					"Telemachus" = "toiletbotjanitor",
-					"WTOperator" = "sleekjanitor",
-					"XI-ALP" = "heavyRes",
-					"Basic" = "JanBot2",
-					"Mopbot"  = "janitorrobot",
-					"Mop Gear Rex" = "mopgearrex",
-					"Drone" = "drone-janitor",
-					"Misato" = "tall2janitor",
-					"L3P1-D0T" = "Glitterfly-Janitor",
-					"Miss M" = "miss-janitor",
-					"Cleriffin" = "coffin-Clerical",
-					"Coffstodial" = "coffin-Custodial",
-					"Handy" = "handy-janitor",
-					"Acheron" = "mechoid-Janitor",
-					"Shellguard Noble" = "Noble-CLN",
-					"ZOOM-BA" = "zoomba-janitor",
-					"W02M" = "worm-janitor"
-					)
+		"M-USE NanoTrasen" = "robotJani",
+		"Arachne" = "crawler",
+		"Cabeiri" = "eyebot-janitor",
+		"Haruka" = "marinaJN",
+		"Telemachus" = "toiletbotjanitor",
+		"WTOperator" = "sleekjanitor",
+		"XI-ALP" = "heavyRes",
+		"Basic" = "JanBot2",
+		"Mopbot"  = "janitorrobot",
+		"Mop Gear Rex" = "mopgearrex",
+		"Drone" = "drone-janitor",
+		"Misato" = "tall2janitor",
+		"L3P1-D0T" = "Glitterfly-Janitor",
+		"Miss M" = "miss-janitor",
+		"Cleriffin" = "coffin-Clerical",
+		"Coffstodial" = "coffin-Custodial",
+		"Handy" = "handy-janitor",
+		"Acheron" = "mechoid-Janitor",
+		"Shellguard Noble" = "Noble-CLN",
+		"ZOOM-BA" = "zoomba-janitor",
+		"W02M" = "worm-janitor"
+	)
 
-/obj/item/robot_module/robot/janitor/Initialize(mapload)
+/obj/item/robot_module/robot/janitor/get_modules()
 	. = ..()
-	src.modules += new /obj/item/soap/nanotrasen(src)
-	src.modules += new /obj/item/storage/bag/trash(src)
-	src.modules += new /obj/item/mop(src)
-	src.modules += new /obj/item/lightreplacer(src)
+	. |= list(
+		/obj/item/soap/nanotrasen,
+		/obj/item/storage/bag/trash,
+		/obj/item/mop,
+		/obj/item/lightreplacer
+	)
+
+/obj/item/robot_module/robot/janitor/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
 	src.emag = new /obj/item/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent("lube", 250)
 	src.emag.name = "Lube spray"
@@ -46,57 +51,57 @@
 	name = "service robot module"
 	channels = list("Service" = 1)
 	languages = list(
-					LANGUAGE_AKHANI		= 1,
-					LANGUAGE_BIRDSONG	= 1,
-					LANGUAGE_CANILUNZT	= 1,
-					LANGUAGE_DAEMON		= 1,
-					LANGUAGE_EAL		= 1,
-					LANGUAGE_ECUREUILIAN= 1,
-					LANGUAGE_ENOCHIAN	= 1,
-					LANGUAGE_GUTTER		= 1,
-					LANGUAGE_ROOTLOCAL	= 0,
-					LANGUAGE_SAGARU		= 1,
-					LANGUAGE_SCHECHI	= 1,
-					LANGUAGE_SIGN		= 0,
-					LANGUAGE_SIIK		= 1,
-					LANGUAGE_SKRELLIAN	= 1,
-					LANGUAGE_SKRELLIANFAR = 0,
-					LANGUAGE_SOL_COMMON	= 1,
-					LANGUAGE_SQUEAKISH	= 1,
-					LANGUAGE_TERMINUS	= 1,
-					LANGUAGE_TRADEBAND	= 1,
-					LANGUAGE_UNATHI		= 1,
-					LANGUAGE_ZADDAT		= 1
-					)
+		LANGUAGE_AKHANI		= 1,
+		LANGUAGE_BIRDSONG	= 1,
+		LANGUAGE_CANILUNZT	= 1,
+		LANGUAGE_DAEMON		= 1,
+		LANGUAGE_EAL		= 1,
+		LANGUAGE_ECUREUILIAN= 1,
+		LANGUAGE_ENOCHIAN	= 1,
+		LANGUAGE_GUTTER		= 1,
+		LANGUAGE_ROOTLOCAL	= 0,
+		LANGUAGE_SAGARU		= 1,
+		LANGUAGE_SCHECHI	= 1,
+		LANGUAGE_SIGN		= 0,
+		LANGUAGE_SIIK		= 1,
+		LANGUAGE_SKRELLIAN	= 1,
+		LANGUAGE_SKRELLIANFAR = 0,
+		LANGUAGE_SOL_COMMON	= 1,
+		LANGUAGE_SQUEAKISH	= 1,
+		LANGUAGE_TERMINUS	= 1,
+		LANGUAGE_TRADEBAND	= 1,
+		LANGUAGE_UNATHI		= 1,
+		LANGUAGE_ZADDAT		= 1
+	)
 
 /obj/item/robot_module/robot/clerical/butler
 	sprites = list(
-					"M-USE NanoTrasen" = "robotServ",
-					"Cabeiri" = "eyebot-standard",
-					"Haruka" = "marinaSV",
-					"Michiru" = "maidbot",
-					"Usagi" = "tallgreen",
-					"Telemachus" = "toiletbot",
-					"WTOperator" = "sleekservice",
-					"WTOmni" = "omoikane",
-					"XI-GUS" = "spider",
-					"XI-ALP" = "heavyServ",
-					"Standard" = "Service2",
-					"Waitress" = "Service",
-					"Bro" = "Brobot",
-					"Rich" = "maximillion",
-					"Drone - Service" = "drone-service",
-					"Drone - Hydro" = "drone-hydro",
-					"Misato" = "tall2service",
-					"L3P1-D0T" = "Glitterfly-Service",
-					"Miss M" = "miss-service",
-					"Handy - Service" = "handy-service",
-					"Handy - Hydro" = "handy-hydro",
-					"Acheron" = "mechoid-Service",
-					"Shellguard Noble" = "Noble-SRV",
-					"ZOOM-BA" = "zoomba-service",
-					"W02M" = "worm-service"
-				  	)
+		"M-USE NanoTrasen" = "robotServ",
+		"Cabeiri" = "eyebot-standard",
+		"Haruka" = "marinaSV",
+		"Michiru" = "maidbot",
+		"Usagi" = "tallgreen",
+		"Telemachus" = "toiletbot",
+		"WTOperator" = "sleekservice",
+		"WTOmni" = "omoikane",
+		"XI-GUS" = "spider",
+		"XI-ALP" = "heavyServ",
+		"Standard" = "Service2",
+		"Waitress" = "Service",
+		"Bro" = "Brobot",
+		"Rich" = "maximillion",
+		"Drone - Service" = "drone-service",
+		"Drone - Hydro" = "drone-hydro",
+		"Misato" = "tall2service",
+		"L3P1-D0T" = "Glitterfly-Service",
+		"Miss M" = "miss-service",
+		"Handy - Service" = "handy-service",
+		"Handy - Hydro" = "handy-hydro",
+		"Acheron" = "mechoid-Service",
+		"Shellguard Noble" = "Noble-SRV",
+		"ZOOM-BA" = "zoomba-service",
+		"W02M" = "worm-service"
+	)
 
 /obj/item/robot_module/robot/clerical/butler/Initialize(mapload)
 	. = ..()
@@ -131,212 +136,205 @@
 	R.add_reagent("beer2", 50)
 	src.emag.name = "Mickey Finn's Special Brew"
 
-/obj/item/robot_module/robot/clerical/general
-	name = "clerical robot module"
-	sprites = list(
-					"M-USE NanoTrasen" = "robotCler",
-					"Cabeiri" = "eyebot-standard",
-					"Haruka" = "marinaSV",
-					"Usagi" = "tallgreen",
-					"Telemachus" = "toiletbot",
-					"WTOperator" = "sleekclerical",
-					"WTOmni" = "omoikane",
-					"XI-GUS" = "spidercom",
-					"XI-ALP" = "heavyServ",
-					"Waitress" = "Service",
-					"Bro" = "Brobot",
-					"Rich" = "maximillion",
-					"Default" = "Service2",
-					"Drone" = "drone-blu",
-					"Misato" = "tall2service",
-					"L3P1-D0T" = "Glitterfly-Clerical",
-					"Miss M" = "miss-service",
-					"Handy" = "handy-clerk",
-					"Acheron" = "mechoid-Service",
-					"Shellguard Noble" = "Noble-SRV",
-					"ZOOM-BA" = "zoomba-clerical",
-					"W02M" = "worm-service"
-					)
-
-/obj/item/robot_module/robot/clerical/general/Initialize(mapload)
-	. = ..()
-	src.modules += new /obj/item/pen/robopen(src)
-	src.modules += new /obj/item/form_printer(src)
-	src.modules += new /obj/item/gripper/paperwork(src)
-	src.modules += new /obj/item/hand_labeler(src)
-	src.modules += new /obj/item/stamp(src)
-	src.modules += new /obj/item/stamp/denied(src)
-	src.emag = new /obj/item/stamp/chameleon(src)
-	src.emag = new /obj/item/pen/chameleon(src)
-
-/obj/item/robot_module/general/butler/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
+/obj/item/robot_module/robot/clerical/butler/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	var/obj/item/reagent_containers/food/condiment/enzyme/E = locate() in src.modules
 	E.reagents.add_reagent("enzyme", 2 * amount)
 	if(src.emag)
 		var/obj/item/reagent_containers/food/drinks/bottle/small/beer/B = src.emag
 		B.reagents.add_reagent("beer2", 2 * amount)
 
-/obj/item/robot_module/robot/quad_jani
+/obj/item/robot_module/robot/clerical/general
+	name = "clerical robot module"
+	sprites = list(
+		"M-USE NanoTrasen" = "robotCler",
+		"Cabeiri" = "eyebot-standard",
+		"Haruka" = "marinaSV",
+		"Usagi" = "tallgreen",
+		"Telemachus" = "toiletbot",
+		"WTOperator" = "sleekclerical",
+		"WTOmni" = "omoikane",
+		"XI-GUS" = "spidercom",
+		"XI-ALP" = "heavyServ",
+		"Waitress" = "Service",
+		"Bro" = "Brobot",
+		"Rich" = "maximillion",
+		"Default" = "Service2",
+		"Drone" = "drone-blu",
+		"Misato" = "tall2service",
+		"L3P1-D0T" = "Glitterfly-Clerical",
+		"Miss M" = "miss-service",
+		"Handy" = "handy-clerk",
+		"Acheron" = "mechoid-Service",
+		"Shellguard Noble" = "Noble-SRV",
+		"ZOOM-BA" = "zoomba-clerical",
+		"W02M" = "worm-service"
+	)
+
+/obj/item/robot_module/robot/clerical/general/get_modules()
+	. = ..()
+	. |= list(
+		/obj/item/pen/robopen,
+		/obj/item/form_printer,
+		/obj/item/gripper/paperwork,
+		/obj/item/hand_labeler,
+		/obj/item/stamp,
+		/obj/item/stamp/denied
+	)
+
+/obj/item/robot_module/robot/clerical/general/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
+	// cba to make emags support more than one item
+	if (prob(50))
+		src.emag = new /obj/item/stamp/chameleon(src)
+	else
+		src.emag = new /obj/item/pen/chameleon(src)
+
+/obj/item/robot_module/robot/quad/jani
 	name = "JaniQuad module"
 	sprites = list(
-					"Custodial Hound" = "scrubpup",
-					"Borgi" = "borgi-jani",
-					"Otieborg" = "otiej",
-					"Janihound, J9" = "J9",
-					"F3-LINE" = "FELI-Janitor"
-					)
+		"Custodial Hound" = "scrubpup",
+		"Borgi" = "borgi-jani",
+		"Otieborg" = "otiej",
+		"Janihound, J9" = "J9",
+		"F3-LINE" = "FELI-Janitor"
+	)
 	channels = list("Service" = 1)
 	can_be_pushed = 0
+	can_shred = TRUE
 
-/obj/item/robot_module/robot/quad_jani/Initialize(mapload)
+/obj/item/robot_module/robot/quad/jani/get_modules()
 	. = ..()
-	var/mob/living/silicon/robot/R = loc
-	src.modules += new /obj/item/dogborg/jaws/small(src)
-	src.modules += new /obj/item/dogborg/boop_module(src)
-	src.modules += new /obj/item/pupscrubber(src)
-	src.emag 	 = new /obj/item/dogborg/pounce(src) //Pounce
+	. |= list(
+		/obj/item/dogborg/jaws/small,
+		/obj/item/pupscrubber
+	)
 
+/obj/item/robot_module/robot/quad/jani/get_synths()
+	. = ..()
 	//Starts empty. Can only recharge with recycled material.
-	var/datum/matter_synth/metal = new /datum/matter_synth/metal()
-	metal.name = "Steel reserves"
-	metal.recharge_rate = 0
-	metal.max_energy = 50000
-	metal.energy = 0
-	var/datum/matter_synth/glass = new /datum/matter_synth/glass()
-	glass.name = "Glass reserves"
-	glass.recharge_rate = 0
-	glass.max_energy = 50000
-	glass.energy = 0
-	var/datum/matter_synth/water = new /datum/matter_synth(500)
-	water.name = "Water reserves"
-	water.recharge_rate = 0
-	R.water_res = water
+	.[MATSYN_METAL] = new /datum/matter_synth/metal {
+		name = "Steel reserves";
+		recharge_rate = 0;
+		max_energy = 50000;
+		energy = 0;
+	}
 
-	synths += metal
-	synths += glass
-	synths += water
+	.[MATSYN_GLASS] = new /datum/matter_synth/glass {
+		name = "Glass reserves";
+		recharge_rate = 0;
+		max_energy = 50000;
+		energy = 0;
+	}
 
-	var/obj/item/dogborg/tongue/T = new /obj/item/dogborg/tongue(src)
-	T.water = water
-	src.modules += T
+/obj/item/robot_module/robot/quad/jani/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
+
+	src.emag = new /obj/item/dogborg/pounce(src) //Pounce
 
 	var/obj/item/lightreplacer/dogborg/LR = new /obj/item/lightreplacer/dogborg(src)
-	LR.glass = glass
-	src.modules += LR
+	LR.glass = synths_by_kind[MATSYN_GLASS]
+	. += LR
 
 	var/obj/item/dogborg/sleeper/compactor/C = new /obj/item/dogborg/sleeper/compactor(src)
-	C.metal = metal
-	C.glass = glass
-	C.water = water
-	src.modules += C
+	C.metal = synths_by_kind[MATSYN_METAL]
+	C.glass = synths_by_kind[MATSYN_GLASS]
+	C.water = synths_by_kind[MATSYN_WATER]
+	. += C
 
 	//Sheet refiners can only produce raw sheets.
 	var/obj/item/stack/material/cyborg/steel/M = new (src)
 	M.name = "steel recycler"
 	M.desc = "A device that refines recycled steel into sheets."
-	M.synths = list(metal)
-	M.recipes = list()
-	M.recipes += new/datum/stack_recipe("steel sheet", /obj/item/stack/material/steel, 1, 1, 20)
-	src.modules += M
+	M.synths = list(synths_by_kind[MATSYN_METAL])
+	M.recipes = list(
+		new/datum/stack_recipe("steel sheet", /obj/item/stack/material/steel, 1, 1, 20)
+	)
+	. += M
 
 	var/obj/item/stack/material/cyborg/glass/G = new (src)
 	G.name = "glass recycler"
 	G.desc = "A device that refines recycled glass into sheets."
 	G.allow_window_autobuild = FALSE
-	G.synths = list(glass)
-	G.recipes = list()
-	G.recipes += new/datum/stack_recipe("glass sheet", /obj/item/stack/material/glass, 1, 1, 20)
-	src.modules += G
-
-	R.icon = 'icons/mob/robots_wide.dmi'
-	R.set_base_pixel_x(-16)
-	R.dogborg = TRUE
-	R.wideborg = TRUE
-	R.icon_dimension_x = 64
-	add_verb(R, /mob/living/silicon/robot/proc/ex_reserve_refill)
-	add_verb(R, /mob/living/proc/shred_limb)
-	add_verb(R, /mob/living/silicon/robot/proc/rest_style)
+	G.synths = list(synths_by_kind[MATSYN_GLASS])
+	G.recipes = list(
+		new/datum/stack_recipe("glass sheet", /obj/item/stack/material/glass, 1, 1, 20)
+	)
+	. += G
 
 // Uses modified K9 sprites.
-/obj/item/robot_module/robot/clerical/quad_serv
+/obj/item/robot_module/robot/quad/serv
 	name = "Service Quadruped module"
 	sprites = list(
-					"Blackhound" = "k50",
-					"Pinkhound" = "k69",
-					"ServicehoundV2" = "serve2",
-					"ServicehoundV2 Darkmode" = "servedark",
-					"F3-LINE" = "FELI-Service"
-					)
+		"Blackhound" = "k50",
+		"Pinkhound" = "k69",
+		"ServicehoundV2" = "serve2",
+		"ServicehoundV2 Darkmode" = "servedark",
+		"F3-LINE" = "FELI-Service"
+	)
+	languages = list(
+		LANGUAGE_AKHANI		= 1,
+		LANGUAGE_BIRDSONG	= 1,
+		LANGUAGE_CANILUNZT	= 1,
+		LANGUAGE_DAEMON		= 1,
+		LANGUAGE_EAL		= 1,
+		LANGUAGE_ECUREUILIAN= 1,
+		LANGUAGE_ENOCHIAN	= 1,
+		LANGUAGE_GUTTER		= 1,
+		LANGUAGE_ROOTLOCAL	= 0,
+		LANGUAGE_SAGARU		= 1,
+		LANGUAGE_SCHECHI	= 1,
+		LANGUAGE_SIGN		= 0,
+		LANGUAGE_SIIK		= 1,
+		LANGUAGE_SKRELLIAN	= 1,
+		LANGUAGE_SKRELLIANFAR = 0,
+		LANGUAGE_SOL_COMMON	= 1,
+		LANGUAGE_SQUEAKISH	= 1,
+		LANGUAGE_TERMINUS	= 1,
+		LANGUAGE_TRADEBAND	= 1,
+		LANGUAGE_UNATHI		= 1,
+		LANGUAGE_ZADDAT		= 1
+	)
 	channels = list("Service" = 1)
 	can_be_pushed = 0
 
-// In a nutshell, basicly service/butler robot but in dog form.
-/obj/item/robot_module/robot/clerical/quad_serv/Initialize(mapload)
+/obj/item/robot_module/robot/quad/serv/get_modules()
 	. = ..()
-	var/mob/living/silicon/robot/R = loc
-	src.modules += new /obj/item/gripper/service(src)
-	src.modules += new /obj/item/reagent_containers/glass/bucket(src)
-	src.modules += new /obj/item/material/minihoe(src)
-	src.modules += new /obj/item/material/knife/machete/hatchet(src)
-	src.modules += new /obj/item/analyzer/plant_analyzer(src)
-	src.modules += new /obj/item/storage/bag/dogborg(src)
-	src.modules += new /obj/item/robot_harvester(src)
-	src.modules += new /obj/item/material/knife(src)
-	src.modules += new /obj/item/material/kitchen/rollingpin(src)
-	src.modules += new /obj/item/multitool(src) //to freeze trays
-	src.modules += new /obj/item/dogborg/jaws/small(src)
-	src.modules += new /obj/item/dogborg/boop_module(src)
-	src.emag 	 = new /obj/item/dogborg/pounce(src) //Pounce
+	. |= list(
+		/obj/item/gripper/service,
+		/obj/item/reagent_containers/glass/bucket,
+		/obj/item/material/minihoe,
+		/obj/item/material/knife/machete/hatchet,
+		/obj/item/analyzer/plant_analyzer,
+		/obj/item/storage/bag/dogborg,
+		/obj/item/robot_harvester,
+		/obj/item/material/knife,
+		/obj/item/material/kitchen/rollingpin,
+		/obj/item/multitool, //to freeze trays
+		/obj/item/dogborg/jaws/small,
+		/obj/item/reagent_containers/dropper/industrial,
+		/obj/item/tray/robotray,
+		/obj/item/reagent_containers/borghypo/service,
+		/obj/item/storage/bag/trash
+	)
 
-	var/datum/matter_synth/water = new /datum/matter_synth(500) // buffy fix, was 0
-	water.name = "Water reserves"
-	water.recharge_rate = 0
-	water.max_energy = 1000
-	R.water_res = water
-	synths += water
+// In a nutshell, basicly service/butler robot but in dog form.
+/obj/item/robot_module/robot/quad/serv/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
+	src.emag = new /obj/item/dogborg/pounce(src)
 
-
-	var/obj/item/dogborg/tongue/T = new /obj/item/dogborg/tongue(src)
-	T.water = water
-	src.modules += T
+	// These get a larger water synth.
+	synths_by_kind[MATSYN_WATER]:max_energy = 1000
 
 	var/obj/item/rsf/M = new /obj/item/rsf(src)
 	M.stored_matter = 30
-	src.modules += M
-
-	src.modules += new /obj/item/reagent_containers/dropper/industrial(src)
+	. += M
 
 	var/obj/item/flame/lighter/zippo/L = new /obj/item/flame/lighter/zippo(src)
 	L.lit = 1
-	src.modules += L
-
-	src.modules += new /obj/item/tray/robotray(src)
-	src.modules += new /obj/item/reagent_containers/borghypo/service(src)
-	src.modules += new /obj/item/storage/bag/trash(src)
+	. += L
 
 /* // I don't know what kind of sleeper to put here, but also no need if you already have "Robot Nom" verb.
 	var/obj/item/dogborg/sleeper/K9/B = new /obj/item/dogborg/sleeper/K9(src)
 	B.water = water
 	src.modules += B
 */
-
-	R.icon = 'icons/mob/robots_wide.dmi'
-	R.set_base_pixel_x(-16)
-	R.dogborg = TRUE
-	R.wideborg = TRUE
-	R.icon_dimension_x = 64
-	add_verb(R, /mob/living/silicon/robot/proc/ex_reserve_refill)
-	add_verb(R, /mob/living/silicon/robot/proc/rest_style)
-
-
-/obj/item/robot_module/Reset(var/mob/living/silicon/robot/R)
-	R.pixel_x = initial(pixel_x)
-	R.pixel_y = initial(pixel_y)
-	R.icon = initial(R.icon)
-	R.dogborg = FALSE
-	R.wideborg = FALSE
-	R.base_pixel_x = initial(pixel_x)
-	R.scrubbing = FALSE
-	remove_verb(R, /mob/living/silicon/robot/proc/ex_reserve_refill)
-	remove_verb(R, /mob/living/proc/shred_limb)
-	remove_verb(R, /mob/living/silicon/robot/proc/rest_style)

--- a/code/modules/mob/living/silicon/robot/robot_modules/swarm.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/swarm.dm
@@ -2,26 +2,29 @@
 	name = "swarm drone module"
 	var/id
 
-/obj/item/robot_module/drone/swarm/Initialize(mapload)
+/obj/item/robot_module/drone/swarm/get_modules()
 	. = ..()
-	var/mob/living/silicon/robot/robot = loc
-	id = robot.idcard
-	src.modules += id
+	. |= list(
+		/obj/item/rcd/electric/mounted/borg/swarm,
+		/obj/item/flash/robot,
+		/obj/item/handcuffs/cable/tape/cyborg,
+		/obj/item/melee/baton/robot,
+		/obj/item/gun/energy/taser/mounted/cyborg/swarm,
+		/obj/item/matter_decompiler/swarm
+	)
 
-	src.modules += new /obj/item/rcd/electric/mounted/borg/swarm(src)
-	src.modules += new /obj/item/flash/robot(src)
-	src.modules += new /obj/item/handcuffs/cable/tape/cyborg(src)
-	src.modules += new /obj/item/melee/baton/robot(src)
-	src.modules += new /obj/item/gun/energy/taser/mounted/cyborg/swarm(src)
-	src.modules += new /obj/item/matter_decompiler/swarm(src)
+/obj/item/robot_module/drone/swarm/handle_special_module_init(mob/living/silicon/robot/robot)
+	. = ..()
+	id = robot.idcard
+	. += id
 
 /obj/item/robot_module/drone/swarm/ranged
 	name = "swarm gunner module"
 
-/obj/item/robot_module/drone/swarm/ranged/Initialize(mapload)
+/obj/item/robot_module/drone/swarm/ranged/get_modules()
 	. = ..()
-	src.modules += new /obj/item/gun/energy/xray/swarm(src)
+	. |= /obj/item/gun/energy/xray/swarm
 
-/obj/item/robot_module/drone/swarm/melee/Initialize(mapload)
+/obj/item/robot_module/drone/swarm/melee/get_modules()
 	. = ..()
-	src.modules += new /obj/item/melee/energy/sword/ionic_rapier/lance(src)
+	. |= /obj/item/melee/energy/sword/ionic_rapier/lance

--- a/code/modules/mob/living/silicon/robot/robot_modules/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/syndicate.dm
@@ -4,45 +4,48 @@
 	name = "illegal robot module"
 	hide_on_manifest = 1
 	languages = list(
-					LANGUAGE_SOL_COMMON = 1,
-					LANGUAGE_TRADEBAND = 1,
-					LANGUAGE_UNATHI = 0,
-					LANGUAGE_SIIK	= 0,
-					LANGUAGE_AKHANI = 0,
-					LANGUAGE_SKRELLIAN = 0,
-					LANGUAGE_SKRELLIANFAR = 0,
-					LANGUAGE_ROOTLOCAL = 0,
-					LANGUAGE_GUTTER = 1,
-					LANGUAGE_SCHECHI = 0,
-					LANGUAGE_EAL	 = 1,
-					LANGUAGE_SIGN	 = 0,
-					LANGUAGE_TERMINUS = 1,
-					LANGUAGE_ZADDAT = 0
-					)
+		LANGUAGE_SOL_COMMON = 1,
+		LANGUAGE_TRADEBAND = 1,
+		LANGUAGE_UNATHI = 0,
+		LANGUAGE_SIIK	= 0,
+		LANGUAGE_AKHANI = 0,
+		LANGUAGE_SKRELLIAN = 0,
+		LANGUAGE_SKRELLIANFAR = 0,
+		LANGUAGE_ROOTLOCAL = 0,
+		LANGUAGE_GUTTER = 1,
+		LANGUAGE_SCHECHI = 0,
+		LANGUAGE_EAL	 = 1,
+		LANGUAGE_SIGN	 = 0,
+		LANGUAGE_TERMINUS = 1,
+		LANGUAGE_ZADDAT = 0
+	)
 	sprites = list(
-					"Cerberus" = "syndie_bloodhound",
-					"Cerberus - Treaded" = "syndie_treadhound",
-					"Ares" = "squats",
-					"Telemachus" = "toiletbotantag",
-					"WTOperator" = "hosborg",
-					"XI-GUS" = "spidersyndi",
-					"XI-ALP" = "syndi-heavy"
-				)
+		"Cerberus" = "syndie_bloodhound",
+		"Cerberus - Treaded" = "syndie_treadhound",
+		"Ares" = "squats",
+		"Telemachus" = "toiletbotantag",
+		"WTOperator" = "hosborg",
+		"XI-GUS" = "spidersyndi",
+		"XI-ALP" = "syndi-heavy"
+	)
 	var/id
 
 // All syndie modules get these, and the base borg items (flash, crowbar, etc).
-/obj/item/robot_module/robot/syndicate/Initialize(mapload)
+/obj/item/robot_module/robot/syndicate/get_modules()
 	. = ..()
-	var/mob/living/silicon/robot/R = loc
-	src.modules += new /obj/item/pinpointer/shuttle/merc(src)
-	src.modules += new /obj/item/melee/energy/sword(src)
+	. |= list(
+		/obj/item/pinpointer/shuttle/merc,
+		/obj/item/melee/energy/sword
+	)
 
+/obj/item/robot_module/robot/syndicate/handle_special_module_init(mob/living/silicon/robot/R)
+	. = ..()
 	var/jetpack = new/obj/item/tank/jetpack/carbondioxide(src)
-	src.modules += jetpack
+	. += jetpack
 	R.internals = jetpack
 
 	id = R.idcard
-	src.modules += id
+	. += id
 
 /obj/item/robot_module/robot/syndicate/Destroy()
 	src.modules -= id
@@ -57,14 +60,16 @@
 		"Cerberus" = "syndie_bloodhound",
 		"Ares" = "squats",
 		"XI-ALP" = "syndi-heavy"
-		)
+	)
 
-/obj/item/robot_module/robot/syndicate/protector/Initialize(mapload)
+/obj/item/robot_module/robot/syndicate/protector/get_modules()
 	. = ..()
-	src.modules += new /obj/item/shield_projector/rectangle/weak(src)
-	src.modules += new /obj/item/gun/energy/dakkalaser(src)
-	src.modules += new /obj/item/handcuffs/cyborg(src)
-	src.modules += new /obj/item/melee/baton/robot(src)
+	. |= list(
+		/obj/item/shield_projector/rectangle/weak,
+		/obj/item/gun/energy/dakkalaser,
+		/obj/item/handcuffs/cyborg,
+		/obj/item/melee/baton/robot
+	)
 
 // 95% engi-borg and 15% roboticist.
 /obj/item/robot_module/robot/syndicate/mechanist
@@ -72,67 +77,73 @@
 	sprites = list(
 		"XI-GUS" = "spidersyndi",
 		"WTOperator" = "sleekhos"
-		)
+	)
 
-/obj/item/robot_module/robot/syndicate/mechanist/Initialize(mapload)
+/obj/item/robot_module/robot/syndicate/mechanist/get_modules()
+	. = ..()
+	. |= list(
+		/obj/item/borg/sight/meson,
+		/obj/item/weldingtool/electric/mounted/cyborg,
+		/obj/item/tool/screwdriver/cyborg,
+		/obj/item/tool/wrench/cyborg,
+		/obj/item/tool/wirecutters/cyborg,
+		/obj/item/multitool/ai_detector,
+		/obj/item/pickaxe/plasmacutter,
+		/obj/item/rcd/electric/mounted/borg/lesser, // Can't eat rwalls to prevent AI core cheese.
+		/obj/item/melee/energy/sword/ionic_rapier,
+
+		// FBP repair.
+		/obj/item/robotanalyzer,
+		/obj/item/shockpaddles/robot/jumper,
+		/obj/item/gripper/no_use/organ/robotics,
+
+		// Hacking other things.
+		/obj/item/card/robot/syndi,
+		/obj/item/card/emag
+	)
+
+/obj/item/robot_module/robot/syndicate/mechanist/get_synths(mob/living/silicon/robot/R)
+	. = ..()
+	MATTER_SYNTH(MATSYN_NANITES, nanite, 10000)
+	MATTER_SYNTH(MATSYN_WIRE, wire)
+	MATTER_SYNTH(MATSYN_METAL, metal, 40000)
+	MATTER_SYNTH(MATSYN_GLASS, glass, 40000)
+
+/obj/item/robot_module/robot/syndicate/mechanist/handle_special_module_init(mob/living/silicon/robot/R)
 	. = ..()
 	// General engineering/hacking.
-	src.modules += new /obj/item/borg/sight/meson(src)
-	src.modules += new /obj/item/weldingtool/electric/mounted/cyborg(src)
-	src.modules += new /obj/item/tool/screwdriver/cyborg(src)
-	src.modules += new /obj/item/tool/wrench/cyborg(src)
-	src.modules += new /obj/item/tool/wirecutters/cyborg(src)
-	src.modules += new /obj/item/multitool/ai_detector(src)
-	src.modules += new /obj/item/pickaxe/plasmacutter(src)
-	src.modules += new /obj/item/rcd/electric/mounted/borg/lesser(src) // Can't eat rwalls to prevent AI core cheese.
-	src.modules += new /obj/item/melee/energy/sword/ionic_rapier(src)
-
-	// FBP repair.
-	src.modules += new /obj/item/robotanalyzer(src)
-	src.modules += new /obj/item/shockpaddles/robot/jumper(src)
-	src.modules += new /obj/item/gripper/no_use/organ/robotics(src)
-
-	// Hacking other things.
-	src.modules += new /obj/item/card/robot/syndi(src)
-	src.modules += new /obj/item/card/emag(src)
 
 	// Materials.
-	var/datum/matter_synth/nanite = new /datum/matter_synth/nanite(10000)
-	synths += nanite
-	var/datum/matter_synth/wire = new /datum/matter_synth/wire()
-	synths += wire
-	var/datum/matter_synth/metal = new /datum/matter_synth/metal(40000)
-	synths += metal
-	var/datum/matter_synth/glass = new /datum/matter_synth/glass(40000)
-	synths += glass
+	var/datum/matter_synth/nanite = synths_by_kind[MATSYN_NANITES]
+	var/datum/matter_synth/wire = synths_by_kind[MATSYN_WIRE]
+	var/datum/matter_synth/metal = synths_by_kind[MATSYN_METAL]
+	var/datum/matter_synth/glass = synths_by_kind[MATSYN_GLASS]
 
 	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	N.uses_charge = 1
 	N.charge_costs = list(1000)
 	N.synths = list(nanite)
-	src.modules += N
+	. += N
 
 	var/obj/item/stack/material/cyborg/steel/M = new (src)
 	M.synths = list(metal)
-	src.modules += M
+	. += M
 
 	var/obj/item/stack/material/cyborg/glass/G = new (src)
 	G.synths = list(glass)
-	src.modules += G
+	. += G
 
 	var/obj/item/stack/rods/cyborg/rods = new /obj/item/stack/rods/cyborg(src)
 	rods.synths = list(metal)
-	src.modules += rods
+	. += rods
 
 	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
 	C.synths = list(wire)
-	src.modules += C
+	. += C
 
 	var/obj/item/stack/material/cyborg/glass/reinforced/RG = new (src)
 	RG.synths = list(metal, glass)
-	src.modules += RG
-
-
+	. += RG
 
 
 // Mediborg optimized for on-the-field healing, but can also do surgery if needed.
@@ -140,53 +151,63 @@
 	name = "combat medic robot module"
 	sprites = list(
 		"Telemachus" = "toiletbotantag"
-		)
+	)
+
+/obj/item/robot_module/robot/syndicate/combat_medic/get_modules()
+	. = ..()
+	. |= list(
+		/obj/item/borg/sight/hud/med,
+		/obj/item/healthanalyzer/advanced,
+		/obj/item/reagent_containers/borghypo/merc,
+
+		// Surgery things.
+		/obj/item/autopsy_scanner,
+		/obj/item/surgical/scalpel/cyborg,
+		/obj/item/surgical/hemostat/cyborg,
+		/obj/item/surgical/retractor/cyborg,
+		/obj/item/surgical/cautery/cyborg,
+		/obj/item/surgical/bonegel/cyborg,
+		/obj/item/surgical/FixOVein/cyborg,
+		/obj/item/surgical/bonesetter/cyborg,
+		/obj/item/surgical/circular_saw/cyborg,
+		/obj/item/surgical/surgicaldrill/cyborg,
+		/obj/item/gripper/no_use/organ,
+
+		// General healing.
+		/obj/item/gripper/medical,
+		/obj/item/shockpaddles/robot/combat,
+		/obj/item/reagent_containers/dropper, // Allows borg to fix necrosis apparently
+		/obj/item/reagent_containers/syringe,
+		/obj/item/roller_holder
+	)
+
+/obj/item/robot_module/robot/syndicate/combat_medic/get_synths(mob/living/silicon/robot/R)
+	. = ..()
+	MATTER_SYNTH(MATSYN_DRUGS, medicine, 15000)
 
 /obj/item/robot_module/robot/syndicate/combat_medic/Initialize(mapload)
 	. = ..()
-	src.modules += new /obj/item/borg/sight/hud/med(src)
-	src.modules += new /obj/item/healthanalyzer/advanced(src)
-	src.modules += new /obj/item/reagent_containers/borghypo/merc(src)
-
-	// Surgery things.
-	src.modules += new /obj/item/autopsy_scanner(src)
-	src.modules += new /obj/item/surgical/scalpel/cyborg(src)
-	src.modules += new /obj/item/surgical/hemostat/cyborg(src)
-	src.modules += new /obj/item/surgical/retractor/cyborg(src)
-	src.modules += new /obj/item/surgical/cautery/cyborg(src)
-	src.modules += new /obj/item/surgical/bonegel/cyborg(src)
-	src.modules += new /obj/item/surgical/FixOVein/cyborg(src)
-	src.modules += new /obj/item/surgical/bonesetter/cyborg(src)
-	src.modules += new /obj/item/surgical/circular_saw/cyborg(src)
-	src.modules += new /obj/item/surgical/surgicaldrill/cyborg(src)
-	src.modules += new /obj/item/gripper/no_use/organ(src)
-
-	// General healing.
-	src.modules += new /obj/item/gripper/medical(src)
-	src.modules += new /obj/item/shockpaddles/robot/combat(src)
-	src.modules += new /obj/item/reagent_containers/dropper(src) // Allows borg to fix necrosis apparently
-	src.modules += new /obj/item/reagent_containers/syringe(src)
-	src.modules += new /obj/item/roller_holder(src)
 
 	// Materials.
-	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(15000)
-	synths += medicine
+	var/datum/matter_synth/medicine = synths_by_kind[MATSYN_DRUGS]
 
 	var/obj/item/stack/medical/advanced/ointment/O = new /obj/item/stack/medical/advanced/ointment(src)
-	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
-	var/obj/item/stack/medical/splint/S = new /obj/item/stack/medical/splint(src)
 	O.uses_charge = 1
 	O.charge_costs = list(1000)
 	O.synths = list(medicine)
+	. += O
+
+	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
 	B.uses_charge = 1
 	B.charge_costs = list(1000)
 	B.synths = list(medicine)
+	. += B
+
+	var/obj/item/stack/medical/splint/S = new /obj/item/stack/medical/splint(src)
 	S.uses_charge = 1
 	S.charge_costs = list(1000)
 	S.synths = list(medicine)
-	src.modules += O
-	src.modules += B
-	src.modules += S
+	. += S
 
 /obj/item/robot_module/robot/syndicate/combat_medic/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -12,7 +12,7 @@
 	return ..()
 
 /mob/living/silicon/robot/movement_delay()
-	. = speed
+	. = ..() + speed
 	if(module_active && istype(module_active,/obj/item/borg/combat/mobility))
 		. -= 2
 
@@ -20,8 +20,6 @@
 		. += 1
 
 	. += config_legacy.robot_delay
-
-	. = ..()
 
 // NEW: Use power while moving.
 /mob/living/silicon/robot/SelfMove(turf/n, direct)

--- a/code/modules/mob/living/silicon/robot/subtypes/lost_drone_vr.dm
+++ b/code/modules/mob/living/silicon/robot/subtypes/lost_drone_vr.dm
@@ -22,7 +22,7 @@
 	aiCamera = new/obj/item/camera/siliconcam/robot_camera(src)
 
 	mmi = new /obj/item/mmi/digital/robot(src) // Explicitly a drone.
-	module = new /obj/item/robot_module/robot/stray(src)
+	module = new /obj/item/robot_module/robot/quad/stray(src)
 	cut_overlays()
 	init_id()
 

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -31,7 +31,7 @@
 		return
 
 	// robots can interact with things they can see within their view range
-	if((src_object in view(src)) && get_dist(src_object, src) <= src.client.view)
+	if((src_object in view(src)) && get_dist(src_object, src) <= min(CEILING(client.current_viewport_width / 2, 1), CEILING(client.current_viewport_height / 2, 1)))
 		return UI_INTERACTIVE	// interactive (green visibility)
 	return UI_DISABLED			// no updates, completely disabled (red visibility)
 


### PR DESCRIPTION
This is more of a reshuffling of borg init than a refactor of it, but at least modifying modules should be less painful now.

Other changes:
- Fixed a runtime that could occur when a cyborg used certain non-TGUI consoles.
- Dogborg rest no longer has visual lag.
- Borg movement delay now actually works.
- Some borg actions now have `target` set for do_after progbars.

:cl:
tweak: Targeted borg emotes now only require a partial case-insensitive match, i.e. `*bark-gla` to bark at a `Glass Airlock`. This only applies to borgs using emotes.
add: Dogborgs can now bark at objects.
fix: Module resets should no longer render dogborgs invisible.
fix: Module resets should no longer temporarily break borg inventories.
fix: Some borg emotes that were supposed to have sounds now actually play said sounds.
/:cl: