### PR TITLE
Snowtile fix

### DIFF
--- a/maps/map_files/rift/rift-05-surface2.dmm
+++ b/maps/map_files/rift/rift-05-surface2.dmm
@@ -15893,7 +15893,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating/lythios43c,
+/turf/simulated/floor/plating,
 /area/maintenance/substation/research/telescience_lab)
 "jXO" = (
 /obj/structure/cable/green{


### PR DESCRIPTION
fixes a plating tile in a substation that was breaking atmosphere/making it snow indoors. it was marked as a lythios turf