### PR TITLE
Z-Mimic (and AO): Minor fixes

### DIFF
--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -261,7 +261,7 @@ SUBSYSTEM_DEF(overlays)
 /atom/movable/cut_overlay(list/overlays, priority)
 	..()
 	// If we removed an automangle-eligible overlay and have automangle enabled, reevaluate automangling.
-	if (!SSoverlays.context_needs_automangle || !(zmm_flags && ZMM_AUTOMANGLE))
+	if (!SSoverlays.context_needs_automangle || !(zmm_flags & ZMM_AUTOMANGLE))
 		return
 
 	var/list/cached_overlays = our_overlays

--- a/code/game/objects/effects/map_effects/portal.dm
+++ b/code/game/objects/effects/map_effects/portal.dm
@@ -50,6 +50,7 @@ when portals are shortly lived, or when portals are made to be obvious with spec
 	opacity = TRUE
 	plane = TURF_PLANE
 	layer = ABOVE_TURF_LAYER
+	zmm_flags = ZMM_IGNORE	// it ain't gonna work chief
 	SET_APPEARANCE_FLAGS(PIXEL_SCALE)
 
 	var/obj/effect/map_effect/portal/counterpart = null // The portal line or master that this is connected to, on the 'other side'.

--- a/code/game/objects/structures/map_blocker.dm
+++ b/code/game/objects/structures/map_blocker.dm
@@ -8,6 +8,7 @@
 	opacity = FALSE
 	density = TRUE
 	unacidable = TRUE
+	zmm_flags = ZMM_IGNORE
 
 /obj/effect/blocker/Initialize(mapload) // For non-gateway maps.
 	. = ..()

--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -275,6 +275,7 @@
 	opacity = TRUE
 	density = TRUE
 	blocks_air = TRUE
+	permit_ao = FALSE
 
 	/// The base iconstate to base sprites on
 	var/base_state = "light"

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -10,7 +10,7 @@
 		// The overlay will handle cleaning itself up on non-openspace turfs.
 		if (isturf(dest))
 			bound_overlay.forceMove(get_step(src, UP))
-			if (dir != bound_overlay.dir)
+			if (bound_overlay && dir != bound_overlay.dir)
 				bound_overlay.setDir(dir)
 		else	// Not a turf, so we need to destroy immediately instead of waiting for the destruction timer to proc.
 			qdel(bound_overlay)
@@ -69,6 +69,19 @@
 
 /atom/movable/openspace/can_fall()
 	return FALSE
+
+// No.
+/atom/movable/openspace/set_glide_size(new_glide_size, recursive)
+	return
+
+// This is an abstract object, we don't care about the move stack or throwing events.
+/atom/movable/openspace/Move()
+	if (bound_overlay)
+		bound_overlay.forceMove(get_step(src, UP))
+		// forceMove could've deleted our overlay
+		if (bound_overlay && bound_overlay.dir != dir)
+			bound_overlay.setDir(dir)
+	return TRUE
 
 // No blowing up abstract objects.
 /atom/movable/openspace/ex_act(ex_sev)

--- a/code/modules/multiz/zmimic/mimic_turf.dm
+++ b/code/modules/multiz/zmimic/mimic_turf.dm
@@ -1,23 +1,25 @@
 
-//! Reference to any open turf that might be above us to speed up atom Entered() updates.
-/turf/var/tmp/turf/above
-/turf/var/tmp/turf/below
-/// If we're a non-overwrite z-turf, this holds the appearance of the bottom-most Z-turf in the z-stack.
-/turf/var/tmp/atom/movable/openspace/turf_proxy/mimic_proxy
-/// Overlay used to multiply color of all OO overlays at once.
-/turf/var/tmp/atom/movable/openspace/multiplier/shadower
-/// If this is a delegate (non-overwrite) Z-turf with a z-turf above, this is the delegate copy that's copying us.
-/turf/var/tmp/atom/movable/openspace/turf_mimic/mimic_above_copy
-/// If we're at the bottom of the stack, a proxy used to fake a below space turf.
-/turf/var/tmp/atom/movable/openspace/turf_proxy/mimic_underlay
-/// How many times this turf is currently queued - multiple queue occurrences are allowed to ensure update consistency.
-/turf/var/tmp/z_queued = 0
-/// If this Z-turf leads to space, uninterrupted.
-/turf/var/tmp/z_eventually_space = FALSE
+/turf
+	/// The z-turf above us, if present.
+	var/tmp/turf/above
+	/// If we're a z-turf, the turf below us.
+	var/tmp/turf/below
+	/// If we're a non-overwrite z-turf, this holds the appearance of the bottom-most Z-turf in the z-stack.
+	var/tmp/atom/movable/openspace/turf_proxy/mimic_proxy
+	/// Overlay used to multiply color of all OO overlays at once.
+	var/tmp/atom/movable/openspace/multiplier/shadower
+	/// If this is a delegate (non-overwrite) Z-turf with a z-turf above, this is the delegate copy that's copying us.
+	var/tmp/atom/movable/openspace/turf_mimic/mimic_above_copy
+	/// If we're at the bottom of the stack, a proxy used to fake a below space turf.
+	var/tmp/atom/movable/openspace/turf_proxy/mimic_underlay
+	/// How many times this turf is currently queued - multiple queue occurrences are allowed to ensure update consistency.
+	var/tmp/z_queued = 0
+	/// If this Z-turf leads to space, uninterrupted.
+	var/tmp/z_eventually_space = FALSE
 
-//! debug
-/turf/var/tmp/z_depth
-/turf/var/tmp/z_generation = 0
+	//debug
+	var/tmp/z_depth
+	var/tmp/z_generation = 0
 
 /turf/update_above()
 	if (TURF_IS_MIMICKING(above))


### PR DESCRIPTION
- Fixes a runtime with ZM and move-up.
- Some types that don't make sense to mimic have been marked IGNORE.
- Mimics can no longer get wet from the pool.
- AO should no longer look weird around diagonal shuttle walls.