### PR TITLE
Enables Helmet Cams on Exploration Voidsuit Helmets

### DIFF
--- a/code/__DEFINES/machinery.dm
+++ b/code/__DEFINES/machinery.dm
@@ -83,6 +83,7 @@ var/global/defer_powernet_rebuild = 0 // True if net rebuild will be called manu
 #define NETWORK_OUTSIDE "Outside"
 #define NETWORK_EXPLORATION "Exploration"
 #define NETWORK_XENOBIO "Xenobiology"
+#define NETWORK_EXPLO_HELMETS "Exploration Helmets"
 
 //! Off Station Camera Networks
 //TODO: Remove. Though we can keep these for now.

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -289,6 +289,7 @@
 	item_state_slots = list(SLOT_ID_RIGHT_HAND = "syndicate-helm-black", SLOT_ID_LEFT_HAND = "syndicate-helm-black")
 	armor = list(melee = 40, bullet = 15, laser = 25,energy = 35, bomb = 30, bio = 70, rad = 70)
 	light_overlay = "helmet_light_dual" //explorer_light
+	camera_networks = list(NETWORK_EXPLO_HELMETS)
 
 /obj/item/clothing/suit/space/void/exploration
 	name = "exploration voidsuit"
@@ -336,6 +337,7 @@
 	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 15, bio = 100, rad = 50)
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	light_overlay = "helmet_light_dual"
+	camera_networks = list(NETWORK_EXPLO_HELMETS)
 
 /obj/item/clothing/suit/space/void/pilot
 	desc = "An atmos resistant voidsuit for space and planet exploration."

--- a/maps/rift/rift_defines.dm
+++ b/maps/rift/rift_defines.dm
@@ -128,7 +128,8 @@
 							NETWORK_ROBOTS,
 							NETWORK_SECURITY,
 							NETWORK_TCOMMS,
-							NETWORK_LYTHIOS
+							NETWORK_LYTHIOS,
+							NETWORK_EXPLO_HELMETS
 							)
 	secondary_networks = list(
 							NETWORK_ERT,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Helmet Cams have been added to Exploration Voidsuit Helmets.**

## Why It's Good For The Game

1. _They've been requested for a while, and apparently they weren't enabled like I thought they were! It makes IC sense for these suits to have cameras mounted on them._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds helmet cams to Explo void helmets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
