### PR TITLE
Double PDA fixes

### DIFF
--- a/code/modules/jobs/job_types/station/admin/centcom_officer.dm
+++ b/code/modules/jobs/job_types/station/admin/centcom_officer.dm
@@ -27,13 +27,13 @@
 
 /datum/outfit/job/station/centcom_officer
 	name = OUTFIT_JOB_NAME("CentCom Officer")
+	id_type = /obj/item/card/id/centcom
+	pda_type = /obj/item/pda/centcom
+
 	glasses = /obj/item/clothing/glasses/omnihud/all
 	uniform = /obj/item/clothing/under/rank/centcom
 	l_ear = /obj/item/radio/headset/centcom
 	shoes = /obj/item/clothing/shoes/laceup
-	id_type = /obj/item/card/id/centcom
 	belt = /obj/item/gun/energy/pulse_pistol
 	gloves = /obj/item/clothing/gloves/white
 	head = /obj/item/clothing/head/beret/centcom/officer
-	r_pocket = /obj/item/pda/centcom
-	id_pda_assignment = "CentCom Officer"

--- a/code/modules/jobs/job_types/station/admin/emergency_responder.dm
+++ b/code/modules/jobs/job_types/station/admin/emergency_responder.dm
@@ -26,15 +26,17 @@
 
 /datum/outfit/job/station/emergency_responder
 	name = OUTFIT_JOB_NAME("Emergency Responder")
+	id_type = /obj/item/card/id/centcom/ERT
+	pda_type = /obj/item/pda/centcom
+
 	uniform = /obj/item/clothing/under/ert
 	shoes = /obj/item/clothing/shoes/boots/swat
 	gloves = /obj/item/clothing/gloves/swat
 	l_ear = /obj/item/radio/headset/ert
 	glasses = /obj/item/clothing/glasses/sunglasses
+
 	back = /obj/item/storage/backpack/satchel
-	id_type = /obj/item/card/id/centcom/ERT
 	belt = /obj/item/gun/energy/pulse_pistol
-	r_pocket = /obj/item/pda/centcom
 	flags = OUTFIT_EXTENDED_SURVIVAL|OUTFIT_COMPREHENSIVE_SURVIVAL
 
 /datum/outfit/job/station/emergency_responder/post_equip(var/mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/station/service/botanist.dm
+++ b/code/modules/jobs/job_types/station/service/botanist.dm
@@ -31,7 +31,6 @@
 	uniform = /obj/item/clothing/under/rank/hydroponics
 	suit = /obj/item/clothing/suit/storage/apron
 	suit_store = /obj/item/analyzer/plant_analyzer
-	belt = /obj/item/pda/botanist
 	gloves = /obj/item/clothing/gloves/botanic_leather
 
 	backpack = /obj/item/storage/backpack/hydroponics


### PR DESCRIPTION
Fixes Botanist, CCO, and ERT spawning with two PDAs instead of one.