### PR TITLE
Fixes Some Crafting Recipes Lacking Reagents

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -229,7 +229,8 @@
 				/obj/item/reagent_containers/glass/beaker)
 	reqs = list(/obj/item/stack/material/cardboard = 1, //so we dont null items in crafting
 				/obj/item/stack/cable_coil = 10,
-				/obj/item/stack/material/gold = 1)
+				/obj/item/stack/material/gold = 1,
+				/datum/reagent/water = 15)
 	time = 40
 	subcategory = CAT_TOOL
 	category = CAT_MISCELLANEOUS
@@ -280,7 +281,8 @@
 	result = /obj/item/tool/screwdriver/brass
 	reqs = list(/obj/item/tool/screwdriver = 1,
 				/obj/item/stack/cable_coil = 10,
-				/obj/item/stack/material/brass = 1
+				/obj/item/stack/material/brass = 1,
+				/datum/reagent/water = 15
 				)
 	time = 40
 	//always_available = FALSE
@@ -294,7 +296,8 @@
 	result = /obj/item/weldingtool/brass
 	reqs = list(/obj/item/weldingtool = 1,
 				/obj/item/stack/cable_coil = 10,
-				/obj/item/stack/material/brass = 1
+				/obj/item/stack/material/brass = 1,
+				/datum/reagent/water = 15
 				)
 	time = 40
 	//always_available = FALSE
@@ -308,7 +311,8 @@
 	result = /obj/item/tool/wirecutters/brass
 	reqs = list(/obj/item/tool/wirecutters = 1,
 				/obj/item/stack/cable_coil = 10,
-				/obj/item/stack/material/brass = 1
+				/obj/item/stack/material/brass = 1,
+				/datum/reagent/water = 15
 				)
 	time = 40
 	//always_available = FALSE
@@ -322,7 +326,8 @@
 	result = /obj/item/tool/crowbar/brass
 	reqs = list(/obj/item/tool/crowbar = 1,
 				/obj/item/stack/cable_coil = 10,
-				/obj/item/stack/material/brass = 1
+				/obj/item/stack/material/brass = 1,
+				/datum/reagent/water = 15
 				)
 	time = 40
 	//always_available = FALSE
@@ -336,7 +341,8 @@
 	result = /obj/item/tool/wrench/brass
 	reqs = list(/obj/item/tool/wrench = 1,
 				/obj/item/stack/cable_coil = 10,
-				/obj/item/stack/material/brass = 1
+				/obj/item/stack/material/brass = 1,
+				/datum/reagent/water = 15
 				)
 	time = 40
 	//always_available = FALSE

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -291,10 +291,10 @@
 /datum/crafting_recipe/IED
 	name = "IED"
 	result = /obj/item/grenade/explosive/ied
-	reqs = list(/obj/item/stack/cable_coil = 1,
+	reqs = list(/datum/reagent/fuel = 50,
+				/obj/item/stack/cable_coil = 1,
 				/obj/item/assembly/igniter = 1,
 				/obj/item/trash/punctured_can = 1)
-	tools = list(TOOL_WELDER)
 	time = 15
 	category = CAT_WEAPONRY
 	subcategory = CAT_OTHER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Restores Reagent Cost to Some Recipes.**

## Why It's Good For The Game

1. _Thanks to Nicc fixing some issues in the code, reagents can now be used in crafting recipes. This restores costs to a few recipes where I removed it in the past._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes crafting recipes that need reagents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
