### PR TITLE
[Salt PR?] Shut the FUCK up about milk nourishment.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Dispenser.dm
@@ -312,8 +312,6 @@
 
 /datum/reagent/phosphorus/affect_blood(mob/living/carbon/M, alien, removed)
 	if(alien == IS_ALRAUNE)
-		if(prob(5))
-			to_chat(M, "<span class='vox'>You feel a rush of nutrients fill your body.</span>")
 		M.nutrition += removed * 2 //cit change - phosphorus is good for plants
 
 /datum/reagent/potassium

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -189,7 +189,7 @@
 
 /datum/reagent/nutriment/coco/affect_ingest(mob/living/carbon/M, alien, removed)
 	if(alien == IS_ALRAUNE) //cit change: choccy is full of natural easily digestible plant fats
-		if(prob(5))
+		if(prob(3))
 			to_chat(M, "<span class='vox'>You feel a rush of nutrients fill your body.</span>")
 		M.nutrition += removed * 5
 /datum/reagent/nutriment/instantjuice
@@ -481,7 +481,7 @@
 	if(alien == IS_DIONA)
 		return
 	if(alien == IS_ALRAUNE) //cit change: it wouldn't affect plants that much.
-		if(prob(5))
+		if(prob(3))
 			to_chat(M, SPAN_ROSE("You feel a pleasant sensation in your mouth."))
 		M.bodytemperature += rand(10, 25)
 		return
@@ -913,7 +913,7 @@
 
 /datum/reagent/drink/milk/chocolate/affect_ingest(mob/living/carbon/M, alien, removed)
 	if(alien == IS_ALRAUNE) //cit change: choccy is full of natural easily digestible plant fats
-		if(prob(5))
+		if(prob(3))
 			to_chat(M, "<span class='vox'>You feel a rush of nutrients fill your body.</span>")
 		M.nutrition += removed * 5
 
@@ -922,7 +922,8 @@
 	if(alien == IS_DIONA)
 		return
 	if(alien == IS_ALRAUNE) //cit change: milk good for plant.
-		to_chat(M, "<span class='vox'>You feel nourished by the milk.</span>")
+		if(prob(3))
+			to_chat(M, "<span class='vox'>You feel nourished by the milk.</span>")
 		M.nutrition += removed * 3
 	M.heal_organ_damage(0.5 * removed, 0)
 	holder.remove_reagent("capsaicin", 10 * removed)
@@ -1109,7 +1110,8 @@
 	if(alien == IS_DIONA)
 		return
 	if(alien == IS_ALRAUNE) //cit change: milk good for plant.
-		to_chat(M, "<span class='vox'>You feel nourished by the milk tea.</span>")
+		if(prob(3))
+			to_chat(M, "<span class='vox'>You feel nourished by the milk tea.</span>")
 		M.nutrition += removed * 3
 	M.heal_organ_damage(0.5 * removed, 0)
 	holder.remove_reagent("capsaicin", 10 * removed)
@@ -1316,7 +1318,7 @@
 /datum/reagent/drink/hot_coco/affect_ingest(mob/living/carbon/M, alien, removed)
 	..()
 	if(alien == IS_ALRAUNE) //cit change: choccy is full of natural easily digestible plant fats
-		if(prob(5))
+		if(prob(3))
 			to_chat(M, "<span class='vox'>You feel a rush of nutrients fill your body.</span>")
 		M.nutrition += removed * 5
 
@@ -1500,7 +1502,7 @@
 
 /datum/reagent/drink/milkshake/chocoshake/affect_ingest(mob/living/carbon/M, alien, removed)
 	if(alien == IS_ALRAUNE) //cit change: choccy is full of natural easily digestible plant fats
-		if(prob(5))
+		if(prob(3))
 			to_chat(M, "<span class='vox'>You feel a rush of nutrients fill your body.</span>")
 		M.nutrition += removed * 5
 

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -1488,7 +1488,7 @@
 	glass_desc = "A refreshing chocolate milkshake, just like mom used to make."
 
 /datum/reagent/drink/milkshake/chocoshake/affect_ingest(mob/living/carbon/M, alien, removed)
-			to_chat(M, "<span class='vox'>You feel a rush of nutrients fill your body.</span>")
+	if(alien == IS_ALRAUNE) //cit change: it wouldn't affect plants that much.
 		M.nutrition += removed * 5
 
 /datum/reagent/drink/milkshake/berryshake

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -188,9 +188,6 @@
 	color = "#302000"
 
 /datum/reagent/nutriment/coco/affect_ingest(mob/living/carbon/M, alien, removed)
-	if(alien == IS_ALRAUNE) //cit change: choccy is full of natural easily digestible plant fats
-		if(prob(3))
-			to_chat(M, "<span class='vox'>You feel a rush of nutrients fill your body.</span>")
 		M.nutrition += removed * 5
 /datum/reagent/nutriment/instantjuice
 	name = "Juice Powder"
@@ -481,8 +478,6 @@
 	if(alien == IS_DIONA)
 		return
 	if(alien == IS_ALRAUNE) //cit change: it wouldn't affect plants that much.
-		if(prob(3))
-			to_chat(M, SPAN_ROSE("You feel a pleasant sensation in your mouth."))
 		M.bodytemperature += rand(10, 25)
 		return
 	if(ishuman(M))
@@ -913,8 +908,6 @@
 
 /datum/reagent/drink/milk/chocolate/affect_ingest(mob/living/carbon/M, alien, removed)
 	if(alien == IS_ALRAUNE) //cit change: choccy is full of natural easily digestible plant fats
-		if(prob(3))
-			to_chat(M, "<span class='vox'>You feel a rush of nutrients fill your body.</span>")
 		M.nutrition += removed * 5
 
 /datum/reagent/drink/milk/affect_ingest(mob/living/carbon/M, alien, removed)
@@ -922,8 +915,6 @@
 	if(alien == IS_DIONA)
 		return
 	if(alien == IS_ALRAUNE) //cit change: milk good for plant.
-		if(prob(3))
-			to_chat(M, "<span class='vox'>You feel nourished by the milk.</span>")
 		M.nutrition += removed * 3
 	M.heal_organ_damage(0.5 * removed, 0)
 	holder.remove_reagent("capsaicin", 10 * removed)
@@ -1110,8 +1101,6 @@
 	if(alien == IS_DIONA)
 		return
 	if(alien == IS_ALRAUNE) //cit change: milk good for plant.
-		if(prob(3))
-			to_chat(M, "<span class='vox'>You feel nourished by the milk tea.</span>")
 		M.nutrition += removed * 3
 	M.heal_organ_damage(0.5 * removed, 0)
 	holder.remove_reagent("capsaicin", 10 * removed)
@@ -1318,8 +1307,6 @@
 /datum/reagent/drink/hot_coco/affect_ingest(mob/living/carbon/M, alien, removed)
 	..()
 	if(alien == IS_ALRAUNE) //cit change: choccy is full of natural easily digestible plant fats
-		if(prob(3))
-			to_chat(M, "<span class='vox'>You feel a rush of nutrients fill your body.</span>")
 		M.nutrition += removed * 5
 
 /datum/reagent/drink/soda/sodawater
@@ -1501,8 +1488,6 @@
 	glass_desc = "A refreshing chocolate milkshake, just like mom used to make."
 
 /datum/reagent/drink/milkshake/chocoshake/affect_ingest(mob/living/carbon/M, alien, removed)
-	if(alien == IS_ALRAUNE) //cit change: choccy is full of natural easily digestible plant fats
-		if(prob(3))
 			to_chat(M, "<span class='vox'>You feel a rush of nutrients fill your body.</span>")
 		M.nutrition += removed * 5
 

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Other.dm
@@ -343,7 +343,7 @@
 
 /datum/reagent/ammonia/affect_blood(mob/living/carbon/M, alien, removed)
 	if(alien == IS_ALRAUNE)
-		if(prob(5))
+		if(prob(3))
 			to_chat(M, "<span class='vox'>You feel a rush of nutrients fill your body.</span>")
 		M.nutrition += removed * 2 //cit change: fertilizer is waste for plants
 		return
@@ -358,7 +358,7 @@
 
 /datum/reagent/diethylamine/affect_blood(mob/living/carbon/M, alien, removed)
 	if(alien == IS_ALRAUNE)
-		if(prob(5))
+		if(prob(3))
 			to_chat(M, "<span class='vox'>You feel a rush of nutrients fill your body.</span>")
 		M.nutrition += removed * 5 //cit change: fertilizer is waste for plants
 		return

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Other.dm
@@ -343,8 +343,6 @@
 
 /datum/reagent/ammonia/affect_blood(mob/living/carbon/M, alien, removed)
 	if(alien == IS_ALRAUNE)
-		if(prob(3))
-			to_chat(M, "<span class='vox'>You feel a rush of nutrients fill your body.</span>")
 		M.nutrition += removed * 2 //cit change: fertilizer is waste for plants
 		return
 
@@ -358,8 +356,6 @@
 
 /datum/reagent/diethylamine/affect_blood(mob/living/carbon/M, alien, removed)
 	if(alien == IS_ALRAUNE)
-		if(prob(3))
-			to_chat(M, "<span class='vox'>You feel a rush of nutrients fill your body.</span>")
 		M.nutrition += removed * 5 //cit change: fertilizer is waste for plants
 		return
 

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Toxins.dm
@@ -353,7 +353,7 @@
 
 /datum/reagent/toxin/fertilizer/affect_blood(mob/living/carbon/M, alien, removed)
 	if(alien == IS_ALRAUNE) //cit change: fertilizer is full of natural easily digestible plant fats
-		if(prob(5))
+		if(prob(3))
 			to_chat(M, "<span class='vox'>You feel a rush of nutrients fill your body.</span>")
 		M.nutrition += removed * 5
 		return

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Toxins.dm
@@ -353,8 +353,6 @@
 
 /datum/reagent/toxin/fertilizer/affect_blood(mob/living/carbon/M, alien, removed)
 	if(alien == IS_ALRAUNE) //cit change: fertilizer is full of natural easily digestible plant fats
-		if(prob(3))
-			to_chat(M, "<span class='vox'>You feel a rush of nutrients fill your body.</span>")
 		M.nutrition += removed * 5
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces probability of message spam for alraune species consuming specific things. Especially milk, which didn't even have any probability and just sent the message per tick or metabolism or something.

## Why It's Good For The Game

:^)
![You feel nourished by the milk.](https://cdn.discordapp.com/attachments/323935657821077524/1109592048274788352/image.png)

## Changelog

:cl:
fix: Alraune know that they are nourished by milk. Shut up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
