### PR TITLE
Map Adjustment: Armory Tweak/Nerf Edition

### DIFF
--- a/_maps/map_files/rift/rift-05-surface2.dmm
+++ b/_maps/map_files/rift/rift-05-surface2.dmm
@@ -9748,17 +9748,8 @@
 "hiK" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/ammo_magazine/m9mmt/rubber,
-/obj/item/ammo_magazine/m9mmt/rubber,
-/obj/item/ammo_magazine/m9mmt/rubber,
-/obj/item/ammo_magazine/m9mmt/rubber,
 /obj/item/ammo_magazine/m9mmt,
 /obj/item/ammo_magazine/m9mmt,
-/obj/item/ammo_magazine/m9mmt,
-/obj/item/ammo_magazine/m9mmt,
-/obj/item/gun/ballistic/automatic/wt550,
-/obj/item/gun/ballistic/automatic/wt550,
-/obj/item/gun/ballistic/automatic/wt550,
 /obj/item/gun/ballistic/automatic/wt550,
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
@@ -16185,9 +16176,6 @@
 /obj/structure/table/rack/shelf/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/gun/ballistic/automatic/z8,
-/obj/item/gun/ballistic/automatic/z8,
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762,
 /obj/item/ammo_magazine/m762,
 /obj/item/ammo_magazine/m762,
 /turf/simulated/floor/tiled/dark,
@@ -25577,13 +25565,13 @@
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "trS" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/suit/armor/vest/alt{
-	pixel_x = 6;
-	pixel_y = -6
-	},
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/suit/armor/vest,
 /obj/item/clothing/suit/armor/vest/alt{
 	pixel_x = -4;
-	pixel_y = -6
+	pixel_y = 6
 	},
 /obj/item/clothing/suit/armor/vest/alt{
 	pixel_x = 6;
@@ -25591,7 +25579,11 @@
 	},
 /obj/item/clothing/suit/armor/vest/alt{
 	pixel_x = -4;
-	pixel_y = 6
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/vest/alt{
+	pixel_x = 6;
+	pixel_y = -6
 	},
 /turf/simulated/floor/tiled/red,
 /area/security/security_equiptment_storage)
@@ -28865,23 +28857,12 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/obj/item/storage/box/flashshells,
-/obj/item/storage/box/stunshells,
-/obj/item/storage/box/shotgunammo,
-/obj/item/storage/box/shotgunammo,
-/obj/item/storage/box/shotgunshells{
-	pixel_x = 6;
-	pixel_y = -1
-	},
-/obj/item/storage/box/shotgunshells{
-	pixel_x = 6;
-	pixel_y = -1
-	},
-/obj/item/gun/ballistic/automatic/as24,
-/obj/item/gun/ballistic/automatic/as24,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/ammo_magazine/m9mmt,
+/obj/item/ammo_magazine/m9mmt,
+/obj/item/gun/ballistic/automatic/wt550,
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
 "vTi" = (
@@ -29114,6 +29095,38 @@
 /obj/item/clothing/suit/armor/pcarrier/medium/security{
 	pixel_x = -3;
 	pixel_y = 4
+	},
+/obj/item/clothing/accessory/armor/tag/nt{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/item/clothing/accessory/armor/tag/nt{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/item/clothing/accessory/armor/tag/nt{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/clothing/accessory/armor/tag/nt{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/clothing/accessory/armor/tag/nt{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/armor/tag/nt{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/armor/tag/nt{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/armor/tag/nt{
+	pixel_x = -5;
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/blue)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Nerfs Tactical Armory.**
2. **Adds Alternate Body Armor.**
3. **Adds Corporate Security tags to carrier rack.**

## Why It's Good For The Game

1. _I've begun to notice the frequent usage of an automatic shotgun by Security. The first time, I assumed it was bought from a Trader. The second time, I took notice. It turns out that there were **two** automatic shotguns in the Tactical Armory. Autoshotguns don't belong on the map period. They've both been removed. The number of map spawn Advanced SMGs has also been reduced by half. The number of map spawn marksman rifles has, again, been reduced by half as well._
2. _A Security player requested access to alternate Security vests. Since this change is (should be) cosmetic, I've added four of these vests to the Security ready room._
3. _As with the above, Security plate carriers have the wrong designation patches. Per the request I have added the correct tags to the plate carrier shelf, to be applied._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds Corporate Security tags to carrier rack.
add: Adds alternate vests to Security ready room.
del: Removes Auto Shotguns from Tactical Armory.
del: Reduces advanced weaponry in Tactical Armory by 50%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
