### PR TITLE
Removal of Cult RNG Attack

### DIFF
--- a/code/modules/events/event_container_vr.dm
+++ b/code/modules/events/event_container_vr.dm
@@ -103,14 +103,14 @@
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",		/datum/event/carp_migration,	20,		list(ASSIGNMENT_SECURITY = 5), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Containment Breach",	/datum/event/prison_break/station,0,	list(ASSIGNMENT_ANY = 5), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",			/datum/event/meteor_wave,		20,		list(ASSIGNMENT_ENGINEER = 15),	1, 0),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Cultist Invasion",	/datum/event/cult,				5,		list(ASSIGNMENT_SECURITY = 15),	1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Pirate Boarders",		/datum/event/pirate, 			0,		list(ASSIGNMENT_SECURITY = 5), 1),
 	)
 	add_disabled_events(list(
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",				/datum/event/blob, 				10,		list(ASSIGNMENT_ENGINEER = 60), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Supply Demand",		/datum/event/supply_demand,		0,		list(ASSIGNMENT_ANY = 5, ASSIGNMENT_SCIENCE = 15, ASSIGNMENT_GARDENER = 10, ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_MEDICAL = 15), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Xenomorph Infestation", /datum/event/xeno_infestation, 0, 	list(ASSIGNMENT_SECURITY = 2), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Xenomorph Infestation (Extreme)", /datum/event/xeno_infestation/extreme, 0, 	list(ASSIGNMENT_SECURITY = 2), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Cultist Invasion",	/datum/event/cult,				0		,list(ASSIGNMENT_SECURITY = 15),	1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Pirate Boarders",		/datum/event/pirate, 			0,		list(ASSIGNMENT_SECURITY = 5), 1),
 	))
 
 #undef ASSIGNMENT_ANY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Moves Screaming Signals and Pirate Boarders to Disabled Event List.**

## Why It's Good For The Game

1. _I want us to move away from non-curated Human on Human combat. Or humanoid, whatever. Same thing. This random event also just kinda sucks for the cult from a storytelling perspective and needs re-evaluation. I'm moving it to disabled - along with pirates - so that they can be manually triggered from now on, instead of using RNG._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Moves Cult and Pirate RNG to Manual Trigger.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
