### PR TITLE
Bridge teleporter fix, and more beacons.

### DIFF
--- a/code/modules/xenoarcheaology/misc.dm
+++ b/code/modules/xenoarcheaology/misc.dm
@@ -81,8 +81,6 @@
 		/obj/item/depth_scanner,
 		/obj/item/core_sampler,
 		/obj/item/gps,
-		/obj/item/beacon_locator,
-		/obj/item/radio/beacon,
 		/obj/item/clothing/glasses/meson,
 		/obj/item/pickaxe,
 		/obj/item/measuring_tape,

--- a/maps/map_files/rift/rift-04-surface1.dmm
+++ b/maps/map_files/rift/rift-04-surface1.dmm
@@ -19220,6 +19220,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/security/checkpoint)
+"mif" = (
+/obj/item/radio/beacon/anchored,
+/turf/simulated/floor/tiled/steel,
+/area/quartermaster/warehouse)
 "mip" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/white,
@@ -54901,7 +54905,7 @@ kjp
 eBp
 qNR
 xBi
-cnk
+mif
 cnk
 srB
 brv

--- a/maps/map_files/rift/rift-05-surface2.dmm
+++ b/maps/map_files/rift/rift-05-surface2.dmm
@@ -10306,6 +10306,7 @@
 "gKK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/radio/beacon/anchored,
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/research/researchdivision)
 "gKT" = (
@@ -17259,8 +17260,8 @@
 "lpy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/blast/regular{
-	name = "Lower Inner TeleSci Blast Door";
-	id = "InnerTeleSciBlastDoor"
+	id = "InnerTeleSciBlastDoor";
+	name = "Lower Inner TeleSci Blast Door"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/telescience_lab/foyer)
@@ -23707,15 +23708,15 @@
 	department = "Telescience Tower"
 	},
 /obj/machinery/button/remote/blast_door{
-	pixel_x = -11;
-	pixel_y = 24;
+	id = "OuterTeleSciBlastDoor";
 	name = "Lower Outer TeleSci Blast Door Button";
-	id = "OuterTeleSciBlastDoor"
+	pixel_x = -11;
+	pixel_y = 24
 	},
 /obj/machinery/button/remote/blast_door{
-	pixel_y = 24;
+	id = "InnerTeleSciBlastDoor";
 	name = "Lower Inner TeleSci Blast Door Button";
-	id = "InnerTeleSciBlastDoor"
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/telescience_lab/storage)
@@ -30237,8 +30238,8 @@
 /area/security/armory/blue)
 "uHP" = (
 /obj/machinery/door/blast/regular{
-	name = "Lower Inner TeleSci Blast Door";
-	id = "InnerTeleSciBlastDoor"
+	id = "InnerTeleSciBlastDoor";
+	name = "Lower Inner TeleSci Blast Door"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/telescience_lab/foyer)

--- a/maps/map_files/rift/rift-06-surface3.dmm
+++ b/maps/map_files/rift/rift-06-surface3.dmm
@@ -12268,13 +12268,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exploration/excursion_dock)
 "aFb" = (
-/obj/machinery/tele_pad,
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/machinery/tele_projector,
 /turf/simulated/floor/tiled/dark,
 /area/teleporter)
 "aFc" = (
@@ -19576,13 +19576,13 @@
 /turf/simulated/floor/plating,
 /area/rift/trade_shop/landing_pad)
 "aXy" = (
-/obj/machinery/tele_projector,
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/machinery/tele_pad,
 /turf/simulated/floor/tiled/dark,
 /area/teleporter)
 "aXA" = (
@@ -22218,6 +22218,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/item/radio/beacon,
 /turf/simulated/floor/plating,
 /area/shuttle/courser/general)
 "gtg" = (
@@ -22505,15 +22506,15 @@
 	dir = 1
 	},
 /obj/machinery/button/remote/blast_door{
-	pixel_y = 24;
+	id = "UpperInnerTeleSciBlastDoor";
 	name = "Upper Inner TeleSci Blast Door Button";
-	id = "UpperInnerTeleSciBlastDoor"
+	pixel_y = 24
 	},
 /obj/machinery/button/remote/blast_door{
-	pixel_x = -11;
-	pixel_y = 24;
+	id = "UpperOuterTeleSciBlastDoor";
 	name = "Upper Outer TeleSci Blast Door Button";
-	id = "UpperOuterTeleSciBlastDoor"
+	pixel_x = -11;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/telescience_lab)
@@ -25298,8 +25299,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/blast/regular{
-	name = "Upper Exterior Telesci Blast Door";
-	id = "UpperInnerTeleSciBlastDoor"
+	id = "UpperInnerTeleSciBlastDoor";
+	name = "Upper Exterior Telesci Blast Door"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/telescience_lab)
@@ -26632,8 +26633,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/blast/regular{
-	name = "Upper Interior Telesci Blast Door";
-	id = "UpperOuterTeleSciBlastDoor"
+	id = "UpperOuterTeleSciBlastDoor";
+	name = "Upper Interior Telesci Blast Door"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/telescience_lab)

--- a/maps/map_files/rift/rift-06-surface3.dmm
+++ b/maps/map_files/rift/rift-06-surface3.dmm
@@ -14758,6 +14758,7 @@
 /turf/simulated/floor/tiled/steel_grid/lythios43c,
 /area/rift/surfacebase/outside/outside3)
 "aLk" = (
+/obj/item/radio/beacon/anchored,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/excursion/cockpit)
 "aLl" = (
@@ -17093,7 +17094,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aRf" = (
-/obj/item/radio/beacon,
 /obj/structure/handrail,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -22218,7 +22218,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/item/radio/beacon,
+/obj/item/radio/beacon/anchored,
 /turf/simulated/floor/plating,
 /area/shuttle/courser/general)
 "gtg" = (

--- a/maps/map_files/rift/rift-08-west_deep.dmm
+++ b/maps/map_files/rift/rift-08-west_deep.dmm
@@ -4949,6 +4949,10 @@
 "TF" = (
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
+"TK" = (
+/obj/item/radio/beacon/anchored,
+/turf/simulated/floor/tiled,
+/area/gateway/prep_room)
 "TR" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 8
@@ -36636,7 +36640,7 @@ xt
 TW
 TF
 qX
-TF
+TK
 TF
 yY
 Dk


### PR DESCRIPTION
One-way teleport that requires command permission is pretty neat compared to Qpad sillyness. ESPECIALLY for events. First step is fixing our existing teleporter, though.

Current beacon locations are: Exploration shuttle, Corser scout shuttle, gateway prep, and the cargo warehouse.

I avoided putting one in the bridge/teleporter room/hammerhead due to security reasons.

All beacons are anchored, and unable to be moved.