### PR TITLE
buffs bioadaptive NIF durability, adds veymed variant of bioadaptive NIF

### DIFF
--- a/code/__DEFINES/items/nifs.dm
+++ b/code/__DEFINES/items/nifs.dm
@@ -1,9 +1,10 @@
 // nifs should die
 
-#define NIF_ID_BASIC			"BASE"
-#define NIF_ID_VEYMED			"VEYMED"
-#define NIF_ID_BOOTLEG			"BAD"
-#define NIF_ID_BIOADAPTIVE		"ADAPTIVE"
+#define NIF_ID_BASIC				"BASE"
+#define NIF_ID_VEYMED				"VEYMED"
+#define NIF_ID_BOOTLEG				"BAD"
+#define NIF_ID_BIOADAPTIVE			"ADAPTIVE"
+#define NIF_ID_VEYMEDBIOADAPTIVE	"VEYMEDBIOADAPTIVE"
 
 // List indexes for software datum references on mobs
 // This also controls the order they are displayed in the NIF stat panel

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -723,27 +723,23 @@
 		to_chat(usr,"<span class='warning'>Target already has a NIF.</span>")
 		return
 
-	if(H.species.species_flags & NO_SCAN)
-		var/obj/item/nif/S = /obj/item/nif/bioadap
-		input_NIF = initial(S.name)
-		new /obj/item/nif/bioadap(H)
+	//if the admins want to adminbus a prommie with a full veymed, let them. screw the system. NIFs aren't in the plans to last long anyways. :^)
+	var/list/NIF_types = typesof(/obj/item/nif)
+	var/list/NIFs = list()
+
+	for(var/NIF_type in NIF_types)
+		var/obj/item/nif/S = NIF_type
+		NIFs[capitalize(initial(S.name))] = NIF_type
+
+	var/list/show_NIFs = sortList(NIFs) // the list that will be shown to the user to pick from
+
+	input_NIF = input("Pick the NIF type","Quick NIF") in show_NIFs
+	var/chosen_NIF = NIFs[capitalize(input_NIF)]
+
+	if(chosen_NIF)
+		new chosen_NIF(H)
 	else
-		var/list/NIF_types = typesof(/obj/item/nif)
-		var/list/NIFs = list()
-
-		for(var/NIF_type in NIF_types)
-			var/obj/item/nif/S = NIF_type
-			NIFs[capitalize(initial(S.name))] = NIF_type
-
-		var/list/show_NIFs = sortList(NIFs) // the list that will be shown to the user to pick from
-
-		input_NIF = input("Pick the NIF type","Quick NIF") in show_NIFs
-		var/chosen_NIF = NIFs[capitalize(input_NIF)]
-
-		if(chosen_NIF)
-			new chosen_NIF(H)
-		else
-			new /obj/item/nif(H)
+		new /obj/item/nif(H)
 
 	log_and_message_admins("[key_name(src)] Quick NIF'd [H.real_name] with a [input_NIF].")
 	feedback_add_details("admin_verb","QNIF") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -636,9 +636,9 @@ GLOBAL_LIST_INIT(nif_id_lookup, init_nif_id_lookup())
 
 /obj/item/nif/bioadap
 	name = "bioadaptive NIF"
-	desc = "A NIF that goes out of it's way to accomidate strange body types. \
+	desc = "A NIF that goes out of it's way to accomodate strange body types. \
 	Will function in species where it normally wouldn't."
-	durability = 25
+	durability = 50
 	bioadap = TRUE
 	id = NIF_ID_BIOADAPTIVE
 

--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -641,6 +641,14 @@ GLOBAL_LIST_INIT(nif_id_lookup, init_nif_id_lookup())
 	durability = 50
 	bioadap = TRUE
 	id = NIF_ID_BIOADAPTIVE
+	
+/obj/item/nif/authenticbioadap
+	name = "\improper Vey-Med bioadaptive NIF"
+	desc = "A genuine Vey-Med nanotechnology fabricator, designed for strange body types. \
+	Will function in species where it normally wouldn't while still being very durable."
+	durability = 500
+	bioadap = TRUE
+	id = NIF_ID_VEYMEDBIOADAPTIVE
 
 ////////////////////////////////
 // Special Promethean """surgery"""


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Changes the durability of bioadaptive NIF to 50% of a normal NIF instead of 25%.
- Adds a bioadaptive VeyMed NIF that's about 10 times more durable than a normal bioadaptive NIF. Exists only through adminspawn only, like the other VeyMed NIF.
- Also updates the Quick NIF admin tool to be "compatible" with this update. _(it just removes the NO_SCAN check. It's an admin tool, it probably didn't need this check to begin with.)_
- Corrects a spelling issue.

## Why It's Good For The Game

While it makes sense that a bioadaptive NIF is less durable than a normal one, as it struggles with the biology of a species that it can't assess very well - it's also a bit _too_ low of durability. Those who have one have one and frequently install programs either through NIFSoft uploaders or other methods generally have to get maintenance at least every five shifts or so. Considering that there's been a struggle of players not existing in both Science or Mining lately, and those two departments usually need someone present in order for someone to get NIF maintenance (unless someone in medical wants to remove a NIF to repair it), I feel this change is necessary. Make it ten shifts instead.

As for the VeyMed Bioadaptive; I feel like a company would have a secondary product available for those who are less compatible with their main product. There's probably no reason why they wouldn't.

NIFs are eventually getting removed anyways from what I understand. Might as well make the best of it while it's still around.

## Changelog

:cl:
balance: Bioadaptive NIFs are now more durable, being 50% of a normal NIF's durability instead of 25%.
add: VeyMed Bioadaptive NIFs are now on the shelf... if you can somehow acquire one. Perhaps if you're lucky...
admin: Quick NIF tool has checks removed for NO_SCAN.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
