### PR TITLE
Remove Teshari xeno wear restriction

### DIFF
--- a/code/modules/preferences/preference_setup/loadout/loadout_xeno.dm
+++ b/code/modules/preferences/preference_setup/loadout/loadout_xeno.dm
@@ -88,7 +88,6 @@
 
 //*Teshari
 /datum/gear/xeno/teshari
-	legacy_species_lock = SPECIES_TESHARI
 
 /datum/gear/xeno/teshari/accessories
 	slot = /datum/inventory_slot_meta/abstract/attach_as_accessory


### PR DESCRIPTION
There are no mechanical advantages people could exploit and it still follows the job requirements. This has been green lit.
