### PR TITLE
Buckets Now Reflect When They're (Mostly) Full of Liquid

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -299,11 +299,18 @@
 	else
 		return ..()
 
+/obj/item/reagent_containers/glass/bucket/afterattack()
+	.=..()
+	update_icon()
+
 /obj/item/reagent_containers/glass/bucket/update_icon()
 	cut_overlays()
 	if (!is_open_container())
 		var/image/lid = image(icon, src, "lid_[initial(icon_state)]")
 		add_overlay(lid)
+	if (is_open_container() && reagents.total_volume > 100)
+		var/image/water = image(icon, src, "water_[initial(icon_state)]")
+		add_overlay(water)
 
 /obj/item/reagent_containers/glass/bucket/wood
 	desc = "An old wooden bucket."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Enables Overlay that Shows When a Bucket Has Liquid In It.**

## Why It's Good For The Game

1. _Just a nice little QOL thing. Or really just an aesthetic thing, really._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Enables check for water overlay on buckets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
