### PR TITLE
Adjusts the vatborn hunger_rate

### DIFF
--- a/code/modules/species/station/standard/human_subspecies.dm
+++ b/code/modules/species/station/standard/human_subspecies.dm
@@ -117,7 +117,7 @@
 	toxins_mod = 1.05
 
 	total_health = 115
-	hunger_factor =  0.075//50% more hungry
+	hunger_factor =  0.035
 
 	species_spawn_flags = SPECIES_SPAWN_CHARACTER
 	species_appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR

--- a/code/modules/species/station/standard/human_subspecies.dm
+++ b/code/modules/species/station/standard/human_subspecies.dm
@@ -117,7 +117,7 @@
 	toxins_mod = 1.05
 
 	total_health = 115
-	hunger_factor = 0.35//less hungry
+	hunger_factor =  0.075//50% more hungry
 
 	species_spawn_flags = SPECIES_SPAWN_CHARACTER
 	species_appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Lowers the vatborn default hunger rate from 700% to 50% higher than the baseline human.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
The comment makes me believe they were originally intended to have a *lower* hunger rate than humans. I feel like it's fine to keep them higher, this is the same value as grav-adpated humans have, without being ridiculous with how much you have to eat.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Balances the vatgrown hunger rate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
