### PR TITLE
allows abstract insertion to hands via ID

### DIFF
--- a/code/modules/mob/inventory/inventory.dm
+++ b/code/modules/mob/inventory/inventory.dm
@@ -43,7 +43,7 @@
 		slot = resolve_inventory_slot_meta(slot)?.type
 		if(!ispath(slot, /datum/inventory_slot_meta/abstract))
 			stack_trace("invalid slot: [slot]")
-		else
+		else if(slot != /datum/inventory_slot_meta/abstract/put_in_hands)
 			stack_trace("attempted usage of slot id in abstract insertion converted successfully")
 	. = FALSE
 	switch(slot)


### PR DESCRIPTION
unlike the other slot IDs, there's a valid use case since this "abstract" type is used by worn slot detection, so it's valid to be passed around as either an ID or a typepath, since things can grab it out of the inventory system.

the other abstract slots cannot be grabbed out of inventory.