### PR TITLE
Effective dose works for alcohol subtypes' effects, + alcohol intolerance

### DIFF
--- a/citadel.dme
+++ b/citadel.dme
@@ -170,7 +170,6 @@
 #include "code\__DEFINES\dcs\signals\signals_item\signals_item_economy.dm"
 #include "code\__DEFINES\dcs\signals\signals_item\signals_item_inventory.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_appearance.dm"
-#include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_carbon.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_combat.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_inventory.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_main.dm"

--- a/citadel.dme
+++ b/citadel.dme
@@ -170,6 +170,7 @@
 #include "code\__DEFINES\dcs\signals\signals_item\signals_item_economy.dm"
 #include "code\__DEFINES\dcs\signals\signals_item\signals_item_inventory.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_appearance.dm"
+#include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_carbon.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_combat.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_inventory.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_main.dm"

--- a/code/__DEFINES/traits/mob.dm
+++ b/code/__DEFINES/traits/mob.dm
@@ -58,3 +58,7 @@ DATUM_TRAIT(/mob, TRAIT_MOB_IS_FISHING)
 /// This mob doesn't count as looking at you if you can only act while unobserved
 #define TRAIT_UNOBSERVANT "trait_unobservant"
 DATUM_TRAIT(/mob, TRAIT_UNOBSERVANT)
+
+/// This mob can't digest alcohol
+#define TRAIT_ALCOHOL_INTOLERANT "alcohol_intolerant"
+DATUM_TRAIT(/mob, TRAIT_ALCOHOL_INTOLERANT)

--- a/code/modules/mob/living/carbon/human/traits/neutral.dm
+++ b/code/modules/mob/living/carbon/human/traits/neutral.dm
@@ -277,3 +277,10 @@
 /datum/trait/neutral/cyberpsycho/apply(datum/species/S, mob/living/carbon/human/H)
 	..(S,H)
 	H.AddComponent(/datum/component/cyberpsychosis)
+
+/datum/trait/neutral/alcohol_intolerance
+	name = "Alcohol Intolerance"
+	desc = "You cannot metabolize alcohol; ingesting it will cause vomiting, toxin build-up, liver damage, pain and other unpleasantness."
+	cost = 0
+	custom_only = FALSE
+	traits = list(TRAIT_ALCOHOL_INTOLERANT)

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Dispenser.dm
@@ -111,9 +111,13 @@
 			to_chat(M, "<span class='danger'>You feel your leaves start to wilt.</span>")
 		strength_mod *=5 //cit change - alcohol ain't good for plants
 
-	M.add_chemical_effect(CE_ALCOHOL, 1)
 	var/effective_dose = dose * strength_mod * (1 + volume/60) //drinking a LOT will make you go down faster
-
+	M.add_chemical_effect(CE_ALCOHOL, 1)
+	if(HAS_TRAIT(M, TRAIT_ALCOHOL_INTOLERANT))
+		if(prob(effective_dose/2))
+			M.add_chemical_effect(CE_ALCOHOL_TOXIC, 1)
+		M.adjustToxLoss(effective_dose/2)
+		return 0
 	if(effective_dose >= strength) // Early warning
 		M.make_dizzy(18) // It is decreased at the speed of 3 per tick
 	if(effective_dose >= strength * 2) // Slurring
@@ -140,6 +144,7 @@
 
 	if(halluci)
 		M.hallucination = max(M.hallucination, halluci*3)
+	return effective_dose
 
 /datum/reagent/ethanol/affect_ingest(mob/living/carbon/M, alien, removed)
 	if(issmall(M)) removed *= 2
@@ -160,21 +165,26 @@
 	if(is_vampire)
 		handle_vampire(M, alien, removed, is_vampire)
 
+	var/effective_dose = strength_mod * dose // this was being recalculated a bunch before--why?
+	if(HAS_TRAIT(M, TRAIT_ALCOHOL_INTOLERANT))
+		if(prob(effective_dose/2))
+			M.add_chemical_effect(CE_ALCOHOL_TOXIC, 1)
+		M.adjustToxLoss(effective_dose/2)
+		return 0
 	M.add_chemical_effect(CE_ALCOHOL, 1)
-
-	if(dose * strength_mod >= strength) // Early warning
+	if(effective_dose >= strength) // Early warning
 		M.make_dizzy(6) // It is decreased at the speed of 3 per tick
-	if(dose * strength_mod >= strength * 2) // Slurring
+	if(effective_dose >= strength * 2) // Slurring
 		M.slurring = max(M.slurring, 30)
-	if(dose * strength_mod >= strength * 3) // Confusion - walking in random directions
+	if(effective_dose >= strength * 3) // Confusion - walking in random directions
 		M.Confuse(20)
-	if(dose * strength_mod >= strength * 4) // Blurry vision
+	if(effective_dose >= strength * 4) // Blurry vision
 		M.eye_blurry = max(M.eye_blurry, 10)
-	if(dose * strength_mod >= strength * 5) // Drowsyness - periodically falling asleep
+	if(effective_dose >= strength * 5) // Drowsyness - periodically falling asleep
 		M.drowsyness = max(M.drowsyness, 20)
-	if(dose * strength_mod >= strength * 6) // Toxic dose
+	if(effective_dose >= strength * 6) // Toxic dose
 		M.add_chemical_effect(CE_ALCOHOL_TOXIC, toxicity)
-	if(dose * strength_mod >= strength * 7) // Pass out
+	if(effective_dose >= strength * 7) // Pass out
 		M.afflict_unconscious(20 * 20)
 		M.afflict_sleeping(20 * 30)
 
@@ -188,6 +198,7 @@
 
 	if(halluci)
 		M.hallucination = max(M.hallucination, halluci)
+	return effective_dose
 
 /datum/reagent/ethanol/touch_obj(obj/O)
 	if(istype(O, /obj/item/paper))

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -2231,10 +2231,9 @@
 	glass_desc = "A freezing pint of beer"
 
 /datum/reagent/ethanol/beer/affect_ingest(mob/living/carbon/M, alien, removed)
-	..()
-	if(alien == IS_DIONA)
-		return
-	M.jitteriness = max(M.jitteriness - 3, 0)
+	. = ..()
+	if(.)
+		M.jitteriness = max(M.jitteriness - 3, 0)
 
 /datum/reagent/ethanol/bluecuracao
 	name = "Blue Curacao"
@@ -2273,10 +2272,9 @@
 	glass_desc = "Now you want to Pray for a pirate suit, don't you?"
 
 /datum/reagent/ethanol/deadrum/affect_ingest(mob/living/carbon/M, alien, removed)
-	..()
-	if(alien == IS_DIONA)
-		return
-	M.dizziness +=5
+	. = ..()
+	if(.)
+		M.dizziness += 5
 
 /datum/reagent/ethanol/firepunch
 	name = "Fire Punch"
@@ -2320,7 +2318,7 @@
 /datum/reagent/ethanol/coffee/affect_ingest(mob/living/carbon/M, alien, removed)
 	if(alien == IS_DIONA)
 		return
-	..()
+	. = ..() // the rest is coffee stuff, ugh, go make reagent traits etc
 	M.dizziness = max(0, M.dizziness - 5)
 	M.drowsyness = max(0, M.drowsyness - 3)
 	M.adjust_sleeping(20 * -2)
@@ -2427,7 +2425,7 @@
 	glass_desc = "This is a glass of Thirteen Loko, it appears to be of the highest quality. The drink, not the glass."
 
 /datum/reagent/ethanol/thirteenloko/affect_ingest(mob/living/carbon/M, alien, removed)
-	..()
+	. = ..()
 	if(alien == IS_DIONA)
 		return
 	M.drowsyness = max(0, M.drowsyness - 7)
@@ -2459,7 +2457,7 @@
 	glass_desc = "The glass contain wodka. Xynta."
 
 /datum/reagent/ethanol/vodka/affect_ingest(mob/living/carbon/M, alien, removed)
-	..()
+	. = ..()
 	M.cure_radiation(RAD_MOB_CURE_STRENGTH_VODKA(removed))
 
 /datum/reagent/ethanol/whiskey
@@ -2693,7 +2691,7 @@
 	glass_desc = "Heavy, hot and strong. Just like the Iron fist of the LAW."
 
 /datum/reagent/ethanol/beepsky_smash/affect_ingest(mob/living/carbon/M, alien, removed)
-	..()
+	. = ..()
 	M.afflict_stun(20 * 2)
 
 /datum/reagent/ethanol/bilk
@@ -3062,7 +3060,7 @@
 	glass_special = list("neuroright")
 
 /datum/reagent/ethanol/neurotoxin/affect_ingest(mob/living/carbon/M, alien, removed)
-	..()
+	. = ..()
 	M.afflict_paralyze(20 * 3)
 
 /datum/reagent/ethanol/patron
@@ -3090,13 +3088,13 @@
 
 /datum/reagent/ethanol/pwine/affect_ingest(mob/living/carbon/M, alien, removed)
 	..()
-	if(dose > 30)
+	if(. > 30)
 		M.adjustToxLoss(2 * removed)
-	if(dose > 60 && ishuman(M) && prob(5))
+	if(. > 60 && ishuman(M) && prob(5))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/internal/heart/L = H.internal_organs_by_name[O_HEART]
 		if (L && istype(L))
-			if(dose < 120)
+			if(. < 120)
 				L.take_damage(10 * removed, 0)
 			else
 				L.take_damage(100, 0)
@@ -3797,9 +3795,9 @@
 	glass_special = list(DRINK_FIZZ)
 
 /datum/reagent/ethanol/godka/affect_ingest(mob/living/carbon/M, alien, removed)
-	..()
-	M.cure_radiation(RAD_MOB_CURE_STRENGTH_GODKA(removed))
-	if(ishuman(M))
+	. = ..()
+	M.cure_radiation(RAD_MOB_CURE_STRENGTH_GODKA(removed * .))
+	if(. && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.species.has_organ[O_LIVER])
 			var/obj/item/organ/L = H.internal_organs_by_name[O_LIVER]
@@ -4218,7 +4216,7 @@
 
 //This functions the same as Doctor's Delight, except it gets you drunk too.
 /datum/reagent/ethanol/royaljelly/affect_ingest(mob/living/carbon/M, alien, removed)
-	..()
+	. = ..()
 	if(alien == IS_DIONA)
 		return
 	M.adjustOxyLoss(-4 * removed)
@@ -4594,11 +4592,11 @@
 	glass_desc = "The perfect blend of the most alcoholic things a bartender can get their hands on."
 
 /datum/reagent/ethanol/deathbell/affect_ingest(mob/living/carbon/M, alien, removed)
-	..()
+	. = ..()
 
-	if(dose * strength >= strength) // Early warning
+	if(. >= strength) // Early warning
 		M.make_dizzy(24) // Intentionally higher than normal to compensate for it's previous effects.
-	if(dose * strength >= strength * 2.5) // Slurring takes longer. Again, intentional.
+	if(. >= strength * 2.5) // Slurring takes longer. Again, intentional.
 		M.slurring = max(M.slurring, 30)
 
 /datum/reagent/ethanol/monstertamer
@@ -4663,15 +4661,12 @@
 	glass_desc = "Looking into this is like staring at the stars."
 
 /datum/reagent/ethanol/galacticpanic/affect_ingest(mob/living/carbon/M, alien, removed)
-	..()
+	. = ..()
+
 	M.afflict_stun(20 * 2)
-
-/datum/reagent/ethanol/galacticpanic/affect_ingest(mob/living/carbon/M, alien, removed)
-	..()
-
-	if(dose * strength >= strength) // Early warning
+	if(. >= strength) // Early warning
 		M.make_dizzy(24) // Intentionally higher than normal to compensate for it's previous effects.
-	if(dose * strength >= strength * 2.5) // Slurring takes longer. Again, intentional.
+	if(. >= strength * 2.5) // Slurring takes longer. Again, intentional.
 		M.slurring = max(M.slurring, 30)
 
 /datum/reagent/ethanol/lotus
@@ -4887,13 +4882,13 @@
 	glass_desc = "Deathbell and nuclear waste. The bane of your liver."
 
 /datum/reagent/ethanol/desiretodie/affect_blood(mob/living/carbon/M, alien, removed)
-	..()
+	. = ..()
 	if(alien == IS_DIONA)
 		return
 	M.bloodstr.add_reagent("radium", 0.3)
 
 /datum/reagent/ethanol/desiretodie/affect_ingest(mob/living/carbon/M, alien, removed)
-	..()
+	. = ..()
 	if(alien == IS_DIONA)
 		return
 	M.ingested.add_reagent("radium", 0.25)

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Medicine.dm
@@ -1032,13 +1032,11 @@
 	M.stuttering = 0
 	M.SetConfused(0)
 	if(M.ingested)
-		for(var/datum/reagent/R in M.ingested.reagent_list)
-			if(istype(R, /datum/reagent/ethanol))
-				R.remove_self(removed * 30)
+		for(var/datum/reagent/ethanol/R in M.ingested.reagent_list)
+			R.remove_self(removed * 30)
 	if(M.bloodstr)
-		for(var/datum/reagent/R in M.bloodstr.reagent_list)
-			if(istype(R, /datum/reagent/ethanol))
-				R.remove_self(removed * 20)
+		for(var/datum/reagent/ethanol/R in M.bloodstr.reagent_list)
+			R.remove_self(removed * 20)
 
 /datum/reagent/hyronalin
 	name = "Hyronalin"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Whoops I accidentally did a balance change with my please-don't-trigger-me PR.

Adds alcohol intolerance, a trait that prevents proper metabolization of most alcohol ingredients; instead of effects simulating drunkenness, you get _immediate_ liver failure, toxin damage, pain and vomiting. Yes, I actually do prefer that personally.

Certain drinks now have their effects modified by the *effective dose* calculated in the main ethanol affect_ingest and affect_blood procs, rather than just sort of guessing at it or doing completely wrong things (deathbell was doing `if(dose * strength > strength)`, which is to say, `if(dose > 1)`, for example).

## Why It's Good For The Game

honestly it's mostly just a personal thing, don't want my character to get drunk. The doses thing should be good, though, since it actually makes effects of various drinks, like, sane.

## Changelog

:cl:
add: Alcohol intolerance (no drunkenness, just horrific amounts of damage)
tweak: Various alcoholic drinks now actually take strength mod of species into account for secondary/additional effects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
