### PR TITLE
Comments out all the rest of modweapons

### DIFF
--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -459,6 +459,7 @@
 	build_path = /obj/item/ammo_casing/microbattery/combat/stripper
 	sort_string = "MAVCG"
 
+/*
 
 /datum/design/item/modweapon/AssembleDesignName()
 	..()
@@ -803,6 +804,8 @@
 	materials = list(MAT_STEEL = 1000, MAT_GLASS = 1000, MAT_SILVER = 500, MAT_GOLD = 500)
 	build_path = /obj/item/modularlaser/controller/fiveburst
 	sort_string = "MAVFI"
+
+*/
 
 //Firing pins to shoot your guns with
 /datum/design/item/pin/AssembleDesignName()


### PR DESCRIPTION
Might as well go all the way with the temp removal
## About The Pull Request

The remaining components are utterly pointless, clutter the menu and waste materials. Nobody would use a weapon with a clickfire delay of anywhere of 3 to 5 seconds depending on the frame unless it fires the laser cannon beam.

Excav beam no matter how much it gets buffed is pointless since one cannot effectively adjust the clickdelay on that without very extensive code changes. If it did 2000 damage to a single rock it still does it to a single rock and with at most getting 3 shots out every 3 seconds it gets severly outclassed by the clunky (and at times buggy) phoron bore or any other mining tool.

Standard lasing medium is nice but with stock parts/regenerative cycler it yields a fire rate of one shot per 3 seconds or one shot per 5 seconds, this makes it worse than the already bad stock AEG research can print and far worse than any standard issue energy pistol or laser carbine.


## Why It's Good For The Game

Less menu clutter. Less waste of materials because somebody accidentally clicks the tricore rifle or deliberately wants to build a "sickass gun" that ultimately falls flat when compared to anything pretty much. Did a bunch of dicking around yesterday after the event with the nerfed modguns. They are just menu clutter just like the sonic shotgun. Ultimately pointless to build and you'd gimp yourself using a modgun right now over stock weapons. Kinda like in TF2.

## Changelog


:cl:
del: Mod guns commented out fully as they clutter the menu, are a waste of mats and get pretty much outclassed by anything else with the temp removal of most components in place
/:cl:

