### PR TITLE
QOL Improvements to Hammerhead & Air Connector Ports for Mechs/Fighters

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -74,6 +74,15 @@
 	storage_name = "Travel Oversight Control"
 	allow_items = TRUE
 
+/obj/machinery/computer/cryopod/psych_ward
+	name = "psych ward oversight console"
+	desc = "An interface between patients and the cryo pod oversight systems tasked with keeping track of all patients who enter deep storage."
+	circuit = "/obj/item/circuitboard/robotstoragecontrol"
+
+	storage_type = "patients"
+	storage_name = "Patient Storage Control"
+	allow_items = TRUE
+
 /obj/machinery/computer/cryopod/ashlander
 	name = "protective warrens token"
 	desc = "A hand carved fetish meant to be hung near entrances to the Warrens, to ward off evil spirits."

--- a/maps/map_files/rift/rift-03-underground1.dmm
+++ b/maps/map_files/rift/rift-03-underground1.dmm
@@ -2522,9 +2522,9 @@
 	req_access = list(47)
 	},
 /obj/machinery/door/blast/regular/open{
+	dir = 4;
 	id = "scistorage6";
-	name = "Blast Doors";
-	dir = 4
+	name = "Blast Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/secure_storage/upper)
@@ -3032,9 +3032,9 @@
 	req_access = list(47)
 	},
 /obj/machinery/door/blast/regular/open{
+	dir = 4;
 	id = "scistorage1";
-	name = "Blast Doors";
-	dir = 4
+	name = "Blast Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/secure_storage/upper)
@@ -3089,9 +3089,9 @@
 	req_access = list(47)
 	},
 /obj/machinery/door/blast/regular/open{
+	dir = 4;
 	id = "scistorage12";
-	name = "Blast Doors";
-	dir = 4
+	name = "Blast Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/secure_storage/upper)
@@ -3308,9 +3308,9 @@
 	req_access = list(47)
 	},
 /obj/machinery/door/blast/regular/open{
+	dir = 4;
 	id = "scistorage2";
-	name = "Blast Doors";
-	dir = 4
+	name = "Blast Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/secure_storage/upper)
@@ -3779,6 +3779,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"lz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/tiled/techmaint,
+/area/rift/station/fighter_bay/hangar)
 "lA" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
@@ -3830,9 +3834,9 @@
 	req_access = list(47)
 	},
 /obj/machinery/door/blast/regular/open{
+	dir = 4;
 	id = "scistorage5";
-	name = "Blast Doors";
-	dir = 4
+	name = "Blast Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/secure_storage/upper)
@@ -3851,6 +3855,13 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/atmos)
+"lP" = (
+/obj/machinery/mech_recharger,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/rift/station/fighter_bay/hangar)
 "lR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 10
@@ -3887,20 +3898,20 @@
 /area/rnd/secure_storage/upper)
 "lY" = (
 /obj/machinery/button/remote/blast_door{
+	dir = 4;
 	id = "scistorage1";
 	name = "Blast Door Controls";
 	pixel_x = -30;
 	pixel_y = -5;
-	req_access = list(47);
-	dir = 4
+	req_access = list(47)
 	},
 /obj/machinery/button/remote/blast_door{
+	dir = 4;
 	id = "scistorage2";
 	name = "Blast Door Controls";
 	pixel_x = -30;
 	pixel_y = 5;
-	req_access = list(47);
-	dir = 4
+	req_access = list(47)
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/secure_storage/upper)
@@ -4147,6 +4158,12 @@
 "mQ" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/atmos/hallway)
+"mU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/rift/station/fighter_bay/maintenance)
 "na" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/clean,
@@ -4662,20 +4679,20 @@
 /area/rift/surfacebase/underground/under1)
 "pa" = (
 /obj/machinery/button/remote/blast_door{
+	dir = 4;
 	id = "scistorage3";
 	name = "Blast Door Controls";
 	pixel_x = -30;
 	pixel_y = -5;
-	req_access = list(47);
-	dir = 4
+	req_access = list(47)
 	},
 /obj/machinery/button/remote/blast_door{
+	dir = 4;
 	id = "scistorage4";
 	name = "Blast Door Controls";
 	pixel_x = -30;
 	pixel_y = 5;
-	req_access = list(47);
-	dir = 4
+	req_access = list(47)
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/secure_storage/upper)
@@ -5071,7 +5088,20 @@
 /obj/mecha/combat/fighter/pinnace/loaded{
 	dir = 1
 	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techmaint,
+/area/rift/station/fighter_bay/hangar)
+"rk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/cyan,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/rift/station/fighter_bay/hangar)
 "rm" = (
 /obj/structure/bed/chair/sofa/black{
@@ -5157,11 +5187,11 @@
 	id = "scistorage_sidedoor"
 	},
 /obj/machinery/button/remote/blast_door{
+	dir = 4;
 	id = "scistorage_sidedoor";
 	name = "Blast Door Controls";
 	pixel_x = -30;
-	req_access = list(47);
-	dir = 4
+	req_access = list(47)
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/secure_storage/upper)
@@ -5621,6 +5651,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/rift/station/fighter_bay)
 "tl" = (
@@ -5970,6 +6003,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/rift/station/fighter_bay/hangar)
 "uz" = (
@@ -6229,9 +6265,9 @@
 	req_access = list(47)
 	},
 /obj/machinery/door/blast/regular/open{
+	dir = 4;
 	id = "scistorage3";
-	name = "Blast Doors";
-	dir = 4
+	name = "Blast Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/secure_storage/upper)
@@ -6284,11 +6320,11 @@
 /area/security/prison)
 "vG" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 4;
 	input_tag = "mix_in";
 	name = "Waste Tank Control";
 	output_tag = "mix_out";
-	sensors = list("mix_sensor"="Tank");
-	dir = 4
+	sensors = list("mix_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
@@ -6500,6 +6536,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/rift/station/fighter_bay)
 "wy" = (
@@ -6513,6 +6552,9 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/rift/station/fighter_bay)
 "wz" = (
@@ -6735,20 +6777,20 @@
 /area/storage/tech)
 "xm" = (
 /obj/machinery/button/remote/blast_door{
+	dir = 4;
 	id = "scistorage6";
 	name = "Blast Door Controls";
 	pixel_x = -30;
 	pixel_y = -5;
-	req_access = list(47);
-	dir = 4
+	req_access = list(47)
 	},
 /obj/machinery/button/remote/blast_door{
+	dir = 4;
 	id = "scistorage7";
 	name = "Blast Door Controls";
 	pixel_x = -30;
 	pixel_y = 5;
-	req_access = list(47);
-	dir = 4
+	req_access = list(47)
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/secure_storage/upper)
@@ -6956,9 +6998,9 @@
 	req_access = list(47)
 	},
 /obj/machinery/door/blast/regular/open{
+	dir = 4;
 	id = "scistorage10";
-	name = "Blast Doors";
-	dir = 4
+	name = "Blast Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/secure_storage/upper)
@@ -7185,9 +7227,9 @@
 	req_access = list(47)
 	},
 /obj/machinery/door/blast/regular/open{
+	dir = 4;
 	id = "scistorage4";
-	name = "Blast Doors";
-	dir = 4
+	name = "Blast Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/secure_storage/upper)
@@ -7455,6 +7497,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/rift/station/fighter_bay/hangar)
 "zz" = (
@@ -7551,20 +7596,20 @@
 /area/maintenance/engineering)
 "zU" = (
 /obj/machinery/button/remote/blast_door{
+	dir = 8;
 	id = "scistorage11";
 	name = "Blast Door Controls";
 	pixel_x = 30;
 	pixel_y = 5;
-	req_access = list(55);
-	dir = 8
+	req_access = list(55)
 	},
 /obj/machinery/button/remote/blast_door{
+	dir = 8;
 	id = "scistorage12";
 	name = "Blast Door Controls";
 	pixel_x = 30;
 	pixel_y = -5;
-	req_access = list(55);
-	dir = 8
+	req_access = list(55)
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/secure_storage/upper)
@@ -7755,6 +7800,20 @@
 /obj/item/integrated_circuit_printer,
 /turf/simulated/floor,
 /area/storage/tech)
+"AH" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular{
+	dir = 2;
+	id = "hangar_maint";
+	name = "Hangar Maintenance Shutter"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/rift/station/fighter_bay)
 "AL" = (
 /obj/structure/catwalk/plank,
 /turf/simulated/open/lythios43c,
@@ -7806,8 +7865,8 @@
 /obj/machinery/air_sensor{
 	frequency = 1443;
 	id_tag = "air_sensor";
-	output = 7;
-	name = "Air Mix Tank Sensor"
+	name = "Air Mix Tank Sensor";
+	output = 7
 	},
 /turf/simulated/floor/reinforced/airmix,
 /area/engineering/atmos)
@@ -8107,12 +8166,12 @@
 /area/hallway/primary/underone)
 "Cn" = (
 /obj/machinery/button/remote/blast_door{
+	dir = 4;
 	id = "scistorage5";
 	name = "Blast Door Controls";
 	pixel_x = -30;
 	pixel_y = -5;
-	req_access = list(47);
-	dir = 4
+	req_access = list(47)
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/secure_storage/upper)
@@ -8470,6 +8529,18 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
+"DH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/rift/station/fighter_bay/hangar)
 "DI" = (
 /obj/spawner/window/reinforced/full/firelocks,
 /turf/simulated/floor/plating,
@@ -9064,6 +9135,13 @@
 /obj/item/fluff/injector,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/engineering)
+"Ge" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/rift/station/fighter_bay/hangar)
 "Gg" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -9076,9 +9154,9 @@
 	req_access = list(47)
 	},
 /obj/machinery/door/blast/regular/open{
+	dir = 4;
 	id = "scistorage9";
-	name = "Blast Doors";
-	dir = 4
+	name = "Blast Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/secure_storage/upper)
@@ -9139,11 +9217,11 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rift/station/fighter_bay/maintenance)
@@ -10141,8 +10219,8 @@
 /obj/structure/sign/atmos_air{
 	pixel_y = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rift/station/fighter_bay/maintenance)
@@ -10186,12 +10264,12 @@
 /area/maintenance/engineering)
 "Kg" = (
 /obj/machinery/button/remote/blast_door{
+	dir = 8;
 	id = "scistorage10";
 	name = "Blast Door Controls";
 	pixel_x = 30;
 	pixel_y = -5;
-	req_access = list(55);
-	dir = 8
+	req_access = list(55)
 	},
 /obj/machinery/camera/network/research{
 	dir = 8
@@ -10625,9 +10703,9 @@
 	req_access = list(47)
 	},
 /obj/machinery/door/blast/regular/open{
+	dir = 4;
 	id = "scistorage7";
-	name = "Blast Doors";
-	dir = 4
+	name = "Blast Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/secure_storage/upper)
@@ -10794,8 +10872,8 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/machinery/atmospherics/component/binary/heat_pump{
 	dir = 4;
-	use_power = 1;
-	target_temp = 80
+	target_temp = 80;
+	use_power = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
@@ -10995,11 +11073,11 @@
 	pixel_x = -24
 	},
 /obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 4;
 	input_tag = "o2_in";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
-	sensors = list("o2_sensor"="Tank");
-	dir = 4
+	sensors = list("o2_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
@@ -11217,6 +11295,9 @@
 	},
 /obj/machinery/camera/network/civilian{
 	dir = 10
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rift/station/fighter_bay/hangar)
@@ -11658,6 +11739,7 @@
 /area/hallway/primary/underone)
 "Pc" = (
 /obj/mecha/combat/fighter/pinnace/loaded,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/tiled/techmaint,
 /area/rift/station/fighter_bay/hangar)
 "Pd" = (
@@ -12548,13 +12630,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/hallway)
-"SH" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/component/unary/outlet_injector{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/rift/station/fighter_bay/maintenance)
 "SI" = (
 /turf/simulated/wall/r_wall,
 /area/rift/station/fighter_bay)
@@ -13049,9 +13124,9 @@
 	req_access = list(47)
 	},
 /obj/machinery/door/blast/regular/open{
+	dir = 4;
 	id = "scistorage8";
-	name = "Blast Doors";
-	dir = 4
+	name = "Blast Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/secure_storage/upper)
@@ -13300,6 +13375,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/rift/station/fighter_bay/hangar)
 "VU" = (
@@ -13467,6 +13545,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/rift/station/fighter_bay/hangar)
 "Wy" = (
@@ -13591,6 +13672,11 @@
 "WT" = (
 /turf/simulated/wall,
 /area/storage/tech)
+"WU" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/rift/station/fighter_bay/hangar)
 "WV" = (
 /obj/structure/cable/green,
 /obj/spawner/window/reinforced/full/firelocks,
@@ -13676,6 +13762,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"Xw" = (
+/obj/machinery/mech_recharger,
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/tiled/techmaint,
+/area/rift/station/fighter_bay/hangar)
 "Xx" = (
 /obj/item/reagent_containers/food/snacks/monkeycube/wrapped/farwacube,
 /turf/simulated/floor/tiled/dark,
@@ -13976,9 +14067,9 @@
 	req_access = list(47)
 	},
 /obj/machinery/door/blast/regular/open{
+	dir = 4;
 	id = "scistorage11";
-	name = "Blast Doors";
-	dir = 4
+	name = "Blast Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/secure_storage/upper)
@@ -14137,6 +14228,10 @@
 /obj/item/arrow/rod,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"Zk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/rift/station/fighter_bay/hangar)
 "Zl" = (
 /obj/structure/snowman/borg,
 /turf/simulated/floor/outdoors/snow/lythios43c,
@@ -14336,20 +14431,20 @@
 /area/crew_quarters/pool)
 "ZY" = (
 /obj/machinery/button/remote/blast_door{
+	dir = 8;
 	id = "scistorage9";
 	name = "Blast Door Controls";
 	pixel_x = 30;
 	pixel_y = -5;
-	req_access = list(55);
-	dir = 8
+	req_access = list(55)
 	},
 /obj/machinery/button/remote/blast_door{
+	dir = 8;
 	id = "scistorage8";
 	name = "Blast Door Controls";
 	pixel_x = 30;
 	pixel_y = 5;
-	req_access = list(55);
-	dir = 8
+	req_access = list(55)
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/secure_storage/upper)
@@ -20469,14 +20564,14 @@ aa
 aa
 aa
 Yu
-xS
-AO
-Vr
+Xw
+lz
+Ge
 zy
-Gn
-OI
-AO
-xS
+Zk
+WU
+lz
+lP
 Yu
 OO
 OO
@@ -20666,7 +20761,7 @@ Yu
 Tf
 AO
 Vr
-zy
+DH
 Gn
 OI
 AO
@@ -21051,13 +21146,13 @@ aa
 aa
 aa
 Yu
-xS
+Xw
 Pc
-Vr
-zy
-Gn
-OI
-AO
+Ge
+rk
+Zk
+WU
+lz
 rj
 Yu
 Ul
@@ -21248,7 +21343,7 @@ Yu
 xS
 AO
 Vr
-zy
+DH
 Gn
 OI
 AO
@@ -21633,13 +21728,13 @@ aa
 aa
 aa
 Yu
-xS
-AO
-Vr
-zy
-Gn
-OI
-AO
+Xw
+lz
+Ge
+rk
+Zk
+WU
+lz
 NH
 Yu
 dP
@@ -21830,7 +21925,7 @@ Yu
 xS
 AO
 Vr
-zy
+DH
 Gn
 OI
 AO
@@ -22800,7 +22895,7 @@ SI
 SI
 yA
 yA
-LJ
+AH
 LJ
 yA
 Db
@@ -22994,7 +23089,7 @@ YZ
 RH
 KJ
 Dw
-BU
+mU
 BU
 BU
 tO
@@ -23773,7 +23868,7 @@ WO
 va
 BU
 uz
-SH
+uz
 RH
 SI
 SI

--- a/maps/map_files/rift/rift-04-surface1.dmm
+++ b/maps/map_files/rift/rift-04-surface1.dmm
@@ -27552,8 +27552,8 @@
 /area/tether/surfacebase/entertainment)
 "rdT" = (
 /obj/machinery/door/airlock/mining{
-	req_one_access = list(31);
-	name = "Cargo Airlock"
+	name = "Cargo Airlock";
+	req_one_access = list(31)
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -31266,6 +31266,9 @@
 	},
 /obj/structure/toilet{
 	dir = 8
+	},
+/obj/machinery/computer/cryopod/gateway{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
@@ -38133,8 +38136,8 @@
 /area/medical/psych)
 "xsn" = (
 /obj/machinery/door/airlock/mining{
-	req_one_access = list(31);
-	name = "Cargo Airlock"
+	name = "Cargo Airlock";
+	req_one_access = list(31)
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,

--- a/maps/map_files/rift/rift-04-surface1.dmm
+++ b/maps/map_files/rift/rift-04-surface1.dmm
@@ -31267,7 +31267,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/computer/cryopod/gateway{
+/obj/machinery/computer/cryopod/psych_ward{
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/white,

--- a/maps/map_files/rift/rift-05-surface2.dmm
+++ b/maps/map_files/rift/rift-05-surface2.dmm
@@ -718,7 +718,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
 "ayE" = (
-/turf/simulated/floor/tiled/techmaint,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/red,
 /area/shuttle/hammerhead/bay)
 "ayG" = (
 /obj/structure/catwalk,
@@ -1184,6 +1187,7 @@
 /obj/structure/handrail{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/hammerhead/general)
 "aMU" = (
@@ -1817,6 +1821,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled/steel,
 /area/assembly/robotics)
 "bfe" = (
@@ -3279,7 +3284,8 @@
 /obj/mecha/combat/fighter/baron/sec/loaded{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/hammerhead/bay)
 "cfz" = (
 /obj/structure/closet/crate/bin{
@@ -4431,6 +4437,18 @@
 "cUW" = (
 /turf/simulated/wall/r_wall,
 /area/rift/surfacebase/outside/outside2)
+"cVK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/hammerhead_bay)
 "cWj" = (
 /obj/structure/bed/chair/backed_grey{
 	dir = 4
@@ -4694,6 +4712,13 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/maintenance/lower/medsec_maintenance)
+"diG" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/monotile,
+/area/assembly/robotics)
 "djg" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -5307,6 +5332,7 @@
 	id = "mech_bay_int";
 	name = "Mech Bay Blast Door"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/chargebay)
 "dBb" = (
@@ -6797,7 +6823,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/hammerhead_bay)
 "eCq" = (
@@ -7305,6 +7333,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
+"eWf" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/hammerhead_bay)
 "eWs" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -8245,6 +8280,12 @@
 /obj/item/hand_labeler,
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
+"fxj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/hammerhead_bay)
 "fyb" = (
 /obj/structure/sign/warning/falling,
 /turf/simulated/wall/r_wall,
@@ -8533,6 +8574,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/hammerhead_bay)
@@ -10337,6 +10381,13 @@
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled,
 /area/security/briefing_room)
+"gQB" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/hammerhead_bay)
 "gQH" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
@@ -10385,6 +10436,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/hammerhead_bay)
 "gSp" = (
@@ -10431,6 +10485,9 @@
 /obj/machinery/mech_recharger,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/assembly/chargebay)
@@ -10850,7 +10907,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
 	},
-/obj/machinery/holopad/ship/starts_inactive,
+/obj/machinery/holopad/ship,
 /turf/simulated/floor/tiled/red,
 /area/shuttle/hammerhead/general)
 "hnY" = (
@@ -11517,7 +11574,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/holodeck_control)
 "hKy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/hammerhead/general)
 "hKz" = (
@@ -11744,6 +11803,13 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/heads/hor)
+"hPc" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/hammerhead_bay)
 "hPi" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -12118,6 +12184,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/hammerhead/general)
 "icx" = (
@@ -12143,10 +12210,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
-"ief" = (
-/obj/machinery/mech_recharger,
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/hammerhead/bay)
+"ieh" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/hammerhead/general)
 "iek" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/space_heater,
@@ -13095,6 +13167,9 @@
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "iMB" = (
 /obj/machinery/mech_recharger,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/assembly/chargebay)
 "iML" = (
@@ -13325,6 +13400,17 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/maintenance/research/rnd)
+"iSS" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/voidcraft/vertical{
+	name = "Ready Room";
+	req_one_access = list(1,38)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/hammerhead/general)
 "iTw" = (
 /turf/simulated/open,
 /area/rnd/telescience_lab/foyer)
@@ -13412,6 +13498,9 @@
 /turf/simulated/floor/water/deep/pool,
 /area/crew_quarters/pool)
 "iXe" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/assembly/chargebay)
 "iXg" = (
@@ -13430,6 +13519,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/research)
+"iXD" = (
+/obj/machinery/mech_recharger,
+/turf/simulated/floor/tiled/red,
+/area/shuttle/hammerhead/bay)
 "iYa" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/effect/floor_decal/corner/green/diagonal{
@@ -14547,6 +14640,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/robotics)
+"jNS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/tiled/red,
+/area/shuttle/hammerhead/bay)
 "jOg" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -15054,6 +15151,9 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/hammerhead_bay)
@@ -15644,6 +15744,9 @@
 /obj/item/gun/ballistic/shotgun/flare,
 /obj/item/storage/box/flashshells,
 /obj/item/duct_tape_roll,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/hammerhead/general)
 "krG" = (
@@ -16146,6 +16249,7 @@
 /obj/structure/handrail{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/hammerhead/general)
 "kIW" = (
@@ -16247,6 +16351,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/medical/surgery_hallway)
+"kMU" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/hammerhead/bay)
 "kNo" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -17106,6 +17216,7 @@
 	id = "hammerfighteraccess";
 	name = "Fighter Bay Access"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/hammerhead/bay)
 "lot" = (
@@ -18570,6 +18681,12 @@
 /obj/item/reagent_containers/food/condiment/small/sugar,
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
+"mkP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/hammerhead/general)
 "mlx" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -18910,6 +19027,9 @@
 /area/crew_quarters/recreation_area)
 "mzl" = (
 /obj/machinery/mech_recharger,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/hammerhead/bay)
 "mzx" = (
@@ -21793,6 +21913,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/coffee_shop)
 "oFw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/hammerhead/bay)
 "oFY" = (
@@ -23414,6 +23535,9 @@
 /area/security/armory/blue)
 "pCM" = (
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/assembly/chargebay)
 "pCP" = (
@@ -23565,6 +23689,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/hammerhead_bay)
@@ -23994,6 +24121,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/hammerhead/general)
@@ -24755,13 +24885,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_5)
-"qDt" = (
-/obj/machinery/door/blast/regular{
-	id = "hammerfighteraccess";
-	name = "Fighter Bay Access"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/hammerhead/bay)
 "qDA" = (
 /obj/machinery/recharge_station,
 /obj/structure/window/reinforced/tinted/frosted{
@@ -25043,6 +25166,11 @@
 /obj/machinery/flasher/portable,
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/blue)
+"qRD" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/hammerhead_bay)
 "qSf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -28269,6 +28397,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/coffee_shop)
+"tll" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/hammerhead_bay)
 "tln" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /turf/simulated/floor/wood,
@@ -28289,6 +28421,9 @@
 "tmg" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/hammerhead/general)
@@ -28982,11 +29117,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/pool/emergency_closet)
 "tJa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/hammerhead/general)
@@ -29157,6 +29292,9 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/hammerhead/general)
 "tSV" = (
@@ -29181,6 +29319,15 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
+"tVi" = (
+/obj/machinery/camera/network/security{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/hammerhead_bay)
 "tVk" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -29642,12 +29789,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/security/hallway)
 "upg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/robotics)
 "upj" = (
@@ -30325,6 +30470,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/hammerhead_bay)
 "uRh" = (
@@ -30952,6 +31100,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
+"vfd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/voidcraft/vertical{
+	name = "Breaching Nose";
+	req_one_access = list(1,38)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/hammerhead/bay)
 "vfq" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 10
@@ -31921,6 +32083,13 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
+"vNM" = (
+/obj/machinery/door/blast/regular{
+	id = "hammerfighteraccess";
+	name = "Fighter Bay Access"
+	},
+/turf/simulated/floor/tiled/red,
+/area/shuttle/hammerhead/bay)
 "vNQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -33368,6 +33537,18 @@
 /obj/item/extinguisher,
 /turf/simulated/floor/lythios43c/indoors,
 /area/rift/surfacebase/outside/outside2)
+"wQl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/hammerhead_bay)
 "wQw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -34354,7 +34535,10 @@
 /area/security/evidence_storage)
 "xya" = (
 /obj/mecha/combat/fighter/baron/sec/loaded,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/red,
 /area/shuttle/hammerhead/bay)
 "xyi" = (
 /obj/structure/cable{
@@ -34893,6 +35077,9 @@
 "xQH" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/steel,
 /area/assembly/chargebay)
@@ -35515,6 +35702,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/hammerhead/general)
 
@@ -52256,7 +52444,7 @@ ilr
 jCg
 kXL
 kXA
-szQ
+mvZ
 aEk
 xco
 xco
@@ -52449,8 +52637,8 @@ rVV
 ilr
 jCg
 kXL
-kXA
-szQ
+qRD
+mvZ
 szQ
 szQ
 szQ
@@ -52641,10 +52829,10 @@ vDu
 kYb
 ilr
 ilr
-jCg
-kXL
-kXA
-szQ
+cVK
+tll
+hPc
+mvZ
 ayG
 cwt
 cwt
@@ -52836,9 +53024,9 @@ ilr
 ilr
 xdW
 gRv
-kXL
-kXA
-szQ
+fxj
+eWf
+mvZ
 gne
 szQ
 szQ
@@ -53030,9 +53218,9 @@ ilr
 eBF
 sXr
 pLd
-gWp
+gQB
 kXA
-szQ
+mvZ
 gne
 szQ
 yjX
@@ -53095,7 +53283,7 @@ iXe
 pCM
 dAH
 beQ
-jeA
+diG
 upg
 sUU
 alW
@@ -53223,7 +53411,7 @@ lrj
 ilr
 ilr
 ilr
-jCg
+wQl
 kaZ
 kXA
 kXA
@@ -53410,15 +53598,15 @@ oOw
 dda
 bJA
 qlB
-oUL
+mkP
 fSv
 tJa
 xZl
 gbj
 jJA
 xci
-jCg
-ezh
+wQl
+tVi
 kXA
 lEq
 nxk
@@ -53798,7 +53986,7 @@ oOw
 qAA
 uZo
 qlB
-oUL
+mkP
 nxS
 tSM
 ymj
@@ -53992,7 +54180,7 @@ ilr
 ilr
 ilr
 ilr
-haT
+iSS
 haa
 haT
 ilr
@@ -54186,7 +54374,7 @@ kXL
 kXL
 ilr
 ybB
-oUL
+mkP
 nxS
 oUL
 aJI
@@ -54380,7 +54568,7 @@ bFP
 ilr
 ilr
 rEL
-azT
+ieh
 vIN
 azT
 vnt
@@ -54574,7 +54762,7 @@ jTU
 jhd
 jhd
 jhd
-mpD
+vfd
 jwp
 mpD
 jhd
@@ -54767,9 +54955,9 @@ bap
 kaH
 ayE
 ceM
-qDt
-oFw
-kCx
+lop
+kMU
+jNS
 oFw
 lop
 mzl
@@ -54959,15 +55147,15 @@ pBj
 kXA
 kXL
 kaH
-ayE
-ief
-qDt
+kCx
+iXD
+vNM
 kCx
 kCx
 kCx
-lop
-mzl
-oFw
+vNM
+iXD
+kCx
 enC
 kXL
 rtk


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Adds Lights and Air Refill System to Hammerhead.**
2. **Adds Psych Ward Cryo Computer.**
3. **Adds Air Connector Ports to Recharging Zones.**

## Why It's Good For The Game

1. _General QOL changes for Hammerhead. Also makes its holopad visible._
2. _Started getting a warning that this was missing, so I made one for the psych ward cryopod._
3. _Fighters and mecha should be able to replenish air. It turns out you can just hide these under recharging pads, which is neat._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds air connector ports to charging pads for mechs/fighters.
add: Psych Ward cryo computer.
tweak: Adjusts Hammerhead layout for QOL.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
