### PR TITLE
Rad insulation for material walls

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -252,6 +252,7 @@
 	Tsrc.PlaceOnTop(/turf/simulated/wall)
 	var/turf/simulated/wall/T = get_turf(src)
 	T.set_materials(M, reinf_material, girder_material)
+	T.set_rad_insulation()
 	if(wall_fake)
 		T.can_open = 1
 	T.add_hiddenprint(usr)

--- a/code/game/turfs/simulated/wall.dm
+++ b/code/game/turfs/simulated/wall.dm
@@ -59,6 +59,7 @@
 	color = null
 
 	set_materials(material, reinf_material, girder_material)
+	set_rad_insulation()
 
 	if(smoothing_flags & SMOOTH_DIAGONAL_CORNERS && fixed_underlay) //Set underlays for the diagonal walls.
 		var/mutable_appearance/underlay_appearance = mutable_appearance(layer = TURF_LAYER, plane = TURF_PLANE)
@@ -300,6 +301,10 @@
 
 	radiation_pulse(src, total_radiation)
 	return total_radiation
+
+/turf/simulated/wall/proc/set_rad_insulation()
+	var/total_rad_insulation = material.weight + material.radiation_resistance + (reinf_material ? (reinf_material.weight + reinf_material.radiation_resistance) / 4 : 0) + (girder_material ? (girder_material.weight + girder_material.radiation_resistance) / 16 : 0)
+	rad_insulation = round(1/(total_rad_insulation**1.35*1/21.25**1.35+1),0.01) // 21.25 would be the total_rad_insulation of basic steel walls and return 0.5 rad_insulation default. 1.35 exponential function helps us to also hit the 0.25 plasteel wall goal of 0.25.
 
 /turf/simulated/wall/proc/burn(temperature)
 	if(material.combustion_effect(src, temperature, 0.7))

--- a/code/game/turfs/simulated/wall.dm
+++ b/code/game/turfs/simulated/wall.dm
@@ -304,7 +304,7 @@
 
 /turf/simulated/wall/proc/set_rad_insulation()
 	var/total_rad_insulation = material.weight + material.radiation_resistance + (reinf_material ? (reinf_material.weight + reinf_material.radiation_resistance) / 4 : 0) + (girder_material ? (girder_material.weight + girder_material.radiation_resistance) / 16 : 0)
-	rad_insulation = round(1/(total_rad_insulation**1.35*1/21.25**1.35+1),0.01) // 21.25 would be the total_rad_insulation of basic steel walls and return 0.5 rad_insulation default. 1.35 exponential function helps us to also hit the 0.25 plasteel wall goal of 0.25.
+	rad_insulation = round(1/(total_rad_insulation**1.35*1/21.25**1.35+1),0.01) // 21.25 would be the total_rad_insulation of basic steel walls and return 0.5 rad_insulation. 1.35 exponential function helps us to also hit the plasteel wall goal of 0.25.
 
 /turf/simulated/wall/proc/burn(temperature)
 	if(material.combustion_effect(src, temperature, 0.7))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds allows costume material walls to now also have modified radiation resistances, while keeping normal steel and reinforced plasteel walls on their old values of 0.5 and 0.25. This involves girders, plating and reinforcements

A snow packed wall for example now has a value of 0.93
A lead wall: 0.23
A reinforced lead wall: 0.19


![grafik](https://user-images.githubusercontent.com/21098781/222881043-c5a2913b-660a-4c25-af01-7059b9c43232.png)



:cl:
add: Material type of girders, plating and reinforcement now influence radiation resistance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
