### PR TITLE
multiz movement now hooks onTransitZ properly

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -79,8 +79,12 @@
 		else
 			to_chat(src, SPAN_WARNING("Gravity stops you from moving upward."))
 			return FALSE
+	var/old_z = get_z(src)
 	if(!Move(destination))
 		return FALSE
+	var/new_z = get_z(src)
+	if(old_z != new_z)
+		onTransitZ(old_z, new_z)
 	return TRUE
 
 /mob/proc/can_overcome_gravity()


### PR DESCRIPTION
the correct fix is to make it use forcemove as you usually do

however I don't have time to refactor multiz outside of the maploader PR

so
this is the best we're getting for now.