### PR TITLE
Creates and adds the Mining Carbine

### DIFF
--- a/code/modules/clothing/suits/hooded.dm
+++ b/code/modules/clothing/suits/hooded.dm
@@ -476,6 +476,7 @@
 		/obj/item/gun/energy/kinetic_accelerator,
 		/obj/item/kinetic_crusher,
 		/obj/item/resonator,
+		/obj/item/gun/energy/gun/miningcarbine,
 		/obj/item/gun/magnetic/matfed
 		)
 

--- a/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
@@ -59,6 +59,7 @@
 		new /datum/data/mining_equipment("Hardsuit - Smoke Bomb Deployer",	/obj/item/rig_module/grenade_launcher/smoke,					2000),
 		new /datum/data/mining_equipment("Industrial Equipment - Phoron Bore",	/obj/item/gun/magnetic/matfed,						3000),
 		new /datum/data/mining_equipment("Industrial Equipment - Sheet-Snatcher",/obj/item/storage/bag/sheetsnatcher,				500),
+		new /datum/data/mining_equipment("Repurposed Equipment - Mining Carbine",	/obj/item/gun/energy/gun/miningcarbine,						5000),
 		new /datum/data/mining_equipment("Digital Tablet - Standard",	/obj/item/modular_computer/tablet/preset/custom_loadout/standard,	500),
 		new /datum/data/mining_equipment("Digital Tablet - Advanced",	/obj/item/modular_computer/tablet/preset/custom_loadout/advanced,	1000),
 		new /datum/data/mining_equipment("Super Resonator",				/obj/item/resonator/upgraded,										2500),

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -44,6 +44,26 @@
 		list(mode_name="lethal burst", burst=3, fire_delay=null, move_delay=4, burst_accuracy=list(65,65,65), dispersion=list(0.0, 0.2, 0.5), projectile_type=/obj/item/projectile/beam/burstlaser, modifystate="fm-2tkill"),
 		)
 
+/obj/item/gun/energy/gun/miningcarbine
+	name = "mining carbine"
+	desc = "Following Miner's demand for a portable excavation laser, a military-favourite FM-2t has been modified to shoot excavation lasers."
+	icon_state = "fm-2tstun100"	//May resprite this to be more rifley
+	item_state = null	//so the human update icon uses the icon_state instead.
+	charge_cost = 20
+	force = 8
+	w_class = ITEMSIZE_LARGE
+	fire_delay = 3
+	projectile_type = /obj/item/projectile/beam/excavation
+	origin_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 2, TECH_ILLEGAL = 2)
+	modifystate = "fm-2tstun"
+
+	firemodes = list(
+		list(mode_name="mine", burst=1, projectile_type=/obj/item/projectile/beam/excavation, modifystate="fm-2tstun", charge_cost = 20),
+		list(mode_name="mine burst", burst=5, fire_delay=null, move_delay=4, burst_accuracy=list(65,65,65), dispersion=list(0.0, 0.2, 0.5), projectile_type=/obj/item/projectile/beam/excavation, modifystate="fm-2tstun"),
+		list(mode_name="scatter", burst=1, projectile_type=/obj/item/projectile/scatter/excavation, modifystate="fm-2tkill", charge_cost = 40),
+		list(mode_name="scatter burst", burst=5, fire_delay=null, move_delay=4, burst_accuracy=list(65,65,65), dispersion=list(0.0, 0.2, 0.5), projectile_type=/obj/item/projectile/scatter/excavation, modifystate="fm-2tkill"),
+		)
+
 /obj/item/gun/energy/gun/nuclear
 	name = "advanced energy gun"
 	desc = "An energy gun with an experimental miniaturized reactor."

--- a/code/modules/projectiles/projectile/beam/beams.dm
+++ b/code/modules/projectiles/projectile/beam/beams.dm
@@ -305,7 +305,7 @@
 /obj/item/projectile/beam/excavation
 	name = "excavation beam"
 	icon_state = "emitter"
-	fire_sound = 'sound/weapons/gauss_shoot.ogg'
+	fire_sound = 'sound/weapons/weaponsounds_laserweak.ogg'
 	light_color = "#00CC33"
 	damage = 1 //mining tool
 	excavation_amount = 1000	// 1 shot to dig a standard rock turf. Made for mining. Should be able to consistently one hit rocks now

--- a/code/modules/projectiles/projectile/scatter.dm
+++ b/code/modules/projectiles/projectile/scatter.dm
@@ -94,7 +94,7 @@
 	submunition_spread_max = 60
 	submunition_spread_min = 30
 	submunitions = list(
-		/obj/item/projectile/beam/gamma = 3 
+		/obj/item/projectile/beam/gamma = 3
 		)
 
 /obj/item/projectile/scatter/laser/heavylaser
@@ -115,7 +115,7 @@
 	submunition_spread_max = 70
 	submunition_spread_min = 30
 	submunitions = list(
-		/obj/item/projectile/beam/stun = 2 
+		/obj/item/projectile/beam/stun = 2
 		)
 	fire_sound = 'sound/weapons/Taser.ogg'
 	nodamage = 1
@@ -123,7 +123,7 @@
 
 /obj/item/projectile/scatter/stun/weak
 	submunitions = list(
-		/obj/item/projectile/beam/stun/weak = 2 
+		/obj/item/projectile/beam/stun/weak = 2
 		)
 	agony = 20
 
@@ -144,9 +144,10 @@
 		)
 
 /obj/item/projectile/scatter/excavation
-	damage = 10
+	damage = 2 //mining tool
 	submunition_spread_max = 80
 	submunition_spread_min = 40
+	fire_sound = 'sound/weapons/weaponsounds_laserweak.ogg'
 	submunitions = list(
 		/obj/item/projectile/beam/excavation = 2
 		)


### PR DESCRIPTION
## About The Pull Request

Introduces the Mining Carbine to items that the Mining Vendor can vend, and also creates the Mining Carbine.

## Why It's Good For The Game

Unless a miner uses explosives to mine, their job lasts pretty long and is quickly repetative.
The Mining Carbine is supposed to be an alternate to the Phoron Bore, which can also be bought at the Mining Vendor, allowing miners to have a little bit more variety.
Different firing modes allow the miner to mine specifically a single ore, or mine a cluster of ores or rocks.
While I was at it, I also massively reduced the amount of damage the Scatter Mining Laser does, since it had no reason to be that high, and also changed the firing sound to something that'd hurt the ears less at continuous use.

Suggestion for the Mining Carbine was made in Discord and was greenlit.

## Changelog

:cl:
add: Created the Mining Carbine
add: Added the Mining Carbine to the Mining Vendor
tweak: Changed excavation laser sound
tweak: Added Mining Carbine to list of items that can be carried on the suit
balance: Drastically reduced the excavation scatter damage
/:cl:
