### PR TITLE
sec maint floor door

### DIFF
--- a/maps/map_files/rift/rift-05-surface2.dmm
+++ b/maps/map_files/rift/rift-05-surface2.dmm
@@ -30843,13 +30843,6 @@
 "tVG" = (
 /turf/simulated/floor/plating/lythios43c,
 /area/rift/surfacebase/outside/outside2)
-"tWb" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Security Substation";
-	secured_wires = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/medsec_maintenance)
 "tWJ" = (
 /obj/effect/floor_decal/borderfloorblack{
 	alpha = 255;
@@ -54417,7 +54410,7 @@ kXL
 qRD
 mvZ
 szQ
-tWb
+szQ
 szQ
 xFu
 byV

--- a/maps/map_files/rift/rift-05-surface2.dmm
+++ b/maps/map_files/rift/rift-05-surface2.dmm
@@ -11207,7 +11207,6 @@
 /area/security/brig)
 "hcy" = (
 /obj/structure/table/steel,
-/obj/item/storage/box/nifsofts_security,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -11217,6 +11216,12 @@
 	},
 /obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 1
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_x = -8
+	},
+/obj/item/storage/box/evidence{
+	pixel_x = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
@@ -15006,12 +15011,6 @@
 /area/maintenance/substation/research)
 "jsy" = (
 /obj/structure/table/steel,
-/obj/item/storage/box/evidence{
-	pixel_x = 8
-	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = -8
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -15022,6 +15021,7 @@
 /obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 8
 	},
+/obj/item/storage/box/nifsofts_security,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "jsz" = (


### PR DESCRIPTION
Removes a door sitting in the middle of the floor in sec maint.

Swaps NIF box with handcuffs and evidence bags so that it's easier to see during prep.