### PR TITLE
adds a delay to translocators

### DIFF
--- a/code/modules/vore/fluffstuff/custom_items.dm
+++ b/code/modules/vore/fluffstuff/custom_items.dm
@@ -986,7 +986,7 @@
 	if(!teleport_checks(target,user))
 		return //The checks proc can send them a message if it wants.
 	
-	if(!do_after(user, 5 SECONDS, target))
+	if(user != target && !do_after(user, 5 SECONDS, target))
 		return
 
 	ready = FALSE

--- a/code/modules/vore/fluffstuff/custom_items.dm
+++ b/code/modules/vore/fluffstuff/custom_items.dm
@@ -985,6 +985,9 @@
 
 	if(!teleport_checks(target,user))
 		return //The checks proc can send them a message if it wants.
+	
+	if(!do_after(user, 5 SECONDS, target))
+		return
 
 	ready = FALSE
 	update_icon()


### PR DESCRIPTION
telescience update will deal with the rest
unfortunately people won't stop gaming with this so

:cl:
balance: translocators now have a 5 second activation delay when teleporting others
/:cl:
