### PR TITLE
Crewkin Resistances Rebalance

### DIFF
--- a/code/modules/species/shadekin/shadekin_blackeyed.dm
+++ b/code/modules/species/shadekin/shadekin_blackeyed.dm
@@ -31,7 +31,7 @@
 
 	rarity_value = 5 // INTERDIMENSIONAL FLUFFERS
 
-	siemens_coefficient = 0 // Completely shockproof (this is no longer the case on virgo, feel free to change if it needs rebalancing)
+	siemens_coefficient = 1 // Mirroring the shockproof removal of Shadekin
 	darksight = 10 // Best darksight around
 
 	slowdown = 0 // Originally 0.5 (As slow as unathi), lowered to 0 to be at human speed.
@@ -41,6 +41,7 @@
 	brute_mod    = 1 // Originally 1.25, lowered to 1 because lower HP and increased damage is a bit heavy.
 	burn_mod     = 1.25 // Furry
 	radiation_mod = 0
+	toxins_mod = 1.2
 
 	blood_volume  = 500 // Slightly less blood than human baseline.
 	hunger_factor = 0.2 // Gets hungrier faster than human baseline.
@@ -49,7 +50,7 @@
 	hazard_low_pressure = -1
 
 	warning_high_pressure = 300
-	hazard_high_pressure = INFINITY
+	hazard_high_pressure = 1000 // Same High Pressure resistance as Voidsuits get
 
 	cold_level_1 = -1 // Immune to cold
 	cold_level_2 = -1


### PR DESCRIPTION
## About The Pull Request

After multiple discussions regarding Crewkin resistances and immunities, I've proposed a set of changes, which was generally well-accepted. This PR turns those suggesttions into code.

## Why It's Good For The Game

In order to change Crewkin balance and not let them be immune against basically everything, the following changes were proposed:
Removal of their Shock immunity
Raising of their Toxin modifier to 1.2
Adjusting Cold/Heat/Pressure resistances to be at the same level as those of a voidsuit, or keep the lower value if they currently have a lower level of protection than that

The resistances were checked and compared to that of a default voidsuit, below are the results:
Crewkin Cold resistance: -1, same as Voidsuit, no change
Crewkin Heat resistance: 1150, lower than the Voidsuit's 5000, no change
Crewkin Min Pressure: -1, same as Voidsuit, no change
Crewkin Max pressure: Infinite, higher than Voidsuit, thus set to the same 10 Atmosphere as Voidsuit

## Changelog

:cl:
balance: Removed Crewkin shock immunity
balance: Raised Crewkin toxin damage mod
balance: Lowered Crewkin maximum pressure
/:cl:
