### PR TITLE
Fixes Shuttle Templates Missing 'No Alarm' APCs

### DIFF
--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -10,7 +10,7 @@
 		return
 	template = SSmapping.map_templates[map]
 
-	var/orientation = text2dir(input(usr, "Choose an orientation for this Map Template.", "Orientation") as null|anything in list("North", "South", "East", "West"))
+	var/orientation = text2dir(input(usr, "Choose an orientation for this Map Template. SOUTH IS THE DEFAULT.", "Orientation") as null|anything in list("North", "South", "East", "West"))
 	if(!orientation)
 		return
 
@@ -46,7 +46,7 @@
 		return
 	template = SSmapping.map_templates[map]
 
-	var/orientation = text2dir(input(usr, "Choose an orientation for this Map Template.", "Orientation") as null|anything in list("North", "South", "East", "West"))
+	var/orientation = text2dir(input(usr, "Choose an orientation for this Map Template. SOUTH IS THE DEFAULT.", "Orientation") as null|anything in list("North", "South", "East", "West"))
 	if(!orientation)
 		return
 

--- a/maps/templates/shuttles/overmaps/generic/bearcat.dmm
+++ b/maps/templates/shuttles/overmaps/generic/bearcat.dmm
@@ -60,7 +60,6 @@
 /obj/machinery/light,
 /obj/machinery/alarm/alarms_hidden{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -104,8 +103,7 @@
 /area/shuttle/bearcat/command_captain)
 "as" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -116,10 +114,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 28
 	},
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 1;
-	icon_state = "apc0"
-	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/comms)
 "at" = (
@@ -127,20 +122,16 @@
 /area/shuttle/bearcat/comms)
 "au" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 4;
-	icon_state = "apc0"
-	},
 /obj/machinery/light_switch{
 	pixel_x = 28
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/command)
 "av" = (
@@ -158,8 +149,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/door/airlock/voidcraft/vertical,
 /turf/simulated/floor/tiled/techmaint,
@@ -179,8 +169,7 @@
 /area/shuttle/bearcat/command)
 "ay" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/gun/energy/stunrevolver,
 /obj/structure/closet/cabinet,
@@ -214,7 +203,6 @@
 	},
 /obj/machinery/alarm/alarms_hidden{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 26
 	},
 /turf/simulated/floor/wood,
@@ -224,23 +212,20 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/door/airlock/voidcraft/vertical,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/command_captain)
 "aE" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/machinery/alarm/alarms_hidden{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 26
 	},
 /obj/structure/handrail{
@@ -253,8 +238,7 @@
 /area/shuttle/bearcat/comms)
 "aF" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -275,8 +259,7 @@
 /area/shuttle/bearcat/command)
 "aH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -308,20 +291,16 @@
 	},
 /obj/machinery/alarm/alarms_hidden{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/dock_central)
 "aM" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/table/woodentable,
 /obj/structure/cable{
@@ -349,8 +328,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/alarms_hidden{
-	dir = 4;
-	icon_state = "apc0"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/shuttle/bearcat/command_captain)
@@ -367,8 +345,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 4;
-	icon_state = "map"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/dock_central)
@@ -440,9 +417,7 @@
 /area/shuttle/bearcat/dock_central)
 "bc" = (
 /obj/machinery/light,
-/obj/structure/closet/crate{
-	dir = 2
-	},
+/obj/structure/closet/crate,
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/westleft,
 /turf/simulated/floor/tiled/techfloor,
@@ -533,8 +508,7 @@
 "br" = (
 /obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
-	dir = 4;
-	icon_state = "map_vent"
+	dir = 4
 	},
 /obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor/airlock_interior{
@@ -560,20 +534,16 @@
 /area/shuttle/bearcat/dock_port)
 "bt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/dock_port)
 "bu" = (
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 4;
-	icon_state = "apc0"
-	},
 /obj/structure/cable,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/dock_port)
 "bx" = (
@@ -598,9 +568,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 28
 	},
-/obj/structure/closet/crate{
-	dir = 2
-	},
+/obj/structure/closet/crate,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -608,14 +576,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/dock_central)
 "bA" = (
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 8;
-	icon_state = "apc0"
-	},
 /obj/structure/cable,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/dock_starboard)
 "bB" = (
@@ -691,8 +656,7 @@
 /area/shuttle/bearcat/dock_port)
 "bJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/wall/rshull,
 /area/shuttle/bearcat/dock_port)
@@ -701,8 +665,7 @@
 /area/shuttle/bearcat/dock_port)
 "bL" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/wall/rshull,
 /area/shuttle/bearcat/dock_starboard)
@@ -716,7 +679,6 @@
 "bN" = (
 /obj/machinery/alarm/alarms_hidden{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
@@ -745,15 +707,13 @@
 /area/shuttle/bearcat/crew_dorms)
 "bU" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/dock_central)
 "bV" = (
 /obj/machinery/alarm/alarms_hidden{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
@@ -763,8 +723,7 @@
 /area/shuttle/bearcat/dock_starboard)
 "bW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/dock_starboard)
@@ -772,16 +731,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/dock_starboard)
 "bY" = (
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 1;
-	icon_state = "apc0"
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/light_switch{
 	pixel_x = 28
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/dock_central)
 "bZ" = (
@@ -799,8 +755,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/dock_starboard)
@@ -861,12 +816,10 @@
 /area/shuttle/bearcat/dock_port)
 "cl" = (
 /obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
+	dir = 4
 	},
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/item/soap,
 /obj/machinery/light{
@@ -877,12 +830,10 @@
 "cm" = (
 /obj/structure/toilet,
 /obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
+	dir = 4
 	},
 /obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
+	dir = 8
 	},
 /obj/effect/debris/cleanable/dirt,
 /obj/machinery/light{
@@ -899,7 +850,6 @@
 	},
 /obj/machinery/alarm/alarms_hidden{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 26
 	},
 /obj/machinery/light{
@@ -919,7 +869,6 @@
 /obj/machinery/vending/snack,
 /obj/machinery/alarm/alarms_hidden{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -928,13 +877,10 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 1;
-	icon_state = "apc0"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/crew_saloon)
 "cr" = (
@@ -965,6 +911,9 @@
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
 /obj/structure/closet/walllocker/emerglocker/west,
+/obj/machinery/light_switch{
+	pixel_x = -25
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/crew_dorms)
 "cv" = (
@@ -977,7 +926,6 @@
 /obj/structure/closet,
 /obj/machinery/alarm/alarms_hidden{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 26
 	},
 /obj/item/clothing/suit/space/void/refurb,
@@ -1053,8 +1001,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 4;
-	icon_state = "map"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/crew_corridors)
@@ -1063,8 +1010,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/door/airlock/voidcraft/vertical,
 /turf/simulated/floor/tiled/techmaint,
@@ -1077,8 +1023,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/crew_dorms)
@@ -1098,28 +1043,23 @@
 /area/shuttle/bearcat/crew_dorms)
 "cM" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
+	dir = 4
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/crew_toilets)
 "cN" = (
 /obj/structure/toilet{
-	dir = 1;
-	icon_state = "toilet00"
+	dir = 1
 	},
 /obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
+	dir = 4
 	},
 /obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
+	dir = 8
 	},
 /obj/effect/debris/cleanable/dirt,
 /obj/machinery/light,
@@ -1131,13 +1071,10 @@
 /obj/machinery/light_switch{
 	pixel_y = -25
 	},
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 4;
-	icon_state = "apc0"
-	},
 /obj/structure/handrail{
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/crew_toilets)
 "cQ" = (
@@ -1276,13 +1213,10 @@
 "dg" = (
 /obj/effect/debris/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/light_switch{
-	pixel_x = -25
-	},
-/obj/machinery/power/apc/alarms_hidden,
 /obj/structure/handrail{
 	dir = 4
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/crew_dorms)
 "dh" = (
@@ -1398,10 +1332,7 @@
 /obj/structure/handrail{
 	dir = 4
 	},
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 4;
-	icon_state = "apc0"
-	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/crew_corridors)
 "dy" = (
@@ -1422,13 +1353,10 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 4;
-	icon_state = "apc0"
-	},
 /obj/structure/handrail{
 	dir = 8
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/crew_kitchen)
 "dC" = (
@@ -1442,7 +1370,6 @@
 /obj/effect/debris/cleanable/dirt,
 /obj/machinery/alarm/alarms_hidden{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /obj/structure/handrail{
@@ -1481,8 +1408,7 @@
 /area/shuttle/bearcat/crew_corridors)
 "dI" = (
 /obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
+	dir = 1
 	},
 /obj/machinery/sleep_console{
 	dir = 4
@@ -1538,8 +1464,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1554,7 +1479,6 @@
 	},
 /obj/machinery/alarm/alarms_hidden{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -1592,8 +1516,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/door/airlock/voidcraft/vertical,
 /turf/simulated/floor/tiled/techmaint,
@@ -1601,8 +1524,7 @@
 "dV" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
-	dir = 1;
-	icon_state = "pipe-t"
+	dir = 1
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/bearcat/maintenance_engine)
@@ -1647,8 +1569,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1667,10 +1588,7 @@
 /obj/item/storage/box/syringes,
 /obj/structure/cable,
 /obj/item/storage/firstaid,
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 8;
-	icon_state = "apc0"
-	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/crew_medbay)
 "ed" = (
@@ -1689,8 +1607,7 @@
 "ef" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	dir = 1;
-	icon_state = "pipe-t"
+	dir = 1
 	},
 /obj/machinery/light_switch{
 	pixel_x = 28
@@ -1711,14 +1628,13 @@
 /area/shuttle/bearcat/unused1)
 "ei" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/structure/handrail{
 	dir = 4
 	},
-/obj/machinery/power/apc/alarms_hidden,
 /obj/structure/cable,
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/plating,
 /area/shuttle/bearcat/maintenance_engine)
 "ej" = (
@@ -1733,8 +1649,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 4;
-	icon_state = "map"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -1772,7 +1687,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/alarm/alarms_hidden{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -1790,13 +1704,10 @@
 "eu" = (
 /obj/effect/debris/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 4;
-	icon_state = "apc0"
-	},
 /obj/structure/handrail{
 	dir = 8
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/cargo)
 "ev" = (
@@ -1856,8 +1767,7 @@
 /obj/effect/debris/cleanable/dirt,
 /obj/effect/debris/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 8;
-	icon_state = "map"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/crew_corridors)
@@ -1877,17 +1787,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/dock_central)
 "eI" = (
-/obj/structure/closet/crate{
-	dir = 2
-	},
+/obj/structure/closet/crate,
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/westleft,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/dock_central)
 "eJ" = (
-/obj/structure/closet/crate{
-	dir = 2
-	},
+/obj/structure/closet/crate,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -1900,8 +1806,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 4;
-	icon_state = "map"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/crew_corridors)
@@ -1915,16 +1820,14 @@
 /area/shuttle/bearcat/maintenance_storage)
 "eM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/door/airlock/voidcraft/vertical,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/crew_medbay)
 "eN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/crew_medbay)
@@ -1934,7 +1837,6 @@
 	},
 /obj/machinery/alarm/alarms_hidden{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -1975,13 +1877,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 1;
-	icon_state = "apc0"
-	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/unused1)
 "eU" = (
@@ -2115,8 +2013,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 8;
-	icon_state = "map"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/maintenance_storage)
@@ -2142,7 +2039,6 @@
 /obj/item/clothing/head/helmet/space/void/refurb/engineering,
 /obj/machinery/alarm/alarms_hidden{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 26
 	},
 /obj/item/storage/belt/utility/full,
@@ -2167,7 +2063,6 @@
 /area/shuttle/bearcat/unused2)
 "fp" = (
 /obj/machinery/atmospherics/pipe/simple{
-	dir = 2;
 	icon_state = "intact";
 	level = 2
 	},
@@ -2185,8 +2080,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 4;
-	icon_state = "map"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/crew_corridors)
@@ -2221,8 +2115,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 4;
-	icon_state = "map"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -2259,8 +2152,7 @@
 /area/shuttle/bearcat/crew_wash)
 "fz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 8;
-	icon_state = "map"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -2276,7 +2168,6 @@
 /obj/structure/cable,
 /obj/machinery/alarm/alarms_hidden{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /obj/machinery/power/apc/alarms_hidden,
@@ -2310,8 +2201,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/structure/handrail{
 	dir = 1
@@ -2324,24 +2214,20 @@
 	icon_state = "conpipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/light,
 /obj/structure/closet/walllocker/emerglocker/south,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/crew_corridors)
 "fG" = (
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 1;
-	icon_state = "apc0"
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/unused2)
 "fH" = (
@@ -2366,8 +2252,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/crew_wash)
@@ -2376,8 +2261,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/door/airlock/voidcraft/vertical,
 /turf/simulated/floor/tiled/techmaint,
@@ -2385,23 +2269,20 @@
 "fM" = (
 /obj/effect/debris/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/crew_corridors)
 "fN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/handrail,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/crew_corridors)
 "fO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2411,8 +2292,7 @@
 /area/shuttle/bearcat/unused2)
 "fP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2436,7 +2316,7 @@
 /area/shuttle/bearcat/unused2)
 "fS" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/alarms_hidden,
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/crew_wash)
 "fT" = (
@@ -2463,8 +2343,7 @@
 /area/shuttle/bearcat/maintenance_power)
 "fW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/handrail,
 /obj/structure/cable{
@@ -2474,8 +2353,7 @@
 /area/shuttle/bearcat/crew_corridors)
 "fX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2491,8 +2369,7 @@
 /area/shuttle/bearcat/maintenance_atmos)
 "fZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 1
@@ -2505,8 +2382,7 @@
 /area/shuttle/bearcat/crew_corridors)
 "ga" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/structure/handrail{
 	dir = 1
@@ -2536,10 +2412,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 1;
-	icon_state = "apc0"
-	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/maintenance_enginecontrol)
 "gf" = (
@@ -2548,7 +2421,6 @@
 	},
 /obj/machinery/alarm/alarms_hidden{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2665,8 +2537,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 1;
-	icon_state = "map"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/maintenance_enginecontrol)
@@ -2675,8 +2546,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/maintenance_enginecontrol)
@@ -2746,8 +2616,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/door/airlock/voidcraft/vertical,
 /obj/structure/sign/nosmoking_2{
@@ -2761,8 +2630,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/maintenance_enginecontrol)
@@ -2802,8 +2670,7 @@
 /area/shuttle/bearcat/maintenance_enginecontrol)
 "gI" = (
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/cable{
@@ -2865,13 +2732,10 @@
 	icon_state = "conpipe-c"
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/alarms_hidden,
 /obj/structure/handrail{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_y = -22
-	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/plating,
 /area/shuttle/bearcat/maintenance_atmos)
 "gP" = (
@@ -2889,7 +2753,6 @@
 	},
 /obj/machinery/alarm/alarms_hidden{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /turf/simulated/floor/plating,
@@ -2922,8 +2785,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/computer/ship/engines{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/maintenance_enginecontrol)
@@ -2951,23 +2813,19 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/maintenance_enginecontrol)
 "gW" = (
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 8;
-	icon_state = "apc0"
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
-	},
-/obj/machinery/alarm/alarms_hidden{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -26
 	},
 /obj/structure/handrail{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
+/obj/machinery/alarm/alarms_hidden{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/bearcat/maintenance_power)
@@ -3012,8 +2870,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 8;
-	icon_state = "map"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -3094,8 +2951,7 @@
 /area/shuttle/bearcat/maintenance_engine)
 "hr" = (
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_x = 0
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/bearcat/maintenance_engine)
@@ -3119,8 +2975,7 @@
 	dir = 9
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/structure/sign/signnew/flammables{
 	pixel_x = 32
@@ -3156,8 +3011,7 @@
 /area/shuttle/bearcat/command)
 "hB" = (
 /obj/machinery/atmospherics/pipe/tank/air{
-	dir = 1;
-	icon_state = "air_map"
+	dir = 1
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/bearcat/dock_port)
@@ -3180,13 +3034,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/bearcat/crew_medbay)
 "jN" = (
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 1;
-	icon_state = "apc0"
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/plating,
 /area/shuttle/bearcat/maintenance_engine_pod_starboard)
 "kD" = (
@@ -3222,8 +3073,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/structure/sign/signnew/flammables{
 	pixel_x = 32
@@ -3323,7 +3173,6 @@
 "Ea" = (
 /obj/machinery/alarm/alarms_hidden{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -26
 	},
 /obj/structure/cable{
@@ -3336,13 +3185,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/crew_corridors)
 "Fe" = (
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 1;
-	icon_state = "apc0"
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/plating,
 /area/shuttle/bearcat/maintenance_engine_pod_port)
 "FG" = (
@@ -3371,8 +3217,7 @@
 "Hu" = (
 /obj/machinery/atmospherics/valve/open,
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/sign/signnew/flammables{
 	pixel_x = -32
@@ -3382,7 +3227,6 @@
 "Ik" = (
 /obj/machinery/alarm/alarms_hidden{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /obj/structure/closet/firecloset/full,
@@ -3434,6 +3278,13 @@
 "MV" = (
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/bearcat/maintenance_engine_pod_port)
+"OY" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/item/radio/intercom{
+	pixel_y = -22
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/bearcat/maintenance_atmos)
 "SJ" = (
 /obj/structure/sign/department/eng,
 /turf/simulated/wall/rshull,
@@ -3495,8 +3346,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3518,8 +3368,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 8;
-	icon_state = "map"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/bearcat/crew_corridors)
@@ -3948,7 +3797,7 @@ fS
 ep
 gl
 gz
-gN
+OY
 ep
 aa
 aa

--- a/maps/templates/shuttles/overmaps/generic/cruise_ship.dmm
+++ b/maps/templates/shuttles/overmaps/generic/cruise_ship.dmm
@@ -511,10 +511,10 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/shuttle/cruise_ship/bedroom)
 "Sx" = (
-/obj/machinery/power/apc/alarms_hidden/west_bump,
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/wood,
 /area/shuttle/cruise_ship)
 "Ub" = (
@@ -581,10 +581,10 @@
 /turf/simulated/floor/wood,
 /area/shuttle/cruise_ship/bedroom)
 "YT" = (
-/obj/machinery/power/apc/alarms_hidden/south_bump,
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/wood,
 /area/shuttle/cruise_ship/bedroom)
 "Za" = (

--- a/maps/templates/shuttles/overmaps/generic/cruiser.dmm
+++ b/maps/templates/shuttles/overmaps/generic/cruiser.dmm
@@ -350,15 +350,10 @@
 /obj/random/mre,
 /obj/random/mre,
 /obj/random/mre,
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list(67)
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/wood,
 /area/mothership/breakroom)
 "aR" = (
@@ -487,15 +482,10 @@
 /obj/item/material/minihoe,
 /obj/item/material/knife,
 /obj/item/material/knife,
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/steel_grid,
 /area/mothership/hydroponics)
 "bn" = (
@@ -931,13 +921,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/mothership/kitchen)
 "ck" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list(67)
-	},
 /obj/structure/cable/cyan,
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/white,
 /area/mothership/kitchen)
 "cl" = (
@@ -1366,15 +1351,10 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/mothership/eva)
 "dd" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list(67)
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/steel_grid,
 /area/mothership/eva)
 "de" = (
@@ -1565,16 +1545,11 @@
 /obj/structure/toilet{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list(67)
-	},
 /obj/structure/cable/cyan,
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/mothership/bathroom1)
 "dw" = (
@@ -1640,16 +1615,11 @@
 /obj/structure/toilet{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list(67)
-	},
 /obj/structure/cable/cyan,
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/mothership/bathroom2)
 "dH" = (
@@ -1808,12 +1778,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/mothership/teleporter)
 "ee" = (
@@ -1979,18 +1944,13 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list(67)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/wood,
 /area/mothership/dorm1)
 "eu" = (
@@ -2094,12 +2054,6 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/mothership/dorm2)
 "eD" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list(67)
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
@@ -2109,6 +2063,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/wood,
 /area/mothership/dorm2)
 "eE" = (
@@ -2772,17 +2727,12 @@
 /turf/simulated/floor/tiled/white,
 /area/mothership/surgery)
 "gd" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/white,
 /area/mothership/surgery)
 "ge" = (
@@ -2812,12 +2762,6 @@
 /turf/simulated/floor/tiled/white,
 /area/mothership/chemistry)
 "gg" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
@@ -2825,6 +2769,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/white,
 /area/mothership/chemistry)
 "gh" = (
@@ -3264,12 +3209,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list(67)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3277,6 +3216,7 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/pathfinder,
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/steel_grid,
 /area/mothership/security)
 "hj" = (
@@ -3461,18 +3401,13 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/wood,
 /area/mothership/dorm3)
 "hK" = (
@@ -3526,18 +3461,13 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/wood,
 /area/mothership/dorm4)
 "hO" = (
@@ -3995,14 +3925,8 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	cell_type = /obj/item/cell/super;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
 /obj/structure/cable/cyan,
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/steel_grid,
 /area/mothership/processing)
 "iS" = (
@@ -4089,17 +4013,11 @@
 /turf/simulated/floor/tiled/white,
 /area/mothership/resleeving)
 "jf" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	cell_type = /obj/item/cell/super;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/mothership/morgue)
 "jg" = (
@@ -4306,18 +4224,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/mothership/sechallway)
 "jB" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
 /obj/structure/cable/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/steel_grid,
 /area/mothership/sechallway)
 "jC" = (
@@ -4367,15 +4280,10 @@
 /turf/simulated/floor/tiled/white,
 /area/mothership/resleeving)
 "jL" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/white,
 /area/mothership/resleeving)
 "jM" = (
@@ -4872,14 +4780,8 @@
 	},
 /obj/item/book/manual/security_space_law,
 /obj/structure/closet/secure_closet/nanotrasen_warden,
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	cell_type = /obj/item/cell/super;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
 /obj/structure/cable/cyan,
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/steel_grid,
 /area/mothership/warden)
 "kM" = (
@@ -4995,18 +4897,13 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list(67)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/wood,
 /area/mothership/dorm5)
 "kX" = (
@@ -5060,18 +4957,13 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list(67)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/wood,
 /area/mothership/dorm6)
 "lb" = (
@@ -5159,16 +5051,11 @@
 /turf/simulated/floor/tiled/white,
 /area/mothership/medical)
 "ll" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
 /obj/structure/cable/cyan,
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/white,
 /area/mothership/medical)
 "lo" = (
@@ -5690,13 +5577,8 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/mothership/rnd)
 "mp" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/cable/cyan,
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/steel_grid,
 /area/mothership/rnd)
 "mq" = (
@@ -5956,12 +5838,6 @@
 /turf/simulated/wall/rpshull,
 /area/mothership/rnd)
 "mU" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/cable/cyan,
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
@@ -5969,6 +5845,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techmaint,
 /area/mothership/hallway)
 "mV" = (
@@ -5993,15 +5870,10 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/steel_grid,
 /area/mothership/bridge)
 "mZ" = (
@@ -6581,18 +6453,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/mothership/armory)
 "oa" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list(67)
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/steel_grid,
 /area/mothership/armory)
 "ob" = (
@@ -6957,17 +6824,13 @@
 /turf/simulated/floor/bluegrid,
 /area/mothership/robotics)
 "oR" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	name = "south bump";
-	pixel_y = -28
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/mothership/robotics)
 "oS" = (
@@ -7067,12 +6930,6 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/mothership/holodeck)
 "pc" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list(67)
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
@@ -7082,6 +6939,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/mothership/holodeck)
 "pd" = (
@@ -7198,12 +7056,6 @@
 /turf/simulated/floor/greengrid,
 /area/mothership/telecomms1)
 "py" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
@@ -7213,6 +7065,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techmaint,
 /area/mothership/telecomms1)
 "pz" = (
@@ -7362,12 +7215,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/mothership/telecomms2)
 "pN" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
@@ -7377,6 +7224,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techmaint,
 /area/mothership/telecomms2)
 "pO" = (
@@ -7765,13 +7613,8 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list(67)
-	},
 /obj/structure/cable/cyan,
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/mothership/cryotube)
 "qZ" = (
@@ -7827,12 +7670,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/steel_grid,
 /area/mothership/engineering)
 "rf" = (

--- a/maps/templates/shuttles/overmaps/generic/curashuttle.dmm
+++ b/maps/templates/shuttles/overmaps/generic/curashuttle.dmm
@@ -97,8 +97,7 @@
 /area/shuttle/curabitur/curashuttle/cockpit)
 "an" = (
 /obj/machinery/computer/shuttle_control/explore/curashuttle{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/shuttle/curabitur/curashuttle/cockpit)
@@ -112,12 +111,6 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24;
-	pixel_y = 0
-	},
 /obj/structure/table/darkglass,
 /obj/item/paper_bin{
 	pixel_x = 8;
@@ -129,6 +122,7 @@
 	name = "curabitur fax machine";
 	pixel_y = 6
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/carpet/bcarpet,
 /area/shuttle/curabitur/curashuttle/cockpit)
 "aq" = (
@@ -176,15 +170,13 @@
 	icon_state = "1-2"
 	},
 /obj/structure/bed/chair/bay/comfy{
-	dir = 1;
-	icon_state = "bay_comfychair_preview"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/shuttle/curabitur/curashuttle/cockpit)
 "ax" = (
 /obj/machinery/computer/ship/engines{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 4;
@@ -248,18 +240,14 @@
 /area/shuttle/curabitur/curashuttle/med)
 "aE" = (
 /obj/machinery/computer/ship/sensors{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -29;
-	pixel_y = 0
+	pixel_x = -29
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 8
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/shuttle/curabitur/curashuttle/cockpit)
@@ -335,13 +323,10 @@
 "aJ" = (
 /obj/machinery/sleep_console{
 	dir = 2;
-	icon_state = "sleeperconsole";
 	pixel_x = -1
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/curabitur/curashuttle/med)
@@ -362,8 +347,7 @@
 	dir = 8;
 	frequency = 1480;
 	id_tag = "curadocking";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/curabitur/curashuttle/med)
@@ -376,8 +360,7 @@
 	req_access = newlist()
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/curabitur/curashuttle/med)
@@ -499,8 +482,7 @@
 /area/shuttle/curabitur/curashuttle/cockpit)
 "aY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 6;
-	icon_state = "intact"
+	dir = 6
 	},
 /obj/structure/table/standard,
 /obj/fiftyspawner/steel,
@@ -527,9 +509,7 @@
 "ba" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 31;
@@ -698,8 +678,7 @@
 /area/shuttle/curabitur/curashuttle/med)
 "bs" = (
 /obj/structure/bed/chair/bay/comfy{
-	dir = 8;
-	icon_state = "bay_comfychair_preview"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/curabitur/curashuttle/med)
@@ -768,21 +747,11 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28;
-	pixel_y = 0
-	},
-/obj/machinery/power/terminal{
-	dir = 8;
-	icon_state = "term"
-	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/curabitur/curashuttle/med)
 "bC" = (
 /obj/structure/sign/department/eng{
-	pixel_x = 0;
 	pixel_y = -31
 	},
 /obj/structure/table/standard,
@@ -816,8 +785,7 @@
 /area/shuttle/curabitur/curashuttle/med)
 "bE" = (
 /obj/structure/bed/chair/sofa/teal/left{
-	dir = 1;
-	icon_state = "sofaend_left"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -840,12 +808,10 @@
 "bF" = (
 /obj/machinery/vending/wallmed1/public{
 	dir = 1;
-	icon_state = "wallmed";
 	pixel_y = -28
 	},
 /obj/structure/bed/chair/sofa/teal{
-	dir = 1;
-	icon_state = "sofamiddle"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -866,8 +832,7 @@
 	pixel_y = -32
 	},
 /obj/structure/bed/chair/sofa/teal{
-	dir = 1;
-	icon_state = "sofamiddle"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -886,12 +851,10 @@
 "bH" = (
 /obj/machinery/vending/wallmed1/public{
 	dir = 1;
-	icon_state = "wallmed";
 	pixel_y = -29
 	},
 /obj/structure/bed/chair/sofa/teal/right{
-	dir = 1;
-	icon_state = "sofaend_right"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -918,8 +881,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4;
-	icon_state = "map-scrubbers"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
@@ -954,8 +916,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/component/binary/pump/fuel{
-	dir = 8;
-	icon_state = "map_off-fuel"
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/curabitur/curashuttle/med)
@@ -969,8 +930,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8;
-	icon_state = "intact-fuel"
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/curabitur/curashuttle/med)
@@ -984,8 +944,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8;
-	icon_state = "intact-fuel"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/curabitur/curashuttle/med)
@@ -1029,7 +988,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/structure/cable{
@@ -1056,8 +1014,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 9;
-	icon_state = "intact-supply"
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
@@ -1157,8 +1114,7 @@
 /area/shuttle/curabitur/curashuttle/eng)
 "cf" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
-	dir = 4;
-	icon_state = "map-scrubbers"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/curabitur/curashuttle/eng)
@@ -1178,12 +1134,10 @@
 "cj" = (
 /obj/machinery/mech_recharger,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	icon_state = "intact-supply"
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	icon_state = "intact-scrubbers"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/curabitur/curashuttle/hangar)
@@ -1291,8 +1245,7 @@
 /area/shuttle/curabitur/curashuttle/eng)
 "cx" = (
 /obj/machinery/computer/ship/engines{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/curabitur/curashuttle/eng)
@@ -1311,9 +1264,7 @@
 "cA" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/structure/handrail{
@@ -1325,7 +1276,6 @@
 /obj/machinery/light,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -1396,7 +1346,6 @@
 	health = 200;
 	max_equip = 1;
 	max_hull_equip = 2;
-	max_special_equip = 1;
 	max_universal_equip = 2;
 	max_utility_equip = 3;
 	maxhealth = 200;
@@ -1426,8 +1375,7 @@
 /area/shuttle/curabitur/curashuttle/eng)
 "cP" = (
 /obj/machinery/ion_engine{
-	dir = 1;
-	icon_state = "nozzle"
+	dir = 1
 	},
 /turf/space,
 /turf/simulated/shuttle/plating/airless/carry,

--- a/maps/templates/shuttles/overmaps/generic/gecko_cr.dmm
+++ b/maps/templates/shuttles/overmaps/generic/gecko_cr.dmm
@@ -191,14 +191,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/gecko_cr_cockpit)
 "eP" = (
@@ -939,16 +935,12 @@
 /area/shuttle/gecko_cr_engineering)
 "sV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/machinery/meter,
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/plating,
 /area/shuttle/gecko_cr)
 "te" = (
@@ -1194,9 +1186,7 @@
 /obj/structure/fuel_port/heavy{
 	pixel_y = 28
 	},
-/obj/structure/closet/crate{
-	dir = 2
-	},
+/obj/structure/closet/crate,
 /obj/item/tool/crowbar/red,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
@@ -2032,14 +2022,10 @@
 /area/shuttle/gecko_cr_engineering)
 "LW" = (
 /obj/structure/handrail,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/gecko_cr_engineering)
 "Mf" = (

--- a/maps/templates/shuttles/overmaps/generic/gecko_sh.dmm
+++ b/maps/templates/shuttles/overmaps/generic/gecko_sh.dmm
@@ -3,14 +3,10 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/gecko_sh_engineering)
 "aF" = (
@@ -274,14 +270,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/gecko_sh_cockpit)
 "eP" = (
@@ -1121,9 +1113,7 @@
 /obj/structure/fuel_port/heavy{
 	pixel_y = 28
 	},
-/obj/structure/closet/crate{
-	dir = 2
-	},
+/obj/structure/closet/crate,
 /obj/item/tool/crowbar/red,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
@@ -1226,15 +1216,11 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/structure/railing/grey,
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/gecko_sh)
 "zM" = (

--- a/maps/templates/shuttles/overmaps/generic/generic_shuttle.dmm
+++ b/maps/templates/shuttles/overmaps/generic/generic_shuttle.dmm
@@ -57,11 +57,9 @@
 /area/shuttle/generic_shuttle/gen)
 "aj" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 8
 	},
 /obj/machinery/button/remote/airlock{
@@ -75,11 +73,9 @@
 /area/shuttle/generic_shuttle/gen)
 "ak" = (
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 4
 	},
 /obj/machinery/button/remote/airlock{
@@ -96,7 +92,6 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 6
 	},
 /turf/simulated/floor/wood,
@@ -105,7 +100,6 @@
 /obj/structure/table/standard,
 /obj/machinery/recharger,
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -201,7 +195,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 9
 	},
 /turf/simulated/floor/tiled{
@@ -210,7 +203,6 @@
 /area/shuttle/generic_shuttle/gen)
 "av" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
@@ -220,8 +212,7 @@
 /area/shuttle/generic_shuttle/gen)
 "aw" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
@@ -248,7 +239,6 @@
 	req_one_access = newlist()
 	},
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -264,7 +254,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central6{
-	icon_state = "steel_decals_central6";
 	dir = 4
 	},
 /turf/simulated/floor/tiled{
@@ -273,7 +262,6 @@
 /area/shuttle/generic_shuttle/gen)
 "aC" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/tiled{
@@ -300,7 +288,6 @@
 /area/shuttle/generic_shuttle/gen)
 "aF" = (
 /obj/machinery/computer/ship/sensors{
-	icon_state = "computer";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor/orange{
@@ -310,14 +297,12 @@
 /area/shuttle/generic_shuttle/gen)
 "aG" = (
 /obj/structure/bed/chair/bay/comfy/green{
-	icon_state = "bay_comfychair_preview";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/generic_shuttle/gen)
 "aH" = (
 /obj/machinery/computer/ship/engines{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/effect/floor_decal/techfloor/orange{
@@ -411,7 +396,6 @@
 /area/shuttle/generic_shuttle/gen)
 "aT" = (
 /obj/structure/bed/chair/bay/chair{
-	icon_state = "bay_chair_preview";
 	dir = 1
 	},
 /turf/simulated/floor/tiled{
@@ -470,7 +454,6 @@
 /area/shuttle/generic_shuttle/gen)
 "aZ" = (
 /obj/structure/bed/chair/bay/chair{
-	icon_state = "bay_chair_preview";
 	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10,
@@ -508,11 +491,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -28
-	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled{
 	icon_state = "monotile"
 	},
@@ -527,7 +506,6 @@
 /area/shuttle/generic_shuttle/gen)
 "bf" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 4
 	},
 /turf/simulated/floor/tiled{
@@ -559,7 +537,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 8
 	},
 /turf/simulated/floor/tiled{
@@ -571,7 +548,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 8
 	},
 /turf/simulated/floor/tiled{
@@ -586,8 +562,7 @@
 /area/shuttle/generic_shuttle/gen)
 "bk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4;
-	icon_state = "map"
+	dir = 4
 	},
 /turf/simulated/wall/shull,
 /area/shuttle/generic_shuttle/gen)
@@ -694,7 +669,6 @@
 /area/shuttle/generic_shuttle/eng)
 "bv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/table/standard,
@@ -719,7 +693,6 @@
 /area/shuttle/generic_shuttle/eng)
 "by" = (
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -728,12 +701,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 28
-	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/plating,
 /area/shuttle/generic_shuttle/eng)
 "bz" = (
@@ -741,7 +709,6 @@
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -779,7 +746,6 @@
 /area/shuttle/generic_shuttle/eng)
 "bE" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -790,7 +756,6 @@
 /area/shuttle/generic_shuttle/eng)
 "bG" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -819,15 +784,13 @@
 "bK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/generic_shuttle/eng)
 "bL" = (
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/table/standard,
 /obj/item/storage/box/metalfoam,
@@ -920,7 +883,6 @@
 "gZ" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
-	destroy_hits = 10;
 	dir = 4;
 	icon_state = "pdoor0";
 	id = "generic_dorm2_blast";
@@ -930,9 +892,7 @@
 /turf/template_noop,
 /area/shuttle/generic_shuttle/gen)
 "jV" = (
-/obj/machinery/shipsensors{
-	dir = 2
-	},
+/obj/machinery/shipsensors,
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 4
 	},
@@ -949,7 +909,6 @@
 "Ue" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
-	destroy_hits = 10;
 	dir = 4;
 	icon_state = "pdoor0";
 	id = "generic_dorm1_blast";

--- a/maps/templates/shuttles/overmaps/generic/hybridshuttle.dmm
+++ b/maps/templates/shuttles/overmaps/generic/hybridshuttle.dmm
@@ -7,28 +7,18 @@
 /area/shuttle/blue_fo)
 "ac" = (
 /obj/structure/railing{
-	icon_state = "railing0";
 	dir = 1
 	},
-/obj/item/stack/flag/blue,
-/turf/space,
+/turf/simulated/shuttle/wall/alien,
 /area/shuttle/blue_fo)
 "ad" = (
-/obj/machinery/ion_engine,
-/obj/item/stack/flag/blue{
-	dir = 8
+/obj/machinery/ion_engine{
+	dir = 1
 	},
 /turf/space,
 /area/shuttle/blue_fo)
 "ae" = (
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/blue_fo)
-"af" = (
-/obj/machinery/ion_engine,
-/obj/item/stack/flag/blue{
-	dir = 4
-	},
-/turf/space,
 /area/shuttle/blue_fo)
 "ag" = (
 /obj/structure/table/alien/blue,
@@ -62,7 +52,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -80,7 +69,6 @@
 "al" = (
 /obj/machinery/light,
 /obj/structure/bed/chair/bay/shuttle{
-	icon_state = "shuttle_chair_preview";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -95,40 +83,25 @@
 "an" = (
 /obj/machinery/light,
 /obj/structure/handrail{
-	icon_state = "handrail";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/blue_fo)
 "ao" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/blue_fo)
-"ap" = (
-/obj/item/stack/flag/blue,
-/turf/space,
-/area/shuttle/blue_fo)
 "aq" = (
 /obj/machinery/door/airlock/alien/blue,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/blue_fo)
-"ar" = (
-/obj/structure/fans/tiny,
-/obj/structure/window/reinforced/full,
-/obj/item/stack/flag/blue{
-	dir = 8
-	},
-/turf/space,
 /area/shuttle/blue_fo)
 "as" = (
 /obj/machinery/sleeper{
 	dir = 8
 	},
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -136,32 +109,27 @@
 "at" = (
 /obj/machinery/sleep_console,
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/blue_fo)
 "au" = (
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/blue_fo)
 "av" = (
 /obj/effect/floor_decal/techfloor/orange/corner{
-	icon_state = "techfloororange_corners";
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor/orange/corner{
-	icon_state = "techfloororange_corners";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/blue_fo)
 "aw" = (
 /obj/structure/railing{
-	icon_state = "railing0";
 	dir = 8
 	},
 /obj/structure/railing,
@@ -169,7 +137,6 @@
 /area/shuttle/blue_fo)
 "ax" = (
 /obj/structure/railing{
-	icon_state = "railing0";
 	dir = 4
 	},
 /obj/structure/railing,
@@ -177,53 +144,35 @@
 /area/shuttle/blue_fo)
 "ay" = (
 /obj/effect/floor_decal/techfloor/orange/corner{
-	icon_state = "techfloororange_corners";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor/orange/corner{
-	icon_state = "techfloororange_corners";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/blue_fo)
 "az" = (
-/obj/structure/bed/chair/sofa/right{
-	sofa_material = "black"
-	},
+/obj/structure/bed/chair/sofa/right,
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/blue_fo)
 "aA" = (
-/obj/structure/bed/chair/sofa/left{
-	sofa_material = "black"
-	},
+/obj/structure/bed/chair/sofa/left,
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/blue_fo)
 "aB" = (
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/blue_fo)
-"aC" = (
-/obj/structure/fans/tiny,
-/obj/structure/window/reinforced/full,
-/obj/item/stack/flag/blue{
-	dir = 4
-	},
-/turf/space,
-/area/shuttle/blue_fo)
 "aD" = (
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -255,7 +204,6 @@
 /area/shuttle/blue_fo)
 "aJ" = (
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 4
 	},
 /obj/machinery/recharge_station,
@@ -266,7 +214,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -283,54 +230,44 @@
 "aN" = (
 /obj/effect/floor_decal/techfloor/orange/corner,
 /obj/effect/floor_decal/techfloor/orange/corner{
-	icon_state = "techfloororange_corners";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/blue_fo)
 "aO" = (
 /obj/structure/railing{
-	icon_state = "railing0";
 	dir = 8
 	},
 /obj/structure/railing{
-	icon_state = "railing0";
 	dir = 1
 	},
 /turf/simulated/shuttle/floor/alien,
 /area/shuttle/blue_fo)
 "aP" = (
 /obj/structure/railing{
-	icon_state = "railing0";
 	dir = 4
 	},
 /obj/structure/railing{
-	icon_state = "railing0";
 	dir = 1
 	},
 /turf/simulated/shuttle/floor/alien,
 /area/shuttle/blue_fo)
 "aQ" = (
 /obj/structure/bed/chair/sofa/left{
-	dir = 1;
-	icon_state = "sofaend_left";
-	sofa_material = "black"
+	dir = 1
 	},
 /obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/blue_fo)
 "aR" = (
 /obj/structure/bed/chair/sofa/right{
-	dir = 1;
-	icon_state = "sofaend_right";
-	sofa_material = "black"
+	dir = 1
 	},
 /obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/blue_fo)
 "aS" = (
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -338,11 +275,9 @@
 "aT" = (
 /obj/machinery/door/airlock/alien/blue,
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -350,18 +285,15 @@
 "aU" = (
 /obj/machinery/door/airlock/alien/blue,
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 8
 	},
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/blue_fo)
 "aV" = (
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 9
 	},
 /obj/structure/closet/secure_closet/guncabinet/excursion,
@@ -369,7 +301,6 @@
 /area/shuttle/blue_fo)
 "aW" = (
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 1
 	},
 /obj/structure/table/alien/blue,
@@ -377,7 +308,6 @@
 /area/shuttle/blue_fo)
 "aX" = (
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 1
 	},
 /obj/machinery/recharger/wallcharger{
@@ -392,18 +322,15 @@
 /area/shuttle/blue_fo)
 "aY" = (
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 1
 	},
 /obj/structure/bed/chair/bay/shuttle{
-	icon_state = "shuttle_chair_preview";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/blue_fo)
 "aZ" = (
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 1
 	},
 /obj/structure/table/alien/blue,
@@ -419,11 +346,9 @@
 /area/shuttle/blue_fo)
 "ba" = (
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 1
 	},
 /obj/structure/bed/chair/bay/shuttle{
-	icon_state = "shuttle_chair_preview";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -431,14 +356,12 @@
 "bb" = (
 /obj/structure/prop/alien/computer,
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/blue_fo)
 "bc" = (
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 5
 	},
 /obj/structure/bed/chair/bay/shuttle,
@@ -446,11 +369,9 @@
 /area/shuttle/blue_fo)
 "bd" = (
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 8
 	},
 /obj/structure/bed/chair/bay/shuttle{
-	icon_state = "shuttle_chair_preview";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -461,7 +382,6 @@
 /area/shuttle/blue_fo)
 "bf" = (
 /obj/structure/bed/chair/bay/shuttle{
-	icon_state = "shuttle_chair_preview";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -480,14 +400,12 @@
 /area/shuttle/blue_fo)
 "bh" = (
 /obj/structure/bed/chair/bay/shuttle{
-	icon_state = "shuttle_chair_preview";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/blue_fo)
 "bi" = (
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 4
 	},
 /obj/structure/table/alien/blue,
@@ -504,11 +422,9 @@
 /area/shuttle/blue_fo)
 "bk" = (
 /obj/effect/floor_decal/techfloor/orange/corner{
-	icon_state = "techfloororange_corners";
 	dir = 8
 	},
 /obj/effect/floor_decal/techfloor/orange/corner{
-	icon_state = "techfloororange_corners";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -527,7 +443,6 @@
 	frequency = 1380;
 	id_tag = "hybrid_shuttle_docker";
 	pixel_x = -6;
-	pixel_y = 0;
 	req_one_access = list(19,43,67);
 	tag_door = "hybrid_shuttle_afts"
 	},
@@ -535,7 +450,6 @@
 /area/shuttle/blue_fo)
 "bm" = (
 /obj/effect/floor_decal/techfloor/orange/corner{
-	icon_state = "techfloororange_corners";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor/orange/corner,
@@ -555,7 +469,6 @@
 /area/shuttle/blue_fo)
 "bp" = (
 /obj/effect/floor_decal/techfloor/orange{
-	icon_state = "techfloororange_edges";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -564,32 +477,25 @@
 /obj/machinery/shipsensors{
 	dir = 1
 	},
-/obj/item/stack/flag/blue{
-	dir = 8
-	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/blue_fo)
 "br" = (
 /obj/structure/railing{
-	icon_state = "railing0";
 	dir = 1
 	},
 /turf/simulated/shuttle/floor/alien,
 /area/shuttle/blue_fo)
 "bs" = (
 /obj/structure/railing{
-	icon_state = "railing0";
 	dir = 1
 	},
 /obj/structure/railing{
-	icon_state = "railing0";
 	dir = 4
 	},
 /turf/simulated/shuttle/floor/alien,
 /area/shuttle/blue_fo)
 "bt" = (
 /obj/effect/floor_decal/techfloor/orange/corner{
-	icon_state = "techfloororange_corners";
 	dir = 8
 	},
 /obj/effect/floor_decal/techfloor/orange/corner,
@@ -603,27 +509,23 @@
 "bv" = (
 /obj/effect/floor_decal/techfloor/orange/corner,
 /obj/effect/floor_decal/techfloor/orange/corner{
-	icon_state = "techfloororange_corners";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/blue_fo)
 "bw" = (
 /obj/structure/railing{
-	icon_state = "railing0";
 	dir = 1
 	},
 /obj/structure/railing{
-	icon_state = "railing0";
 	dir = 8
 	},
 /turf/simulated/shuttle/floor/alien,
 /area/shuttle/blue_fo)
 "bx" = (
-/obj/structure/fans/tiny,
+/obj/structure/grille,
 /obj/structure/window/reinforced/full,
-/obj/item/stack/flag/blue,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/blue_fo)
 "by" = (
 /obj/machinery/computer/shuttle_control/explore/hybridshuttle,
@@ -639,16 +541,12 @@
 /area/shuttle/blue_fo)
 "bB" = (
 /obj/machinery/computer/ship/engines{
-	icon_state = "computer";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/blue_fo)
 "bC" = (
-/obj/item/stack/flag/blue{
-	dir = 4
-	},
-/turf/space,
+/turf/space/basic,
 /area/shuttle/blue_fo)
 "La" = (
 /obj/machinery/light,
@@ -758,18 +656,18 @@ aa
 aa
 aa
 bq
-ap
 ab
-ap
-ar
-ar
-ar
-ap
+ab
+ab
+bx
+bx
+bx
+ab
 ab
 ab
 bj
 ab
-ap
+ab
 ad
 aa
 aa
@@ -781,8 +679,8 @@ aa
 aa
 aa
 aa
-ap
-ap
+ab
+ab
 bB
 ab
 as
@@ -794,7 +692,7 @@ bd
 bk
 aD
 ac
-ap
+ab
 aa
 aa
 aa
@@ -1021,8 +919,8 @@ aa
 aa
 aa
 aa
-ap
-ap
+ab
+ab
 ag
 ab
 aB
@@ -1034,7 +932,7 @@ bi
 bm
 bp
 ac
-ap
+ab
 aa
 aa
 aa
@@ -1046,19 +944,19 @@ aa
 aa
 aa
 bC
-ap
 ab
-ap
-aC
-aC
-aC
-ap
+ab
+ab
+bx
+bx
+bx
+ab
 ab
 ab
 bj
 ab
-ap
-af
+ab
+ad
 aa
 aa
 aa

--- a/maps/templates/shuttles/overmaps/generic/itglight.dmm
+++ b/maps/templates/shuttles/overmaps/generic/itglight.dmm
@@ -460,16 +460,12 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/itglight/crew4)
 "cp" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	pixel_x = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/browndouble,
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/carpet/turcarpet,
 /area/itglight/crew4)
 "cv" = (
@@ -515,11 +511,8 @@
 /obj/structure/bed/chair/bay/chair/padded/brown{
 	dir = 8
 	},
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	pixel_y = -25
-	},
 /obj/structure/cable/pink,
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/wood,
 /area/itglight/captain)
 "cU" = (
@@ -696,11 +689,8 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/itglight/crew1)
 "ed" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	pixel_y = -25
-	},
 /obj/structure/cable/pink,
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/carpet,
 /area/itglight/readyroom)
 "ei" = (
@@ -1611,10 +1601,6 @@
 /turf/simulated/floor/tiled/eris/dark/monofloor,
 /area/itglight/cockpit)
 "ky" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	pixel_y = -25
-	},
 /obj/structure/cable/pink,
 /obj/item/radio,
 /obj/structure/closet/walllocker/autolok_wall{
@@ -1624,6 +1610,7 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/eris/dark/monofloor,
 /area/itglight/cockpit)
 "kH" = (
@@ -1679,14 +1666,10 @@
 /turf/simulated/floor/tiled/eris/steel/gray_platform,
 /area/itglight/starboardcargo)
 "kU" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	pixel_x = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/white,
 /area/itglight/showers)
 "kY" = (
@@ -1708,14 +1691,10 @@
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
 /area/itglight/metingroom)
 "lh" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	pixel_x = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
 /area/itglight/afthall)
 "li" = (
@@ -1945,14 +1924,10 @@
 /turf/simulated/floor/carpet,
 /area/itglight/readyroom)
 "mZ" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 8;
-	pixel_x = -25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/eris/steel/gray_platform,
 /area/itglight/porthighsec)
 "na" = (
@@ -2264,11 +2239,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
 	},
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 8;
-	pixel_x = -25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-4"
 	},
@@ -2279,6 +2249,7 @@
 /obj/fiftyspawner/phoron,
 /obj/fiftyspawner/phoron,
 /obj/structure/closet/crate,
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor,
 /area/itglight/starboardengi)
 "pm" = (
@@ -2340,14 +2311,10 @@
 /turf/simulated/floor/tiled/eris/steel/gray_platform,
 /area/itglight/starboardcargo)
 "pL" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	pixel_x = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/eris/white/cargo,
 /area/itglight/medbay)
 "pU" = (
@@ -2667,14 +2634,10 @@
 /obj/structure/bed/chair/bay/chair{
 	dir = 1
 	},
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	pixel_x = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/itglightshuttle)
 "sQ" = (
@@ -3302,16 +3265,12 @@
 /turf/simulated/floor/tiled/eris/steel/gray_platform,
 /area/itglight/starboardhighsec)
 "xE" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 1;
-	pixel_y = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/structure/catwalk,
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor,
 /area/itglight/portdocking)
 "xM" = (
@@ -3506,16 +3465,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/itglight/starboarddocking)
 "yY" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 1;
-	pixel_y = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/structure/catwalk,
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor,
 /area/itglight/starboarddocking)
 "yZ" = (
@@ -3603,14 +3558,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/itglight/portdocking)
 "zL" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	pixel_x = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/eris/steel/gray_platform,
 /area/itglight/starboardhighsec)
 "zM" = (
@@ -3740,14 +3691,10 @@
 /turf/simulated/floor/tiled/eris/white/techfloor_grid,
 /area/itglight/medbay)
 "AJ" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 1;
-	pixel_y = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/monotile,
 /area/itglight/forehall)
 "AK" = (
@@ -3802,14 +3749,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	pixel_x = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/monotile,
 /area/itglight/lockers)
 "Bj" = (
@@ -3907,16 +3850,12 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/itglight/crew4)
 "BU" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	pixel_x = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/browndouble,
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/carpet/turcarpet,
 /area/itglight/crew1)
 "BW" = (
@@ -5057,14 +4996,10 @@
 /turf/simulated/wall/shull,
 /area/itglight/crew1)
 "IM" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	pixel_x = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
 /area/itglight/shuttlebay)
 "IN" = (
@@ -5093,14 +5028,10 @@
 /turf/simulated/floor/tiled/eris/steel/gray_platform,
 /area/itglight/starboardcargo)
 "Jc" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 1;
-	pixel_y = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/eris/steel/gray_platform,
 /area/itglight/portcargo)
 "Jg" = (
@@ -5228,16 +5159,12 @@
 /turf/simulated/floor/tiled/eris/steel/gray_platform,
 /area/itglight/portcargo)
 "JR" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	pixel_x = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/browndouble,
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/carpet/turcarpet,
 /area/itglight/crew3)
 "JT" = (
@@ -5281,14 +5208,10 @@
 /turf/simulated/floor/tiled/eris/steel/gray_platform,
 /area/itglight/starboardcargo)
 "Kh" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 1;
-	pixel_y = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/eris/steel/gray_platform,
 /area/itglight/starboardcargo)
 "Kj" = (
@@ -5343,14 +5266,10 @@
 /turf/simulated/floor/tiled/eris/steel/gray_platform,
 /area/itglight/portcargo)
 "KB" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	pixel_x = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor,
 /area/itglight/portengi)
 "KG" = (
@@ -5519,16 +5438,12 @@
 /turf/simulated/floor/carpet,
 /area/itglight/readyroom)
 "Mk" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	pixel_x = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/browndouble,
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/carpet/turcarpet,
 /area/itglight/crew2)
 "Ml" = (
@@ -5834,12 +5749,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/itglight/lockers)
 "NY" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	pixel_x = 25
-	},
 /obj/structure/cable/pink,
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/eris/cafe,
 /area/itglight/kitchen)
 "Oc" = (
@@ -5849,11 +5760,7 @@
 /obj/structure/cable/pink{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 1;
-	pixel_y = 25
-	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/dark,
 /area/itglight/passengersleeping)
 "Oe" = (
@@ -6155,14 +6062,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 1;
-	pixel_y = 25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
 /area/itglight/metingroom)
 "Qi" = (
@@ -7027,11 +6930,8 @@
 "WG" = (
 /obj/structure/table/wooden_reinforced,
 /obj/random/plushie,
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	pixel_y = -25
-	},
 /obj/structure/cable/pink,
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
 /area/itglight/common)
 "WN" = (
@@ -7115,14 +7015,10 @@
 /turf/space,
 /area/space)
 "Xl" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 8;
-	pixel_x = -25
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/white,
 /area/itglight/restrooms)
 "Xn" = (

--- a/maps/templates/shuttles/overmaps/generic/mackerel_hc.dmm
+++ b/maps/templates/shuttles/overmaps/generic/mackerel_hc.dmm
@@ -728,17 +728,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/mackerel_hc)
 "TG" = (

--- a/maps/templates/shuttles/overmaps/generic/mackerel_hc_skel.dmm
+++ b/maps/templates/shuttles/overmaps/generic/mackerel_hc_skel.dmm
@@ -116,17 +116,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/mackerel_hc_skel_eng)
 "fI" = (
@@ -518,11 +514,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/plating,
 /area/shuttle/mackerel_hc_skel)
 "Dl" = (
@@ -1019,14 +1011,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/mackerel_hc_skel_cockpit)
 "ZJ" = (

--- a/maps/templates/shuttles/overmaps/generic/mackerel_lc.dmm
+++ b/maps/templates/shuttles/overmaps/generic/mackerel_lc.dmm
@@ -273,17 +273,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/mackerel_lc)
 "sL" = (

--- a/maps/templates/shuttles/overmaps/generic/mackerel_sh.dmm
+++ b/maps/templates/shuttles/overmaps/generic/mackerel_sh.dmm
@@ -281,17 +281,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/mackerel_sh)
 "sL" = (

--- a/maps/templates/shuttles/overmaps/generic/mercenarybase.dmm
+++ b/maps/templates/shuttles/overmaps/generic/mercenarybase.dmm
@@ -28,34 +28,22 @@
 /area/mercbase/airlock)
 "ae" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /obj/machinery/atmospherics/portables_connector/aux{
-	icon_state = "map_connector-aux";
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor,
 /area/mercbase/airlock)
 "af" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	icon_state = "map-aux";
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor,
 /area/mercbase/airlock)
 "ag" = (
@@ -75,7 +63,6 @@
 /area/mercbase/airlock)
 "ai" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 10
 	},
 /turf/simulated/floor,
@@ -85,7 +72,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/component/binary/passive_gate{
-	icon_state = "map";
 	dir = 1
 	},
 /turf/simulated/floor,
@@ -103,18 +89,15 @@
 /area/mercbase/airlock)
 "al" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/mercbase/airlock)
 "am" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	icon_state = "map-aux";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -124,11 +107,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 5
 	},
 /turf/simulated/floor/plating,
@@ -141,14 +122,12 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/mercbase/airlock)
 "ap" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	icon_state = "map_universal";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -162,28 +141,23 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/mercbase/airlock)
 "as" = (
 /obj/machinery/atmospherics/component/binary/passive_gate{
-	icon_state = "map";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/mercbase/airlock)
 "at" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 5
 	},
-/obj/machinery/alarm{
+/obj/machinery/alarm/alarms_hidden{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/simulated/floor/plating,
 /area/mercbase/airlock)
@@ -281,9 +255,7 @@
 /area/mercbase/panels)
 "de" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -301,19 +273,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/barracks)
 "fK" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/power)
 "fM" = (
@@ -351,11 +314,9 @@
 /turf/simulated/floor,
 /area/mercbase/atmos)
 "fY" = (
-/obj/machinery/alarm{
+/obj/machinery/alarm/alarms_hidden{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/command)
@@ -416,13 +377,11 @@
 /turf/simulated/floor,
 /area/mercbase/fuel)
 "gq" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
 /obj/machinery/computer/operating,
+/obj/machinery/alarm/alarms_hidden{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medicalOR)
 "gr" = (
@@ -431,7 +390,6 @@
 /area/mercbase/fuel)
 "gs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 9
 	},
 /turf/simulated/floor,
@@ -442,14 +400,12 @@
 /area/mercbase/fuel)
 "gu" = (
 /obj/machinery/atmospherics/component/binary/pump/fuel{
-	icon_state = "map_off-fuel";
 	dir = 1
 	},
 /turf/simulated/floor,
 /area/mercbase/fuel)
 "gv" = (
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/phoron,
@@ -465,7 +421,6 @@
 /area/mercbase/atmos)
 "gy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	icon_state = "map_universal";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -476,7 +431,6 @@
 /area/mercbase/atmos)
 "gA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/simulated/floor,
@@ -496,17 +450,14 @@
 /turf/simulated/floor,
 /area/mercbase/atmos)
 "gD" = (
-/obj/machinery/alarm{
+/obj/machinery/alarm/alarms_hidden{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/power)
 "gE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -521,21 +472,18 @@
 /area/mercbase/atmos)
 "gH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/simulated/floor,
 /area/mercbase/atmos)
 "gI" = (
 /obj/machinery/atmospherics/component/binary/pump{
-	icon_state = "map_off";
 	dir = 4
 	},
 /turf/simulated/floor,
 /area/mercbase/atmos)
 "gJ" = (
 /obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
@@ -549,7 +497,6 @@
 /area/mercbase/atmos)
 "gL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -570,7 +517,6 @@
 /area/mercbase/command)
 "gQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 5
 	},
 /turf/simulated/floor,
@@ -582,17 +528,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/command)
 "gS" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -32
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/command)
 "gT" = (
@@ -637,17 +576,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/power)
 "gZ" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -32
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medicalOR)
 "ha" = (
@@ -707,7 +639,6 @@
 /area/mercbase/hall)
 "hh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -723,7 +654,6 @@
 /area/mercbase/hall)
 "hj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -735,7 +665,6 @@
 /area/mercbase/hall)
 "hk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 5
 	},
 /obj/structure/cable{
@@ -748,7 +677,6 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -758,11 +686,9 @@
 /area/mercbase/barracks)
 "hm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -780,11 +706,9 @@
 /area/mercbase/medical)
 "ho" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -802,7 +726,6 @@
 /area/mercbase/dock)
 "hq" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -828,11 +751,9 @@
 /area/mercbase/airlock)
 "hv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -845,14 +766,12 @@
 /area/mercbase/hall)
 "hw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /turf/simulated/floor,
 /area/mercbase/airlock)
 "hy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -874,7 +793,6 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 10
 	},
 /obj/structure/cable{
@@ -890,18 +808,15 @@
 /area/mercbase/command)
 "hD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/command)
 "hE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -911,7 +826,6 @@
 /area/mercbase/command)
 "hF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -921,7 +835,6 @@
 /area/mercbase/command)
 "hG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
@@ -934,7 +847,6 @@
 /area/mercbase/medicalstorage)
 "hJ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -943,20 +855,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/engineering)
 "hL" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/closet/hydrant,
+/obj/machinery/power/apc/alarms_hidden/north_bump,
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/solar)
 "hM" = (
@@ -973,11 +878,9 @@
 /area/mercbase/medical)
 "hN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -995,7 +898,6 @@
 /area/mercbase/medicalstorage)
 "hP" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /obj/structure/closet/syndicate{
@@ -1027,11 +929,9 @@
 /area/mercbase/medical)
 "hR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -1041,7 +941,6 @@
 /area/mercbase/medicalOR)
 "hS" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -1051,7 +950,6 @@
 /area/mercbase/medical)
 "hT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1064,19 +962,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medical)
 "hU" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/eqroom)
 "hV" = (
@@ -1087,11 +976,9 @@
 /area/mercbase/medical)
 "hW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -1101,7 +988,6 @@
 /area/mercbase/medicalOR)
 "hX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -1112,7 +998,6 @@
 /area/mercbase/airlock)
 "hZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 9
 	},
 /turf/simulated/floor/plating,
@@ -1120,7 +1005,6 @@
 "ia" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -1130,7 +1014,6 @@
 /area/mercbase/medical)
 "ib" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1141,20 +1024,19 @@
 /area/mercbase/hall)
 "id" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/closet/hydrant,
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
 /turf/simulated/floor,
 /area/mercbase/airlock)
 "ie" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -1177,15 +1059,12 @@
 /area/mercbase/airlock)
 "ig" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -1195,11 +1074,9 @@
 /area/mercbase/hall)
 "ih" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -1244,14 +1121,12 @@
 /area/mercbase/medicalstorage)
 "ik" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medicalstorage)
 "il" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1272,9 +1147,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/solar)
@@ -1299,13 +1172,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medicalstorage)
 "is" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -32
-	},
-/obj/machinery/power/terminal,
 /obj/structure/cable,
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/barracks)
 "iw" = (
@@ -1327,11 +1195,9 @@
 /area/mercbase/power)
 "iy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -1346,7 +1212,6 @@
 /area/mercbase/command)
 "iB" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1361,7 +1226,6 @@
 /area/mercbase/barracks)
 "iE" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1372,12 +1236,13 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/closet/hydrant,
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medicalstorage)
 "iG" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1396,19 +1261,19 @@
 /area/mercbase/solar)
 "iJ" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 8
 	},
-/obj/structure/closet/hydrant,
+/obj/structure/closet/hydrant{
+	dir = 4;
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medicalOR)
 "iK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -1423,35 +1288,30 @@
 /area/mercbase/dock)
 "iL" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/eqroom)
 "iM" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/eqroom)
 "iN" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/hall)
 "iO" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medical)
 "iP" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1476,12 +1336,13 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/closet/hydrant,
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
 /turf/simulated/floor,
 /area/mercbase/atmos)
 "iV" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1492,15 +1353,12 @@
 /area/mercbase/airlock)
 "iX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 9
 	},
 /obj/structure/cable{
@@ -1513,7 +1371,6 @@
 /area/mercbase/hall)
 "iY" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1535,8 +1392,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medical)
 "jc" = (
-/obj/structure/closet/hydrant,
 /obj/structure/bed/roller,
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medical)
 "jd" = (
@@ -1545,7 +1404,6 @@
 /area/mercbase/medical)
 "je" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1556,7 +1414,6 @@
 /area/mercbase/medical)
 "jg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1576,44 +1433,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/hall)
 "jj" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medicalstorage)
 "jk" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/hall)
 "jl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -1637,19 +1474,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/hall)
 "jn" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/engineering)
 "jo" = (
@@ -1662,7 +1490,6 @@
 /area/mercbase/engineering)
 "jp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -1673,7 +1500,6 @@
 /area/mercbase/hall)
 "jq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -1684,11 +1510,9 @@
 /area/mercbase/hall)
 "jr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 9
 	},
 /obj/structure/cable{
@@ -1698,11 +1522,9 @@
 /area/mercbase/medical)
 "js" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -1712,7 +1534,6 @@
 /area/mercbase/hall)
 "ju" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 1
 	},
 /turf/simulated/floor,
@@ -1759,7 +1580,6 @@
 "jA" = (
 /obj/machinery/power/solar_control/config_start{
 	dir = 8;
-	icon_state = "solar";
 	id = "syndsol"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1854,19 +1674,10 @@
 /turf/simulated/floor/plating,
 /area/mercbase/panels)
 "jM" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor,
 /area/mercbase/atmos)
 "jN" = (
@@ -1903,7 +1714,6 @@
 /area/mercbase/medical)
 "jS" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -1925,7 +1735,6 @@
 /area/mercbase/airlock)
 "jW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /obj/machinery/door/airlock/glass_external,
@@ -1933,7 +1742,6 @@
 /area/mercbase/airlock)
 "jX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /obj/machinery/door/airlock/glass_external,
@@ -1956,8 +1764,7 @@
 "jZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1966,11 +1773,9 @@
 /area/mercbase/fuel)
 "ka" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -1991,12 +1796,10 @@
 /area/mercbase/engineering)
 "kc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -2027,35 +1830,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/hall)
 "kg" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/plating,
 /area/mercbase/airlock)
 "kh" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor,
 /area/mercbase/fuel)
 "ki" = (
@@ -2088,7 +1873,6 @@
 /area/mercbase/engineering)
 "km" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 5
 	},
 /obj/machinery/light,
@@ -2119,11 +1903,9 @@
 /area/mercbase/engineering)
 "kq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -2142,7 +1924,6 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 6
 	},
 /obj/structure/cable{
@@ -2152,11 +1933,9 @@
 /area/mercbase/hall)
 "ks" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/door/airlock/security{
@@ -2193,7 +1972,6 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -2207,11 +1985,9 @@
 /area/mercbase/eqroom)
 "kB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -2228,7 +2004,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/closet/hydrant,
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/eqroom)
 "kD" = (
@@ -2258,7 +2036,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2294,18 +2071,15 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/eqroom)
 "kI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -2319,7 +2093,6 @@
 /area/mercbase/eqroom)
 "kJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2327,7 +2100,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2338,35 +2110,30 @@
 /area/mercbase/eqroom)
 "kL" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/hall)
 "kM" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /turf/simulated/floor,
 /area/mercbase/airlock)
 "kN" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/hall)
 "kO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/mercbase/airlock)
 "kP" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2379,25 +2146,21 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/solar)
 "kR" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/engineering)
 "kS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -2409,7 +2172,6 @@
 "kT" = (
 /obj/machinery/atmospherics/component/unary/freezer,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2423,14 +2185,12 @@
 /area/mercbase/medicalstorage)
 "kV" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medical)
 "kW" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /turf/simulated/floor,
@@ -2438,20 +2198,16 @@
 "kX" = (
 /obj/machinery/atmospherics/portables_connector/fuel,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor,
 /area/mercbase/fuel)
 "kY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/light,
@@ -2459,7 +2215,6 @@
 /area/mercbase/atmos)
 "kZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/meter,
@@ -2467,25 +2222,21 @@
 /turf/simulated/floor,
 /area/mercbase/atmos)
 "lB" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 22;
-	pixel_y = 0
-	},
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/closet/secure_closet/chemical{
 	req_access = list(150)
 	},
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medicalstorage)
 "lC" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -32
 	},
@@ -2497,11 +2248,9 @@
 /area/mercbase/medical)
 "lD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -2514,55 +2263,44 @@
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medical)
 "lE" = (
-/obj/machinery/alarm{
+/obj/machinery/alarm/alarms_hidden{
 	dir = 8;
-	pixel_x = 22;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/engineering)
 "lF" = (
-/obj/machinery/alarm{
+/obj/machinery/alarm/alarms_hidden{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/hall)
 "lG" = (
-/obj/machinery/alarm{
+/obj/machinery/alarm/alarms_hidden{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/simulated/floor,
 /area/mercbase/airlock)
 "lH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /turf/simulated/floor,
 /area/mercbase/atmos)
 "lJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 5
 	},
-/obj/machinery/alarm{
+/obj/machinery/alarm/alarms_hidden{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/simulated/floor,
 /area/mercbase/fuel)
@@ -2572,7 +2310,6 @@
 /area/mercbase/barracks)
 "lL" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /obj/structure/bed/padded,
@@ -2631,18 +2368,15 @@
 /area/mercbase/eqroom)
 "lR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /obj/machinery/recharger/wallcharger{
@@ -2686,11 +2420,9 @@
 /area/mercbase/engineering)
 "lV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -2717,9 +2449,7 @@
 "lZ" = (
 /obj/structure/bed/padded,
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2746,7 +2476,6 @@
 /area/mercbase/engineering)
 "mf" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /obj/structure/table/reinforced,
@@ -2754,7 +2483,6 @@
 /area/mercbase/engineering)
 "mm" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2775,17 +2503,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/dock)
 "mt" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -32
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/dock)
 "mu" = (
@@ -2809,11 +2530,9 @@
 /area/mercbase/dock)
 "mz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -2850,29 +2569,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medicalstorage)
 "mC" = (
-/obj/machinery/alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/roid)
 "mD" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/roid)
 "mE" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2933,7 +2643,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -2946,19 +2655,16 @@
 /area/mercbase/command)
 "mO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/dock)
 "mP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -2966,11 +2672,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/dock)
 "mQ" = (
-/obj/machinery/alarm{
+/obj/machinery/alarm/alarms_hidden{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/dock)
@@ -3011,7 +2715,6 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -3029,11 +2732,9 @@
 /area/mercbase/roid)
 "mX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3043,7 +2744,6 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3076,11 +2776,9 @@
 /area/mercbase/engineering)
 "nb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/door/airlock/security{
@@ -3096,11 +2794,9 @@
 /area/mercbase/eqroom)
 "nc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -3151,7 +2847,6 @@
 /area/mercbase/roid)
 "nk" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 1
 	},
 /obj/structure/table/standard,
@@ -3160,7 +2855,6 @@
 /area/mercbase/roid)
 "nl" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 1
 	},
 /obj/structure/table/standard,
@@ -3180,19 +2874,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/roid)
 "np" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
+/obj/machinery/alarm/alarms_hidden{
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/roid)
 "nq" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3200,36 +2889,28 @@
 "nr" = (
 /obj/machinery/optable,
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medicalOR)
 "ns" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/power)
 "nt" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/solar)
 "nu" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3237,27 +2918,21 @@
 "nv" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/hall)
 "nw" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor,
 /area/mercbase/atmos)
 "nx" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3344,7 +3019,6 @@
 /area/mercbase/hall)
 "nM" = (
 /obj/structure/sign/vacuum{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3403,15 +3077,12 @@
 /area/mercbase/hall)
 "nV" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/dock)
 "nW" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3445,41 +3116,54 @@
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medicalstorage)
 "of" = (
-/obj/structure/closet/hydrant,
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/hall)
 "og" = (
-/obj/structure/closet/hydrant,
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/command)
 "oh" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /obj/structure/bed/roller,
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/medical)
 "oi" = (
-/obj/structure/closet/hydrant,
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/barracks)
 "oj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/meter,
-/obj/structure/closet/hydrant,
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
 /turf/simulated/floor,
 /area/mercbase/fuel)
 "ok" = (
-/obj/structure/closet/hydrant,
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/roid)
 "ol" = (
-/obj/structure/closet/hydrant,
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/dock)
 "om" = (
-/obj/structure/closet/hydrant,
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/power)
 "on" = (
@@ -3506,7 +3190,6 @@
 /area/mercbase/medical)
 "op" = (
 /obj/structure/bed/chair/office/light{
-	icon_state = "officechair_white";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3599,24 +3282,19 @@
 /area/mercbase/roid)
 "oJ" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mercbase/command)
 "oK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /obj/structure/cable{

--- a/maps/templates/shuttles/overmaps/generic/mercship.dmm
+++ b/maps/templates/shuttles/overmaps/generic/mercship.dmm
@@ -7,28 +7,24 @@
 /area/ship/mercenary/engine1)
 "ac" = (
 /obj/machinery/atmospherics/component/unary/engine{
-	icon_state = "nozzle";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/ship/mercenary/engine1)
 "ad" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/ship/mercenary/engine1)
 "ae" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/wall/rshull,
 /area/ship/mercenary/engine1)
 "af" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -38,20 +34,16 @@
 	dir = 6
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/simulated/floor/plating,
 /area/ship/mercenary/engine1)
 "ag" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	icon_state = "map-fuel";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
@@ -61,22 +53,18 @@
 /area/ship/mercenary/engine1)
 "ah" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	icon_state = "map-fuel";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/ship/mercenary/engine1)
 "ai" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 10
 	},
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -101,7 +89,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -111,7 +98,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	icon_state = "map-fuel";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -125,13 +111,11 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/alarm{
 	breach_detection = 0;
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 25;
 	rcon_setting = 3;
 	report_danger_level = 0
@@ -145,19 +129,17 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume/aux{
 	dir = 4;
 	frequency = 1313;
-	icon_state = "map_vent_aux";
 	id_tag = "northpump"
 	},
 /turf/simulated/floor,
 /area/ship/mercenary/northairlock)
 "ar" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 10
 	},
 /obj/machinery/airlock_sensor{
-	id_tag = "northchambersensor";
-	frequency = 1313
+	frequency = 1313;
+	id_tag = "northchambersensor"
 	},
 /turf/simulated/floor,
 /area/ship/mercenary/northairlock)
@@ -177,35 +159,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/ship/mercenary/engine1)
 "av" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -32
-	},
-/obj/machinery/power/terminal,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 9
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/plating,
 /area/ship/mercenary/engine1)
 "aw" = (
 /obj/machinery/atmospherics/component/binary/pump/fuel{
-	icon_state = "map_off-fuel";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/ship/mercenary/engine1)
 "ax" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	icon_state = "map-aux";
 	dir = 4
 	},
 /obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller{
@@ -251,7 +224,6 @@
 /area/ship/mercenary/hangar)
 "aC" = (
 /obj/machinery/atmospherics/portables_connector/fuel{
-	icon_state = "map_connector-fuel";
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -284,7 +256,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_black";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -320,48 +291,33 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume/aux{
 	dir = 4;
 	frequency = 1313;
-	icon_state = "map_vent_aux";
 	id_tag = "northpump"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/ship/mercenary/northairlock)
 "aM" = (
 /obj/machinery/atmospherics/portables_connector/aux{
-	icon_state = "map_connector-aux";
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor,
 /area/ship/mercenary/barracks)
 "aN" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor,
 /area/ship/mercenary/barracks)
 "aO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 6
 	},
 /obj/machinery/meter,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -371,7 +327,6 @@
 /area/ship/mercenary/barracks)
 "aP" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -398,7 +353,6 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -461,22 +415,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/hangar)
 "ba" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/hangar)
 "bb" = (
@@ -492,9 +437,9 @@
 /area/ship/mercenary/hangar)
 "bc" = (
 /obj/machinery/airlock_sensor/airlock_interior{
+	frequency = 1313;
 	id_tag = "northinteriorsensor";
-	master_tag = "northairlock";
-	frequency = 1313
+	master_tag = "northairlock"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -510,7 +455,6 @@
 /area/ship/mercenary/hangar)
 "be" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -529,21 +473,18 @@
 /area/ship/mercenary/med)
 "bg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/med)
 "bh" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/med)
 "bi" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/closet/firecloset,
@@ -560,18 +501,15 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	icon_state = "map-aux";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_black";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/hall1)
 "bk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	icon_state = "map-aux";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -584,16 +522,13 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/barracks)
 "bm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -603,7 +538,6 @@
 /area/ship/mercenary/barracks)
 "bn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -613,7 +547,6 @@
 /area/ship/mercenary/barracks)
 "bo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -633,11 +566,9 @@
 	req_one_access = list(150)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
@@ -646,7 +577,6 @@
 /area/ship/mercenary/med1)
 "br" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_black";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -659,7 +589,6 @@
 /area/ship/mercenary/bridge)
 "bt" = (
 /obj/structure/bed/chair/bay/comfy/brown{
-	icon_state = "bay_comfychair_preview";
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack/corner,
@@ -668,7 +597,6 @@
 "bu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -678,9 +606,7 @@
 	id = "mercblast"
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/dark,
@@ -698,7 +624,6 @@
 /area/shuttle/mercboat)
 "bx" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -747,7 +672,6 @@
 "bD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 10
 	},
 /obj/structure/cable{
@@ -757,7 +681,6 @@
 /area/ship/mercenary/barracks)
 "bE" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -771,36 +694,31 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_black";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/barracks)
 "bG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/barracks)
 "bH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/bed/chair/comfy/red{
-	icon_state = "comfychair";
-	dir = 4
+	dir = 4;
+	icon_state = "comfychair"
 	},
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/barracks)
 "bI" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /obj/structure/closet/secure_closet{
@@ -810,7 +728,6 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -831,12 +748,11 @@
 /area/ship/mercenary/barracks)
 "bJ" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 8
 	},
 /obj/structure/bed/chair/comfy/red{
-	icon_state = "comfychair";
-	dir = 8
+	dir = 8;
+	icon_state = "comfychair"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -845,12 +761,11 @@
 /area/ship/mercenary/barracks)
 "bK" = (
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
 	dir = 8
 	},
 /obj/structure/bed/chair/comfy/red{
-	icon_state = "comfychair";
-	dir = 4
+	dir = 4;
+	icon_state = "comfychair"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/barracks)
@@ -861,8 +776,8 @@
 /area/ship/mercenary/barracks)
 "bM" = (
 /obj/structure/bed/chair/comfy/red{
-	icon_state = "comfychair";
-	dir = 8
+	dir = 8;
+	icon_state = "comfychair"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -871,8 +786,8 @@
 /area/ship/mercenary/barracks)
 "bN" = (
 /obj/structure/bed/chair/comfy/red{
-	icon_state = "comfychair";
-	dir = 8
+	dir = 8;
+	icon_state = "comfychair"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/barracks)
@@ -896,7 +811,6 @@
 	dir = 6
 	},
 /obj/structure/bed/chair/bay/comfy/captain{
-	icon_state = "capchair_preview";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -909,7 +823,6 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -930,49 +843,34 @@
 /area/ship/mercenary/barracks)
 "bR" = (
 /obj/structure/bed/chair/bay/comfy/brown{
-	icon_state = "bay_comfychair_preview";
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_black";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/bridge)
 "bS" = (
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/barracks)
 "bT" = (
 /obj/structure/bed/chair/backed_red{
-	icon_state = "onestar_chair_red";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mercboat)
 "bU" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/bed/chair/backed_red{
-	icon_state = "onestar_chair_red";
 	dir = 4
 	},
 /obj/machinery/recharger/wallcharger,
@@ -1004,7 +902,6 @@
 /area/ship/mercenary/med1)
 "bY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/table/standard,
@@ -1038,7 +935,6 @@
 /area/ship/mercenary/barracks)
 "cb" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 8
 	},
 /obj/structure/table/reinforced,
@@ -1047,7 +943,6 @@
 /area/ship/mercenary/bridge)
 "cc" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
@@ -1059,9 +954,7 @@
 	alarm_id = "anomaly_testing";
 	breach_detection = 0;
 	dir = 8;
-	frequency = 1439;
 	pixel_x = 22;
-	pixel_y = 0;
 	report_danger_level = 0
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1092,11 +985,9 @@
 /area/ship/mercenary/med1)
 "cf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1109,12 +1000,10 @@
 /area/ship/mercenary/barracks)
 "cg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -1128,15 +1017,12 @@
 /area/ship/mercenary/barracks)
 "ci" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
@@ -1150,31 +1036,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/barracks)
 "cj" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/med1)
 "ck" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -1207,22 +1082,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mercboat)
 "cp" = (
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/engineeringcntrl)
 "cq" = (
@@ -1239,20 +1105,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/med)
 "cr" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -32
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/northairlock)
 "cs" = (
@@ -1281,7 +1140,6 @@
 /area/ship/mercenary/barracks)
 "cu" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 4
 	},
 /obj/machinery/recharger/wallcharger,
@@ -1325,22 +1183,18 @@
 /area/ship/mercenary/northairlock)
 "cz" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_black";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/hall1)
 "cA" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/danger{
-	icon_state = "danger";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1374,9 +1228,7 @@
 "cE" = (
 /obj/structure/table/rack,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -1414,7 +1266,6 @@
 /area/ship/mercenary/hall1)
 "cH" = (
 /obj/effect/floor_decal/industrial/danger{
-	icon_state = "danger";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1441,12 +1292,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
+	id_tag = "merc_boatbay";
 	pixel_x = 27;
-	pixel_y = -4;
-	id_tag = "merc_boatbay"
+	pixel_y = -4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -1470,7 +1320,6 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 5
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -1481,11 +1330,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -1493,11 +1340,9 @@
 /area/ship/mercenary/med1)
 "cO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/bed/chair/backed_red{
-	icon_state = "onestar_chair_red";
 	dir = 8
 	},
 /obj/machinery/recharger/wallcharger,
@@ -1508,11 +1353,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -1526,11 +1369,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack/corner,
@@ -1542,7 +1383,6 @@
 	req_one_access = list(150)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
@@ -1556,15 +1396,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_black";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1574,12 +1411,10 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1589,7 +1424,6 @@
 /area/ship/mercenary/med)
 "cU" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -1614,20 +1448,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/med)
 "cX" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -32
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/hall1)
 "cY" = (
@@ -1645,33 +1472,23 @@
 /area/ship/mercenary/hall1)
 "cZ" = (
 /obj/structure/bed/chair/comfy/red{
-	icon_state = "comfychair";
-	dir = 4
+	dir = 4;
+	icon_state = "comfychair"
 	},
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack/corner,
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/barracks)
 "da" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/bridge)
 "db" = (
@@ -1691,11 +1508,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
@@ -1704,7 +1519,6 @@
 /area/ship/mercenary/hangar)
 "dd" = (
 /obj/machinery/computer/ship/helm{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -1721,8 +1535,8 @@
 /area/ship/mercenary/bridge)
 "df" = (
 /obj/structure/bed/chair/comfy/red{
-	icon_state = "comfychair";
-	dir = 8
+	dir = 8;
+	icon_state = "comfychair"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1732,12 +1546,11 @@
 /area/ship/mercenary/barracks)
 "dg" = (
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
 	dir = 8
 	},
 /obj/structure/bed/chair/comfy/red{
-	icon_state = "comfychair";
-	dir = 4
+	dir = 4;
+	icon_state = "comfychair"
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
@@ -1753,11 +1566,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
@@ -1766,8 +1577,7 @@
 /area/ship/mercenary/hall1)
 "dk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/structure/cable{
@@ -1790,11 +1600,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
@@ -1810,11 +1618,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
@@ -1848,11 +1654,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -1879,11 +1683,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -1900,11 +1702,9 @@
 	req_one_access = list(150)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
@@ -1954,20 +1754,13 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/mercenary/armoury)
 "dB" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -32
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/southairlock)
 "dC" = (
@@ -1982,8 +1775,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -35;
-	pixel_y = 0
+	pixel_x = -35
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/barracks)
@@ -1996,7 +1788,6 @@
 /area/ship/mercenary/hall2)
 "dE" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -2010,7 +1801,6 @@
 /area/ship/mercenary/atmos)
 "dG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -2019,21 +1809,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/hall1)
 "dH" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/air)
 "dI" = (
@@ -2041,11 +1823,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -2059,11 +1839,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -2075,16 +1853,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/engineering)
 "dL" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -2092,11 +1860,11 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/med)
 "dM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/wall/rshull,
@@ -2104,7 +1872,6 @@
 "dN" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
@@ -2154,7 +1921,6 @@
 /area/ship/mercenary/fighter)
 "dS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -2184,7 +1950,6 @@
 /area/ship/mercenary/fighter)
 "dW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -2207,7 +1972,6 @@
 /area/ship/mercenary/med)
 "dZ" = (
 /obj/machinery/atmospherics/component/binary/pump{
-	icon_state = "map_off";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2225,11 +1989,9 @@
 /area/ship/mercenary/atmos)
 "ec" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -2247,14 +2009,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/air)
 "ee" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -32
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -2262,6 +2016,7 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/engineering)
 "ef" = (
@@ -2273,7 +2028,6 @@
 /area/ship/mercenary/engineering)
 "eg" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2289,7 +2043,6 @@
 /area/ship/mercenary/engineering)
 "ei" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 10
 	},
 /obj/structure/reagent_dispensers/fueltank,
@@ -2319,7 +2072,6 @@
 /area/ship/mercenary/engineeringcntrl)
 "en" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -2333,16 +2085,13 @@
 "eo" = (
 /obj/structure/closet/crate,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/fiftyspawner/uranium,
@@ -2370,14 +2119,12 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/sleep_console{
-	icon_state = "sleeperconsole";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/mercenary/armoury)
 "et" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -2392,7 +2139,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 9
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -2427,11 +2173,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_black";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2491,27 +2235,17 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/mercenary/armoury)
 "eJ" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/hall2)
 "eK" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/table/rack,
@@ -2524,7 +2258,6 @@
 "eL" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -2546,11 +2279,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2578,8 +2309,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -35;
-	pixel_y = 0
+	pixel_x = -35
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/med)
@@ -2588,11 +2318,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2602,11 +2330,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -2617,11 +2343,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 9
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -2631,9 +2355,7 @@
 	alarm_id = "anomaly_testing";
 	breach_detection = 0;
 	dir = 8;
-	frequency = 1439;
 	pixel_x = 22;
-	pixel_y = 0;
 	report_danger_level = 0
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2658,11 +2380,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -2684,7 +2404,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -2695,11 +2414,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/light,
@@ -2718,8 +2435,7 @@
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/engineeringcntrl)
@@ -2728,11 +2444,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -2748,9 +2462,7 @@
 "fb" = (
 /obj/structure/table/rack,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -2762,9 +2474,7 @@
 "fc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -2788,7 +2498,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -2806,14 +2515,12 @@
 /area/ship/mercenary/air)
 "fh" = (
 /obj/machinery/atmospherics/component/unary/engine{
-	icon_state = "nozzle";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/ship/mercenary/engine)
 "fi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -2829,29 +2536,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/ship/mercenary/engine)
 "fl" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 10
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/plating,
 /area/ship/mercenary/engine)
 "fm" = (
@@ -2862,14 +2558,12 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume/aux{
 	dir = 4;
 	frequency = 1414;
-	icon_state = "map_vent_aux";
 	id_tag = "southpump"
 	},
 /turf/simulated/floor,
 /area/ship/mercenary/southairlock)
 "fo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	icon_state = "map-aux";
 	dir = 4
 	},
 /obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller{
@@ -2892,7 +2586,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -2902,7 +2595,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	icon_state = "map-fuel";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -2916,13 +2608,11 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/alarm{
 	breach_detection = 0;
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 25;
 	rcon_setting = 3;
 	report_danger_level = 0
@@ -2931,7 +2621,6 @@
 /area/ship/mercenary/engine)
 "ft" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 9
 	},
 /obj/machinery/airlock_sensor{
@@ -2954,14 +2643,12 @@
 /area/ship/mercenary/engineeringcntrl)
 "fw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 5
 	},
 /obj/machinery/firealarm{
@@ -2976,7 +2663,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -2984,18 +2670,15 @@
 "fy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/ship/mercenary/engine)
 "fz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 9
 	},
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -3005,15 +2688,13 @@
 /area/ship/mercenary/southairlock)
 "fB" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 4
 	},
 /turf/simulated/floor,
 /area/ship/mercenary/barracks)
 "fC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/meter,
 /obj/machinery/firealarm{
@@ -3029,7 +2710,6 @@
 /area/ship/mercenary/barracks)
 "fE" = (
 /obj/machinery/atmospherics/component/binary/passive_gate{
-	icon_state = "map";
 	dir = 1
 	},
 /turf/simulated/floor,
@@ -3039,11 +2719,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3056,11 +2734,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -3068,9 +2744,9 @@
 /area/ship/mercenary/hall2)
 "fH" = (
 /obj/machinery/airlock_sensor/airlock_exterior{
+	frequency = 1313;
 	id_tag = "northairlock";
-	master_tag = "northexteriorsensor";
-	frequency = 1313
+	master_tag = "northexteriorsensor"
 	},
 /turf/space,
 /area/space)
@@ -3079,7 +2755,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -3097,7 +2772,6 @@
 /area/ship/mercenary/air)
 "fK" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
@@ -3113,7 +2787,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -3139,11 +2812,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/door/airlock/atmos{
@@ -3159,11 +2830,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/door/airlock/engineering{
@@ -3183,11 +2852,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
@@ -3195,35 +2862,24 @@
 /area/ship/mercenary/engineeringcntrl)
 "fR" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/hangar)
 "fS" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/hangar)
 "fT" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/white,
 /area/ship/mercenary/fighter)
 "fU" = (
@@ -3253,11 +2909,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -3306,7 +2960,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -3324,13 +2977,10 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume/aux{
 	dir = 4;
 	frequency = 1414;
-	icon_state = "map_vent_aux";
 	id_tag = "southpump"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/ship/mercenary/southairlock)
@@ -3345,11 +2995,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -3393,22 +3041,13 @@
 /turf/simulated/floor,
 /area/ship/mercenary/med)
 "gh" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/white,
 /area/ship/mercenary/armoury)
 "gi" = (
@@ -3420,7 +3059,6 @@
 /area/ship/mercenary/engineering)
 "gj" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 8
 	},
 /obj/structure/table/rack,
@@ -3453,7 +3091,6 @@
 /area/ship/mercenary/hall1)
 "gp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -3466,7 +3103,6 @@
 /area/ship/mercenary/hall2)
 "gq" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/danger{
@@ -3492,16 +3128,13 @@
 	alarm_id = "anomaly_testing";
 	breach_detection = 0;
 	dir = 8;
-	frequency = 1439;
 	pixel_x = 22;
-	pixel_y = 0;
 	report_danger_level = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/southairlock)
 "gt" = (
 /obj/machinery/computer/ship/navigation{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -3516,22 +3149,13 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/mercenary/armoury)
 "gv" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/atmos)
 "gw" = (
@@ -3562,7 +3186,6 @@
 	alarm_id = "pen_nine";
 	breach_detection = 0;
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3572,11 +3195,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -3586,7 +3207,6 @@
 	alarm_id = "pen_nine";
 	breach_detection = 0;
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3603,23 +3223,19 @@
 	alarm_id = "pen_nine";
 	breach_detection = 0;
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/atmos)
 "gB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3631,7 +3247,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -3644,7 +3259,6 @@
 /area/ship/mercenary/air)
 "gD" = (
 /obj/structure/bed/chair/backed_red{
-	icon_state = "onestar_chair_red";
 	dir = 4
 	},
 /obj/machinery/recharger/wallcharger,
@@ -3652,7 +3266,6 @@
 /area/shuttle/mercboat)
 "gE" = (
 /obj/structure/bed/chair/backed_red{
-	icon_state = "onestar_chair_red";
 	dir = 8
 	},
 /obj/machinery/recharger/wallcharger,
@@ -3660,7 +3273,6 @@
 /area/shuttle/mercboat)
 "gF" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/phoron,
@@ -3685,7 +3297,6 @@
 /area/ship/mercenary/engineering)
 "gI" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 1
 	},
 /obj/machinery/suit_cycler/syndicate,
@@ -3711,7 +3322,6 @@
 /area/ship/mercenary/med1)
 "gL" = (
 /obj/machinery/sleep_console{
-	icon_state = "sleeperconsole";
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -3724,7 +3334,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3744,11 +3353,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -3771,7 +3378,6 @@
 /area/ship/mercenary/hangar)
 "gQ" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -3786,11 +3392,9 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/computer/operating{
-	icon_state = "computer";
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -3798,7 +3402,6 @@
 /area/ship/mercenary/fighter)
 "gS" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 8
 	},
 /obj/machinery/optable,
@@ -3808,9 +3411,7 @@
 "gT" = (
 /obj/machinery/sleeper,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -3819,11 +3420,9 @@
 /area/ship/mercenary/armoury)
 "gU" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_black";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3833,9 +3432,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3857,7 +3454,6 @@
 /area/ship/mercenary/hangar)
 "gY" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
-	icon_state = "map_vent_out";
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -3865,8 +3461,7 @@
 /area/ship/mercenary/armoury)
 "gZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -3880,7 +3475,6 @@
 /area/ship/mercenary/armoury)
 "ha" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -3888,7 +3482,6 @@
 /area/ship/mercenary/armoury)
 "hb" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -3896,11 +3489,9 @@
 /area/ship/mercenary/armoury)
 "hc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -3914,11 +3505,9 @@
 /area/ship/mercenary/engineering)
 "hd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -3941,11 +3530,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -3978,7 +3565,6 @@
 /area/ship/mercenary/southairlock)
 "hj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/table/reinforced,
@@ -3993,11 +3579,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -4021,8 +3605,8 @@
 /area/ship/mercenary/med)
 "hn" = (
 /obj/structure/bed/chair/comfy/red{
-	icon_state = "comfychair";
-	dir = 8
+	dir = 8;
+	icon_state = "comfychair"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -4064,11 +3648,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -4087,11 +3669,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -4099,7 +3679,6 @@
 	alarm_id = "pen_nine";
 	breach_detection = 0;
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4121,7 +3700,6 @@
 /area/ship/mercenary/med)
 "hy" = (
 /obj/machinery/computer/ship/sensors{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -4143,7 +3721,6 @@
 "hB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -4159,11 +3736,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -4193,7 +3768,6 @@
 /area/ship/mercenary/bridge)
 "hF" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_black";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4263,11 +3837,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{

--- a/maps/templates/shuttles/overmaps/generic/salamander.dmm
+++ b/maps/templates/shuttles/overmaps/generic/salamander.dmm
@@ -69,11 +69,6 @@
 "bI" = (
 /obj/structure/bed/chair/bay/chair,
 /obj/structure/handrail,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -84,6 +79,7 @@
 	dir = 8;
 	pixel_x = -32
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/salamander_galley)
 "bK" = (
@@ -149,10 +145,6 @@
 /obj/structure/handrail{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -163,6 +155,7 @@
 	dir = 8;
 	pixel_x = -32
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/salamander_head)
 "cC" = (
@@ -389,11 +382,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/salamander_q2)
 "gv" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -410,6 +398,7 @@
 /obj/structure/bed/chair/bay/comfy{
 	dir = 4
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/salamander_cockpit)
 "gC" = (
@@ -1070,11 +1059,6 @@
 "qn" = (
 /obj/structure/bed/chair/bay/chair,
 /obj/structure/handrail,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -1085,6 +1069,7 @@
 	dir = 8;
 	pixel_x = -32
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/salamander_q2)
 "qu" = (
@@ -1289,10 +1274,6 @@
 /obj/structure/handrail{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -1303,6 +1284,7 @@
 	dir = 8;
 	pixel_x = -32
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/salamander_q2)
 "Bf" = (
@@ -1737,14 +1719,10 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/handrail{
 	dir = 8
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/salamander_engineering)
 "Vs" = (
@@ -1895,16 +1873,12 @@
 	name = "Salamander Master Docking Controller";
 	pixel_y = -22
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/cable,
 /obj/machinery/light,
 /obj/structure/railing/grey{
 	dir = 8
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/salamander)
 

--- a/maps/templates/shuttles/overmaps/generic/screebarge.dmm
+++ b/maps/templates/shuttles/overmaps/generic/screebarge.dmm
@@ -14,7 +14,6 @@
 /area/shuttle/screebarge/fore)
 "ae" = (
 /obj/structure/disposaloutlet{
-	icon_state = "outlet";
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
@@ -24,7 +23,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -33,18 +31,15 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-s";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/screebarge/fore)
 "ah" = (
 /obj/machinery/power/emitter{
-	icon_state = "emitter";
 	dir = 1
 	},
 /obj/structure/cable/cyan{
@@ -58,7 +53,6 @@
 "ai" = (
 /obj/machinery/computer/ship/helm,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-s";
 	dir = 1
 	},
 /turf/simulated/floor/reinforced,
@@ -73,7 +67,6 @@
 /area/shuttle/screebarge/fore)
 "al" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-s";
 	dir = 1
 	},
 /obj/machinery/computer/shuttle_control/explore/screebarge,
@@ -83,7 +76,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -99,11 +91,9 @@
 /area/shuttle/screebarge/fore)
 "ao" = (
 /obj/structure/bed/chair/bay/chair{
-	icon_state = "bay_chair_preview";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-s";
 	dir = 1
 	},
 /obj/structure/cable/cyan{
@@ -113,7 +103,6 @@
 /area/shuttle/screebarge/fore)
 "ap" = (
 /obj/structure/bed/chair/bay/chair{
-	icon_state = "bay_chair_preview";
 	dir = 1
 	},
 /obj/structure/cable/cyan{
@@ -144,7 +133,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -157,7 +145,6 @@
 /area/shuttle/screebarge/fore)
 "au" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-s";
 	dir = 1
 	},
 /turf/simulated/floor/reinforced,
@@ -170,22 +157,20 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/screebarge/fore)
 "aw" = (
-/obj/machinery/power/apc{
-	pixel_x = -28
-	},
+/obj/structure/cable/cyan,
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/reinforced,
 /area/shuttle/screebarge/fore)
 "ax" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/screebarge/fore)
 "ay" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
 	dir = 8
 	},
 /turf/simulated/floor/reinforced,
@@ -193,7 +178,6 @@
 "az" = (
 /obj/structure/table/standard,
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -204,21 +188,19 @@
 "aA" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
 	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/screebarge/fore)
 "aB" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "conpipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "conpipe-c"
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/screebarge/fore)
 "aC" = (
 /obj/structure/bed/chair/bay/chair{
-	icon_state = "bay_chair_preview";
 	dir = 8
 	},
 /obj/structure/cable/cyan{
@@ -228,7 +210,6 @@
 /area/shuttle/screebarge/fore)
 "aD" = (
 /obj/structure/bed/chair/bay/chair{
-	icon_state = "bay_chair_preview";
 	dir = 4
 	},
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
@@ -246,7 +227,6 @@
 /area/shuttle/screebarge/fore)
 "aF" = (
 /obj/structure/bed/chair/bay/chair{
-	icon_state = "bay_chair_preview";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -275,7 +255,6 @@
 /area/shuttle/screebarge/fore)
 "aJ" = (
 /obj/machinery/power/emitter{
-	icon_state = "emitter";
 	dir = 1
 	},
 /obj/structure/cable/cyan{
@@ -309,14 +288,12 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/screebarge/mid)
 "aP" = (
 /obj/structure/bed/chair/bay/chair{
-	icon_state = "bay_chair_preview";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -326,14 +303,12 @@
 /area/shuttle/screebarge/mid)
 "aR" = (
 /obj/structure/bed/chair/bay/chair{
-	icon_state = "bay_chair_preview";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/shuttle/screebarge/mid)
 "aS" = (
 /obj/machinery/sleeper{
-	icon_state = "sleeper_0";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -352,7 +327,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -422,9 +396,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	pixel_x = 28
-	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/shuttle/screebarge/mid)
 "bg" = (
@@ -456,7 +428,6 @@
 /area/shuttle/screebarge/aft)
 "bk" = (
 /obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/red,
@@ -465,7 +436,6 @@
 /area/shuttle/screebarge/aft)
 "bl" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	icon_state = "map";
 	dir = 1
 	},
 /obj/structure/cable/cyan{
@@ -475,7 +445,6 @@
 /area/shuttle/screebarge/aft)
 "bm" = (
 /obj/machinery/atmospherics/component/binary/pump{
-	icon_state = "map_off";
 	dir = 4
 	},
 /obj/structure/cable/cyan{
@@ -485,35 +454,28 @@
 /area/shuttle/screebarge/aft)
 "bn" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	icon_state = "map";
 	dir = 1
 	},
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	pixel_x = 0;
-	pixel_y = 28
-	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/plating,
 /area/shuttle/screebarge/aft)
 "bo" = (
 /obj/machinery/atmospherics/component/binary/pump{
-	icon_state = "map_off";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/screebarge/aft)
 "bp" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	icon_state = "map";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/screebarge/aft)
 "bq" = (
 /obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/red,
@@ -522,7 +484,6 @@
 /area/shuttle/screebarge/aft)
 "br" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/simulated/floor/plating,
@@ -536,35 +497,30 @@
 /area/shuttle/screebarge/fore)
 "bt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	icon_state = "intact";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/screebarge/aft)
 "bu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/screebarge/aft)
 "bv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/simulated/wall/shull,
 /area/shuttle/screebarge/aft)
 "bw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	icon_state = "map";
 	dir = 1
 	},
 /turf/simulated/wall/shull,
 /area/shuttle/screebarge/aft)
 "bx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/simulated/wall/shull,
@@ -575,7 +531,6 @@
 /area/shuttle/screebarge/aft)
 "bz" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/simulated/wall/shull,
@@ -610,17 +565,16 @@
 /area/shuttle/screebarge/mid)
 "bD" = (
 /obj/machinery/button/remote/airlock{
+	desiredstate = 1;
+	id = "battlebarge_frontdoor";
 	pixel_x = 26;
 	pixel_y = 5;
-	id = "battlebarge_frontdoor";
-	desiredstate = 1;
 	specialfunctions = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/screebarge/fore)
 "bE" = (
 /obj/structure/bed/chair/bay/chair{
-	icon_state = "bay_chair_preview";
 	dir = 4
 	},
 /obj/machinery/light/small{

--- a/maps/templates/shuttles/overmaps/generic/shelter_5.dmm
+++ b/maps/templates/shuttles/overmaps/generic/shelter_5.dmm
@@ -89,8 +89,7 @@
 	},
 /obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_x = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/shuttle/deployable/escapepod)
@@ -103,8 +102,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_x = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/deployable/escapepod)
@@ -147,7 +145,6 @@
 "p" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
 	dir = 8
 	},
 /obj/map_helper/airlock/door/ext_door,
@@ -187,18 +184,13 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/deployable/escapepod)
 "t" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -28
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 6
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/deployable/escapepod)
 "u" = (

--- a/maps/templates/shuttles/overmaps/generic/shelter_6.dmm
+++ b/maps/templates/shuttles/overmaps/generic/shelter_6.dmm
@@ -1038,16 +1038,10 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/tabiranth)
 "aX" = (
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	cell_type = /obj/item/cell/super;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/tabiranth)
 "aY" = (
@@ -1642,7 +1636,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/tabiranth)
 "bG" = (
-/obj/machinery/ion_engine,
+/obj/machinery/ion_engine{
+	dir = 1
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/tabiranth)
 "bH" = (

--- a/maps/templates/shuttles/overmaps/generic/vespa.dmm
+++ b/maps/templates/shuttles/overmaps/generic/vespa.dmm
@@ -62,7 +62,6 @@
 "al" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -106,14 +105,12 @@
 /area/ship/expe/atmospherics)
 "at" = (
 /obj/machinery/atmospherics/component/binary/pump{
-	icon_state = "map_off";
 	dir = 4
 	},
 /turf/simulated/floor,
 /area/ship/expe/atmospherics)
 "au" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/simulated/wall/rpshull,
@@ -135,8 +132,7 @@
 /area/ship/expe/atmospherics)
 "az" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1;
-	icon_state = "map"
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/ship/expe/atmospherics)
@@ -146,8 +142,7 @@
 /area/ship/expe/atmospherics)
 "aB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /turf/simulated/floor,
 /area/ship/expe/atmospherics)
@@ -156,7 +151,6 @@
 	name = "gas pump - air - distro"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -167,7 +161,6 @@
 /area/ship/expe/atmospherics)
 "aE" = (
 /obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
@@ -175,9 +168,8 @@
 /area/ship/expe/atmospherics)
 "aF" = (
 /obj/machinery/atmospherics/component/binary/pump/on{
-	name = "gas pump - waste - scrubbers";
-	icon_state = "map_on";
-	dir = 1
+	dir = 1;
+	name = "gas pump - waste - scrubbers"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -186,21 +178,18 @@
 /area/ship/expe/atmospherics)
 "aG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 10
 	},
 /turf/simulated/floor,
 /area/ship/expe/maintenancerim)
 "aH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 5
 	},
 /turf/simulated/floor,
 /area/ship/expe/maintenancerim)
 "aI" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 6
 	},
 /obj/structure/cable{
@@ -216,14 +205,12 @@
 /area/ship/expe/corridor1)
 "aJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/simulated/floor,
 /area/ship/expe/atmospherics)
 "aK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -253,17 +240,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/maintenancerim)
 "aO" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -32
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor,
 /area/ship/expe/atmospherics)
 "aP" = (
@@ -291,7 +271,6 @@
 /area/ship/expe/maintenancerim)
 "aT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	icon_state = "map-fuel";
 	dir = 1
 	},
 /turf/simulated/floor,
@@ -302,7 +281,6 @@
 /area/ship/expe/atmospherics)
 "aV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 5
 	},
 /obj/machinery/meter,
@@ -351,22 +329,19 @@
 /area/ship/expe/northairlock)
 "be" = (
 /obj/machinery/access_button/airlock_exterior{
-	pixel_x = 0;
-	pixel_y = -28;
+	frequency = 1449;
 	master_tag = "northairlock";
-	frequency = 1449
+	pixel_y = -28
 	},
 /turf/space,
 /area/space)
 "bf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -403,24 +378,14 @@
 /turf/simulated/floor,
 /area/ship/expe/maintenancerim)
 "bm" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor,
 /area/ship/expe/maintenancerim)
 "bn" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -461,7 +426,6 @@
 /area/space)
 "bu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -471,7 +435,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -483,14 +446,12 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -500,14 +461,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -521,14 +480,12 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -540,14 +497,12 @@
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -572,16 +527,13 @@
 /area/ship/expe/maintenancerim)
 "bD" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/firealarm,
 /turf/simulated/floor/tiled/techfloor,
@@ -594,7 +546,6 @@
 /area/ship/expe/maintenancerim)
 "bF" = (
 /obj/machinery/atmospherics/portables_connector/aux{
-	icon_state = "map_connector-aux";
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
@@ -621,15 +572,13 @@
 	pixel_y = -21
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	icon_state = "map-aux";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/northairlock)
 "bI" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	frequency = 1449;
@@ -642,7 +591,6 @@
 	tag_interior_door = "northint"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -676,19 +624,10 @@
 /turf/simulated/floor,
 /area/ship/expe/maintenancerim)
 "bN" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/northairlock)
 "bO" = (
@@ -714,7 +653,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
@@ -725,7 +663,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -736,11 +673,9 @@
 /area/ship/expe/maintenance1)
 "bU" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -755,7 +690,6 @@
 /area/ship/expe/engineeringstorage)
 "bW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 6
 	},
 /turf/simulated/floor,
@@ -779,14 +713,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -840,29 +772,18 @@
 	pixel_y = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
 /turf/simulated/floor,
 /area/ship/expe/maintenance2)
 "cp" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 8
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor,
 /area/ship/expe/maintenance2)
 "cq" = (
@@ -870,7 +791,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 10
 	},
 /turf/simulated/floor,
@@ -886,7 +806,6 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/aux{
 	dir = 1;
 	frequency = 1459;
-	icon_state = "map_vent_aux";
 	id_tag = "southvent"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -906,11 +825,9 @@
 /obj/machinery/airlock_sensor{
 	frequency = 1459;
 	id_tag = "southsensor";
-	pixel_x = 0;
 	pixel_y = 21
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -945,14 +862,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -967,19 +882,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin1)
 "cD" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin1)
@@ -997,19 +903,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin2)
 "cG" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin2)
@@ -1026,19 +923,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin3)
 "cJ" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin3)
@@ -1055,19 +943,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin4)
 "cM" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin4)
@@ -1085,19 +964,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin5)
 "cP" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin5)
@@ -1115,19 +985,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin6)
 "cS" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin6)
@@ -1144,19 +1005,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin7)
 "cV" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin7)
@@ -1173,19 +1025,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin8)
 "cY" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin8)
@@ -1203,19 +1046,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin9)
 "db" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin9)
@@ -1237,8 +1071,7 @@
 "df" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/access_button/airlock_interior{
 	frequency = 1449;
@@ -1249,13 +1082,11 @@
 /area/ship/expe/northairlock)
 "dg" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	frequency = 1459;
 	id_tag = "southairlock";
-	pixel_x = 0;
 	pixel_y = 21;
 	tag_airpump = "southvent";
 	tag_chamber_sensor = "southsensor";
@@ -1263,7 +1094,6 @@
 	tag_interior_door = "southint"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	icon_state = "map-aux";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -1274,26 +1104,16 @@
 /area/ship/expe/maintenance1)
 "di" = (
 /obj/machinery/atmospherics/portables_connector/aux{
-	icon_state = "map_connector-aux";
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor,
 /area/ship/expe/maintenance2)
 "dj" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor,
 /area/ship/expe/maintenance1)
 "dk" = (
@@ -1312,7 +1132,6 @@
 /area/ship/expe/maintenance1)
 "dm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	icon_state = "map-aux";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -1320,14 +1139,12 @@
 "dn" = (
 /obj/item/handcuffs/fuzzy,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 9
 	},
 /turf/simulated/floor,
 /area/ship/expe/maintenance2)
 "do" = (
 /obj/machinery/atmospherics/component/unary/engine{
-	icon_state = "nozzle";
 	dir = 4
 	},
 /turf/space,
@@ -1389,11 +1206,9 @@
 /area/ship/expe/cabin1)
 "dy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 10
 	},
 /obj/structure/cable{
@@ -1417,11 +1232,9 @@
 /area/ship/expe/cabin2)
 "dB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 10
 	},
 /obj/structure/cable{
@@ -1445,11 +1258,9 @@
 /area/ship/expe/cabin3)
 "dE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 10
 	},
 /obj/structure/cable{
@@ -1473,11 +1284,9 @@
 /area/ship/expe/cabin4)
 "dH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 10
 	},
 /obj/structure/cable{
@@ -1501,11 +1310,9 @@
 /area/ship/expe/cabin5)
 "dK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 10
 	},
 /obj/structure/cable{
@@ -1529,11 +1336,9 @@
 /area/ship/expe/cabin6)
 "dN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 10
 	},
 /obj/structure/cable{
@@ -1557,11 +1362,9 @@
 /area/ship/expe/cabin7)
 "dQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 10
 	},
 /obj/structure/cable{
@@ -1585,11 +1388,9 @@
 /area/ship/expe/cabin8)
 "dT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 10
 	},
 /obj/structure/cable{
@@ -1613,11 +1414,9 @@
 /area/ship/expe/cabin9)
 "dW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 10
 	},
 /obj/structure/cable{
@@ -1677,7 +1476,6 @@
 /area/ship/expe/corridor1)
 "eh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 5
 	},
 /turf/simulated/floor,
@@ -1930,35 +1728,30 @@
 /area/ship/expe/bridge)
 "eW" = (
 /obj/machinery/atmospherics/component/binary/pump/fuel{
-	icon_state = "map_off-fuel";
 	dir = 4
 	},
 /turf/simulated/floor,
 /area/ship/expe/engines)
 "eX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor,
 /area/ship/expe/engines)
 "eY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	icon_state = "map-fuel";
 	dir = 4
 	},
 /turf/simulated/floor,
 /area/ship/expe/engines)
 "eZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 9
 	},
 /turf/simulated/floor,
 /area/ship/expe/engines)
 "fa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /obj/machinery/meter,
@@ -1966,7 +1759,6 @@
 /area/ship/expe/engines)
 "fb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -1992,18 +1784,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/hangarcontrol)
 "ff" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/hangarcontrol)
 "fg" = (
@@ -2134,18 +1918,15 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor4)
 "fs" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
@@ -2157,7 +1938,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2165,14 +1945,12 @@
 "fu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor4)
 "fv" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/machinery/door/firedoor/glass,
@@ -2184,7 +1962,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2192,7 +1969,6 @@
 "fx" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2205,18 +1981,15 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor4)
 "fz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 10
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
@@ -2224,7 +1997,6 @@
 /area/ship/expe/corridor4)
 "fA" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2235,35 +2007,23 @@
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor4)
 "fC" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor4)
 "fD" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -2274,7 +2034,6 @@
 "fE" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2284,14 +2043,12 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor4)
 "fG" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -2305,21 +2062,18 @@
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor6)
 "fI" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor6)
 "fJ" = (
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2330,35 +2084,23 @@
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/bridge)
 "fL" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/bridge)
 "fM" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2366,7 +2108,6 @@
 "fN" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2375,14 +2116,12 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor,
 /area/ship/expe/engines2)
 "fP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -2390,14 +2129,12 @@
 "fQ" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor,
 /area/ship/expe/maintenancerim)
 "fR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	icon_state = "map-fuel";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -2407,7 +2144,6 @@
 /area/ship/expe/maintenancerim)
 "fS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	icon_state = "map-fuel";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -2431,14 +2167,12 @@
 /area/ship/expe/engines)
 "fV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/wall/rpshull,
 /area/ship/expe/engines2)
 "fW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 9
 	},
 /turf/simulated/floor,
@@ -2447,7 +2181,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -2515,7 +2248,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -2532,11 +2264,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner_techfloor_grid/full{
-	icon_state = "corner_techfloor_grid_full";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2554,36 +2284,30 @@
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor3)
 "gg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor3)
 "gh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -2593,7 +2317,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
@@ -2609,54 +2332,45 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor3)
 "gj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor3)
 "gk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor3)
 "gl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -2666,7 +2380,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2681,18 +2394,15 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor3)
 "gn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 10
 	},
 /obj/structure/cable{
@@ -2702,7 +2412,6 @@
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/corner_techfloor_grid/full{
-	icon_state = "corner_techfloor_grid_full";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -2716,7 +2425,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor,
@@ -2732,11 +2440,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor4)
@@ -2749,7 +2453,6 @@
 /area/ship/expe/corridor4)
 "gr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 5
 	},
 /obj/structure/cable{
@@ -2766,11 +2469,9 @@
 /area/ship/expe/corridor4)
 "gs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 5
 	},
 /obj/structure/cable{
@@ -2781,11 +2482,9 @@
 /area/ship/expe/corridor4)
 "gt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -2798,11 +2497,9 @@
 /area/ship/expe/corridor4)
 "gu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -2817,7 +2514,6 @@
 "gv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -2828,11 +2524,9 @@
 /area/ship/expe/corridor4)
 "gw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -2843,7 +2537,6 @@
 /area/ship/expe/corridor4)
 "gx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -2855,11 +2548,9 @@
 /area/ship/expe/corridor4)
 "gy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -2873,11 +2564,9 @@
 /area/ship/expe/corridor4)
 "gz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 9
 	},
 /obj/structure/cable{
@@ -2888,7 +2577,6 @@
 /area/ship/expe/corridor4)
 "gA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 9
 	},
 /obj/structure/cable{
@@ -2918,7 +2606,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner_techfloor_grid{
-	icon_state = "corner_techfloor_grid";
 	dir = 8
 	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
@@ -2928,29 +2615,24 @@
 /area/ship/expe/corridor6)
 "gE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 10
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor6)
 "gF" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/structure/closet/walllocker/emerglocker/west,
@@ -2958,14 +2640,12 @@
 /area/ship/expe/bridge)
 "gG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/bridge)
 "gH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -2975,7 +2655,6 @@
 /area/ship/expe/bridge)
 "gI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2986,14 +2665,12 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/bridge)
 "gK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -3013,7 +2690,6 @@
 /area/ship/expe/corridor1)
 "gM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3071,7 +2747,6 @@
 /area/ship/expe/corridor3)
 "gU" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -32
 	},
@@ -3112,14 +2787,12 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner_techfloor_grid/full{
-	icon_state = "corner_techfloor_grid_full";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor3)
 "ha" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor,
@@ -3129,18 +2802,15 @@
 /area/ship/expe/corridor3)
 "hb" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor4)
 "hc" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -3172,7 +2842,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -3180,21 +2849,18 @@
 "hj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 10
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor6)
 "hk" = (
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -3202,36 +2868,30 @@
 "hl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 6
 	},
 /obj/structure/bed/chair/bay/comfy{
-	icon_state = "bay_comfychair_preview";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/bridge)
 "hm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/computer/ship/helm{
-	icon_state = "computer";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/bridge)
 "hn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/bed/chair/bay/comfy{
-	icon_state = "bay_comfychair_preview";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -3244,7 +2904,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -3265,15 +2924,12 @@
 /area/ship/expe/corridor1)
 "hr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -3282,36 +2938,25 @@
 "hs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor1)
 "ht" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -3319,7 +2964,6 @@
 /area/ship/expe/corridor1)
 "hu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3327,7 +2971,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -3343,7 +2986,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -3354,15 +2996,12 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -3375,7 +3014,6 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -3428,11 +3066,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -3473,32 +3109,20 @@
 /turf/simulated/floor,
 /area/ship/expe/corridor4)
 "hM" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringstorage)
 "hN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /obj/machinery/alarm{
@@ -3509,22 +3133,18 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringstorage)
 "hO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 6
 	},
 /obj/structure/cable{
@@ -3534,66 +3154,54 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringstorage)
 "hP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringstorage)
 "hQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringstorage)
 "hR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -3609,11 +3217,9 @@
 /area/ship/expe/engineeringstorage)
 "hS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/machinery/alarm{
@@ -3624,32 +3230,18 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/bordercorner{
-	icon_state = "bordercolorcorner";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineering)
 "hT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -3660,15 +3252,14 @@
 	},
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/yellow/bordercorner,
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineering)
 "hU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -3683,11 +3274,9 @@
 /area/ship/expe/engineering)
 "hV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -3699,11 +3288,9 @@
 /area/ship/expe/engineering)
 "hW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -3716,11 +3303,9 @@
 /area/ship/expe/engineering)
 "hX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -3738,11 +3323,9 @@
 /area/ship/expe/engineering)
 "hY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -3775,30 +3358,24 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor4)
 "ia" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -3814,36 +3391,30 @@
 /area/ship/expe/sm)
 "ib" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/simulated/floor,
 /area/ship/expe/sm)
 "ic" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/door/firedoor/glass,
@@ -3854,22 +3425,10 @@
 /area/ship/expe/sm)
 "id" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -3878,9 +3437,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor,
 /area/ship/expe/sm)
 "ie" = (
@@ -3888,14 +3447,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -3906,18 +3463,15 @@
 /area/ship/expe/sm)
 "if" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -3930,14 +3484,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -3947,18 +3499,15 @@
 /area/ship/expe/sm)
 "ih" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -3974,7 +3523,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3984,43 +3532,36 @@
 /area/ship/expe/sm)
 "ij" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 1
 	},
 /turf/simulated/floor,
 /area/ship/expe/sm)
 "ik" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 10
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue{
-	icon_state = "map";
 	dir = 1
 	},
 /turf/simulated/floor,
 /area/ship/expe/sm)
 "il" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/meter,
@@ -4028,21 +3569,18 @@
 /area/ship/expe/sm)
 "im" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/space,
 /area/ship/expe/sm)
 "in" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/space,
 /area/ship/expe/sm)
 "io" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4054,7 +3592,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4084,21 +3621,18 @@
 /area/ship/expe/bridge)
 "iu" = (
 /obj/effect/floor_decal/corner/blue/bordercorner{
-	icon_state = "bordercolorcorner";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/bridge)
 "iv" = (
 /obj/machinery/computer/ship/navigation{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4107,7 +3641,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -4118,7 +3651,6 @@
 /area/ship/expe/corridor1)
 "ix" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -4134,7 +3666,6 @@
 "iy" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -4144,7 +3675,6 @@
 /area/ship/expe/maintenancerim)
 "iz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -4154,15 +3684,12 @@
 /area/ship/expe/maintenancerim)
 "iA" = (
 /obj/machinery/atmospherics/pipe/cap/visible/scrubbers{
-	icon_state = "cap-scrubbers";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/cap/visible/supply{
-	icon_state = "cap-supply";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 9
 	},
 /obj/structure/cable{
@@ -4172,14 +3699,12 @@
 /area/ship/expe/maintenancerim)
 "iB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/wall/rpshull,
 /area/ship/expe/engines)
 "iC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 10
 	},
 /turf/simulated/floor,
@@ -4193,11 +3718,9 @@
 	name = "taser cabinet"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
 /obj/item/gun/energy/taser,
@@ -4206,47 +3729,32 @@
 /area/ship/expe/seceq)
 "iF" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seceq)
 "iG" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seceq)
 "iH" = (
 /obj/structure/table/rack/shelf,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/item/clothing/suit/storage/vest,
@@ -4259,11 +3767,9 @@
 	},
 /obj/structure/table/rack/shelf,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
 /obj/item/clothing/suit/storage/vest,
@@ -4275,47 +3781,32 @@
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/secmain)
 "iK" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/secmain)
 "iL" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4326,11 +3817,9 @@
 /obj/item/handcuffs,
 /obj/item/storage/backpack/satchel/sec,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/item/clothing/under/brandjumpsuit/hephaestus,
@@ -4352,11 +3841,9 @@
 "iN" = (
 /obj/machinery/vending/security,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4366,15 +3853,12 @@
 /area/ship/expe/medicalchem)
 "iP" = (
 /obj/machinery/firealarm{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
 /obj/structure/closet/secure_closet/medical1,
@@ -4383,11 +3867,9 @@
 "iQ" = (
 /obj/structure/closet/walllocker/emerglocker/north,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -4401,37 +3883,24 @@
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalchem)
 "iS" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalchem)
 "iT" = (
@@ -4440,11 +3909,9 @@
 /area/ship/expe/medicalchem)
 "iU" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
@@ -4452,44 +3919,36 @@
 /area/ship/expe/medicalmain)
 "iV" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalmain)
 "iW" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/sleep_console{
-	icon_state = "sleeperconsole";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalmain)
 "iX" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/machinery/sleeper{
-	icon_state = "sleeper_0";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -4497,22 +3956,18 @@
 "iY" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalmain)
 "iZ" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/machinery/atmospherics/component/unary/freezer,
@@ -4520,11 +3975,9 @@
 /area/ship/expe/medicalmain)
 "ja" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/machinery/atmospherics/portables_connector,
@@ -4536,11 +3989,9 @@
 /area/ship/expe/medicalmain)
 "jb" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/structure/table/reinforced,
@@ -4549,11 +4000,9 @@
 /area/ship/expe/medicalmain)
 "jc" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
 /obj/machinery/atmospherics/component/unary/cryo_cell,
@@ -4565,11 +4014,9 @@
 "je" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
 /obj/item/storage/firstaid/o2,
@@ -4580,11 +4027,9 @@
 /obj/structure/table/reinforced,
 /obj/structure/closet/walllocker/emerglocker/north,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/item/storage/firstaid/regular,
@@ -4599,11 +4044,9 @@
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/item/storage/firstaid/toxin,
@@ -4615,11 +4058,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
 /obj/structure/closet/crate,
@@ -4630,18 +4071,15 @@
 /area/ship/expe/medicaleq)
 "ji" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4651,14 +4089,12 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner_techfloor_grid{
-	icon_state = "corner_techfloor_grid";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4667,7 +4103,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact-fuel";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -4701,11 +4136,9 @@
 /obj/fiftyspawner/uranium,
 /obj/fiftyspawner/uranium,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4715,11 +4148,9 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4734,11 +4165,9 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4757,23 +4186,18 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4784,21 +4208,18 @@
 /area/ship/expe/sm)
 "jv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/simulated/wall/r_lead,
 /area/ship/expe/sm)
 "jw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/simulated/wall/r_lead,
 /area/ship/expe/sm)
 "jx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/simulated/floor,
@@ -4813,7 +4234,6 @@
 /area/ship/expe/sm)
 "jz" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -4843,7 +4263,6 @@
 /area/ship/expe/sm)
 "jD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/cable{
@@ -4860,7 +4279,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -4873,7 +4291,6 @@
 /area/ship/expe/sm)
 "jF" = (
 /obj/machinery/atmospherics/component/binary/pump{
-	icon_state = "map_off";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -4886,7 +4303,6 @@
 /area/ship/expe/sm)
 "jG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -4899,7 +4315,6 @@
 /area/ship/expe/sm)
 "jH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -4912,14 +4327,12 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/simulated/floor,
 /area/ship/expe/sm)
 "jJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -4931,7 +4344,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/simulated/floor,
@@ -4943,21 +4355,18 @@
 /area/ship/expe/sm)
 "jM" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/space,
 /area/ship/expe/sm)
 "jN" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/space,
 /area/ship/expe/sm)
 "jO" = (
 /obj/structure/bed/chair/bay/comfy/captain{
-	icon_state = "capchair_preview";
 	dir = 4
 	},
 /obj/machinery/computer/ship/navigation/telescreen{
@@ -4965,7 +4374,6 @@
 	pixel_y = 1
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4974,7 +4382,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/modular_computer/console{
-	icon_state = "console";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4988,18 +4395,15 @@
 /area/ship/expe/bridge)
 "jR" = (
 /obj/structure/bed/chair/bay/comfy{
-	icon_state = "bay_comfychair_preview";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/bridge)
 "jS" = (
 /obj/machinery/computer/ship/helm{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -5059,11 +4463,9 @@
 	name = "e-gun cabinet"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/item/gun/energy/gun,
@@ -5081,26 +4483,21 @@
 /area/ship/expe/seceq)
 "kg" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seceq)
 "kh" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -5122,22 +4519,18 @@
 /area/ship/expe/secmain)
 "kl" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/secmain)
 "km" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/structure/table/reinforced,
@@ -5151,11 +4544,9 @@
 /area/ship/expe/medicalchem)
 "ko" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
@@ -5165,18 +4556,15 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -5190,7 +4578,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -5203,18 +4590,15 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -5224,7 +4608,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -5237,14 +4620,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalmain)
 "ku" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -5263,7 +4644,6 @@
 /area/ship/expe/medicalmain)
 "kw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
@@ -5274,40 +4654,33 @@
 /area/ship/expe/medicalmain)
 "ky" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalmain)
 "kz" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/machinery/vending/wallmed1{
 	layer = 3.3;
 	name = "Emergency NanoMed";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalmain)
 "kA" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/item/storage/firstaid/fire,
@@ -5325,33 +4698,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicaleq)
 "kE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -5364,11 +4731,9 @@
 /area/ship/expe/engineeringequipment)
 "kG" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -5380,37 +4745,24 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineering)
 "kI" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringpower)
 "kJ" = (
@@ -5419,11 +4771,9 @@
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -5433,11 +4783,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/structure/closet/radiation,
@@ -5445,11 +4793,9 @@
 /area/ship/expe/engineeringpower)
 "kL" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
@@ -5458,11 +4804,9 @@
 /area/ship/expe/engineeringpower)
 "kM" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -5472,11 +4816,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -5484,11 +4826,9 @@
 "kO" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -5496,11 +4836,9 @@
 "kP" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
 /obj/machinery/telecomms/allinone,
@@ -5513,40 +4851,33 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor4)
 "kR" = (
 /obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
 	dir = 4
 	},
 /turf/simulated/floor,
 /area/ship/expe/sm)
 "kS" = (
 /obj/machinery/atmospherics/component/binary/pump/high_power{
-	icon_state = "map_off";
 	dir = 4
 	},
 /turf/simulated/floor,
 /area/ship/expe/sm)
 "kT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue{
-	icon_state = "map";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -5605,11 +4936,9 @@
 /area/ship/expe/sm)
 "lc" = (
 /obj/machinery/atmospherics/pipe/cap/visible/supply{
-	icon_state = "cap-supply";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/cap/visible/scrubbers{
-	icon_state = "cap-scrubbers";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -5619,14 +4948,12 @@
 /area/ship/expe/sm)
 "ld" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/space,
 /area/ship/expe/sm)
 "le" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 8
 	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
@@ -5636,7 +4963,6 @@
 /area/ship/expe/corridor6)
 "lf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5644,7 +4970,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -5655,12 +4980,10 @@
 /area/ship/expe/bridge)
 "lh" = (
 /obj/machinery/computer/ship/sensors{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -5701,11 +5024,9 @@
 /area/ship/expe/corridor1)
 "ln" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/danger/corner{
-	icon_state = "dangercorner";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -5714,11 +5035,9 @@
 /obj/structure/table/rack/shelf,
 /obj/item/storage/box/holobadge,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -5734,11 +5053,9 @@
 /obj/item/storage/box/handcuffs,
 /obj/item/storage/box/handcuffs,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/machinery/holopad/ship/starts_inactive,
@@ -5750,41 +5067,33 @@
 /area/ship/expe/secmain)
 "ls" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/secmain)
 "lt" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/secmain)
 "lu" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/machinery/chem_master,
@@ -5792,7 +5101,6 @@
 /area/ship/expe/medicalchem)
 "lv" = (
 /obj/structure/bed/chair/office/light{
-	icon_state = "officechair_white";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -5804,11 +5112,9 @@
 /area/ship/expe/medicalchem)
 "lx" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -5819,11 +5125,9 @@
 /area/ship/expe/medicalchem)
 "lz" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -5833,14 +5137,12 @@
 /area/ship/expe/medicalmain)
 "lB" = (
 /obj/machinery/sleep_console{
-	icon_state = "sleeperconsole";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalmain)
 "lC" = (
 /obj/machinery/sleeper{
-	icon_state = "sleeper_0";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -5855,35 +5157,28 @@
 /area/ship/expe/medicalmain)
 "lE" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalmain)
 "lF" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/item/storage/firstaid/adv,
 /obj/item/storage/firstaid/adv,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicaleq)
@@ -5895,11 +5190,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/structure/table/reinforced,
@@ -5909,11 +5202,9 @@
 "lI" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
 /obj/structure/dispenser/oxygen,
@@ -5922,11 +5213,9 @@
 "lJ" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
@@ -5938,11 +5227,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/engineering_welding,
@@ -5954,38 +5241,25 @@
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringequipment)
 "lM" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringequipment)
 "lN" = (
@@ -5993,11 +5267,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6021,18 +5293,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/pipedispenser/disposal,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringpower)
 "lT" = (
 /obj/machinery/atmospherics/component/binary/pump/high_power{
-	icon_state = "map_off";
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -6076,7 +5345,6 @@
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced/full,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6084,14 +5352,12 @@
 "ma" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6100,7 +5366,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/bed/chair/bay/comfy{
-	icon_state = "bay_comfychair_preview";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6110,18 +5375,15 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/computer/ship/sensors{
-	icon_state = "computer";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/bridge)
 "md" = (
 /obj/item/modular_computer/console{
-	icon_state = "console";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6131,22 +5393,18 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/danger{
-	icon_state = "danger";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/hangar)
 "mf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6156,70 +5414,57 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/hangar)
 "mh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor1)
 "mi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor1)
 "mj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor1)
 "mk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6231,22 +5476,18 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor1)
 "mm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
@@ -6260,11 +5501,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/danger{
-	icon_state = "danger";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6272,11 +5511,9 @@
 "mo" = (
 /obj/structure/table/rack/shelf,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/item/clothing/accessory/armor/armorplate,
@@ -6307,11 +5544,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6331,11 +5566,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6367,11 +5600,9 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6380,11 +5611,9 @@
 /obj/structure/table/reinforced,
 /obj/machinery/chemical_dispenser,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -6392,11 +5621,9 @@
 "my" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/item/storage/box/pillbottles,
@@ -6404,22 +5631,17 @@
 /area/ship/expe/medicalchem)
 "mz" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalmain)
@@ -6437,11 +5659,9 @@
 /area/ship/expe/medicalmain)
 "mC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 5
 	},
 /obj/structure/cable{
@@ -6454,7 +5674,6 @@
 /area/ship/expe/medicalmain)
 "mD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -6470,7 +5689,6 @@
 /area/ship/expe/medicalmain)
 "mE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -6480,11 +5698,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -6501,7 +5717,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -6514,18 +5729,15 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -6535,7 +5747,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -6552,19 +5763,15 @@
 /area/ship/expe/medicaleq)
 "mJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 9
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/structure/table/reinforced,
@@ -6579,7 +5786,6 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/yellow/border,
 /obj/machinery/firealarm{
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6587,44 +5793,36 @@
 "mM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringequipment)
 "mN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringequipment)
 "mO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringequipment)
 "mP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6641,11 +5839,9 @@
 /area/ship/expe/engineeringequipment)
 "mR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -6661,33 +5857,27 @@
 /area/ship/expe/engineeringequipment)
 "mS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineering)
 "mT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -6697,11 +5887,9 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6714,11 +5902,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6740,11 +5926,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/pipedispenser,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6752,25 +5936,21 @@
 "mY" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/simulated/floor,
 /area/ship/expe/sm)
 "mZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue{
-	icon_state = "map";
 	dir = 1
 	},
 /turf/simulated/floor,
 /area/ship/expe/sm)
 "na" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue{
-	icon_state = "map";
 	dir = 4
 	},
 /obj/machinery/meter,
@@ -6810,7 +5990,6 @@
 "ng" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/door/blast/regular{
@@ -6821,7 +6000,6 @@
 /area/ship/expe/sm)
 "nh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/meter,
@@ -6829,11 +6007,9 @@
 /area/ship/expe/sm)
 "ni" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -6843,18 +6019,15 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor6)
 "nj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -6869,18 +6042,15 @@
 /area/ship/expe/bridge)
 "nk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6888,7 +6058,6 @@
 "nl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -6898,7 +6067,6 @@
 /area/ship/expe/bridge)
 "nm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 10
 	},
 /obj/structure/cable{
@@ -6915,11 +6083,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/danger{
-	icon_state = "danger";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6929,14 +6095,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/hangar)
 "nq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6946,18 +6110,15 @@
 /area/ship/expe/hangar)
 "nr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/hangar)
 "ns" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6973,7 +6134,6 @@
 "nu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6998,7 +6158,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -7051,7 +6210,6 @@
 /area/ship/expe/corridor1)
 "nD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -7059,11 +6217,9 @@
 "nE" = (
 /obj/structure/table/rack/shelf,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /obj/item/clothing/accessory/holster/leg,
@@ -7078,11 +6234,9 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/machinery/firealarm,
@@ -7111,11 +6265,9 @@
 "nI" = (
 /obj/structure/table/rack/shelf,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /obj/item/clothing/suit/armor/pcarrier,
@@ -7123,8 +6275,7 @@
 /obj/item/clothing/accessory/storage/pouches/large/navy,
 /obj/item/clothing/accessory/storage/pouches/large/navy,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seceq)
@@ -7169,11 +6320,9 @@
 "nO" = (
 /obj/machinery/chem_master,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -7183,14 +6332,12 @@
 	dir = 4
 	},
 /obj/structure/bed/chair/office/light{
-	icon_state = "officechair_white";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalchem)
 "nQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7199,11 +6346,9 @@
 "nR" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/item/storage/box/syringes,
@@ -7215,11 +6360,9 @@
 	pixel_y = -1
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -7232,14 +6375,12 @@
 /area/ship/expe/medicalmain)
 "nU" = (
 /obj/machinery/body_scanconsole{
-	icon_state = "scanner_terminal_off";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalmain)
 "nV" = (
 /obj/machinery/bodyscanner{
-	icon_state = "scanner_open";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -7256,11 +6397,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7281,17 +6420,13 @@
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicaleq)
@@ -7307,11 +6442,9 @@
 /area/ship/expe/medicaleq)
 "ob" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/structure/table/reinforced,
@@ -7326,11 +6459,9 @@
 /area/ship/expe/corridor4)
 "oe" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -7341,7 +6472,6 @@
 /area/ship/expe/engineeringequipment)
 "of" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7358,7 +6488,6 @@
 /area/ship/expe/engineeringequipment)
 "oh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7371,15 +6500,12 @@
 /area/ship/expe/engineeringequipment)
 "oi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 10
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/machinery/suit_cycler/engineering,
@@ -7390,33 +6516,27 @@
 /area/ship/expe/engineeringequipment)
 "oj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 5
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineering)
 "ok" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7432,33 +6552,27 @@
 /area/ship/expe/engineeringpower)
 "ol" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringpower)
 "om" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -7466,7 +6580,6 @@
 "on" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7479,7 +6592,6 @@
 /area/ship/expe/engineeringpower)
 "oo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -7490,11 +6602,9 @@
 /area/ship/expe/engineeringpower)
 "op" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7507,11 +6617,9 @@
 /area/ship/expe/engineeringpower)
 "oq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7521,11 +6629,9 @@
 /area/ship/expe/engineeringpower)
 "or" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7535,26 +6641,21 @@
 /area/ship/expe/engineeringpower)
 "os" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringpower)
 "ot" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 9
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -7566,40 +6667,33 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor5)
 "ov" = (
 /obj/machinery/atmospherics/component/unary/freezer{
-	icon_state = "freezer_0";
 	dir = 1
 	},
 /turf/simulated/floor,
 /area/ship/expe/sm)
 "ow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/simulated/floor,
 /area/ship/expe/sm)
 "ox" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/cable{
@@ -7616,7 +6710,6 @@
 /area/ship/expe/sm)
 "oz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/machinery/power/rad_collector,
@@ -7627,20 +6720,12 @@
 /area/ship/expe/sm)
 "oA" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/power/terminal{
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor6)
 "oB" = (
@@ -7650,7 +6735,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7664,7 +6748,6 @@
 /area/ship/expe/bridge)
 "oD" = (
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /obj/machinery/photocopier,
@@ -7685,18 +6768,15 @@
 /area/ship/expe/bridge)
 "oG" = (
 /obj/machinery/computer/message_monitor{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/bridge)
 "oH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7704,7 +6784,6 @@
 /area/ship/expe/hangar)
 "oI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -7712,18 +6791,15 @@
 "oJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/hangar)
 "oK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -7738,15 +6814,13 @@
 "oM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/hangar)
 "oN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -7758,11 +6832,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/danger{
-	icon_state = "danger";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -7778,18 +6850,15 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor1)
 "oR" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/danger{
-	icon_state = "danger";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -7813,15 +6882,12 @@
 /area/ship/expe/seccells)
 "oV" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -7831,35 +6897,24 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/sechall)
 "oX" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seclobby2)
 "oY" = (
@@ -7867,11 +6922,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -7885,11 +6938,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -7902,11 +6953,9 @@
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -7915,11 +6964,9 @@
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -7936,25 +6983,16 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalchem)
 "pe" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalmain)
 "pf" = (
@@ -7974,7 +7012,6 @@
 /area/ship/expe/medicalmain)
 "ph" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -7990,11 +7027,9 @@
 	pixel_x = -28
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -8007,11 +7042,9 @@
 /area/ship/expe/medicaleq)
 "pk" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -8025,11 +7058,9 @@
 /obj/fiftyspawner/glass,
 /obj/fiftyspawner/steel,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8044,11 +7075,9 @@
 "pp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/structure/table/rack,
@@ -8058,22 +7087,18 @@
 /area/ship/expe/engineeringequipment)
 "pq" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineering)
 "pr" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8102,11 +7127,9 @@
 /area/ship/expe/engineeringpower)
 "pv" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8120,9 +7143,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/button/remote/blast_door{
+	id = "SuperMatterDoors";
 	pixel_x = 24;
-	pixel_y = 1;
-	id = "SuperMatterDoors"
+	pixel_y = 1
 	},
 /turf/simulated/floor,
 /area/ship/expe/sm)
@@ -8150,22 +7173,18 @@
 /area/ship/expe/sm)
 "pB" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/danger{
-	icon_state = "danger";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/hangar)
 "pC" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/danger/corner{
-	icon_state = "dangercorner";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8173,11 +7192,9 @@
 "pD" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/danger{
-	icon_state = "danger";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8185,33 +7202,27 @@
 "pE" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/danger{
-	icon_state = "danger";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/hangar)
 "pF" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/danger{
-	icon_state = "danger";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/hangar)
 "pG" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/danger/corner{
-	icon_state = "dangercorner";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8234,7 +7245,6 @@
 /area/ship/expe/hangar)
 "pJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8245,11 +7255,9 @@
 /area/ship/expe/hangar)
 "pK" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
 /obj/structure/closet,
@@ -8259,11 +7267,9 @@
 /area/ship/expe/expedition)
 "pL" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/structure/closet,
@@ -8284,11 +7290,9 @@
 /area/ship/expe/hangarcontrol)
 "pN" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/structure/table/rack/shelf,
@@ -8299,11 +7303,9 @@
 /area/ship/expe/expedition)
 "pO" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/structure/table/rack/shelf,
@@ -8315,27 +7317,16 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/expedition)
 "pP" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/expedition)
 "pQ" = (
@@ -8344,22 +7335,18 @@
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/expedition)
 "pR" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
 /obj/machinery/autolathe{
@@ -8376,7 +7363,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8386,16 +7372,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/alarms_hidden/east_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/hangar)
 "pU" = (
@@ -8404,41 +7382,27 @@
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seccells)
 "pV" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seccells)
 "pW" = (
@@ -8446,22 +7410,18 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seccells)
 "pX" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8471,45 +7431,32 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/machinery/firealarm,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seclobby)
 "pZ" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/sechall)
 "qa" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /obj/machinery/firealarm,
@@ -8518,11 +7465,9 @@
 "qb" = (
 /obj/structure/bed/chair/office/light,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8537,11 +7482,9 @@
 "qd" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/item/paper_bin,
@@ -8561,11 +7504,9 @@
 "qg" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /obj/item/storage/box/beakers,
@@ -8579,14 +7520,12 @@
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /obj/structure/bed/chair/office/light{
-	icon_state = "officechair_white";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalchem)
 "qi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 9
 	},
 /obj/effect/floor_decal/borderfloorwhite,
@@ -8597,11 +7536,9 @@
 "qj" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /obj/item/reagent_containers/spray/cleaner,
@@ -8609,11 +7546,9 @@
 /area/ship/expe/medicalchem)
 "qk" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -8671,11 +7606,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /obj/structure/cable{
@@ -8686,11 +7619,9 @@
 "qs" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -8704,11 +7635,9 @@
 "qu" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
@@ -8717,11 +7646,9 @@
 /obj/structure/table/steel_reinforced,
 /obj/fiftyspawner/plasteel,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8729,11 +7656,9 @@
 "qw" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8744,7 +7669,6 @@
 /area/ship/expe/engineeringpower)
 "qy" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -8759,11 +7683,9 @@
 "qA" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8775,23 +7697,18 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8805,11 +7722,9 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -8850,23 +7765,13 @@
 /turf/simulated/wall/rpshull,
 /area/ship/expe/captqua)
 "qJ" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/captqua)
 "qK" = (
@@ -8876,7 +7781,6 @@
 	},
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/machinery/photocopier/faxmachine,
@@ -8884,7 +7788,6 @@
 /area/ship/expe/captqua)
 "qL" = (
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/machinery/photocopier,
@@ -8893,7 +7796,6 @@
 "qM" = (
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8901,7 +7803,6 @@
 "qN" = (
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8911,14 +7812,12 @@
 /area/ship/expe/captqua)
 "qP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 10
 	},
 /turf/simulated/floor,
 /area/ship/expe/maintenance1)
 "qQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	icon_state = "map-aux";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -8932,22 +7831,18 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	icon_state = "intact-aux";
 	dir = 9
 	},
 /turf/simulated/floor,
 /area/ship/expe/maintenance1)
 "qT" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8971,32 +7866,16 @@
 /area/ship/expe/expedition)
 "qY" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/expedition)
-"qZ" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/expe/corridor1)
 "ra" = (
 /obj/structure/catwalk,
 /turf/simulated/floor,
@@ -9006,11 +7885,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -9054,11 +7931,9 @@
 /area/ship/expe/seccells)
 "rf" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -9071,11 +7946,9 @@
 /area/ship/expe/seccells)
 "rh" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -9086,11 +7959,9 @@
 "rj" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/item/folder/red,
@@ -9180,11 +8051,9 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/mechanical,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -9218,11 +8087,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /obj/structure/closet/firecloset/full,
@@ -9230,22 +8097,18 @@
 /area/ship/expe/engineeringequipment)
 "rC" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineering)
 "rD" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -9253,11 +8116,9 @@
 "rE" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -9290,17 +8151,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringpower)
 "rI" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -32
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor,
 /area/ship/expe/corridor4)
 "rJ" = (
@@ -9321,11 +8175,9 @@
 "rL" = (
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -9347,7 +8199,6 @@
 /area/ship/expe/smstorage)
 "rO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/structure/cable{
@@ -9360,7 +8211,6 @@
 /area/ship/expe/sm)
 "rP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -9370,7 +8220,6 @@
 /area/ship/expe/sm)
 "rQ" = (
 /obj/machinery/atmospherics/component/trinary/atmos_filter/m_filter{
-	icon_state = "mmap";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -9390,29 +8239,24 @@
 /area/ship/expe/sm)
 "rT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor6)
 "rU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -9427,11 +8271,9 @@
 /area/ship/expe/captqua)
 "rV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -9441,40 +8283,33 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/captqua)
 "rW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/captqua)
 "rX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/captqua)
 "rY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -9484,12 +8319,10 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -9512,18 +8345,15 @@
 /area/ship/expe/corridor4)
 "sh" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/expedition)
 "si" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -9531,7 +8361,6 @@
 "sj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 6
 	},
 /obj/structure/bed/chair,
@@ -9539,11 +8368,9 @@
 /area/ship/expe/expedition)
 "sk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/bed/chair,
@@ -9551,7 +8378,6 @@
 /area/ship/expe/expedition)
 "sl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -9560,11 +8386,9 @@
 /area/ship/expe/expedition)
 "sm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -9575,11 +8399,9 @@
 /area/ship/expe/expedition)
 "sn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -9589,33 +8411,27 @@
 /area/ship/expe/expedition)
 "so" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/expedition)
 "sp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -9630,22 +8446,18 @@
 /area/ship/expe/expedition)
 "sq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -9663,25 +8475,16 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seccells)
 "su" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seclobby)
 "sv" = (
@@ -9689,11 +8492,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -9707,11 +8508,9 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
 /obj/machinery/light{
@@ -9722,38 +8521,31 @@
 "sx" = (
 /obj/machinery/holoplant,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medical)
 "sy" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medical)
 "sz" = (
 /obj/machinery/firealarm{
-	pixel_x = 0;
 	pixel_y = 31
 	},
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -9762,29 +8554,24 @@
 /obj/structure/closet/walllocker/emerglocker/north,
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medical)
 "sB" = (
 /obj/structure/closet/secure_closet/medical_wall{
-	pixel_x = 0;
 	pixel_y = 32;
 	req_access = "";
 	req_one_access = ""
 	},
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -9796,11 +8583,9 @@
 	},
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -9810,37 +8595,26 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medical)
 "sE" = (
 /obj/structure/table/reinforced,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
 /obj/item/storage/box/freezer,
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalsur)
 "sF" = (
@@ -9852,11 +8626,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -9866,22 +8638,18 @@
 /area/ship/expe/medicalsur)
 "sG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 5
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -9895,11 +8663,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -9910,11 +8676,9 @@
 "sI" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
 /obj/item/storage/box/freezer,
@@ -9924,11 +8688,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 9
 	},
 /obj/structure/cable{
@@ -9942,11 +8704,9 @@
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -9959,11 +8719,9 @@
 /obj/structure/bed,
 /obj/structure/curtain/medical,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -9976,11 +8734,9 @@
 /obj/structure/bed,
 /obj/structure/curtain/medical,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -9989,11 +8745,9 @@
 /obj/structure/bed,
 /obj/structure/curtain/medical,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -10002,11 +8756,9 @@
 /obj/structure/bed,
 /obj/structure/curtain/medical,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
@@ -10030,20 +8782,16 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/machinery/door/airlock/glass,
@@ -10057,7 +8805,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -10068,7 +8815,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/structure/closet/walllocker/emerglocker/west,
@@ -10086,25 +8832,21 @@
 	dir = 1
 	},
 /obj/structure/bed/chair/bay/comfy/captain{
-	icon_state = "capchair_preview";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/captqua)
 "tb" = (
 /obj/item/modular_computer/console{
-	icon_state = "console";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/captqua)
 "to" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 5
 	},
 /obj/structure/bed/chair{
@@ -10114,7 +8856,6 @@
 /area/ship/expe/expedition)
 "tp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10124,7 +8865,6 @@
 /area/ship/expe/expedition)
 "tq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/table/steel_reinforced,
@@ -10133,7 +8873,6 @@
 /area/ship/expe/expedition)
 "tr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/table/steel_reinforced,
@@ -10142,7 +8881,6 @@
 /area/ship/expe/expedition)
 "ts" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/table/steel_reinforced,
@@ -10151,7 +8889,6 @@
 /area/ship/expe/expedition)
 "tt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 10
 	},
 /obj/structure/bed/chair{
@@ -10161,11 +8898,9 @@
 /area/ship/expe/expedition)
 "tu" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -10175,7 +8910,6 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -10190,19 +8924,15 @@
 "tz" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -10213,11 +8943,9 @@
 /area/ship/expe/seclobby)
 "tB" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -10230,11 +8958,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -10259,26 +8985,21 @@
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medical)
 "tI" = (
 /obj/machinery/firealarm{
-	pixel_x = -31;
-	pixel_y = 0
+	pixel_x = -31
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /obj/structure/table/reinforced,
@@ -10296,41 +9017,29 @@
 "tL" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/item/storage/firstaid/surgery,
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalsur)
 "tM" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
+/obj/machinery/power/apc/alarms_hidden/west_bump,
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medical1)
 "tN" = (
@@ -10347,29 +9056,24 @@
 /area/ship/expe/medical1)
 "tP" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medical1)
 "tS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
@@ -10377,33 +9081,27 @@
 /area/ship/expe/corridor4)
 "tT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor4)
 "tU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/machinery/door/firedoor/glass,
@@ -10412,26 +9110,21 @@
 /area/ship/expe/corridor4)
 "tV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor4)
 "tW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/machinery/alarm{
@@ -10439,65 +9132,46 @@
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor5)
 "tX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor5)
 "tY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor5)
 "tZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
@@ -10505,15 +9179,12 @@
 /area/ship/expe/corridor5)
 "ua" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -10523,36 +9194,30 @@
 /area/ship/expe/corridor5)
 "ub" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor5)
 "uc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -10567,88 +9232,72 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor5)
 "ue" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor5)
 "uf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor5)
 "ug" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor5)
 "uh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor5)
 "ui" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/machinery/door/firedoor/glass,
@@ -10657,34 +9306,27 @@
 /area/ship/expe/corridor5)
 "uj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner_techfloor_grid{
-	icon_state = "corner_techfloor_grid";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor6)
 "uk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -10695,14 +9337,12 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/captqua)
 "um" = (
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -10750,7 +9390,6 @@
 /area/ship/expe/expedition)
 "uC" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -10765,11 +9404,9 @@
 /area/ship/expe/seccells)
 "uG" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -10779,11 +9416,9 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -10803,11 +9438,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -10828,11 +9461,9 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -10842,11 +9473,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -10866,7 +9495,6 @@
 /area/ship/expe/medical)
 "uP" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -32
 	},
@@ -10883,32 +9511,26 @@
 "uQ" = (
 /obj/machinery/holoplant,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /obj/machinery/vending/wallmed1{
 	layer = 3.3;
 	name = "Emergency NanoMed";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medical)
 "uR" = (
 /obj/machinery/computer/operating{
-	icon_state = "computer";
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -10940,15 +9562,12 @@
 /area/ship/expe/medicalsur)
 "uV" = (
 /obj/machinery/computer/operating{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
@@ -10958,11 +9577,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -10984,11 +9601,9 @@
 /obj/structure/bed,
 /obj/structure/curtain/medical,
 /obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
@@ -11000,7 +9615,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -11133,7 +9747,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -11146,7 +9759,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -11172,7 +9784,6 @@
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/captaindouble,
 /obj/effect/floor_decal/corner/blue/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -11192,11 +9803,9 @@
 /area/ship/expe/expedition)
 "vA" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
@@ -11240,7 +9849,6 @@
 /area/ship/expe/corridor2)
 "vJ" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /obj/machinery/door/firedoor/glass,
@@ -11260,13 +9868,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor2)
@@ -11320,15 +9925,12 @@
 /area/ship/expe/expedition)
 "vY" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 4
 	},
 /obj/structure/table/rack/shelf,
@@ -11342,22 +9944,18 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor1)
 "wb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor,
@@ -11370,69 +9968,49 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner_techfloor_grid/full{
-	icon_state = "corner_techfloor_grid_full";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor2)
 "wd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor2)
 "we" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor2)
 "wf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
@@ -11440,15 +10018,12 @@
 /area/ship/expe/corridor2)
 "wg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -11458,15 +10033,12 @@
 /area/ship/expe/corridor2)
 "wh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/machinery/alarm{
@@ -11477,15 +10049,12 @@
 /area/ship/expe/corridor2)
 "wi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -11495,45 +10064,36 @@
 /area/ship/expe/corridor2)
 "wj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor2)
 "wk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor2)
 "wl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
@@ -11541,31 +10101,25 @@
 /area/ship/expe/corridor2)
 "wm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner_techfloor_grid/full{
-	icon_state = "corner_techfloor_grid_full";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor2)
 "wn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/machinery/door/firedoor/glass,
@@ -11574,18 +10128,15 @@
 /area/ship/expe/corridor2)
 "wo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 9
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 9
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -11623,11 +10174,9 @@
 /area/ship/expe/maintenance2)
 "wC" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 10
 	},
 /obj/structure/table/steel_reinforced,
@@ -11677,11 +10226,9 @@
 /area/ship/expe/expedition)
 "wJ" = (
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 6
 	},
 /obj/structure/table/rack/shelf,
@@ -11692,7 +10239,6 @@
 /area/ship/expe/expedition)
 "wK" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 10
 	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
@@ -11705,7 +10251,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor,
@@ -11820,7 +10365,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner_techfloor_grid/full{
-	icon_state = "corner_techfloor_grid_full";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -11831,7 +10375,6 @@
 	},
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/machinery/door/firedoor/glass,
@@ -11843,7 +10386,6 @@
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -11851,7 +10393,6 @@
 "xb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 5
 	},
 /obj/structure/cable{
@@ -11864,8 +10405,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/access_button/airlock_interior{
 	pixel_x = 24;
@@ -11938,7 +10478,6 @@
 /area/ship/expe/southairlock)
 "xE" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
 	dir = 1
 	},
 /obj/structure/closet/firecloset/full,
@@ -11946,19 +10485,13 @@
 /area/ship/expe/maintenancerim)
 "xG" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
 	dir = 1
 	},
 /turf/simulated/floor,
 /area/ship/expe/maintenancerim)
 "xH" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -32
-	},
-/obj/machinery/power/terminal,
 /obj/structure/cable,
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/southairlock)
 "xI" = (
@@ -12005,19 +10538,10 @@
 /turf/simulated/floor,
 /area/ship/expe/engines)
 "xY" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor,
 /area/ship/expe/engines)
 "xZ" = (
@@ -12043,9 +10567,7 @@
 /turf/simulated/floor,
 /area/ship/expe/engines)
 "yu" = (
-/obj/effect/overmap/visitable/ship/vespa{
-	fore_dir = 4
-	},
+/obj/effect/overmap/visitable/ship/vespa,
 /turf/space,
 /area/space)
 "yv" = (
@@ -12066,7 +10588,6 @@
 /area/space)
 "yH" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -12076,18 +10597,15 @@
 /area/ship/expe/corridor4)
 "yI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -12097,18 +10615,15 @@
 /area/ship/expe/corridor3)
 "yJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -12118,15 +10633,12 @@
 /area/ship/expe/corridor3)
 "yK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -12137,11 +10649,9 @@
 "yL" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -12151,15 +10661,12 @@
 /area/ship/expe/expedition)
 "yM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -12169,15 +10676,12 @@
 /area/ship/expe/corridor2)
 "yN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -12200,11 +10704,9 @@
 /obj/item/handcuffs,
 /obj/item/storage/backpack/satchel/sec,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_black";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	icon_state = "bordercolor";
 	dir = 1
 	},
 /obj/item/clothing/under/brandjumpsuit/hephaestus,
@@ -12247,7 +10749,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -17586,7 +16087,7 @@ mk
 nC
 oQ
 pS
-qZ
+tv
 sq
 tv
 uC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Replaces all Shuttle Template APCs with 'No Alarm' variants.**

## Why It's Good For The Game

1. _Turns out people who mapped these didn't put 'No Alarm' APCs in. Had to fix it myself._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes No Alarm APC lack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
