### PR TITLE
Makes passive vents not permanently kill themselves if they can't find a pipenet for one (1) tick

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/vent.dm
+++ b/code/modules/atmospherics/machinery/pipes/vent.dm
@@ -18,8 +18,6 @@
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "passive vent"
 
-	var/build_killswitch = 1
-
 /obj/machinery/atmospherics/pipe/vent/init_dir()
 	initialize_directions = dir
 
@@ -28,14 +26,7 @@
 	volume = 1000
 
 /obj/machinery/atmospherics/pipe/vent/process(delta_time)
-	if(!parent)
-		if(build_killswitch <= 0)
-			. = PROCESS_KILL
-		else
-			build_killswitch--
-		..()
-		return
-	else
+	if(parent)
 		parent.mingle_with_turf(loc, volume)
 
 /obj/machinery/atmospherics/pipe/vent/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

as title. instead it just only does its parent processing if it has a pipenet. worst case scenario is that you have like two vents in the entire map separated from a pipenet and repeatedly doing a single null check every 2 seconds, who cares, that's not a real problem actually, god i hate premature optimizers so much

## Why It's Good For The Game

because believe it or not microoptimizations that can ruin rounds for people and don't actually improve performance any are a bad idea. GOD I HATE PREMATURE OPTIMIZERS SO MUCH

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: passive vents no longer break with no feedback intentionally for reasons unfathomable to the user
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
