### PR TITLE
Security Armor Vests

### DIFF
--- a/code/game/objects/items/gunbox.dm
+++ b/code/game/objects/items/gunbox.dm
@@ -145,15 +145,35 @@
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "gunbox"
 
-/obj/item/gunbox/carrier/attack_self(mob/user)
+/obj/item/gunbox/carrier/blueshield/attack_self(mob/user)
 	var/list/options = list()
-	options["Black"] = list(/obj/item/clothing/suit/storage/hooded/covertcarrier/blueshield, /obj/item/clothing/accessory/armor/armorplate)
-	options["Black-Short"] = list(/obj/item/clothing/suit/storage/hooded/covertcarrier/blueshield/alt, /obj/item/clothing/accessory/armor/armorplate)
-	options["Navy"] = list(/obj/item/clothing/suit/storage/hooded/covertcarrier/blueshield/navy, /obj/item/clothing/accessory/armor/armorplate)
+	options["\improper Black Carrier"] = list(/obj/item/clothing/suit/storage/hooded/covertcarrier/blueshield, /obj/item/clothing/accessory/armor/armorplate)
+	options["\improper Black-Short Carrier"] = list(/obj/item/clothing/suit/storage/hooded/covertcarrier/blueshield/alt, /obj/item/clothing/accessory/armor/armorplate)
+	options["\improper Navy Carrier"] = list(/obj/item/clothing/suit/storage/hooded/covertcarrier/blueshield/navy, /obj/item/clothing/accessory/armor/armorplate)
 	var/choice = input(user,"Select your plate carrier.") as null|anything in options
 	if(src && choice)
 		var/list/things_to_spawn = options[choice]
-		for(var/new_type in things_to_spawn) // Spawn all the things, the gun and the ammo.
+		for(var/new_type in things_to_spawn)
+			var/atom/movable/AM = new new_type(get_turf(src))
+			if(istype(AM, /obj/item/clothing))
+				to_chat(user, "You withdraw \the [AM].")
+		qdel(src)
+
+/obj/item/gunbox/armor/security
+	name = "\improper Security armor box"
+	desc = "A secure box containing a single Corporate Security armor vest."
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "gunbox"
+
+/obj/item/gunbox/armor/security/attack_self(mob/user)
+	var/list/options = list()
+	options["\improper Flat Vest"] = list(/obj/item/clothing/suit/armor/vest)
+	options["\improper Security Vest"] = list(/obj/item/clothing/suit/armor/vest/alt)
+	options["\improper Webbed Vest"] = list(/obj/item/clothing/suit/storage/vest/officer)
+	var/choice = input(user,"Select your armor vest.") as null|anything in options
+	if(src && choice)
+		var/list/things_to_spawn = options[choice]
+		for(var/new_type in things_to_spawn)
 			var/atom/movable/AM = new new_type(get_turf(src))
 			if(istype(AM, /obj/item/clothing))
 				to_chat(user, "You withdraw \the [AM].")

--- a/maps/map_files/rift/rift-05-surface2.dmm
+++ b/maps/map_files/rift/rift-05-surface2.dmm
@@ -811,6 +811,24 @@
 	alpha = 255
 	},
 /obj/effect/floor_decal/corner/red/border,
+/obj/item/gunbox/armor/security{
+	pixel_y = 8
+	},
+/obj/item/gunbox/armor/security{
+	pixel_y = 8
+	},
+/obj/item/gunbox/armor/security{
+	pixel_y = 8
+	},
+/obj/item/gunbox/armor/security{
+	pixel_y = 8
+	},
+/obj/item/gunbox/armor/security{
+	pixel_y = 8
+	},
+/obj/item/gunbox/armor/security{
+	pixel_y = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "ayE" = (


### PR DESCRIPTION
Adds an armor vest selection box, and maps it into the general sec storage area. 

In-character, there is only one vest per box. 

**Do not propagate scenarios where you're magically selecting one of three vests** like some kinda bluespace magic. You're all better than that.