### PR TITLE
stops drinks saying they need to be opened if target is not something that can be poured into

### DIFF
--- a/code/modules/food/food/drinks.dm
+++ b/code/modules/food/food/drinks.dm
@@ -68,7 +68,7 @@
 	return ..()
 
 /obj/item/reagent_containers/food/drinks/standard_pour_into(var/mob/user, var/atom/target)
-	if(!is_open_container())
+	if(!is_open_container() && target.reagents)
 		to_chat(user, "<span class='notice'>You need to open [src]!</span>")
 		return 1
 	if(target == loc) //prevent filling a machine with a glass you just put into it.


### PR DESCRIPTION
## About The Pull Request
grab soda can
put in backpack
"this needs to be opened to pour it"

## Why It's Good For The Game
fixes a bug

## Changelog

:cl:
fix: stops drinks saying they need to be opened if target is not something that can be poured into
/:cl:
