### PR TITLE
Holsters and Rigs

### DIFF
--- a/code/modules/preferences/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/preferences/preference_setup/loadout/loadout_accessories.dm
@@ -149,6 +149,22 @@
 	path = /obj/item/clothing/accessory/storage/white_drop_pouches
 	cost = 2
 
+/datum/gear/accessory/holster_selection
+	name = "Holster - Selection"
+	path = /obj/item/clothing/accessory/holster
+	cost = 1
+
+/datum/gear/accessory/holster_selection/New()
+	..()
+	var/holstertype = list()
+	holstertype["Holster - Shoulder"] = /obj/item/clothing/accessory/holster
+	holstertype["Holster - Armpit"] = /obj/item/clothing/accessory/holster/armpit
+	holstertype["Holster - Waist"] = /obj/item/clothing/accessory/holster/waist
+	holstertype["Holster - Hip"] = /obj/item/clothing/accessory/holster/hip
+	holstertype["Holster - Leg"] = /obj/item/clothing/accessory/holster/leg
+	holstertype["Holster - Machete"] = /obj/item/clothing/accessory/holster/machete
+	gear_tweaks += new/datum/gear_tweak/path(holstertype)
+
 /datum/gear/accessory/fannypack
 	name = "Fannypack - Selection"
 	cost = 2

--- a/code/modules/preferences/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/preferences/preference_setup/loadout/loadout_utility.dm
@@ -224,6 +224,12 @@ modular computers
 	name = "Dufflebag - Black"
 	path = /obj/item/storage/backpack/dufflebag/fluff
 
+/datum/gear/utility/rigbag
+	name = "Rig Storage Unit"
+	path = /obj/item/storage/backpack/rig
+	slot = SLOT_ID_BACK
+	cost = 0
+
 /datum/gear/utility/welding_helmet
 	name = "Welding Helmet"
 	path = /obj/item/clothing/head/welding


### PR DESCRIPTION
Adds holsters to the loadout's accessory menu, and adds matrix recolorable/renamable rigs to the utility section.

Yes the bug with machete holsters spawning filled was fixed, ping me if people somehow find a way to spawn with them since it should be impossible. Would likely be a result of some witchcraft, and very intentional abuse of the loadout system.