### PR TITLE
Buffs Excav Laser Module

### DIFF
--- a/code/modules/projectiles/projectile/beam/beams.dm
+++ b/code/modules/projectiles/projectile/beam/beams.dm
@@ -305,10 +305,10 @@
 /obj/item/projectile/beam/excavation
 	name = "excavation beam"
 	icon_state = "emitter"
-	fire_sound = 'sound/weapons/emitter.ogg'
+	fire_sound = 'sound/weapons/gauss_shoot.ogg'
 	light_color = "#00CC33"
 	damage = 1 //mining tool
-	excavation_amount = 500	// 1 shot to dig a standard rock turf. Made for mining.
+	excavation_amount = 1000	// 1 shot to dig a standard rock turf. Made for mining. Should be able to consistently one hit rocks now
 
 	muzzle_type = /obj/effect/projectile/muzzle/emitter
 	tracer_type = /obj/effect/projectile/tracer/emitter


### PR DESCRIPTION

## About The Pull Request

Buffs Excav laser module. Inconsisten with the one hit of rocks. Hopefully this ammends it specially since scatterlenses are getting removed (although nobody used them in combat yet.)

## Why It's Good For The Game

Scatter lense gone, legitimate mining tool needs a buff. The other options (Phoron Bore) are a sick joke with how slow clunky they are to use.


## Changelog
:cl:
balance: Meatier sound on excav laser. Higher excav power to consistently one shot rocks.
/:cl:


