### PR TITLE
Fixes Proteans loosing their PAN when playing an RD

### DIFF
--- a/code/modules/jobs/job_types/station/science/research_director.dm
+++ b/code/modules/jobs/job_types/station/science/research_director.dm
@@ -75,7 +75,6 @@
 	l_ear = /obj/item/radio/headset/heads/rd
 	uniform = /obj/item/clothing/under/rank/research_director
 	shoes = /obj/item/clothing/shoes/brown
-	l_hand = /obj/item/clipboard
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/rd
 
 	id_type = /obj/item/card/id/science/head


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Clipboard spawns in the same spot as the Protean box containing the PAN. At the same time, the RD office has clipboards, so spawning with one is not really needed.

## Why It's Good For The Game

Please do not make me repeat myself

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
remove: Removes clipboard from the RD standard loadout. Powergamers rejoyce.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
