### PR TITLE
Fixes borg descriptions being duplicated

### DIFF
--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -53,6 +53,9 @@
 	if(ooc_notes)
 		. += SPAN_BOLDNOTICE("\nOOC Notes: <a href='?src=\ref[src];ooc_notes=1'>\[View\]</a>")
 
+	if(showvoreprefs && ckey) //ckey so non-controlled mobs don't display it.
+		. += SPAN_BOLDNOTICE("<a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a>")
+
 	if(print_flavor_text())
 		. += "\n[print_flavor_text()]\n"
 
@@ -61,9 +64,10 @@
 			pose = addtext(pose,".") //Makes sure all emotes end with a period.
 		. += "\nIt is [pose]"
 
+	if(laws && isobserver(user))
+		user.showLaws(src)
+
 	if(LAZYLEN(.) > 1)
 		.[2] = "<hr>[.[2]]"
 
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, usr, .)
-
-	. += ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stops the examine text for cyborgs from getting duplicated.

## Why It's Good For The Game

Heehoo shorter and clearer examine profiles.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Cyborg examine texts will now only show up once.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
