### PR TITLE
buffs the everloving heck out of corpsemend surgeries

### DIFF
--- a/code/modules/surgery/external_repair.dm
+++ b/code/modules/surgery/external_repair.dm
@@ -92,8 +92,8 @@
 
 	priority = 3
 
-	min_duration = 5
-	max_duration = 5
+	min_duration = 20
+	max_duration = 20
 
 /datum/surgery_step/repairflesh/repair_burns/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -162,8 +162,8 @@
 
 	priority = 3
 
-	min_duration = 5
-	max_duration = 5
+	min_duration = 20
+	max_duration = 20
 
 /datum/surgery_step/repairflesh/repair_brute/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())

--- a/code/modules/surgery/external_repair.dm
+++ b/code/modules/surgery/external_repair.dm
@@ -39,8 +39,8 @@
 
 	can_infect = 0 //The only exception here. Sweeping a scanner probably won't transfer many germs.
 
-	min_duration = 20
-	max_duration = 40
+	min_duration = 10
+	max_duration = 20
 
 /datum/surgery_step/repairflesh/scan_injury/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -92,8 +92,8 @@
 
 	priority = 3
 
-	min_duration = 90
-	max_duration = 120
+	min_duration = 5
+	max_duration = 5
 
 /datum/surgery_step/repairflesh/repair_burns/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -162,8 +162,8 @@
 
 	priority = 3
 
-	min_duration = 90
-	max_duration = 120
+	min_duration = 5
+	max_duration = 5
 
 /datum/surgery_step/repairflesh/repair_brute/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())


### PR DESCRIPTION

## About The Pull Request

corpsemend surgeries are down to 2 seconds instead of 9-12

## Why It's Good For The Game

if you are on a table being corpsemended instead of being normally medicated (which has far less complications, mind you), it should not take them 15 minutes to fix your 1500 points of brute/burn

i understand being able to fix people that fast on a table is honestly stupid
but our med system is currently buggy as hell and people are dying and coming back with uncapped damage amounts

eventually we want corpsemend to be a "repeatable" surgery so you can do other stuff like talk while doing it instead of continue to click a button but for now i feel this is a viable change.

## Changelog

:cl:
balance: *temporarily* makes corpsemend surgeries take 2 seconds instead of 9-12.
/:cl:

