### PR TITLE
Dogborgs now CRUSH people's heads VERY RARELY when sharing a tile and resting.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -906,16 +906,6 @@
 		if (stat == CONSCIOUS && resting)
 			if(sitting)
 				icon_state = "[module_sprites[icontype]]-sit"
-				spawn(-1) // Let's not wait for this to update the sprites, lol.
-					for(var/mob/living/carbon/human/smooshed in loc) // Literally the worstbest place for this code.
-						if(prob(1))
-							. = smooshed.apply_damage(60, BRUTE, BP_HEAD)
-						if(.)
-							smooshed.visible_message(
-								"[name] slams their chassis into [smooshed]'s head! That looked painful!",
-								"Your [BP_HEAD] is crushed by [name]'s mechanical parts!",
-								"You hear the sound of bones being crunching!",
-							)
 			else if(bellyup)
 				icon_state = "[module_sprites[icontype]]-bellyup"
 			else
@@ -1437,6 +1427,20 @@
 			sitting = TRUE
 		if("Belly up")
 			bellyup = TRUE
+
+/mob/living/silicon/robot/lay_down()
+	. = ..()
+	set waitfor = FALSE
+	if(sitting)
+		for(var/mob/living/carbon/human/smooshed in loc) // Literally the worstbest place for this code.
+			if(prob(1))
+				. = smooshed.apply_damage(60, BRUTE, BP_HEAD)
+			if(.)
+				smooshed.visible_message(
+					"[name] slams their chassis into [smooshed]'s head! That looked painful!",
+					"Your [BP_HEAD] is crushed by [name]'s mechanical parts!",
+					"You hear the sound of bones being crunching!",
+				)
 
 /mob/living/silicon/robot/proc/ex_reserve_refill()
 	set name = "Refill Extinguisher"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1436,10 +1436,11 @@
 			if(prob(1))
 				. = smooshed.apply_damage(60, BRUTE, BP_HEAD)
 			if(.) //Hooray, we damaged something.
+				var/obj/head = smooshed.get_organ(BP_HEAD) | "head mount" // Yeah, we probably already have a head if the first check passed anyways.
 				smooshed.visible_message(
-					"[name] slams their chassis into [smooshed]'s head! That looked painful!",
-					"Your [smooshed.get_organ(BP_HEAD)] is crushed by [name]'s mechanical parts!",
-					"You hear the sound of bones being crunching!",
+					"[name] slams their chassis into [smooshed]'s [head]! That looked painful!",
+					"Your [head] is crushed by [name]'s mechanical parts!",
+					"You hear a loud crack!",
 				)
 
 /mob/living/silicon/robot/proc/ex_reserve_refill()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -896,6 +896,8 @@
 /mob/living/silicon/robot/update_canmove()
 	. = ..()
 	updateicon()
+	spawn(-1) // We don't need to wait for this.
+		check_clearance()
 
 
 /mob/living/silicon/robot/updateicon()
@@ -1428,14 +1430,12 @@
 		if("Belly up")
 			bellyup = TRUE
 
-/mob/living/silicon/robot/lay_down()
-	. = ..()
-	set waitfor = FALSE
-	if(sitting)
-		for(var/mob/living/carbon/human/smooshed in loc) // Literally the worstbest place for this code.
+/mob/living/silicon/robot/proc/check_clearance() // Literally just for sitting.
+	if(sitting || resting) // should it be sitting, resting, or both?
+		for(var/mob/living/carbon/smooshed in loc)
 			if(prob(1))
 				. = smooshed.apply_damage(60, BRUTE, BP_HEAD)
-			if(.)
+			if(.) //Hooray, we damaged something.
 				smooshed.visible_message(
 					"[name] slams their chassis into [smooshed]'s head! That looked painful!",
 					"Your [BP_HEAD] is crushed by [name]'s mechanical parts!",

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -906,6 +906,16 @@
 		if (stat == CONSCIOUS && resting)
 			if(sitting)
 				icon_state = "[module_sprites[icontype]]-sit"
+				spawn(-1) // Let's not wait for this to update the sprites, lol.
+					for(var/mob/living/carbon/human/smooshed in loc) // Literally the worstbest place for this code.
+						if(prob(1))
+							. = smooshed.apply_damage(60, BRUTE, BP_HEAD)
+						if(.)
+							smooshed.visible_message(
+								"[name] slams their chassis into [smooshed]'s head! That looked painful!",
+								"Your [BP_HEAD] is crushed by [name]'s mechanical parts!",
+								"You hear the sound of bones being crunching!",
+							)
 			else if(bellyup)
 				icon_state = "[module_sprites[icontype]]-bellyup"
 			else

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1438,7 +1438,7 @@
 			if(.) //Hooray, we damaged something.
 				smooshed.visible_message(
 					"[name] slams their chassis into [smooshed]'s head! That looked painful!",
-					"Your [BP_HEAD] is crushed by [name]'s mechanical parts!",
+					"Your [smooshed.get_organ(BP_HEAD)] is crushed by [name]'s mechanical parts!",
 					"You hear the sound of bones being crunching!",
 				)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/77420409/228638715-dc067f1e-e12e-44bc-a270-0722cafd778d.png)
Bet
## Why It's Good For The Game

It'd probably be very rare and pretty funny ss13 soul to have incidents revolving around getting injured by machinery you climbed under. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a very small chance to have mechanical incidents with dogborgs. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
