### PR TITLE
Storage Opening QOL

### DIFF
--- a/code/game/objects/items/storage/_storage.dm
+++ b/code/game/objects/items/storage/_storage.dm
@@ -50,6 +50,14 @@
 	QDEL_NULL(closer)
 	return ..()
 
+/obj/item/storage/attack_self(mob/user)
+	if(user in is_seeing)
+		src.close(user)
+	else if(isliving(user) && user.Reachability(src))
+		src.open(user)
+	else
+		return ..()
+
 /obj/item/storage/AltClick(mob/user)
 	if(user in is_seeing)
 		src.close(user)

--- a/code/game/objects/items/storage/_storage.dm
+++ b/code/game/objects/items/storage/_storage.dm
@@ -50,13 +50,7 @@
 	QDEL_NULL(closer)
 	return ..()
 
-/obj/item/storage/attack_self(mob/user)
-	if(user in is_seeing)
-		src.close(user)
-	else if(isliving(user) && user.Reachability(src))
-		src.open(user)
-	else
-		return ..()
+
 
 /obj/item/storage/AltClick(mob/user)
 	if(user in is_seeing)
@@ -609,6 +603,13 @@
 		if(src.verbs.Find(/obj/item/storage/verb/quick_empty))
 			src.quick_empty()
 			return 1
+
+	if(user in is_seeing)
+		src.close(user)
+	else if(isliving(user) && user.Reachability(src))
+		src.open(user)
+	else
+		return ..()
 
 //Returns the storage depth of an atom. This is the number of storage items the atom is contained in before reaching toplevel (the area).
 //Returns -1 if the atom was not found on container.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Using a storage object in hand will open/close the inventory, **_IF_** it's not a quick-empty bag, like the hydroponics' plant bag.

## Why It's Good For The Game

QOL~ Don't have to click-drag/alt-click a storage object to yourself if it's in your hands, just to open it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Using most storage items in-hand (ie: bags, boxes) will now open/close the inventory.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
