### PR TITLE
Dropping magazines

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -242,7 +242,7 @@
 	else if(ammo_magazine)
 		ammo_magazine.forceMove(user.drop_location())
 		user.visible_message("[user] dumps [ammo_magazine] from [src] onto the floor.", SPAN_NOTICE("You dump [ammo_magazine] from [src] onto the floor."))
-		playsound (src, mag_remove_sound, 50, 1)
+		playsound(src, mag_remove_sound, 50, 1)
 		ammo_magazine.update_icon()
 		ammo_magazine = null
 	else

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -240,7 +240,6 @@
 	if(firemodes.len > 1)
 		switch_firemodes(user)
 	else if(ammo_magazine)
-		user.drop_item_to_ground(ammo_magazine)
 		ammo_magazine.loc = user.loc
 		user.visible_message("[user] dumps [ammo_magazine] from [src] onto the floor.", "<span class='notice'>You dump [ammo_magazine] from [src] onto the floor.</span>")
 		playsound(src.loc, mag_remove_sound, 50, 1)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -240,9 +240,9 @@
 	if(firemodes.len > 1)
 		switch_firemodes(user)
 	else if(ammo_magazine)
-		ammo_magazine.loc = user.loc
-		user.visible_message("[user] dumps [ammo_magazine] from [src] onto the floor.", "<span class='notice'>You dump [ammo_magazine] from [src] onto the floor.</span>")
-		playsound(src.loc, mag_remove_sound, 50, 1)
+		ammo_magazine.forceMove(user.drop_location())
+		user.visible_message("[user] dumps [ammo_magazine] from [src] onto the floor.", SPAN_NOTICE("You dump [ammo_magazine] from [src] onto the floor."))
+		playsound (src, mag_remove_sound, 50, 1)
 		ammo_magazine.update_icon()
 		ammo_magazine = null
 	else

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -239,8 +239,16 @@
 /obj/item/gun/ballistic/attack_self(mob/user)
 	if(firemodes.len > 1)
 		switch_firemodes(user)
+	else if(ammo_magazine)
+		user.drop_item_to_ground(ammo_magazine)
+		ammo_magazine.loc = user.loc
+		user.visible_message("[user] dumps [ammo_magazine] from [src] onto the floor.", "<span class='notice'>You dump [ammo_magazine] from [src] onto the floor.</span>")
+		playsound(src.loc, mag_remove_sound, 50, 1)
+		ammo_magazine.update_icon()
+		ammo_magazine = null
 	else
 		unload_ammo(user)
+	update_icon()
 
 /obj/item/gun/ballistic/attack_hand(mob/user, list/params)
 	if(user.get_inactive_held_item() == src)


### PR DESCRIPTION
Drops mags when self-attacking an item (Z) that doesnt have a firemode selector, instead of putting it into your other hand. 

A bug would cause putting it into a filled offhand to delete the magazine, and it made me realize it didnt make sense to do it in the first place. Pulling the mag out yourself with a click makes more sense than hotkey pulling. So instead, you now drop a mag from the gun via hotkey, and manually pull it from the gun via click. Slower reload for less tense situations, when its beneficial to keep your magazine.