### PR TITLE
Qpad Precursor Tech Requirement

### DIFF
--- a/code/modules/research/designs/circuits/circuits_vr.dm
+++ b/code/modules/research/designs/circuits/circuits_vr.dm
@@ -22,7 +22,7 @@
 /datum/design/circuit/quantum_pad
 	name = "Quantum Pad"
 	id = "quantum_pad"
-	req_tech = list(TECH_ENGINEERING = 4, TECH_POWER = 4, TECH_BLUESPACE = 4)
+	req_tech = list(TECH_ENGINEERING = 4, TECH_POWER = 4, TECH_BLUESPACE = 4, TECH_PRECURSOR = 1)
 	build_path = /obj/item/circuitboard/quantumpad
 	sort_string = "HABAH"
 
@@ -137,7 +137,7 @@
 /datum/design/circuit/quantum_pad
 	name = "Quantum Pad"
 	id = "quantum_pad"
-	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_PHORON = 4, TECH_BLUESPACE = 5)
+	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_PHORON = 4, TECH_BLUESPACE = 5, TECH_PRECURSOR = 1)
 	build_path = /obj/item/circuitboard/quantumpad
 	sort_string = "HAAC"
 

--- a/code/modules/research/designs_vr.dm
+++ b/code/modules/research/designs_vr.dm
@@ -178,7 +178,7 @@
 /datum/design/circuit/quantum_pad
 	name = "Quantum Pad"
 	id = "quantum_pad"
-	req_tech = list(TECH_ENGINEERING = 4, TECH_POWER = 4, TECH_BLUESPACE = 4)
+	req_tech = list(TECH_ENGINEERING = 4, TECH_POWER = 4, TECH_BLUESPACE = 4, TECH_PRECURSOR = 1)
 	build_path = /obj/item/circuitboard/quantumpad
 	sort_string = "HABAH"
 

--- a/code/modules/telesci/construction.dm
+++ b/code/modules/telesci/construction.dm
@@ -25,7 +25,7 @@
 	name = T_BOARD("quantum pad")
 	board_type = new /datum/frame/frame_types/machine
 	build_path = /obj/machinery/power/quantumpad
-	origin_tech = list(TECH_ENGINEERING = 4, TECH_POWER = 4, TECH_BLUESPACE = 4)
+	origin_tech = list(TECH_ENGINEERING = 4, TECH_POWER = 4, TECH_BLUESPACE = 4, TECH_PRECURSOR = 1)
 	req_components = list(
 		/obj/item/ore/bluespace_crystal = 1,
 		/obj/item/stock_parts/capacitor = 1,
@@ -51,7 +51,7 @@
 /datum/design/circuit/quantum_pad
 	name = "Quantum Pad"
 	id = "quantum_pad"
-	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_PHORON = 4, TECH_BLUESPACE = 5)
+	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_PHORON = 4, TECH_BLUESPACE = 5, TECH_PRECURSOR = 1)
 	build_path = /obj/item/circuitboard/quantumpad
 	sort_string = "HAAC"
 


### PR DESCRIPTION
Makes Qpads require precursor tech to be created.

#5489 fixes the bridge teleporter and gives a one-way option to command instead of a two-way option to literally anyone science hands Qpad machinery to. (exploration)
