### PR TITLE
further drops job switch lockout (10 to 3 minutes)

### DIFF
--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -223,7 +223,7 @@
 /obj/machinery/computer/timeclock/proc/checkCardCooldown()
 	if(!card)
 		return FALSE
-	var/time_left = 10 MINUTES - (world.time - card.last_job_switch)
+	var/time_left = 3 MINUTES - (world.time - card.last_job_switch)
 	if(time_left > 0)
 		to_chat(usr, "You need to wait another [round((time_left/10)/60, 1)] minute\s before you can switch.")
 		return FALSE


### PR DESCRIPTION
## Why this is good for the game

![image](https://user-images.githubusercontent.com/2003111/234417333-b61ee9cd-6d6b-418d-bfbd-a6a3b6cced00.png)

## Changelog

:cl: 
tweak: Job on/off duty swapping is now a 3 minute lockout instead of 10.
/:cl:
