### PR TITLE
Scattershot nerfs

### DIFF
--- a/code/modules/projectiles/projectile/scatter.dm
+++ b/code/modules/projectiles/projectile/scatter.dm
@@ -94,28 +94,28 @@
 	submunition_spread_max = 60
 	submunition_spread_min = 30
 	submunitions = list(
-		/obj/item/projectile/beam/gamma = 3
+		/obj/item/projectile/beam/gamma = 3 
 		)
 
 /obj/item/projectile/scatter/laser/heavylaser
 	damage = 60
 	armor_penetration = 30
 	submunitions = list(
-		/obj/item/projectile/beam/heavylaser = 3
+		/obj/item/projectile/beam/heavylaser = 1 //nope
 		)
 
 /obj/item/projectile/scatter/laser/heavylaser/cannon
 	damage = 80
 	armor_penetration = 50
 	submunitions = list(
-		/obj/item/projectile/beam/heavylaser/cannon = 2
+		/obj/item/projectile/beam/heavylaser/cannon = 1 //haha no
 		)
 
 /obj/item/projectile/scatter/stun
 	submunition_spread_max = 70
 	submunition_spread_min = 30
 	submunitions = list(
-		/obj/item/projectile/beam/stun = 4
+		/obj/item/projectile/beam/stun = 2 
 		)
 	fire_sound = 'sound/weapons/Taser.ogg'
 	nodamage = 1
@@ -123,13 +123,13 @@
 
 /obj/item/projectile/scatter/stun/weak
 	submunitions = list(
-		/obj/item/projectile/beam/stun/weak = 4
+		/obj/item/projectile/beam/stun/weak = 2 
 		)
 	agony = 20
 
 /obj/item/projectile/scatter/stun/electrode
 	submunitions = list(
-		/obj/item/projectile/energy/electrode = 3
+		/obj/item/projectile/energy/electrode = 1
 		)
 	agony = 55
 


### PR DESCRIPTION
Sniper laser was tame.

## About The Pull Request

This is bullshit. Splurting out 180 damage with high AP with no delay is not okay. Its as bullshit as most FCU we had. Mainly removed scatter on high powered lasers and bloody stuns so the scatter lense may stay for the mining tool (as there is no way to increase firerate on a projectile.

## Why It's Good For The Game

Ever got hit at close range by the particle defender on main? Yeah that is not fun. 

## Changelog
:cl:
balance: Scattershot on high powered weapons nerfed. Heavy laser and laser cannon beam and electrode now wont create submunitions. Stun beam submunition count lowered.
/:cl:

