### PR TITLE
Shuttle colors, Allure Skrell lore, and more

### DIFF
--- a/code/game/mecha/combat/fighter.dm
+++ b/code/game/mecha/combat/fighter.dm
@@ -238,7 +238,7 @@
 ////////////// Gunpod //////////////
 
 /obj/mecha/combat/fighter/gunpod
-	name = "Gunpod"
+	name = "\improper Gunpod"
 	desc = "Small mounted weapons platform capable of space and surface combat. More like a flying tank than a dedicated fightercraft."
 	icon = 'icons/mecha/fighters64x64.dmi'
 	icon_state = "gunpod"
@@ -265,7 +265,7 @@
 	ME.attach(src)
 
 /obj/mecha/combat/fighter/gunpod/recon
-	name = "Reconnaissance Gunpod"
+	name = "\improper Reconnaissance Gunpod"
 	desc = "Small mounted weapons platform capable of space and surface combat. More like a flying tank than a dedicated fightercraft. This stripped down model is used for long range reconnaissance ."
 
 /obj/mecha/combat/fighter/gunpod/recon/Initialize(mapload) //Blinky
@@ -322,7 +322,7 @@
 ////////////// Baron //////////////
 
 /obj/mecha/combat/fighter/baron
-	name = "Baron"
+	name = "\improper Baron"
 	desc = "A conventional space superiority fighter, one-seater. Not capable of ground operations."
 	icon = 'icons/mecha/fighters64x64.dmi'
 	icon_state = "baron"
@@ -349,7 +349,7 @@
 	bound_height = 64
 
 /obj/mecha/combat/fighter/baron/sec
-	name = "Baron-SV"
+	name = "\improper Baron-SV"
 	desc = "A conventional space superiority fighter, one-seater. Not capable of ground operations. The Baron-SV (Security Variant) is frequently used by NT Security forces during EVA patrols."
 
 /obj/mecha/combat/fighter/baron/sec/loaded/Initialize(mapload) //Loaded version with gans
@@ -370,7 +370,7 @@
 ////////////// Scoralis //////////////
 
 /obj/mecha/combat/fighter/scoralis
-	name = "scoralis"
+	name = "\improper Scoralis"
 	desc = "An imported space fighter with integral cloaking device. Beware the power consumption, though. Not capable of ground operations."
 	icon = 'icons/mecha/fighters64x64.dmi'
 	icon_state = "scoralis"
@@ -406,8 +406,8 @@
 ////////////// Allure //////////////
 
 /obj/mecha/combat/fighter/allure
-	name = "allure"
-	desc = "A fighter of Zorren design, it's blocky appearance is made up for by it's stout armor and finely decorated hull paint."
+	name = "\improper Allure"
+	desc = "A fighter of Skrellian design. Its angular shape and wide overhead cross-section is made up for by it's stout armor and carefully crafted hull paint."
 	icon = 'icons/mecha/fighters64x64.dmi'
 	icon_state = "allure"
 	initial_icon = "allure"
@@ -443,7 +443,7 @@
 ////////////// Pinnace //////////////
 
 /obj/mecha/combat/fighter/pinnace
-	name = "pinnace"
+	name = "\improper Pinnace"
 	desc = "A cramped ship's boat, capable of atmospheric and space flight. Not capable of mounting traditional weapons. Capable of fitting one pilot and one passenger."
 	icon = 'icons/mecha/fighters64x64.dmi'
 	icon_state = "pinnace"
@@ -485,7 +485,7 @@
 ////////////// Cludge //////////////
 
 /obj/mecha/combat/fighter/cludge
-	name = "Cludge"
+	name = "\improper Cludge"
 	desc = "A heater, nozzle, and fuel tank strapped together. There are exposed wires strewn about it."
 	icon = 'icons/mecha/fighters64x64.dmi'
 	icon_state = "cludge"

--- a/maps/map_files/rift/rift-06-surface3.dmm
+++ b/maps/map_files/rift/rift-06-surface3.dmm
@@ -6800,21 +6800,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/turretid{
-	check_access = 0;
-	control_area = /area/shuttle/excursion/general;
-	gl_uid = "exploration";
-	pixel_x = -32;
-	req_access = null;
-	req_one_access = list(19,43,62,67);
-	uid = "exploration"
-	},
 /obj/machinery/light{
 	dir = 8;
 	light_range = 12
 	},
 /obj/item/storage/toolbox/mechanical,
 /obj/item/tank/phoron,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/cockpit)
 "anx" = (
@@ -12320,11 +12315,16 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 8
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/turretid{
+	check_access = 0;
+	control_area = /area/shuttle/excursion/general;
+	gl_uid = "exploration";
+	pixel_x = 32;
+	req_access = null;
+	req_one_access = list(19,43,62,67);
+	uid = "exploration"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/excursion/cockpit)
 "ayS" = (
@@ -24592,15 +24592,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/mineral/equipment_vendor/survey,
-/obj/machinery/turretid{
-	check_access = 0;
-	control_area = /area/shuttle/excursion/general;
-	gl_uid = "exploration";
-	pixel_x = 32;
-	req_access = null;
-	req_one_access = list(19,43,62,67);
-	uid = "exploration"
-	},
 /obj/machinery/light{
 	dir = 4
 	},

--- a/maps/map_levels/140x140/tradeport.dmm
+++ b/maps/map_levels/140x140/tradeport.dmm
@@ -3511,9 +3511,6 @@
 /turf/simulated/wall/r_wall,
 /area/tradeport/pads)
 "nr" = (
-/obj/structure/closet/walllocker/autolok_wall{
-	pixel_y = 24
-	},
 /obj/structure/closet/secure_closet/guncabinet{
 	anchored = 1;
 	req_access = list(160);

--- a/maps/map_levels/192x192/tradeport.dmm
+++ b/maps/map_levels/192x192/tradeport.dmm
@@ -1904,9 +1904,6 @@
 /turf/simulated/floor/wood,
 /area/tradeport/commons)
 "hs" = (
-/obj/structure/closet/walllocker/autolok_wall{
-	pixel_y = 24
-	},
 /obj/structure/closet/secure_closet/guncabinet{
 	anchored = 1;
 	req_access = list(160);

--- a/maps/nsv_triumph/triumph_overmap.dm
+++ b/maps/nsv_triumph/triumph_overmap.dm
@@ -5,7 +5,7 @@
 /obj/effect/overmap/visitable/ship/landable/excursion
 	name = "Excursion Shuttle"
 	desc = "A modified Excursion shuttle thats seen in use of the Marksman fleet of NanoTrasen."
-	color = "#ba00f2" //Purple
+	color = "#72388d" //Purple
 	fore_dir = WEST
 	vessel_mass = 10000
 	vessel_size = SHIP_SIZE_SMALL
@@ -31,7 +31,7 @@
 /obj/effect/overmap/visitable/ship/landable/courser
 	name = "Courser Scouting Vessel"
 	desc = "Where there's a cannon, there's a way."
-	color = "#f200f2" //Pinkish Purple
+	color = "#af3e97" //Pinkish Purple
 	fore_dir = EAST
 	vessel_mass = 8000
 	vessel_size = SHIP_SIZE_SMALL
@@ -65,7 +65,7 @@
 /obj/effect/overmap/visitable/ship/landable/trade
 	name = "Beruang Trade Ship"
 	desc = "You know our motto: 'We deliver!'"
-	color = "#7c3902" //Brown
+	color = "#754116" //Brown
 	fore_dir = WEST
 	vessel_mass = 25000
 	vessel_size = SHIP_SIZE_SMALL

--- a/maps/nsv_triumph/triumph_overmap.dm
+++ b/maps/nsv_triumph/triumph_overmap.dm
@@ -5,6 +5,7 @@
 /obj/effect/overmap/visitable/ship/landable/excursion
 	name = "Excursion Shuttle"
 	desc = "A modified Excursion shuttle thats seen in use of the Marksman fleet of NanoTrasen."
+	color = "#ba00f2" //Purple
 	fore_dir = WEST
 	vessel_mass = 10000
 	vessel_size = SHIP_SIZE_SMALL
@@ -30,6 +31,7 @@
 /obj/effect/overmap/visitable/ship/landable/courser
 	name = "Courser Scouting Vessel"
 	desc = "Where there's a cannon, there's a way."
+	color = "#f200f2" //Pinkish Purple
 	fore_dir = EAST
 	vessel_mass = 8000
 	vessel_size = SHIP_SIZE_SMALL
@@ -52,6 +54,7 @@
 /obj/effect/overmap/visitable/ship/landable/mining
 	name = "Mining Shuttle"
 	desc = "It ain't much, but it's honest work."
+	color = "#ba7d4b" //Tan
 	fore_dir = WEST
 	vessel_mass = 7000
 	vessel_size = SHIP_SIZE_SMALL
@@ -62,6 +65,7 @@
 /obj/effect/overmap/visitable/ship/landable/trade
 	name = "Beruang Trade Ship"
 	desc = "You know our motto: 'We deliver!'"
+	color = "#7c3902" //Brown
 	fore_dir = WEST
 	vessel_mass = 25000
 	vessel_size = SHIP_SIZE_SMALL
@@ -72,6 +76,7 @@
 /obj/effect/overmap/visitable/ship/landable/emt
 	name = "Dart EMT Shuttle"
 	desc = "The budget didn't allow for flashing lights."
+	color = "#00a5f2" //Light Blue
 	fore_dir = EAST
 	vessel_mass = 9000
 	vessel_size = SHIP_SIZE_SMALL

--- a/maps/overmap/shuttles/pirateskiff.dm
+++ b/maps/overmap/shuttles/pirateskiff.dm
@@ -14,6 +14,7 @@
 /obj/effect/overmap/visitable/ship/landable/pirate
 	name = "Unknown Vessel"
 	desc = "Scans inconclusive."
+	color = "#751713" //Dark Red
 	fore_dir = WEST
 	vessel_mass = 8000
 	vessel_size = SHIP_SIZE_SMALL

--- a/maps/rift/rift_shuttles.dm
+++ b/maps/rift/rift_shuttles.dm
@@ -120,7 +120,7 @@
 /obj/effect/overmap/visitable/ship/landable/excursion
 	name = "Excursion Shuttle"
 	desc = "The Mk2 Excursion Shuttle. NT Approved!"
-	color = "#ba00f2" //Purple
+	color = "#72388d" //Purple
 	fore_dir = WEST
 	vessel_mass = 10000
 	vessel_size = SHIP_SIZE_SMALL
@@ -146,7 +146,7 @@
 /obj/effect/overmap/visitable/ship/landable/courser
 	name = "Courser Scouting Vessel"
 	desc = "Where there's a cannon, there's a way."
-	color = "#f200f2" //Pinkish Purple
+	color = "#af3e97" //Pinkish Purple
 	fore_dir = EAST
 	vessel_mass = 8000
 	vessel_size = SHIP_SIZE_SMALL
@@ -175,7 +175,7 @@
 /obj/effect/overmap/visitable/ship/landable/hammerhead
 	name = "Hammerhead Patrol Barge"
 	desc = "To Detain and Enforce."
-	color = "#d20700" //Vibrant Red
+	color = "#b91a14" //Vibrant Red
 	fore_dir = EAST
 	vessel_mass = 10000
 	vessel_size = SHIP_SIZE_SMALL
@@ -232,7 +232,7 @@
 /obj/effect/overmap/visitable/ship/landable/trade
 	name = "Beruang Trade Ship"
 	desc = "You know our motto: 'We deliver!'"
-	color = "#7c3902" //Brown
+	color = "#754116" //Brown
 	fore_dir = WEST
 	vessel_mass = 25000
 	vessel_size = SHIP_SIZE_SMALL
@@ -261,7 +261,7 @@
 /obj/effect/overmap/visitable/ship/landable/emt
 	name = "Dart EMT Shuttle"
 	desc = "The budget didn't allow for flashing lights."
-	color = "#00a5f2" //Light Blue
+	color = "#69b9de" //Light Blue
 	fore_dir = NORTH
 	vessel_mass = 9000
 	vessel_size = SHIP_SIZE_SMALL

--- a/maps/rift/rift_shuttles.dm
+++ b/maps/rift/rift_shuttles.dm
@@ -120,6 +120,7 @@
 /obj/effect/overmap/visitable/ship/landable/excursion
 	name = "Excursion Shuttle"
 	desc = "The Mk2 Excursion Shuttle. NT Approved!"
+	color = "#ba00f2" //Purple
 	fore_dir = WEST
 	vessel_mass = 10000
 	vessel_size = SHIP_SIZE_SMALL
@@ -145,6 +146,7 @@
 /obj/effect/overmap/visitable/ship/landable/courser
 	name = "Courser Scouting Vessel"
 	desc = "Where there's a cannon, there's a way."
+	color = "#f200f2" //Pinkish Purple
 	fore_dir = EAST
 	vessel_mass = 8000
 	vessel_size = SHIP_SIZE_SMALL
@@ -173,6 +175,7 @@
 /obj/effect/overmap/visitable/ship/landable/hammerhead
 	name = "Hammerhead Patrol Barge"
 	desc = "To Detain and Enforce."
+	color = "#d20700" //Vibrant Red
 	fore_dir = EAST
 	vessel_mass = 10000
 	vessel_size = SHIP_SIZE_SMALL
@@ -229,6 +232,7 @@
 /obj/effect/overmap/visitable/ship/landable/trade
 	name = "Beruang Trade Ship"
 	desc = "You know our motto: 'We deliver!'"
+	color = "#7c3902" //Brown
 	fore_dir = WEST
 	vessel_mass = 25000
 	vessel_size = SHIP_SIZE_SMALL
@@ -257,6 +261,7 @@
 /obj/effect/overmap/visitable/ship/landable/emt
 	name = "Dart EMT Shuttle"
 	desc = "The budget didn't allow for flashing lights."
+	color = "#00a5f2" //Light Blue
 	fore_dir = NORTH
 	vessel_mass = 9000
 	vessel_size = SHIP_SIZE_SMALL


### PR DESCRIPTION
Replaces Zorren lore with Skrellian for the Allure Fighter.

Removes a buggy wall mount that blocks a locker on the trade ship

Removes a duplicate turret control panel on the exploration shuttle, and moves it to a more visible location.

Gives most overmap shuttles a unique color, except for civilian shuttles.