### PR TITLE
Ashlanders and Pirates Now Spawn In With Character Slots.

### DIFF
--- a/code/modules/ghostroles/instantiator.dm
+++ b/code/modules/ghostroles/instantiator.dm
@@ -155,13 +155,19 @@
 	var/equip_loadout = TRUE
 	/// equip traits
 	var/equip_traits = TRUE
+	/// Allows the selection of specific species for ghost roles.
+	var/species_required = null
 
 /datum/ghostrole_instantiator/human/player_static/Create(client/C, atom/location, list/params)
 	var/mob/living/carbon/human/H = ..()
 	var/list/errors = list()
 	// todo: respect warnings; we ignore them right now so we don't block joins.
-	if(!C.prefs.spawn_checks(PREF_COPY_TO_FOR_GHOSTROLE, errors))
+	if(!C.prefs.spawn_checks(PREF_COPY_TO_FOR_GHOSTROLE | PREF_COPY_TO_NO_CHECK_SPECIES, errors))
 		to_chat(C, SPAN_WARNING("<h3><center>--- Character Setup Errors - Please resolve these to continue ---</center></h3><br><b>-&nbsp;&nbsp;&nbsp;&nbsp;[jointext(errors, "<br>-&nbsp;&nbsp;&nbsp;&nbsp;")]</b>"))
+		return
+
+	if(!isnull(species_required) && species_required != C.prefs.real_species_datum().type)
+		to_chat(C, SPAN_WARNING("<h3><center>--- Character Species Errors - Please resolve these to continue ---</center></h3><br><b>-&nbsp;&nbsp;&nbsp;&nbsp;[jointext(errors, "<br>-&nbsp;&nbsp;&nbsp;&nbsp;")]</b>"))
 		return
 
 	LoadSavefile(C, H)
@@ -169,7 +175,7 @@
 
 /datum/ghostrole_instantiator/human/player_static/proc/LoadSavefile(client/C, mob/living/carbon/human/H)
 	C.prefs.copy_to(H)
-	SSjob.EquipRank(H, USELESS_JOB)
+	//SSjob.EquipRank(H, USELESS_JOB)
 	// if(equip_loadout)
 	// 	SSjob.EquipLoadout(H, FALSE, null, C.prefs, C.ckey)
 	// if(equip_traits && CONFIG_GET(flag/roundstart_traits))

--- a/code/modules/ghostroles/instantiator.dm
+++ b/code/modules/ghostroles/instantiator.dm
@@ -172,19 +172,8 @@
 		to_chat(C, SPAN_WARNING("<h3><center>--- Character Species Is Not Allowed In This Role - Please resolve these to continue ---</center></h3><br><b>-&nbsp;&nbsp;&nbsp;&nbsp;[jointext(errors, "<br>-&nbsp;&nbsp;&nbsp;&nbsp;")]</b>"))
 		return
 
-	/*
-	if(!isnull(species_restricted) && species_restricted == C.prefs.real_species_datum().type)
-		to_chat(C, SPAN_WARNING("<h3><center>--- Character Species Is Not Allowed In This Role - Please resolve these to continue ---</center></h3><br><b>-&nbsp;&nbsp;&nbsp;&nbsp;[jointext(errors, "<br>-&nbsp;&nbsp;&nbsp;&nbsp;")]</b>"))
-		return
-	*/
-
 	LoadSavefile(C, H)
 	return H
 
 /datum/ghostrole_instantiator/human/player_static/proc/LoadSavefile(client/C, mob/living/carbon/human/H)
 	C.prefs.copy_to(H)
-	//SSjob.EquipRank(H, USELESS_JOB)
-	// if(equip_loadout)
-	// 	SSjob.EquipLoadout(H, FALSE, null, C.prefs, C.ckey)
-	// if(equip_traits && CONFIG_GET(flag/roundstart_traits))
-	// 	SSquirks.AssignQuirks(H, C, TRUE, FALSE, null, FALSE, C)

--- a/code/modules/ghostroles/instantiator.dm
+++ b/code/modules/ghostroles/instantiator.dm
@@ -157,6 +157,8 @@
 	var/equip_traits = TRUE
 	/// Allows the selection of specific species for ghost roles.
 	var/species_required = null
+	/// Allows the blacklisting of specific species from ghost roles.
+	//var/species_restricted = null
 
 /datum/ghostrole_instantiator/human/player_static/Create(client/C, atom/location, list/params)
 	var/mob/living/carbon/human/H = ..()
@@ -167,8 +169,14 @@
 		return
 
 	if(!isnull(species_required) && species_required != C.prefs.real_species_datum().type)
-		to_chat(C, SPAN_WARNING("<h3><center>--- Character Species Errors - Please resolve these to continue ---</center></h3><br><b>-&nbsp;&nbsp;&nbsp;&nbsp;[jointext(errors, "<br>-&nbsp;&nbsp;&nbsp;&nbsp;")]</b>"))
+		to_chat(C, SPAN_WARNING("<h3><center>--- Character Species Is Not Allowed In This Role - Please resolve these to continue ---</center></h3><br><b>-&nbsp;&nbsp;&nbsp;&nbsp;[jointext(errors, "<br>-&nbsp;&nbsp;&nbsp;&nbsp;")]</b>"))
 		return
+
+	/*
+	if(!isnull(species_restricted) && species_restricted == C.prefs.real_species_datum().type)
+		to_chat(C, SPAN_WARNING("<h3><center>--- Character Species Is Not Allowed In This Role - Please resolve these to continue ---</center></h3><br><b>-&nbsp;&nbsp;&nbsp;&nbsp;[jointext(errors, "<br>-&nbsp;&nbsp;&nbsp;&nbsp;")]</b>"))
+		return
+	*/
 
 	LoadSavefile(C, H)
 	return H

--- a/code/modules/ghostroles/roles/ashlander.dm
+++ b/code/modules/ghostroles/roles/ashlander.dm
@@ -4,7 +4,7 @@
 	desc = "You are an Ashlander! An old and storied race of subterranean xenos."
 	spawntext = "Your tribe still worships the Buried Ones. The wastes are sacred ground, its monsters a blessed bounty - your people have long farmed these creatures. From Goliaths you can harvest fresh meat and hardy leather, and you may breed them using Bentar seeds. Goliaths produce sacred fire powder, which can be milked to replenish certain weapons. Gutshank glands may be milked for water. You would never willingly leave your homeland behind. You have seen lights in the distance - falling from the heavens, and returning. They foreshadow the arrival of outsiders to your domain. Ensure your tribe remains protected at all costs."
 	important_info = "The nomadic Ashlanders are a neutral party. The Ashlander race (Scorian), is selected by default. If you accidentally swap, make sure to change it back. Ashlanders are all permadeath characters. They have gray skin of varying hues, red eyes, and - typically - white, black, or brown hair. These options are selectable through the appearance menu, directly below the race block, and above hairstyles. "
-	instantiator = /datum/ghostrole_instantiator/human/random/species/ashlander
+	instantiator = /datum/ghostrole_instantiator/human/player_static/ashlander
 
 /datum/role/ghostrole/ashlander/Instantiate(client/C, atom/loc, list/params)
 	var/rp = rand(1, 7)
@@ -71,10 +71,10 @@
 			you all up into the wastes. You feel the weight of the holy tools granted to you by the Buried Ones. They are worth more than your life. Guide your people well.</i>"
 	to_chat(created, flavour_text)
 
-/datum/ghostrole_instantiator/human/random/species/ashlander
-	possible_species = list(
-		/datum/species/scori
-	)
+/datum/ghostrole_instantiator/human/player_static/ashlander
+	equip_loadout = FALSE
+	equip_traits = FALSE
+	species_required = /datum/species/scori
 	var/list/ashlander_crafting = list(/datum/crafting_recipe/bonetalisman, /datum/crafting_recipe/bonecodpiece, /datum/crafting_recipe/bracers, /datum/crafting_recipe/goliathcloak,
 		/datum/crafting_recipe/drakecloak, /datum/crafting_recipe/bonebag, /datum/crafting_recipe/bonespear, /datum/crafting_recipe/boneaxe, /datum/crafting_recipe/bone_bow,
 		/datum/crafting_recipe/quiver_ashlander, /datum/crafting_recipe/rib, /datum/crafting_recipe/skull, /datum/crafting_recipe/halfskull, /datum/crafting_recipe/boneshovel, /datum/crafting_recipe/bonehatchet,
@@ -89,7 +89,7 @@
 		/datum/crafting_recipe/goliathcowl, /datum/crafting_recipe/primitive_splint, /datum/crafting_recipe/bone_pipe, /datum/crafting_recipe/spark_striker
 		)
 
-/datum/ghostrole_instantiator/human/random/species/ashlander/GetOutfit(client/C, mob/M, list/params)
+/datum/ghostrole_instantiator/human/player_static/ashlander/GetOutfit(client/C, mob/M, list/params)
 	var/datum/outfit/outfit = ..()
 	switch(params["fluff"])
 		if("nomad")
@@ -108,7 +108,7 @@
 			return /datum/outfit/ashlander/priest
 	return outfit
 
-/datum/ghostrole_instantiator/human/random/species/ashlander/AfterSpawn(mob/created, list/params)
+/datum/ghostrole_instantiator/human/player_static/ashlander/AfterSpawn(mob/created, list/params)
 	. = ..()
 	created.faction = "lavaland"
 	created.mind.teach_crafting_recipe(ashlander_crafting)
@@ -123,119 +123,3 @@
 	density = TRUE
 	role_type = /datum/role/ghostrole/ashlander
 	role_spawns = 1
-	//var/datum/team/ashlanders/team
-
-//This is the old backstory data. I'm retaining it in case we've ever got a use for it in the future!
-/*
-/datum/ghostrole/ashlander/Instantiate(client/C, atom/loc, list/params)
-	var/rp = rand(1, 4)
-	switch(rp)
-		if(1)
-			params["fluff"] = "nomad"
-		if(2)
-			params["fluff"] = "hunter"
-		if(3)
-			params["fluff"] = "exile"
-		if(4)
-			params["fluff"] = "sentry"
-	return ..()
-
-/datum/role/ghostrole/ashlander/Greet(mob/created, datum/component/ghostrole_spawnpoint/spawnpoint, list/params)
-	. = ..()
-	var/flavour_text = "<i>Fine particles of ash slip past the fluttering Goliath hide covering your doorway to settle on the floor of the yurt. \
-	The hide is patched, and worn from years of use - it was gifted to you many Storms ago. Outside, the baking heat of the planet's surface \
-	sends howling winds across your threshold. Leaning back against a pile of tanned hide, you peer upwards through the roof at the ever-scarlet \
-	sky. Your mind drifts to how you came to be here...</i>"
-	switch(params["fluff"])
-		if("nomad")
-			flavour_text += "<i>You served the caravan as a [pick("trader", "butcher", "shaman")], and much was the joy to be found in crossing the Mother's plains. \
-			The caravan moved ever onwards, settling only when the skies were right and the omens favorable. You trekked across the deceptive Ash Dunes, and \
-			paddled across the Sunlight Sea in a blessed vessel. There was great comfort in the caravan. Until one day, when a great ash storm rose up and drove \
-			you from their warm embrace. Lost and alone, you set up this yurt and resolved to wait until your tribesmen could find you.</i>"
-		if("hunter")
-			flavour_text += "<i>You have long bemoaned life in the Deep Veins. These ancient caverns have been home to your people since the beginning of time. \
-			The farms have not been doing well these last few Storms. The Mother heaves and vomits her firey blood into passages which have been untouched \
-			for centuries. The priests foretell an impending cataclysm, but such concerns are beyond you. With the farms failing, you and many others have been \
-			sent to the surface, to find whatever game you may. So it is that you shelter in this yurt and rest before the next hunt.</i>"
-		if("exile")
-			flavour_text += "<i>You had always imagined yourself a good steward. Loyal to the [pick("tribe", "caravan")], it came as a great shock to you and your \
-			kinsmen when the priests declared you a sinner. For the crime of [pick("murder", "theft", "blasphemy")] you were cast out. Left with nothing but your \
-			wits and your strength, you have long traversed this world alone. The brand on your chest marks you among all who may find you - Exile. This simple \
-			yurt has become your latest haven. Rarely do others come across you here - a blessing, and a curse.</i>"
-		if("sentry") //Credit to YourDoom for writing this one! <3
-			flavour_text += "<i>You were one of the [pick("tribe", "caravan")]'s most reliable guards. It was your sacred duty to keep the Mother's \
-			more dangerous children away from those you called family. However, the new threat of the Corrupted has thrown daily life into disarray. The priests \
-			believe these abominations are the harbingers of an impending cataclysm - they were right. A twisted horde of Corrupted overwhelmed your post as \
-			you slept. In the ensuing battle, a tunnel collapse separated you from your charges. Alone, you shelter in this yurt and wait for your kin to return.</i>"
-	to_chat(created, flavour_text)
-
-/datum/ghostrole_instantiator/human/random/species/ashlander/GetOutfit(client/C, mob/M, list/params)
-	var/datum/outfit/outfit = ..()
-	switch(params["fluff"])
-		if("nomad")
-			outfit.uniform = /obj/item/clothing/under/tribal_tunic/ashlander
-			outfit.shoes = /obj/item/clothing/shoes/footwraps
-			outfit.belt = /obj/item/material/knife/tacknife/combatknife/bone
-			outfit.back = /obj/item/storage/backpack/satchel/bone
-			outfit.r_hand = /obj/item/material/twohanded/spear/bone
-		if("hunter")
-			outfit.uniform = /obj/item/clothing/under/gladiator/ashlander
-			outfit.head = /obj/item/clothing/head/helmet/gladiator/ashlander
-			outfit.shoes = /obj/item/clothing/shoes/ashwalker
-			outfit.back = /obj/item/gun/ballistic/bow/ashen
-			outfit.belt = /obj/item/storage/belt/quiver/full/ash
-			outfit.r_hand = /obj/item/material/knife/tacknife/combatknife/bone
-		if("exile")
-			outfit.uniform = /obj/item/clothing/under/tribal_tunic/ashlander
-			outfit.belt = /obj/item/material/knife/tacknife/combatknife/bone
-			outfit.back = /obj/item/bo_staff
-		if("sentry")
-			outfit.uniform = /obj/item/clothing/under/gladiator/ashlander
-			outfit.shoes = /obj/item/clothing/shoes/ashwalker
-			outfit.belt = /obj/item/reagent_containers/glass/powder_horn/tribal
-			outfit.back = /obj/item/storage/backpack/satchel/bone
-			outfit.r_hand = /obj/item/gun/ballistic/musket/tribal
-			outfit.l_hand = /obj/item/storage/box/munition_box
-	return outfit
-*/
-
-
-//This is stuff from the port that just didn't seem like it belonged in my imagining of Ashlanders.
-/*
-/obj/structure/ghost_role_spawner/ashlander/Destroy()
-	new /obj/structure/fluff/empty_cryostasis_sleeper(get_turf(src))
-	return ..()
-
-//This all appears to be /tg/ flavored stuff. Retaining in case we want to use it later.
-	var/turf/T = get_turf(created)
-	if(is_mining_level(T.z))
-		to_chat(created, "<b>Drag the corpses of men and beasts to your yurt. The bounty may attract more of your tribe. Glory to the Buried Ones!</b>")
-		to_chat(created, "<b>You can expand the weather proof area provided by your shelters by using the 'New Area' key near the bottom right of your HUD.</b>")
-	else
-		to_chat(created, "<span class='userdanger'>You have awoken outside of your natural home! Whether you decide to return below the surface, or make due with your current surroundings is your own decision.</span>")
-
-/datum/role/ghostrole/ashlander/AllowSpawn(client/C, list/params)
-	if(params && params["team"])
-		var/datum/team/ashlanders/team = params["team"]
-		if(C.ckey in team.players_spawned)
-			to_chat(C, span_warning("<b>You have exhausted your usefulness to the tribe</b>."))
-			return FALSE
-	return ..()
-
-/datum/role/ghostrole/ashlander/PostInstantiate(mob/created, datum/component/ghostrole_spawnpoint/spawnpoint, list/params)
-	. = ..()
-	if(params["team"])
-		var/datum/team/ashlanders/team = spawnpoint.params["team"]
-		team.players_spawned += ckey(created.key)
-		created.mind.add_antag_datum(/datum/antagonist/ashlander, team)
-
-/obj/structure/ghost_role_spawner/ashlander/Destroy()
-	var/mob/living/carbon/human/yolk = new /mob/living/carbon/human/(get_turf(src))
-	yolk.fully_replace_character_name(null,random_name(gender))
-	yolk.set_species(/datum/species/human/ashlander)
-	yolk.underwear = "Nude"
-	yolk.equipOutfit(/datum/outfit/ashlander)//this is an authentic mess we're making
-	yolk.update_body()
-	yolk.gib()
-	return ..()
-*/

--- a/code/modules/ghostroles/roles/pirate.dm
+++ b/code/modules/ghostroles/roles/pirate.dm
@@ -4,7 +4,7 @@
 	desc = "You are a pirate! A legendary, if oft maligned, profession."
 	spawntext = "There are countless roving gangs of pirates across the Frontier. A constant menace to honest traders and Corporate convoys alike, pirates are part of a never ending conflict with local SDF and private security forces from system to system."
 	important_info = "You are a member of a pirate crew. You pillage, kidnap, and steal for profit and pleasure. Although you recently moved into this system, it is owned by NanoTrasen. A Corporate presence provides plenty of opportunities for plunder, but beware! Certain areas are considered off limits, even to pirates. Only a fool would anger Nebula Gas by raiding their station, although NebGas vessels in transit are fair game. Attempting to visit NanoTrasen's primary facility is equally dangerous and ill-advised. Focusing on isolated vessels in flight or expeditions on planets may be the most reliable way to score precious booty. Proteans and Xenochimerae are currently excluded from being Pirates, if you own either Whitelist."
-	instantiator = /datum/ghostrole_instantiator/human/random/species/pirate
+	instantiator = /datum/ghostrole_instantiator/human/player_static/pirate
 
 /datum/role/ghostrole/pirate/Instantiate(client/C, atom/loc, list/params)
 	var/rp = rand(1, 3)
@@ -42,12 +42,12 @@
 			because you were born to be here, whether this is the band you started out with or not doesn't matter. All that matters to you is the job.</i>"
 	to_chat(created, flavour_text)
 
-/datum/ghostrole_instantiator/human/random/species/pirate
-	possible_species = list(
-		/datum/species/human
-	)
+/datum/ghostrole_instantiator/human/player_static/pirate
+	//species_restricted = /datum/species/protean
+	equip_loadout = FALSE
+	equip_traits = FALSE
 
-/datum/ghostrole_instantiator/human/random/species/pirate/GetOutfit(client/C, mob/M, list/params)
+/datum/ghostrole_instantiator/human/player_static/pirate/GetOutfit(client/C, mob/M, list/params)
 	var/datum/outfit/outfit = ..()
 	//var/mob/M = /mob/living/carbon/human/H
 	M.faction = "pirate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Ashlander players may now spawn in with their custom slots without admin intervention.**
2. **Pirates use the same system.**

## Why It's Good For The Game

1. _Following tons of requests, I have finally sat down and figured out the Player Static instantiator with Kevin's help. Players can now set up Scorian character slots and load in using them directly._
2. _The same as the above, but for pirates. Pirates necessarily have less racial restrictions. I want to blacklist certain races, but I'm having issues with the code._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Changes ghostrole spawning to allow slots.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
