### PR TITLE
Fixing singular_name for sandbags

### DIFF
--- a/code/game/objects/items/stacks/sandbag.dm
+++ b/code/game/objects/items/stacks/sandbag.dm
@@ -49,7 +49,7 @@
 /obj/item/stack/sandbags
 	name = "sandbag"
 	desc = "This is a synthetic bag tightly packed with sand. It is designed to provide structural support and serve as a portable barrier."
-	singular name = "sandbag"
+	singular_name = "sandbag"
 	icon_state = "sandbags"
 	w_class = ITEMSIZE_NORMAL
 	damage_force = 10


### PR DESCRIPTION
## About The Pull Request
Fixing a typo, it resulted in a type of
```dm
/obj/item/stack/sandbags/singular
	name = "sandbag"
```
instead of

```dm
/obj/item/stack/sandbags
	singular_name = "sandbag"
```