### PR TITLE
Cyborg-KA

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station/cargo.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station/cargo.dm
@@ -34,6 +34,7 @@
 		/obj/item/tool/screwdriver/cyborg,
 		/obj/item/storage/bag/ore,
 		/obj/item/pickaxe/borgdrill,
+		/obj/item/gun/energy/kinetic_accelerator/cyborg,
 		/obj/item/storage/bag/sheetsnatcher/borg,
 		/obj/item/gripper/miner,
 		/obj/item/mining_scanner
@@ -68,6 +69,7 @@
 		/obj/item/tool/screwdriver/cyborg,
 		/obj/item/storage/bag/ore,
 		/obj/item/pickaxe/borgdrill,
+		/obj/item/gun/energy/kinetic_accelerator/cyborg,
 		/obj/item/storage/bag/sheetsnatcher/borg,
 		/obj/item/gripper/miner,
 		/obj/item/mining_scanner,


### PR DESCRIPTION
## About The Pull Request

This adds the, so far unused but existing, Cyborg Kinetic Accelerator to the Mining Borgs.

## Why It's Good For The Game

We already have the Cyborg Kinetic Accelerator in the code and upon asking it turned out, that Mining Cyborgs not having it was not intentional. This PR fixes this.

## Changelog

:cl:
add: Added the Cybork Kinetic Accelerator to the Mining Borg and the Mining Quad.
/:cl:
