### PR TITLE
fixes chem dispensers not being used by silicons

### DIFF
--- a/code/modules/reagents/machinery/dispenser/dispenser.dm
+++ b/code/modules/reagents/machinery/dispenser/dispenser.dm
@@ -23,7 +23,7 @@
 	allow_unanchor = TRUE
 	allow_deconstruct = TRUE
 
-	interaction_flags_machine = INTERACT_MACHINE_OFFLINE | INTERACT_MACHINE_OPEN | INTERACT_MACHINE_OPEN_SILICON
+	interaction_flags_machine = INTERACT_MACHINE_OFFLINE | INTERACT_MACHINE_OPEN | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_ALLOW_SILICON
 
 	/// reagent synthesizers in us - set to list of typepaths to init on Initialize().
 	var/list/obj/item/reagent_synth/synthesizers
@@ -434,7 +434,7 @@
 		inserted = I
 		SStgui.update_uis(src)
 		return CLICKCHAIN_DO_NOT_PROPAGATE
-		
+
 	return ..()
 
 /obj/machinery/chemical_dispenser/proc/check_reagent_id(id)


### PR DESCRIPTION
we really need to have INTERACT_MACHINE_REMOTE_SILICON instead huh