### PR TITLE
Actually fixes statbrowser button text backgrounds

### DIFF
--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -244,16 +244,20 @@ function set_style_sheet(sheet) {
 
 	.grid-item-text {
 		display: inline-block;
-		width: calc(98%);
+		width: calc(100%);
 		background-color: #F0F0F0;
 		margin: 0 -6px;
-		padding: 0 6px;
+		padding: 0px;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		pointer-events: none;
 	}
 
+	.grid-item-text:hover {
+		padding: 0 3px;
+	}
+	
 	.dark .grid-item-text {
 		background-color: #222222;
 	}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So what I did originally fixed the ellipses issue, but I think I had conflicting CSS or whatever.
Regardless, this makes it so the text no longer has a visible background until you hover over the button.