### PR TITLE
Update Shadekin energy regenerations

### DIFF
--- a/code/modules/species/shadekin/shadekin_traits.dm
+++ b/code/modules/species/shadekin/shadekin_traits.dm
@@ -2,13 +2,13 @@
 	allowed_species = list(SPECIES_SHADEKIN)
 	var/color = BLUE_EYES
 	name = "Shadekin Blue Adaptation"
-	desc = "Makes your shadekin adapted as a Blue eyed kin! This gives you decreased energy regeneration in darkness, decreased regeneration in the light amd unchanged health!"
+	desc = "Makes your shadekin adapted as a Blue eyed kin! This gives you good energy regeneration in darkness, decreased regeneration in the light and unchanged health!"
 	cost = 0
 	custom_only = FALSE
 	var_changes = list(
 		"total_health" = 100,
 		"energy_light" = 0.5,
-		"energy_dark" = 0.5,
+		"energy_dark" = 1,
 		"unarmed_types" = list(
 			/datum/unarmed_attack/stomp,
 			/datum/unarmed_attack/kick,
@@ -21,11 +21,11 @@
 /datum/trait/kintype/red
 	name = "Shadekin Red Adaptation"
 	color =	RED_EYES
-	desc = "Makes your shadekin adapted as a Red eyed kin! This gives you minimal energy regeneration in darkness, moderate regeneration in the light amd increased health!"
+	desc = "Makes your shadekin adapted as a Red eyed kin! This gives you minimal energy regeneration in darkness, good regeneration in the light and increased health!"
 	var_changes = list(
 		"total_health" = 200,
-		"energy_light" = -1,
-		"energy_dark" = 0.1,
+		"energy_light" = 1,
+		"energy_dark" = 0.25,
 		"unarmed_types" = list(
 			/datum/unarmed_attack/stomp,
 			/datum/unarmed_attack/kick,
@@ -38,11 +38,11 @@
 /datum/trait/kintype/purple
 	name = "Shadekin Purple Adaptation"
 	color = PURPLE_EYES
-	desc = "Makes your shadekin adapted as a Purple eyed kin! This gives you moderate energy regeneration in darkness, minor degeneration in the light amd increased health!"
+	desc = "Makes your shadekin adapted as a Purple eyed kin! This gives you very good energy regeneration in darkness, minor degeneration in the light and increased health!"
 	var_changes = list(
 		"total_health" = 150,
-		"energy_light" = 1,
-		"energy_dark" = -0.5,
+		"energy_light" = -0.5,
+		"energy_dark" = 1.5,
 		"unarmed_types" = list(
 			/datum/unarmed_attack/stomp,
 			/datum/unarmed_attack/kick,
@@ -55,11 +55,11 @@
 /datum/trait/kintype/yellow
 	name = "Shadekin Yellow Adaptation"
 	color = YELLOW_EYES
-	desc = "Makes your shadekin adapted as a Yellow eyed kin! This gives you the highest energy regeneration in darkness, high degeneration in the light amd unchanged health!"
+	desc = "Makes your shadekin adapted as a Yellow eyed kin! This gives you the highest energy regeneration in darkness, high degeneration in the light and unchanged health!"
 	var_changes = list(
 		"total_health" = 100,
-		"energy_light" = 3,
-		"energy_dark" = -2,
+		"energy_light" = -1,
+		"energy_dark" = 3,
 		"unarmed_types" = list(
 			/datum/unarmed_attack/stomp,
 			/datum/unarmed_attack/kick,
@@ -72,11 +72,11 @@
 /datum/trait/kintype/green
 	name = "Shadekin Green Adaptation"
 	color = GREEN_EYES
-	desc = "Makes your shadekin adapted as a Green eyed kin! This gives you high energy regeneration in darkness, minor regeneration in the light amd unchanged health!"
+	desc = "Makes your shadekin adapted as a Green eyed kin! This gives you high energy regeneration in darkness, minor regeneration in the light and unchanged health!"
 	var_changes = list(
 		"total_health" = 100,
-		"energy_light" = 2,
-		"energy_dark" = 0.125,
+		"energy_light" = 0.25,
+		"energy_dark" = 2,
 		"unarmed_types" = list(
 			/datum/unarmed_attack/stomp,
 			/datum/unarmed_attack/kick,
@@ -89,11 +89,11 @@
 /datum/trait/kintype/orange
 	name = "Shadekin Orange Adaptation"
 	color = ORANGE_EYES
-	desc = "Makes your shadekin adapted as a Orange eyed kin! This gives you minor energy regeneration in darkness, modeate degeneration in the light amd increased health!"
+	desc = "Makes your shadekin adapted as a Orange eyed kin! This gives you good energy regeneration in darkness, small degeneration in the light and increased health!"
 	var_changes = list(
 		"total_health" = 175,
-		"energy_light" = 0.25,
-		"energy_dark" = -0.5,
+		"energy_light" = -0.5,
+		"energy_dark" = 1,
 		"unarmed_types" = list(
 			/datum/unarmed_attack/stomp,
 			/datum/unarmed_attack/kick,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Shadekin energy modifiers have been set up inversed. The Values for Light and for Dark were mixed.
In addition, some of the recharge values were pure CBT, which is not needed for an adminspawn role.

## Why It's Good For The Game

This way the regeneration rates actually fit with the description of the traits. Also, it removes unnecessary CBT, which is always good.

## Changelog

:cl:
fix: fixed Shadekin energy regen inversion
tweak: tweaked Shadekin energy regeneration
/:cl:
