### PR TITLE
removes as null|anything from set default lang

### DIFF
--- a/code/modules/mob/living/default_language.dm
+++ b/code/modules/mob/living/default_language.dm
@@ -1,7 +1,7 @@
 /mob/living
 	var/datum/language/default_language
 
-/mob/living/verb/set_default_language(language as null|anything in languages)
+/mob/living/verb/set_default_language(language as anything in languages)
 	set name = "Set Default Language"
 	set category = "IC"
 


### PR DESCRIPTION
tl;dr it makes no sense to set null| as it's a verb