### PR TITLE
removes dumb assemblies debug message

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -138,7 +138,6 @@
 		var/obj/item/integrated_circuit/IC = I
 		/* Uncomment for debugging purposes. */
 		if(!IC)
-			TO_WORLD(SPAN_DEBUGERROR("Bad assembly_components entry in [src].  Has remove() been called incorrectly?"))
 			var/x = assembly_components.Find(null)
 			assembly_components.Cut(x,++x)
 			return


### PR DESCRIPTION
## About The Pull Request

before, the entire server would be notified if an assembly had a null value in its assembly_components list while it was checking its power consumption. although funny, this was also annoying. this pr stops it from doing that by just deleting that line

## Why It's Good For The Game

Bad assembly_components entry in [src].  Has remove() been called incorrectly?
