### PR TITLE
proteans now always drop brains on death, fixes runtime

### DIFF
--- a/code/modules/species/protean/protean_species.dm
+++ b/code/modules/species/protean/protean_species.dm
@@ -223,12 +223,11 @@ I redid the calculations, as the burn weakness has been changed. This should be 
 	var/obj/item/organ/internal/the_brain = H.internal_organs_by_name[O_BRAIN]
 	if(the_brain)
 		the_brain.removed(H)
-		the_brain.forceMove(H.drop_location())
 	if(istype(H.temporary_form, /mob/living/simple_mob/protean_blob))
 		var/mob/living/simple_mob/protean_blob/B = H.temporary_form
 		to_chat(B, deathmsg)
 	else if(!gibbed)
-		to_chat(H)
+		to_chat(H, deathmsg)
 		H.gib()
 
 /datum/species/protean/proc/getActualDamage(mob/living/carbon/human/H)

--- a/code/modules/species/protean/protean_species.dm
+++ b/code/modules/species/protean/protean_species.dm
@@ -219,6 +219,11 @@ I redid the calculations, as the burn weakness has been changed. This should be 
 
 /datum/species/protean/handle_death(var/mob/living/carbon/human/H, gibbed)		// citadel edit - FUCK YOU ACTUALLY GIB THE MOB AFTER REMOVING IT FROM THE BLOB HOW HARD CAN THIS BE!!
 	var/deathmsg = "<span class='userdanger'>You have died as a Protean. You may be revived by nanite chambers (once available), but otherwise, you may roleplay as your disembodied posibrain or respawn on another character.</span>"
+	// force eject brain
+	var/obj/item/organ/internal/the_brain = H.internal_organs_by_name[O_BRAIN]
+	if(the_brain)
+		the_brain.removed(H)
+		the_brain.forceMove(H.drop_location())
 	if(istype(H.temporary_form, /mob/living/simple_mob/protean_blob))
 		var/mob/living/simple_mob/protean_blob/B = H.temporary_form
 		to_chat(B, deathmsg)


### PR DESCRIPTION

## About The Pull Request

## Why It's Good For The Game

proteans can't be mirrored; their brain serves as their mirror.

## Changelog

:cl:
balance: proteans now drop their brains on death, always.
/:cl:
