### PR TITLE
Statpanel buttons fix

### DIFF
--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -235,12 +235,17 @@ function set_style_sheet(sheet) {
 	.grid-item:hover .grid-item-text {
 		width: auto;
 		text-decoration: underline;
+		background-color: #ffffff;
+	}
+
+	.dark .grid-item:hover .grid-item-text {
+		background-color: #131313;
 	}
 
 	.grid-item-text {
 		display: inline-block;
-		width: 100%;
-		background-color: #dfdfdf;
+		width: calc(98%);
+		background-color: #F0F0F0;
 		margin: 0 -6px;
 		padding: 0 6px;
 		white-space: nowrap;

--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -240,7 +240,7 @@ function set_style_sheet(sheet) {
 	.grid-item-text {
 		display: inline-block;
 		width: 100%;
-		background-color: #ffffff;
+		background-color: #dfdfdf;
 		margin: 0 -6px;
 		padding: 0 6px;
 		white-space: nowrap;
@@ -250,7 +250,7 @@ function set_style_sheet(sheet) {
 	}
 
 	.dark .grid-item-text {
-		background-color: #131313;
+		background-color: #222222;
 	}
 
 	.link {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The bars behind the statpanel text (on buttons) no longer eat the borders of the button, and are now coloured the same as the button (until hovered over).

Also fixes the ellipses wrap not working. (via `calc(98%)`) 

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

Less visual noise! I think!
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Statpanel buttons no longer have a coloured bar under the text, unless you hover over the text.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
