### PR TITLE
Rift Arrival spawn fix + classm dorms

### DIFF
--- a/code/__DEFINES/jobs/spawnpoints.dm
+++ b/code/__DEFINES/jobs/spawnpoints.dm
@@ -4,7 +4,7 @@
 /// Arrivals shuttle
 #define LATEJOIN_METHOD_ARRIVALS_SHUTTLE	"Arrivals Shuttle"
 /// Cryostorage
-#define LATEJOIN_METHOD_CRYOGENIC_STORAGE	"Cryogenics bay"
+#define LATEJOIN_METHOD_CRYOGENIC_STORAGE	"Cryogenic storage"
 /// Gateway teleport in
 #define LATEJOIN_METHOD_GATEWAY				"Gateway"
 /// Robotic storage

--- a/code/game/landmarks/spawnpoint/station/misc.dm
+++ b/code/game/landmarks/spawnpoint/station/misc.dm
@@ -31,7 +31,7 @@
 
 /obj/landmark/spawnpoint/latejoin/station/cryogenics
 	method = LATEJOIN_METHOD_CRYOGENIC_STORAGE
-	announce_template = "%NAME%, %JOB%, has complated cryogenic revival."
+	announce_template = "%NAME%, %JOB%, has completed cryogenic revival."
 
 /obj/landmark/spawnpoint/latejoin/station/cyborg
 	method = LATEJOIN_METHOD_ROBOT_STORAGE

--- a/maps/map_files/rift/rift-02-underground2.dmm
+++ b/maps/map_files/rift/rift-02-underground2.dmm
@@ -4466,7 +4466,6 @@
 /obj/machinery/camera/network/civilian{
 	dir = 10
 	},
-/obj/landmark/spawnpoint/latejoin/station/cryogenics,
 /turf/simulated/floor/tiled/techfloor,
 /area/cryo)
 "my" = (
@@ -5410,7 +5409,6 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
-/obj/landmark/spawnpoint/latejoin/station/cryogenics,
 /turf/simulated/floor/tiled/techfloor,
 /area/cryo)
 "oT" = (
@@ -7452,13 +7450,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/secure_storage/lower)
-"vS" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/landmark/spawnpoint/latejoin/station/cryogenics,
-/turf/simulated/floor/tiled/techfloor,
-/area/cryo)
 "vT" = (
 /obj/effect/floor_decal/chapel{
 	dir = 4
@@ -32149,9 +32140,9 @@ Ze
 Ze
 Kw
 jL
-vS
+kJ
 GP
-vS
+kJ
 pl
 Kw
 mu

--- a/maps/map_files/rift/rift-06-surface3.dmm
+++ b/maps/map_files/rift/rift-06-surface3.dmm
@@ -13390,6 +13390,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/landmark/spawnpoint/latejoin/station/shuttle_dock,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway)
 "aBk" = (
@@ -14124,6 +14125,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/landmark/spawnpoint/latejoin/station/shuttle_dock,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway)
 "aCQ" = (
@@ -25797,16 +25799,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
-"hZy" = (
-/obj/effect/floor_decal/industrial/halfstair{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/landmark/spawnpoint/latejoin/station/shuttle_dock,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/secondary/docking_hallway)
 "idS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -26201,16 +26193,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacethree)
-"mic" = (
-/obj/effect/floor_decal/industrial/halfstair{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/landmark/spawnpoint/latejoin/station/shuttle_dock,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/secondary/docking_hallway)
 "mrO" = (
 /obj/machinery/holoposter{
 	pixel_x = 32
@@ -27047,6 +27029,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/telescience_lab)
+"wXZ" = (
+/obj/landmark/spawnpoint/latejoin/station/shuttle_dock,
+/turf/simulated/floor/tiled/steel,
+/area/hallway/secondary/docking_hallway)
 "xbo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -40234,7 +40220,7 @@ asG
 aWo
 alz
 asq
-ave
+wXZ
 axJ
 aRS
 aEu
@@ -42172,7 +42158,7 @@ aUu
 aUu
 aUu
 aMw
-hZy
+weY
 aRJ
 anG
 aoX
@@ -42948,7 +42934,7 @@ aUu
 aUu
 aUu
 aMw
-mic
+kXF
 aRJ
 anG
 aoX
@@ -44890,7 +44876,7 @@ aqB
 aGN
 asp
 aDI
-ave
+wXZ
 axJ
 aRS
 aEu

--- a/maps/map_files/rift/rift-06-surface3.dmm
+++ b/maps/map_files/rift/rift-06-surface3.dmm
@@ -25642,6 +25642,16 @@
 /obj/machinery/smartfridge/food,
 /turf/simulated/wall,
 /area/crew_quarters/kitchen)
+"ggM" = (
+/obj/effect/floor_decal/industrial/halfstair{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/landmark/spawnpoint/latejoin/station/arrivals_shuttle,
+/turf/simulated/floor/tiled/steel_grid,
+/area/hallway/secondary/docking_hallway)
 "gjR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -25876,6 +25886,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"iUa" = (
+/obj/effect/floor_decal/industrial/halfstair{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/landmark/spawnpoint/latejoin/station/shuttle_dock,
+/turf/simulated/floor/tiled/steel_grid,
+/area/hallway/secondary/docking_hallway)
 "jbR" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -26031,7 +26051,6 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/landmark/spawnpoint/latejoin/station/arrivals_shuttle,
 /obj/landmark/spawnpoint/latejoin/station/shuttle_dock,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/secondary/docking_hallway)
@@ -26983,7 +27002,6 @@
 	dir = 4
 	},
 /obj/landmark/spawnpoint/latejoin/station/arrivals_shuttle,
-/obj/landmark/spawnpoint/latejoin/station/shuttle_dock,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/secondary/docking_hallway)
 "wgh" = (
@@ -42930,7 +42948,7 @@ aUu
 aUu
 aUu
 aMw
-kXF
+ggM
 aRJ
 anG
 aoX
@@ -43124,7 +43142,7 @@ aUu
 aUu
 aUu
 aMw
-weY
+iUa
 aRJ
 anG
 aoX

--- a/maps/map_files/rift/rift-06-surface3.dmm
+++ b/maps/map_files/rift/rift-06-surface3.dmm
@@ -13390,7 +13390,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/landmark/spawnpoint/latejoin/station/shuttle_dock,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway)
 "aBk" = (
@@ -14125,7 +14124,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/landmark/spawnpoint/latejoin/station/shuttle_dock,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway)
 "aCQ" = (
@@ -26034,6 +26032,7 @@
 	dir = 8
 	},
 /obj/landmark/spawnpoint/latejoin/station/arrivals_shuttle,
+/obj/landmark/spawnpoint/latejoin/station/shuttle_dock,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/secondary/docking_hallway)
 "lcP" = (
@@ -26984,6 +26983,7 @@
 	dir = 4
 	},
 /obj/landmark/spawnpoint/latejoin/station/arrivals_shuttle,
+/obj/landmark/spawnpoint/latejoin/station/shuttle_dock,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/secondary/docking_hallway)
 "wgh" = (
@@ -27029,10 +27029,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/telescience_lab)
-"wXZ" = (
-/obj/landmark/spawnpoint/latejoin/station/shuttle_dock,
-/turf/simulated/floor/tiled/steel,
-/area/hallway/secondary/docking_hallway)
 "xbo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -40220,7 +40216,7 @@ asG
 aWo
 alz
 asq
-wXZ
+ave
 axJ
 aRS
 aEu
@@ -44876,7 +44872,7 @@ aqB
 aGN
 asp
 aDI
-wXZ
+ave
 axJ
 aRS
 aEu

--- a/maps/map_files/rift/rift-06-surface3.dmm
+++ b/maps/map_files/rift/rift-06-surface3.dmm
@@ -25615,6 +25615,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/rift/trade_shop/landing_pad)
+"fLu" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/landmark/spawnpoint/latejoin/station,
+/turf/simulated/floor/tiled/steel,
+/area/hallway/secondary/docking_hallway)
 "fOF" = (
 /obj/structure/table/wooden_reinforced,
 /obj/effect/floor_decal/spline/plain{
@@ -42173,7 +42183,7 @@ aUu
 aUu
 aMw
 weY
-aRJ
+fLu
 anG
 aoX
 aly
@@ -42949,7 +42959,7 @@ aUu
 aUu
 aMw
 ggM
-aRJ
+fLu
 anG
 aoX
 aPw

--- a/maps/map_files/rift/rift-06-surface3.dmm
+++ b/maps/map_files/rift/rift-06-surface3.dmm
@@ -25394,7 +25394,9 @@
 	pixel_x = -28;
 	pixel_y = -24
 	},
-/obj/landmark/spawnpoint/latejoin/station/gateway,
+/obj/landmark{
+	name = "JoinLateTeleport"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/teleporter/departing)
 "exb" = (
@@ -25615,16 +25617,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/rift/trade_shop/landing_pad)
-"fLu" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/obj/landmark/spawnpoint/latejoin/station,
-/turf/simulated/floor/tiled/steel,
-/area/hallway/secondary/docking_hallway)
 "fOF" = (
 /obj/structure/table/wooden_reinforced,
 /obj/effect/floor_decal/spline/plain{
@@ -25652,16 +25644,6 @@
 /obj/machinery/smartfridge/food,
 /turf/simulated/wall,
 /area/crew_quarters/kitchen)
-"ggM" = (
-/obj/effect/floor_decal/industrial/halfstair{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/landmark/spawnpoint/latejoin/station/arrivals_shuttle,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/secondary/docking_hallway)
 "gjR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -26349,7 +26331,9 @@
 	},
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/light,
-/obj/landmark/spawnpoint/latejoin/station/cyborg,
+/obj/landmark{
+	name = "JoinLateRobotic"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_server_room)
 "nSV" = (
@@ -26842,7 +26826,9 @@
 	pixel_x = -28;
 	pixel_y = 24
 	},
-/obj/landmark/spawnpoint/latejoin/station/gateway,
+/obj/landmark{
+	name = "JoinLateTeleport"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/teleporter/departing)
 "uoG" = (
@@ -27004,16 +26990,6 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/maintenance/research/xenobio)
-"weY" = (
-/obj/effect/floor_decal/industrial/halfstair{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/landmark/spawnpoint/latejoin/station/arrivals_shuttle,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/secondary/docking_hallway)
 "wgh" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
@@ -42182,8 +42158,8 @@ aUu
 aUu
 aUu
 aMw
-weY
-fLu
+iUa
+aRJ
 anG
 aoX
 aly
@@ -42958,8 +42934,8 @@ aUu
 aUu
 aUu
 aMw
-ggM
-fLu
+kXF
+aRJ
 anG
 aoX
 aPw

--- a/maps/map_levels/192x192/Class_M.dmm
+++ b/maps/map_levels/192x192/Class_M.dmm
@@ -464,6 +464,20 @@
 	name = "beach"
 	},
 /area/class_m/outside)
+"cz" = (
+/obj/machinery/door/airlock{
+	id_tag = "room11";
+	name = "Room 11"
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
+"cB" = (
+/obj/machinery/door/airlock{
+	id_tag = "room7";
+	name = "Room 7"
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
 "cE" = (
 /obj/structure/flora/rock,
 /obj/effect/mist,
@@ -806,6 +820,20 @@
 	},
 /turf/simulated/floor/tiled/monowhite,
 /area/class_m/inside/garage)
+"eR" = (
+/obj/machinery/button/remote/airlock{
+	id = "room9";
+	name = "Room 9 Lock";
+	pixel_x = 25;
+	pixel_y = -2;
+	specialfunctions = 4
+	},
+/obj/machinery/light/flamp/noshade{
+	light_range = 8;
+	nightshift_allowed = 0
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
 "eS" = (
 /obj/effect/floor_decal/corner/blue/bordercorner{
 	dir = 1
@@ -2395,6 +2423,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/class_m/inside/main)
+"nf" = (
+/obj/machinery/door/airlock{
+	id_tag = "room13";
+	name = "Room 13"
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
 "ng" = (
 /obj/structure/railing/grey,
 /obj/structure/railing/grey{
@@ -2999,9 +3034,6 @@
 /area/class_m/inside/hotspringcaves)
 "qG" = (
 /obj/structure/table/rack,
-/obj/item/material/fishing_rod/modern/strong,
-/obj/item/material/fishing_net,
-/obj/item/material/fishing_rod/modern/strong,
 /turf/simulated/floor/wood/classm,
 /area/class_m/inside/cabin)
 "qH" = (
@@ -3360,6 +3392,20 @@
 	name = "beach"
 	},
 /area/class_m/outside)
+"sl" = (
+/obj/machinery/button/remote/airlock{
+	id = "room14";
+	name = "Room 14 Lock";
+	pixel_x = 26;
+	pixel_y = -4;
+	specialfunctions = 4
+	},
+/obj/machinery/light/flamp/noshade{
+	light_range = 8;
+	nightshift_allowed = 0
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
 "sm" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -4047,6 +4093,20 @@
 	},
 /turf/simulated/floor/outdoors/grass,
 /area/class_m/outside)
+"wA" = (
+/obj/machinery/button/remote/airlock{
+	id = "room11";
+	name = "Room 11 Lock";
+	pixel_x = -25;
+	pixel_y = -2;
+	specialfunctions = 4
+	},
+/obj/machinery/light/flamp/noshade{
+	light_range = 8;
+	nightshift_allowed = 0
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
 "wB" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -5727,6 +5787,20 @@
 "Gb" = (
 /turf/simulated/floor/carpet/turcarpet,
 /area/class_m/inside/cabin)
+"Gf" = (
+/obj/machinery/button/remote/airlock{
+	id = "room7";
+	name = "Room 7 Lock";
+	pixel_x = 26;
+	pixel_y = -4;
+	specialfunctions = 4
+	},
+/obj/machinery/light/flamp/noshade{
+	light_range = 8;
+	nightshift_allowed = 0
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
 "Gj" = (
 /turf/simulated/floor/water/deep/classm,
 /area/class_m/outside/island2)
@@ -5984,6 +6058,20 @@
 /obj/structure/sink/puddle,
 /turf/simulated/floor/outdoors/dirt/classm/outdoors,
 /area/class_m/outside/beachmiddle)
+"HG" = (
+/obj/machinery/button/remote/airlock{
+	id = "room12";
+	name = "Room 12 Lock";
+	pixel_x = -25;
+	pixel_y = -2;
+	specialfunctions = 4
+	},
+/obj/machinery/light/flamp/noshade{
+	light_range = 8;
+	nightshift_allowed = 0
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
 "HI" = (
 /obj/machinery/icecream_vat,
 /obj/machinery/light/spot{
@@ -6124,6 +6212,20 @@
 	},
 /turf/simulated/floor/water/deep/classm,
 /area/class_m/outside)
+"ID" = (
+/obj/machinery/button/remote/airlock{
+	id = "room15";
+	name = "Room 15 Lock";
+	pixel_x = 25;
+	pixel_y = -2;
+	specialfunctions = 4
+	},
+/obj/machinery/light/flamp/noshade{
+	light_range = 8;
+	nightshift_allowed = 0
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
 "IF" = (
 /obj/structure/fence{
 	dir = 4
@@ -6353,6 +6455,20 @@
 /obj/effect/mist,
 /turf/simulated/floor/concrete/indoors,
 /area/class_m/inside/hotspringcaves)
+"JX" = (
+/obj/machinery/door/airlock{
+	id_tag = "room10";
+	name = "Room 10"
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
+"JY" = (
+/obj/machinery/door/airlock{
+	id_tag = "room12";
+	name = "Room 12"
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
 "Ka" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -6479,6 +6595,13 @@
 	dir = 8
 	},
 /area/class_m/outside)
+"KF" = (
+/obj/machinery/door/airlock{
+	id_tag = "room8";
+	name = "Room 8"
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
 "KG" = (
 /obj/machinery/door/airlock{
 	id_tag = "gaiarestroom2";
@@ -6526,6 +6649,13 @@
 "KS" = (
 /turf/simulated/floor/wood/classm/outdoors,
 /area/class_m/outside/beachmiddle)
+"KU" = (
+/obj/machinery/door/airlock{
+	id_tag = "room15";
+	name = "Room 15"
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
 "KV" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/water/deep/indoors,
@@ -7539,6 +7669,20 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/outdoors/grass/classm,
 /area/class_m/outside)
+"Pw" = (
+/obj/machinery/button/remote/airlock{
+	id = "room13";
+	name = "Room 13 Lock";
+	pixel_x = 26;
+	pixel_y = -4;
+	specialfunctions = 4
+	},
+/obj/machinery/light/flamp/noshade{
+	light_range = 8;
+	nightshift_allowed = 0
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
 "Py" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -8203,6 +8347,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/class_m/inside/main)
+"Ty" = (
+/obj/machinery/button/remote/airlock{
+	id = "room10";
+	name = "Room 10 Lock";
+	pixel_x = -25;
+	pixel_y = -2;
+	specialfunctions = 4
+	},
+/obj/machinery/light/flamp/noshade{
+	light_range = 8;
+	nightshift_allowed = 0
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
 "Tz" = (
 /turf/simulated/floor/water/beach/corner{
 	dir = 1
@@ -8279,6 +8437,13 @@
 /obj/structure/table/bench/marble,
 /turf/simulated/floor/tiled/classm/outdoors,
 /area/class_m/outside)
+"TX" = (
+/obj/machinery/door/airlock{
+	id_tag = "room9";
+	name = "Room 9"
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
 "TZ" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -8520,19 +8685,9 @@
 /area/class_m/outside)
 "VT" = (
 /obj/structure/table/rack,
-/obj/item/material/fishing_net,
-/obj/item/material/fishing_net,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/item/material/fishing_net,
-/obj/item/material/fishing_net,
-/obj/item/material/fishing_net,
-/obj/item/material/fishing_net,
-/obj/item/material/fishing_net,
-/obj/item/material/fishing_net,
-/obj/item/material/fishing_net,
-/obj/item/material/fishing_net,
 /turf/simulated/floor/concrete/tile/classm/outdoors,
 /area/class_m/outside/beachmiddle)
 "VU" = (
@@ -8561,6 +8716,13 @@
 /obj/structure/railing/grey,
 /turf/simulated/floor/concrete/rng/classm/outdoors,
 /area/class_m/outside)
+"VZ" = (
+/obj/machinery/door/airlock{
+	id_tag = "room14";
+	name = "Room 14"
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
 "Wb" = (
 /turf/simulated/floor/concrete/tile/classm/outdoors,
 /area/class_m/outside)
@@ -8593,6 +8755,20 @@
 	name = "Room 4 Lock";
 	pixel_x = -25;
 	pixel_y = -2;
+	specialfunctions = 4
+	},
+/obj/machinery/light/flamp/noshade{
+	light_range = 8;
+	nightshift_allowed = 0
+	},
+/turf/simulated/floor/wood/classm,
+/area/class_m/inside/dorms)
+"Wj" = (
+/obj/machinery/button/remote/airlock{
+	id = "room8";
+	name = "Room 8 Lock";
+	pixel_x = 26;
+	pixel_y = -4;
 	specialfunctions = 4
 	},
 /obj/machinery/light/flamp/noshade{
@@ -10417,19 +10593,19 @@ tF
 vr
 vr
 vr
-DC
+nf
 EN
 EN
 vr
 vr
 vr
-KC
+VZ
 EN
 EN
 vr
 vr
 vr
-OC
+KU
 EN
 EN
 vr
@@ -11386,19 +11562,19 @@ HA
 tF
 vr
 zf
-AS
+Pw
 DO
 EP
 Hj
 vr
 Ij
-Jc
+sl
 DO
 EP
 LH
 vr
 LY
-MR
+ID
 DO
 EP
 kO
@@ -11581,19 +11757,19 @@ gW
 vr
 vr
 vr
-DC
+nf
 vr
 vr
 vr
 vr
 vr
-KC
+VZ
 vr
 vr
 vr
 vr
 vr
-OC
+KU
 vr
 vr
 vr
@@ -12357,19 +12533,19 @@ CV
 vr
 vr
 vr
-kW
+JX
 vr
 vr
 vr
 vr
 vr
-za
+cz
 vr
 vr
 vr
 vr
 vr
-We
+JY
 vr
 vr
 vr
@@ -12550,19 +12726,19 @@ oT
 Xb
 vr
 qv
-Wi
+Ty
 DO
 Ai
 lO
 vr
 qv
-yD
+wA
 DO
 Ai
 HC
 vr
 qv
-BH
+HG
 DO
 Ai
 kY
@@ -13521,19 +13697,19 @@ tF
 vr
 vr
 vr
-kW
+JX
 aQ
 aQ
 vr
 vr
 vr
-za
+cz
 aQ
 aQ
 vr
 vr
 vr
-We
+JY
 aQ
 aQ
 vr
@@ -15267,19 +15443,19 @@ tF
 vr
 vr
 vr
-DC
+cB
 EN
 EN
 vr
 vr
 vr
-KC
+KF
 EN
 EN
 vr
 vr
 vr
-OC
+TX
 EN
 EN
 vr
@@ -16236,19 +16412,19 @@ oT
 GA
 vr
 zf
-AS
+Gf
 DO
 EP
 Hj
 vr
 Ij
-Jc
+Wj
 DO
 EP
 LH
 vr
 LY
-MR
+eR
 DO
 EP
 kO
@@ -16431,19 +16607,19 @@ UA
 vr
 vr
 vr
-DC
+cB
 vr
 vr
 vr
 vr
 vr
-KC
+KF
 vr
 vr
 vr
 vr
 vr
-OC
+TX
 vr
 vr
 vr


### PR DESCRIPTION
Placed shuttle dock spawns instead of arrival shuttle spawns. Moved shuttle dock, placed arrival spawns where they used to be.

Class M dorms had linked door bolts on 1/3rd of dorm rooms. Fixed here.