### PR TITLE
Fixes gun packs spawning with incorrect crate type

### DIFF
--- a/code/modules/cargo/supplypacks/security.dm
+++ b/code/modules/cargo/supplypacks/security.dm
@@ -663,7 +663,7 @@
 			/obj/item/ammo_magazine/m95 = 4
 			)
 	cost = 60
-	container_type = /obj/structure/closet/crate/heph
+	container_type = /obj/structure/closet/crate/secure/heph
 	access = access_armory
 
 /datum/supply_pack/security/quadshot
@@ -674,5 +674,5 @@
 			/obj/item/storage/belt/security/tactical/bandolier = 2,
 			)
 	cost = 70
-	container_type = /obj/structure/closet/crate/heph
+	container_type = /obj/structure/closet/crate/secure/heph
 	access = access_armory


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turns out a couple gun packs were spawning in unsecured crates

## Why It's Good For The Game

Do I really need to answer this?