### PR TITLE
removes AI-controlled mob vore

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -79,23 +79,7 @@
 			icon_state = "[icon_rest]-[vore_fullness]"
 
 /mob/living/simple_mob/proc/will_eat(var/mob/living/M)
-	if(client) //You do this yourself, dick!
-		return 0
-	if(!istype(M)) //Can't eat 'em if they ain't /mob/living
-		return 0
-	if(src == M) //Don't eat YOURSELF dork
-		return 0
-	if(vore_ignores_undigestable && !M.digestable) //Don't eat people with nogurgle prefs
-		return 0
-	if(!M.allowmobvore) // Don't eat people who don't want to be ate by mobs
-		return 0
-	if(M in prey_excludes) // They're excluded
-		return 0
-	if(M.size_multiplier < vore_min_size || M.size_multiplier > vore_max_size)
-		return 0
-	if(vore_capacity != 0 && (vore_fullness >= vore_capacity)) // We're too full to fit them
-		return 0
-	return 1
+	return FALSE // no more mobvore
 
 /mob/living/simple_mob/apply_attack(atom/A, damage_to_do)
 	if(isliving(A)) // Converts target to living

--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/gaslamp_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/gaslamp_vr.dm
@@ -80,19 +80,3 @@ TODO: Make them light up and heat the air when exposed to oxygen.
 	speak_chance = 1
 	wander = TRUE
 	base_wander_delay = 9
-
-// Activate Noms!
-/mob/living/simple_mob/animal/passive/gaslamp
-	vore_active = 1
-	vore_capacity = 2
-	vore_bump_chance = 90 //they're frickin' jellyfish anenome filterfeeders, get tentacled
-	vore_bump_emote = "lazily wraps its tentacles around"
-	vore_standing_too = 1 // Defaults to trying to give you that big tentacle hug.
-	vore_ignores_undigestable = 0 // they absorb rather than digest, you're going in either way
-	vore_default_mode = DM_HOLD
-	vore_digest_chance = 0			// Chance to switch to digest mode if resisted
-	vore_absorb_chance = 20			// BECOME A PART OF ME.
-	vore_pounce_chance = 5 // Small chance to punish people who abuse their nomming behaviour to try and kite them forever with repeated melee attacks.
-	vore_stomach_name = "internal chamber"
-	vore_stomach_flavor	= "You are squeezed into the tight embrace of the alien creature's warm and cozy insides."
-	vore_icons = SA_ICON_LIVING

--- a/code/modules/species/protean/protean_blob.dm
+++ b/code/modules/species/protean/protean_blob.dm
@@ -394,7 +394,6 @@
 		blob.devourable = P.devourable
 		blob.feeding = P.feeding
 		blob.digest_leave_remains = P.digest_leave_remains
-		blob.allowmobvore = P.allowmobvore
 		blob.vore_taste = P.vore_taste
 		blob.permit_healbelly = P.permit_healbelly
 		blob.can_be_drop_prey = P.can_be_drop_prey

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -4,7 +4,6 @@
 	var/devourable = TRUE				// Can the mob be devoured at all?
 	var/feeding = TRUE					// Can the mob be vorishly force fed or fed to others?
 	var/digest_leave_remains = FALSE	// Will this mob leave bones/skull/etc after the melty demise?
-	var/allowmobvore = TRUE				// Will simplemobs attempt to eat the mob?
 	var/showvoreprefs = TRUE			// Determines if the mechanical vore preferences button will be displayed on the mob or not.
 	var/obj/belly/vore_selected			// Default to no vore capability.
 	var/list/vore_organs = list()		// List of vore containers inside a mob
@@ -231,7 +230,6 @@
 	P.devourable = src.devourable
 	P.feeding = src.feeding
 	P.digest_leave_remains = src.digest_leave_remains
-	P.allowmobvore = src.allowmobvore
 	P.vore_taste = src.vore_taste
 	P.vore_smell = src.vore_smell
 	P.permit_healbelly = src.permit_healbelly
@@ -265,7 +263,6 @@
 	devourable = P.devourable
 	feeding = P.feeding
 	digest_leave_remains = P.digest_leave_remains
-	allowmobvore = P.allowmobvore
 	vore_taste = P.vore_taste
 	vore_smell = P.vore_smell
 	permit_healbelly = P.permit_healbelly
@@ -775,7 +772,6 @@
 	dispvoreprefs += "<b>Devourable:</b> [devourable ? "Enabled" : "Disabled"]<br>"
 	dispvoreprefs += "<b>Feedable:</b> [feeding ? "Enabled" : "Disabled"]<br>"
 	dispvoreprefs += "<b>Leaves Remains:</b> [digest_leave_remains ? "Enabled" : "Disabled"]<br>"
-	dispvoreprefs += "<b>Mob Vore:</b> [allowmobvore ? "Enabled" : "Disabled"]<br>"
 	dispvoreprefs += "<b>Healbelly permission:</b> [permit_healbelly ? "Allowed" : "Disallowed"]<br>"
 	dispvoreprefs += "<b>Spontaneous vore prey:</b> [can_be_drop_prey ? "Enabled" : "Disabled"]<br>"
 	dispvoreprefs += "<b>Spontaneous vore pred:</b> [can_be_drop_pred ? "Enabled" : "Disabled"]<br>"

--- a/code/modules/vore/eating/simple_animal_vr.dm
+++ b/code/modules/vore/eating/simple_animal_vr.dm
@@ -15,6 +15,9 @@
 		return
 	if (istype(src,/mob/living/simple_mob/animal/passive/mouse) && T.ckey == null)
 		return
+	if(!T.devourable)
+		to_chat(src, SPAN_WARNING("[T] is not edible."))
+		return
 	if (client && IsAdvancedToolUser())
 		to_chat(src,"<span class='warning'>Put your hands to good use instead!</span>")
 		return

--- a/code/modules/vore/eating/vore_vr.dm
+++ b/code/modules/vore/eating/vore_vr.dm
@@ -26,7 +26,6 @@
 	var/devourable = FALSE
 	var/feeding = FALSE
 	var/digest_leave_remains = FALSE
-	var/allowmobvore = FALSE
 	var/list/belly_prefs = list()
 	var/vore_taste = "nothing in particular"
 	var/vore_smell = "nothing in particular"
@@ -101,7 +100,6 @@
 	devourable = json_FROM_FILE["devourable"]
 	feeding = json_FROM_FILE["feeding"]
 	digest_leave_remains = json_FROM_FILE["digest_leave_remains"]
-	allowmobvore = json_FROM_FILE["allowmobvore"]
 	vore_taste = json_FROM_FILE["vore_taste"]
 	vore_smell = json_FROM_FILE["vore_smell"]
 	permit_healbelly = json_FROM_FILE["permit_healbelly"]
@@ -122,8 +120,6 @@
 		feeding = TRUE
 	if(isnull(digest_leave_remains))
 		digest_leave_remains = FALSE
-	if(isnull(allowmobvore))
-		allowmobvore = TRUE
 	if(isnull(permit_healbelly))
 		permit_healbelly = TRUE
 	if(isnull(can_be_drop_prey))
@@ -153,7 +149,6 @@
 			"devourable"			= devourable,
 			"feeding"				= feeding,
 			"digest_leave_remains"	= digest_leave_remains,
-			"allowmobvore"			= allowmobvore,
 			"vore_taste"			= vore_taste,
 			"vore_smell"			= vore_smell,
 			"permit_healbelly"		= permit_healbelly,

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -327,11 +327,6 @@
 			dat += "<a style='background:#173d15;' href='?src=\ref[src];toggledlm=1'>Toggle Leaving Remains (Currently: ON)</a>"
 		if(FALSE)
 			dat += "<a style='background:#990000;' href='?src=\ref[src];toggledlm=1'>Toggle Leaving Remains (Currently: OFF)</a>"
-	switch(user.allowmobvore)
-		if(TRUE)
-			dat += "<br><a style='background:#173d15;' href='?src=\ref[src];togglemv=1'>Toggle Mob Vore (Currently: ON)</a>"
-		if(FALSE)
-			dat += "<br><a style='background:#990000;' href='?src=\ref[src];togglemv=1'>Toggle Mob Vore (Currently: OFF)</a>"
 	switch(user.permit_healbelly)
 		if(TRUE)
 			dat += "<a style='background:#173d15;' href='?src=\ref[src];togglehealbelly=1'>Toggle Healbelly Permission (Currently: ON)</a>"
@@ -1006,19 +1001,6 @@
 
 		if(user.client.prefs_vr)
 			user.client.prefs_vr.digest_leave_remains = user.digest_leave_remains
-
-	if(href_list["togglemv"])
-		var/choice = alert(user, "This button is for those who don't like being eaten by mobs. Mobs are currently: [user.allowmobvore ? "Allowed to eat" : "Prevented from eating"] you.", "", "Allow Mob Predation", "Cancel", "Prevent Mob Predation")
-		switch(choice)
-			if("Cancel")
-				return FALSE
-			if("Allow Mob Predation")
-				user.allowmobvore = TRUE
-			if("Prevent Mob Predation")
-				user.allowmobvore = FALSE
-
-		if(user.client.prefs_vr)
-			user.client.prefs_vr.allowmobvore = user.allowmobvore
 
 	if(href_list["togglehealbelly"])
 		var/choice = alert(user, "This button is for those who don't like healbelly used on them as a mechanic. It does not affect anything, but is displayed under mechanical prefs for ease of quick checks. You are currently: [user.allowmobvore ? "Okay" : "Not Okay"] with players using healbelly on you.", "", "Allow Healing Belly", "Cancel", "Disallow Healing Belly")

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -1003,7 +1003,7 @@
 			user.client.prefs_vr.digest_leave_remains = user.digest_leave_remains
 
 	if(href_list["togglehealbelly"])
-		var/choice = alert(user, "This button is for those who don't like healbelly used on them as a mechanic. It does not affect anything, but is displayed under mechanical prefs for ease of quick checks. You are currently: [user.allowmobvore ? "Okay" : "Not Okay"] with players using healbelly on you.", "", "Allow Healing Belly", "Cancel", "Disallow Healing Belly")
+		var/choice = alert(user, "This button is for those who don't like healbelly used on them as a mechanic. It does not affect anything, but is displayed under mechanical prefs for ease of quick checks. You are currently: [user.permit_healbelly ? "Okay" : "Not Okay"] with players using healbelly on you.", "", "Allow Healing Belly", "Cancel", "Disallow Healing Belly")
 		switch(choice)
 			if("Cancel")
 				return FALSE


### PR DESCRIPTION

## About The Pull Request

## Why It's Good For The Game

vore as a mechanic exists only for player to player roleplay
i'm not interested in maintaining or entertaining mechanical vore from mechanical ais. it's not rp for the players.
players retain the ability to vore each other as a mob.

## Changelog

:cl:
del: mobvore
/:cl:
