### PR TITLE
Makes xeno loadout items non-species locked

### DIFF
--- a/code/modules/preferences/preference_setup/loadout/loadout_xeno.dm
+++ b/code/modules/preferences/preference_setup/loadout/loadout_xeno.dm
@@ -38,7 +38,7 @@
 //**Species-Specific Datum Declarations
 //*Tajaran
 /datum/gear/xeno/tajaran
-	legacy_species_lock = SPECIES_TAJ
+	// legacy_species_lock = SPECIES_TAJ
 
 /datum/gear/xeno/tajaran/accessories
 	slot = /datum/inventory_slot_meta/abstract/attach_as_accessory
@@ -63,7 +63,7 @@
 
 //*Promethean
 /datum/gear/xeno/promethean
-	legacy_species_lock = SPECIES_PROMETHEAN
+	// legacy_species_lock = SPECIES_PROMETHEAN
 
 /datum/gear/xeno/promethean/accessories
 	slot = /datum/inventory_slot_meta/abstract/attach_as_accessory
@@ -187,7 +187,7 @@
 
 //*Unathi
 /datum/gear/xeno/unathi
-	legacy_species_lock = SPECIES_UNATHI
+	// legacy_species_lock = SPECIES_UNATHI
 
 /datum/gear/xeno/unathi/accessories
 	slot = /datum/inventory_slot_meta/abstract/attach_as_accessory


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
I really only did this for the veils, but the other things previously species-locked were nice, too, so I unlocked them.
I kept the Teshari and Vox ones locked, since they use different sprites than the regular humanoid ones. And the fact that Vox get magboots and insuls for free

## Why It's Good For The Game

Why was this even put in?
In other words, customization
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Removed most of the species locks in the loadout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
