### PR TITLE
more cursed movespeed rebalancing (teshari buff), slightly, slightly buffs custom species trait selection temporarily

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -441,7 +441,7 @@ GLOBAL_LIST_EMPTY(##LIST_NAME);\
 #define HERM "herm"
 // For custom species
 #define STARTING_SPECIES_POINTS	1
-#define MAX_SPECIES_TRAITS		5
+#define MAX_SPECIES_TRAITS		7
 
 // Xenochimera thing mostly
 #define REVIVING_NOW		-1

--- a/code/modules/mob/living/carbon/human/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/traits/positive.dm
@@ -15,7 +15,7 @@
 	name = "Major Hardy"
 	desc = "Allows you to carry heavy equipment with almost no slowdown."
 	cost = 2
-	var_changes = list("item_slowdown_mod" = 0.1)
+	var_changes = list("item_slowdown_mod" = 0.25)
 
 /datum/trait/positive/endurance_plus
 	name = "Better Endurance"

--- a/code/modules/species/station/standard/teshari.dm
+++ b/code/modules/species/station/standard/teshari.dm
@@ -55,7 +55,7 @@
 
 	slowdown          = -0.5
 	snow_movement     = -1
-	item_slowdown_mod = 0.25
+	item_slowdown_mod = 0.5
 
 	total_health = 75
 	brute_mod    = 1.1

--- a/code/modules/species/station/standard/teshari.dm
+++ b/code/modules/species/station/standard/teshari.dm
@@ -54,8 +54,8 @@
 	move_trail = /obj/effect/debris/cleanable/blood/tracks/paw
 
 	slowdown          = -0.5
-	snow_movement     = -1 // Ignores light snow
-	item_slowdown_mod = 1.25 // Tiny birds don't like heavy things
+	snow_movement     = -1
+	item_slowdown_mod = 0.25
 
 	total_health = 75
 	brute_mod    = 1.1


### PR DESCRIPTION
Values are experimental

## Why

Since I anti fun'd two races and am about to anti fun rigs and proteans I might as well fully rebalance the most common sources of movespeed mods to make things more equal.

Teshari's old modifier accounted for their old speed. This more accurately reflects where they're at right *now*.

Major Hardy is next on the chopping block after Haste.

Sorry, this is anti fun, but I'd rather encourage people to work on unique species than continue to have Custom Species be the absolute meta with its value tweaks.

In exchange, I'm also lifting the maximum amount of traits you can take for *now*.

All values are subject to change as we roll out rig / species updates in the next few months.

## Changelog

:cl:
tweak: Teshari are more resistant to slowdown now to match their nerfed speed.
tweak: Major Hardy has been nerfed to 0.25x instead of 0.1x.
/:cl: