### PR TITLE
AI will now properly spawn in core at roundstart

### DIFF
--- a/code/game/landmarks/spawnpoint/station/jobs.dm
+++ b/code/game/landmarks/spawnpoint/station/jobs.dm
@@ -214,6 +214,7 @@
 /obj/landmark/spawnpoint/job/ai
 	name = "AI"
 	icon_state = "AI"
+	latejoin = TRUE // AIize in transform_procs.dm uses get_latejoin_spawnpoint() for spawning in a AI -- including at roundstart.
 	delete_on_roundstart = TRUE
 	job_path = /datum/job/station/ai
 	var/primary_ai = TRUE

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -89,6 +89,8 @@
 
 	O.add_ai_verbs()
 
+	O.view_core()
+
 	O.rename_self("ai")
 	// Mobs still instantly del themselves, thus we need to spawn or O will never be returned.
 	spawn(0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

AIs currently spawn at the arrival spawnpoints. The reason why is because in order to make a player into an AI, the server calls `AIize()`.
https://github.com/Citadel-Station-13/Citadel-Station-13-RP/blob/856c98845adcdee05b876b3b1ddf866a7fdd7621/code/modules/mob/transform_procs.dm#L84
...which finds valid AI spawnpoints with get_latejoin_spawnpoint.

This PR sets the AI spawnpoint to `latejoin = TRUE`, so that it can be found as a valid spawnpoint. I considered checking whether the game was in the lobby state or in-game, to determine which proc to use, _but_ the game state is set to in-game before characters are spawned in.
https://github.com/Citadel-Station-13/Citadel-Station-13-RP/blob/856c98845adcdee05b876b3b1ddf866a7fdd7621/code/controllers/subsystem/ticker.dm#L278-L279
The spawnpoint will still get cleaned up after characters are spawned, as usual.

**_Additionally_**, the AI's view will be reset to their core near the end of the AIize proc, so they don't just see black void.

## Why It's Good For The Game

AIs are no longer FedEx'd to the arrival doors, and will see their core by default, instead of a black static void.
Fixes https://github.com/Citadel-Station-13/Citadel-Station-13-RP/issues/4989

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: AIs will now properly spawn in the AI core, instead of at arrivals.
tweak: Spawned-in AIs will have their view reset to their core automagically.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
