### PR TITLE
Armor gunbox touchups

### DIFF
--- a/code/game/objects/items/gunbox.dm
+++ b/code/game/objects/items/gunbox.dm
@@ -147,10 +147,10 @@
 
 /obj/item/gunbox/carrier/blueshield/attack_self(mob/user)
 	var/list/options = list()
-	options["\improper Black Carrier"] = list(/obj/item/clothing/suit/storage/hooded/covertcarrier/blueshield, /obj/item/clothing/accessory/armor/armorplate)
-	options["\improper Black-Short Carrier"] = list(/obj/item/clothing/suit/storage/hooded/covertcarrier/blueshield/alt, /obj/item/clothing/accessory/armor/armorplate)
-	options["\improper Navy Carrier"] = list(/obj/item/clothing/suit/storage/hooded/covertcarrier/blueshield/navy, /obj/item/clothing/accessory/armor/armorplate)
-	var/choice = input(user,"Select your plate carrier.") as null|anything in options
+	options["\improper Black Carrier"] = list(/obj/item/clothing/suit/storage/hooded/covertcarrier/blueshield)
+	options["\improper Black-Short Carrier"] = list(/obj/item/clothing/suit/storage/hooded/covertcarrier/blueshield/alt)
+	options["\improper Navy Carrier"] = list(/obj/item/clothing/suit/storage/hooded/covertcarrier/blueshield/navy)
+	var/choice = input(user,"Select which plate carrier you find within the box.") as null|anything in options
 	if(src && choice)
 		var/list/things_to_spawn = options[choice]
 		for(var/new_type in things_to_spawn)
@@ -170,7 +170,7 @@
 	options["\improper Flat Vest"] = list(/obj/item/clothing/suit/armor/vest)
 	options["\improper Security Vest"] = list(/obj/item/clothing/suit/armor/vest/alt)
 	options["\improper Webbed Vest"] = list(/obj/item/clothing/suit/storage/vest/officer)
-	var/choice = input(user,"Select your armor vest.") as null|anything in options
+	var/choice = input(user,"Select the armor vest you find within the box.") as null|anything in options
 	if(src && choice)
 		var/list/things_to_spawn = options[choice]
 		for(var/new_type in things_to_spawn)

--- a/code/modules/clothing/suits/hooded.dm
+++ b/code/modules/clothing/suits/hooded.dm
@@ -570,7 +570,6 @@
 	icon = 'icons/obj/clothing/modular_armor.dmi'
 	item_icons = list(SLOT_ID_SUIT = 'icons/mob/clothing/modular_armor.dmi')
 	icon_state = "pcarrier"
-	inv_hide_flags = HIDEHOLSTER
 	body_cover_flags = UPPER_TORSO|LOWER_TORSO
 	hoodtype = /obj/item/clothing/head/hood/covertcarrier
 	valid_accessory_slots = (\
@@ -626,18 +625,18 @@
 	desc = "The NT-COV/OV-4a plate carrier is an experimental armor system designed for usage by Blueshields. The covert/overt plate carrier is slim enough to be concealed beneath certain types of jackets or coverings. During a crisis, the vest's retractable helmet may be deployed for added protection. Contains a removable light armor plate for potential upgrading."
 	icon_state = "pcarrier"
 	hoodtype = /obj/item/clothing/head/hood/covertcarrier/blueshield
-	starting_accessories = list(/obj/item/clothing/accessory/armor/tag/ntbs)
+	starting_accessories = list(/obj/item/clothing/accessory/armor/tag/ntbs, /obj/item/clothing/accessory/armor/armorplate)
 
 /obj/item/clothing/suit/storage/hooded/covertcarrier/blueshield/alt
 	name = "experimental plate carrier"
 	desc = "The NT-COV/OV-4a plate carrier is an experimental armor system designed for usage by Blueshields. The covert/overt plate carrier is slim enough to be concealed beneath certain types of jackets or coverings. During a crisis, the vest's retractable helmet may be deployed for added protection. Contains a removable light armor plate for potential upgrading."
 	icon_state = "pcarrier_alt"
 	hoodtype = /obj/item/clothing/head/hood/covertcarrier/blueshield
-	starting_accessories = list(/obj/item/clothing/accessory/armor/tag/ntbs)
+	starting_accessories = list(/obj/item/clothing/accessory/armor/tag/ntbs, /obj/item/clothing/accessory/armor/armorplate)
 
 /obj/item/clothing/suit/storage/hooded/covertcarrier/blueshield/navy
 	name = "experimental plate carrier"
 	desc = "The NT-COV/OV-4a plate carrier is an experimental armor system designed for usage by Blueshields. The covert/overt plate carrier is slim enough to be concealed beneath certain types of jackets or coverings. During a crisis, the vest's retractable helmet may be deployed for added protection. Contains a removable light armor plate for potential upgrading."
 	icon_state = "pcarrier_navy"
 	hoodtype = /obj/item/clothing/head/hood/covertcarrier/blueshield/navy
-	starting_accessories = list(/obj/item/clothing/accessory/armor/tag/ntbs)
+	starting_accessories = list(/obj/item/clothing/accessory/armor/tag/ntbs, /obj/item/clothing/accessory/armor/armorplate)

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -128,12 +128,12 @@
 
 /obj/item/clothing/accessory/holster/armpit
 	name = "armpit holster"
-	desc = "A worn-out handgun holster. Perfect for concealed carry."
+	desc = "A handgun holster that fits under the user's arm. Perfect for concealed carry."
 	icon_state = "holster"
 
 /obj/item/clothing/accessory/holster/waist
 	name = "waist holster"
-	desc = "A handgun holster. Made of expensive leather."
+	desc = "A handgun holster that's worn around the waist. Made of expensive leather."
 	icon_state = "holster"
 	overlay_state = "holster_low"
 	concealed_holster = 0
@@ -141,14 +141,14 @@
 
 /obj/item/clothing/accessory/holster/hip
 	name = "hip holster"
-	desc = "A handgun holster slung low on the hip, draw pardner!"
+	desc = "A handgun holster slung low on the hip."
 	icon_state = "holster_hip"
 	concealed_holster = 0
 	slot = ACCESSORY_SLOT_WEAPON
 
 /obj/item/clothing/accessory/holster/leg
 	name = "leg holster"
-	desc = "A tacticool handgun holster. Worn on the upper leg."
+	desc = "A modern black handgun holster. Worn on the upper leg."
 	icon_state = "holster_leg"
 	overlay_state = "holster_leg"
 	concealed_holster = 0


### PR DESCRIPTION
Rewords some of the gunbox text to properly convey what the player/character is seeing/doing.
Makes armor plates spawn within covert carriers instead of outside.
Alters holster descriptions.
Covert carriers no longer hide holsters on inspect.