### PR TITLE
[DNM] Telescience Restoration

### DIFF
--- a/maps/map_files/rift/rift-05-surface2.dmm
+++ b/maps/map_files/rift/rift-05-surface2.dmm
@@ -311,6 +311,24 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/research/rnd)
+"anL" = (
+/obj/structure/table/reinforced,
+/obj/item/gps,
+/obj/item/gps,
+/obj/item/gps,
+/obj/item/gps,
+/obj/item/gps,
+/obj/item/gps,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	pixel_y = 23;
+	name = "Lower Telesci Blast Doors";
+	id = "telescidoorlower"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/telescience_lab/storage)
 "anZ" = (
 /obj/machinery/button/remote/blast_door{
 	id = "xenocont1";
@@ -8703,11 +8721,15 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/assembly/chargebay)
 "fOe" = (
-/obj/machinery/light_construct{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/rnd/telescience_lab/foyer)
+/obj/machinery/light{
+	dir = 8;
+	light_range = 12
+	},
+/turf/simulated/floor/reinforced,
+/area/rnd/telescience_lab/chamber)
 "fOh" = (
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/plating,
@@ -10365,6 +10387,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rift/turbolift/maint)
+"gOk" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/rnd/telescience_lab/chamber)
 "gOV" = (
 /turf/simulated/wall,
 /area/rift/station/public_garden/gantry)
@@ -10404,6 +10432,9 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/telescience_lab/storage)
@@ -11104,7 +11135,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/rnd/telescience_lab/storage)
 "htU" = (
 /obj/structure/grille,
@@ -13057,7 +13088,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/rnd/telescience_lab/storage)
 "iIr" = (
 /obj/machinery/power/apc{
@@ -16335,7 +16366,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/rnd/telescience_lab/storage)
 "kMS" = (
 /obj/machinery/door/airlock/maintenance/medical{
@@ -17229,7 +17260,8 @@
 "lpy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/blast/regular/open{
-	dir = 4
+	dir = 4;
+	id = "telescidoorlower"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/telescience_lab/foyer)
@@ -19019,7 +19051,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/rnd/telescience_lab/storage)
 "myY" = (
 /obj/machinery/fitness/heavy/lifter,
@@ -19193,7 +19225,8 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
+/obj/structure/closet/secure_closet/scientist,
+/turf/simulated/floor/tiled,
 /area/rnd/telescience_lab/storage)
 "mCO" = (
 /obj/structure/railing,
@@ -20833,7 +20866,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/light_construct,
+/obj/structure/closet/secure_closet/scientist,
 /turf/simulated/floor/tiled,
 /area/rnd/telescience_lab/storage)
 "nMd" = (
@@ -21517,6 +21550,13 @@
 /obj/random/medical/lite,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"ooD" = (
+/obj/machinery/light{
+	dir = 8;
+	light_range = 12
+	},
+/turf/simulated/floor/reinforced,
+/area/rnd/telescience_lab/chamber)
 "opb" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/masks{
@@ -24846,6 +24886,9 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/reinforced,
 /area/rnd/telescience_lab/chamber)
 "qBo" = (
@@ -26237,7 +26280,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
 "rBx" = (
-/turf/simulated/floor/plating,
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine{
+	department = "Telescience Tower"
+	},
+/turf/simulated/floor/tiled,
 /area/rnd/telescience_lab/storage)
 "rBB" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -26477,6 +26524,9 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/reinforced,
@@ -28784,6 +28834,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
+"tzB" = (
+/obj/machinery/telepad,
+/turf/simulated/floor/plating,
+/area/rnd/telescience_lab/chamber)
 "tAd" = (
 /obj/machinery/light{
 	dir = 4
@@ -29141,6 +29195,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/pool/emergency_closet)
+"tMk" = (
+/obj/structure/closet/secure_closet/scientist,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/telescience_lab/storage)
 "tMQ" = (
 /turf/simulated/wall/r_wall,
 /area/security/interrogation)
@@ -30150,7 +30211,8 @@
 /area/security/armory/blue)
 "uHP" = (
 /obj/machinery/door/blast/regular/open{
-	dir = 4
+	dir = 4;
+	id = "telescidoorlower"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/telescience_lab/foyer)
@@ -30755,9 +30817,6 @@
 "uUw" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
-	},
-/obj/machinery/light_construct{
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/telescience_lab/foyer)
@@ -32045,12 +32104,16 @@
 /turf/simulated/floor/tiled/steel,
 /area/security/range)
 "vLT" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/binoculars,
+/obj/item/folder/blue{
+	pixel_x = -4;
+	pixel_y = 5
 	},
-/obj/machinery/light_construct,
-/turf/simulated/floor/reinforced,
-/area/rnd/telescience_lab/chamber)
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled,
+/area/rnd/telescience_lab/storage)
 "vMq" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -35013,7 +35076,8 @@
 /area/hallway/primary/surfacetwo)
 "xPs" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
-/turf/simulated/floor/plating,
+/obj/landmark/spawnpoint/job/scientist,
+/turf/simulated/floor/tiled,
 /area/rnd/telescience_lab/storage)
 "xPt" = (
 /turf/simulated/wall,
@@ -39123,12 +39187,12 @@ ddZ
 mhX
 oul
 oul
+ooD
 oul
 oul
-oul
-pIR
+fOe
 mhX
-dNx
+anL
 kMj
 iIa
 gQI
@@ -39323,7 +39387,7 @@ oul
 pIR
 mhX
 rBx
-rBx
+dNx
 hsO
 nLU
 aMW
@@ -39509,15 +39573,15 @@ srw
 mIn
 oLJ
 mhX
+gOk
 oul
-oul
-scS
+tzB
 oul
 oul
 hOq
 mhX
-rBx
-rBx
+vLT
+dNx
 myW
 mCM
 aMW
@@ -39708,9 +39772,9 @@ oul
 oul
 oul
 oul
-vLT
+pIR
 mhX
-dNx
+tMk
 ehO
 xPs
 mbS
@@ -40676,7 +40740,7 @@ mhX
 jZo
 scS
 qIa
-fOe
+kCB
 uQA
 lpy
 gEC

--- a/maps/map_files/rift/rift-06-surface3.dmm
+++ b/maps/map_files/rift/rift-06-surface3.dmm
@@ -20873,7 +20873,8 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/turf/simulated/floor/plating,
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled,
 /area/rnd/telescience_lab)
 "cAo" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
@@ -21232,7 +21233,7 @@
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/rnd/telescience_lab)
 "dSP" = (
 /obj/structure/cable/orange{
@@ -21733,7 +21734,6 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/item/barrier_tape_segment/engineering,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -22498,14 +22498,19 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/emt/general)
 "hAi" = (
-/obj/item/barrier_tape_segment/engineering,
-/obj/structure/door_assembly/door_assembly_research,
-/obj/structure/firedoor_assembly,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	pixel_y = 23;
+	name = "Upper Telesci Blast Doors";
+	id = "telescidoorupper"
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/telescience_lab)
 "hAM" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/rnd/telescience_lab)
 "hBp" = (
 /obj/machinery/door/airlock/command{
@@ -23307,9 +23312,6 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
-"klx" = (
-/turf/simulated/floor/plating,
-/area/rnd/telescience_lab)
 "kmY" = (
 /obj/structure/handrail,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -23622,9 +23624,6 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/machinery/light_construct{
-	dir = 4
-	},
 /turf/simulated/floor/reinforced,
 /area/rnd/telescience_lab)
 "lJb" = (
@@ -23804,7 +23803,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/rnd/telescience_lab)
 "lZF" = (
 /obj/machinery/holopad/ship,
@@ -23817,10 +23816,6 @@
 /obj/effect/debris/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/commandmaint)
-"mcA" = (
-/obj/item/barrier_tape_segment/engineering,
-/turf/simulated/floor/plating,
-/area/rnd/telescience_lab)
 "mhO" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -24945,9 +24940,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/exploration/excursion_dock)
-"pGn" = (
-/turf/simulated/open,
-/area/rnd/telescience_lab)
 "pKx" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -25183,10 +25175,6 @@
 /obj/spawner/window/borosillicate/reinforced/full/firelocks,
 /turf/simulated/floor/plating,
 /area/rnd/telescience_lab/chamber)
-"qtT" = (
-/obj/item/storage/toolbox/mechanical,
-/turf/simulated/floor/plating,
-/area/rnd/telescience_lab)
 "qvL" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -25292,7 +25280,8 @@
 /area/rift/surfaceeva/airlock/arrivals)
 "qIs" = (
 /obj/machinery/door/blast/regular/open{
-	dir = 4
+	dir = 4;
+	id = "telescidoorupper"
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -25332,7 +25321,7 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/rnd/telescience_lab)
 "qZl" = (
 /obj/effect/floor_decal/borderfloor{
@@ -25810,15 +25799,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/surfacethree)
-"tuh" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/light_construct{
-	dir = 1
-	},
-/turf/simulated/open,
-/area/rnd/telescience_lab)
 "tvp" = (
 /obj/structure/table/hardwoodtable,
 /obj/machinery/chemical_dispenser/catering/bar_alc{
@@ -26305,12 +26285,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacethree)
-"uWY" = (
-/obj/structure/frame{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/rnd/telescience_lab)
 "uYx" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
@@ -26424,7 +26398,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/security/checkpoint2)
 "vmV" = (
-/obj/machinery/light_construct{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/reinforced,
@@ -26627,7 +26601,8 @@
 /area/exploration/courser_dock)
 "vEF" = (
 /obj/machinery/door/blast/regular/open{
-	dir = 4
+	dir = 4;
+	id = "telescidoorupper"
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -26895,8 +26870,24 @@
 /turf/simulated/floor/plating,
 /area/maintenance/station/exploration)
 "wtK" = (
-/obj/structure/frame/computer{
-	dir = 4
+/obj/structure/table/steel,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 28
+	},
+/obj/machinery/recharger{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 12
+	},
+/obj/item/multitool{
+	pixel_x = 6;
+	pixel_y = -4
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/telescience_lab)
@@ -26999,9 +26990,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway)
 "wPr" = (
-/obj/machinery/light_construct{
-	dir = 4
-	},
+/obj/machinery/computer/telescience,
 /turf/simulated/floor/tiled,
 /area/rnd/telescience_lab)
 "wTy" = (
@@ -27151,11 +27140,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/courser_dock)
 "xmO" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/open,
+/turf/simulated/floor/tiled,
 /area/rnd/telescience_lab)
 "xqb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -27259,8 +27247,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/barrestroom)
 "xyj" = (
-/obj/structure/lattice,
-/turf/simulated/open,
+/obj/structure/frame{
+	anchored = 1
+	},
+/turf/simulated/floor/tiled,
 /area/rnd/telescience_lab)
 "xzV" = (
 /turf/simulated/wall,
@@ -30858,9 +30848,9 @@ jZk
 jZk
 vPu
 wtK
-wtK
-uWY
-uWY
+mOy
+mOy
+mOy
 mOy
 eIi
 vPu
@@ -31051,11 +31041,11 @@ jRd
 jRd
 jZk
 knK
-mOy
-klx
-qtT
-klx
 xyj
+mOy
+mOy
+mOy
+mOy
 mOy
 eDa
 acH
@@ -31245,11 +31235,11 @@ jRd
 jRd
 jZk
 knK
+wPr
 mOy
-xyj
 qYP
 dRq
-xyj
+mOy
 mOy
 eDa
 acH
@@ -31439,8 +31429,8 @@ jRd
 jRd
 jZk
 knK
+xyj
 mOy
-pGn
 xmO
 lSN
 von
@@ -31634,8 +31624,8 @@ jRd
 jZk
 vPu
 hAi
-mcA
-klx
+mOy
+mOy
 iCv
 vPu
 vPu
@@ -31827,9 +31817,9 @@ mTQ
 mTQ
 jZk
 vPu
-tuh
+rZg
 lPF
-klx
+mOy
 nin
 eDa
 aOi
@@ -32993,7 +32983,7 @@ aOi
 aHj
 aus
 eDa
-klx
+mOy
 ebz
 eDa
 aOi
@@ -33381,7 +33371,7 @@ aKW
 aHj
 aus
 vPu
-wPr
+mOy
 ebz
 vPu
 aOi


### PR DESCRIPTION
## About The Pull Request

Reintroduces the telescience lab for research purposes and in preparation with telesci 2.0 by sillycons. Note: Please do not use this to teleport to Surt, that's not allowed. Telecrystals need to be added manually to the lab.

![image](https://user-images.githubusercontent.com/93557430/236649084-76c5644d-a1ae-4d8c-b3ae-9ded07aea06a.png)
![image](https://user-images.githubusercontent.com/93557430/236649090-9d6ee1f1-8842-4601-a6a4-b06e693a00fb.png)
Fax machine has been added in order to fax anything that might be impossible to relay through headset.

## Why It's Good For The Game

Rentroduces the Telesci Lab for Telesci 2 whenever that arrives. Blast doors have been setup to prevent EMPs and any incidents from happening.

## Changelog

:cl:
add: Added tiles to z level 6 and 5
add: Added the terminal and pad on z level 5
/:cl:
