### PR TITLE
Removing a few non-standard pets

### DIFF
--- a/maps/map_files/rift/rift-02-underground2.dmm
+++ b/maps/map_files/rift/rift-02-underground2.dmm
@@ -10448,6 +10448,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/mob/living/simple_mob/animal/passive/bird/parrot/polly,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_room)
 "Ii" = (

--- a/maps/map_files/rift/rift-05-surface2.dmm
+++ b/maps/map_files/rift/rift-05-surface2.dmm
@@ -860,19 +860,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research/rnd)
-"azd" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/mob/living/simple_mob/otie/red/friendly{
-	desc = "The Head of Security's loyal Red Otie. Seems this ominous looking longdog has been infused with wicked infernal forces. This one seems rather peaceful though.";
-	name = "Brutus"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/hos)
 "azK" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -2686,10 +2673,6 @@
 "bxf" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
-	},
-/obj/structure/dogbed{
-	desc = "A bed made especially for dogs, or other similarly sized pets. Brutus has since grown out of his bed it seems.";
-	name = "Brutus' Bed"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
@@ -22598,6 +22581,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
+"odF" = (
+/obj/structure/table/steel,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/medsec_maintenance)
 "odS" = (
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - Research Main Subgrid";
@@ -24193,7 +24181,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_4)
 "pge" = (
-/obj/structure/barricade/cutout/clown,
+/obj/structure/table/rack,
+/obj/random/firstaid,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
 "pgh" = (
@@ -29759,6 +29748,12 @@
 /obj/effect/floor_decal/corner/purple/bordercorner,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
+"teZ" = (
+/obj/structure/filingcabinet/chestdrawer{
+	name = "Scan Records"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/medsec_maintenance)
 "tfp" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -53912,8 +53907,8 @@ jnK
 szQ
 qUB
 sLu
-pge
-pge
+mYq
+szQ
 pge
 sLu
 szQ
@@ -54106,9 +54101,9 @@ jnK
 szQ
 qUB
 sLu
-pge
-pge
-pge
+szQ
+szQ
+mYq
 sLu
 sLu
 sLu
@@ -54300,9 +54295,9 @@ oXc
 qUB
 qUB
 sLu
-pge
-pge
-pge
+teZ
+szQ
+odF
 sLu
 sLu
 sLu
@@ -58749,7 +58744,7 @@ hLf
 cvH
 qgw
 cqp
-azd
+cqp
 dwr
 gQH
 ioQ

--- a/maps/map_files/rift/rift-05-surface2.dmm
+++ b/maps/map_files/rift/rift-05-surface2.dmm
@@ -14819,11 +14819,6 @@
 	pixel_x = -22;
 	pixel_y = 32
 	},
-/obj/structure/dogbed,
-/mob/living/simple_mob/animal/passive/dog/tamaskan{
-	desc = "The robotics spry new canine friend! The name 'Sprocket' Can be found on her collar. She seems to love old rock music from Sol.";
-	name = "Sprocket"
-	},
 /turf/simulated/floor/tiled/steel,
 /area/assembly/robotics)
 "jnl" = (

--- a/maps/map_files/rift/rift-06-surface3.dmm
+++ b/maps/map_files/rift/rift-06-surface3.dmm
@@ -8256,14 +8256,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/office)
-"auB" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/structure/dogbed{
-	name = "pet bed"
-	},
-/mob/living/simple_mob/animal/passive/fox/renault,
-/turf/simulated/floor/wood,
-/area/crew_quarters/captain)
 "auC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -11799,15 +11791,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
 "aDK" = (
-/obj/structure/dogbed,
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 10
-	},
-/mob/living/simple_mob/animal/passive/dog/corgi/Lisa{
-	desc = "It's Lisa, the exploration teams trusty Corgi."
 	},
 /turf/simulated/floor/tiled/steel,
 /area/exploration/pathfinder_office)
@@ -47553,7 +47541,7 @@ aCl
 aYJ
 aXc
 aGk
-auB
+aNT
 aWw
 abo
 aLK

--- a/maps/map_levels/192x192/lavaland.dmm
+++ b/maps/map_levels/192x192/lavaland.dmm
@@ -633,6 +633,12 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/outdoors/lava/lavaland,
 /area/lavaland/central/explored)
+"ny" = (
+/mob/living/simple_mob/animal/passive/mouse/gray{
+	name = "Jerry"
+	},
+/turf/simulated/floor/plating,
+/area/lavaland/central/base/common)
 "nz" = (
 /obj/machinery/atmospherics/component/unary/outlet_injector{
 	dir = 4
@@ -1420,9 +1426,6 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
 	},
-/mob/living/simple_mob/animal/passive/mouse/gray{
-	name = "Jerry"
-	},
 /obj/machinery/camera/network/mining{
 	dir = 4
 	},
@@ -1480,6 +1483,10 @@
 /area/lavaland/central/base/common)
 "AO" = (
 /turf/simulated/wall/r_wall,
+/area/lavaland/central/base/common)
+"Bh" = (
+/mob/living/simple_mob/animal/passive/mouse/brown/Tom,
+/turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "BY" = (
 /obj/spawner/window/reinforced/full/firelocks,
@@ -10299,7 +10306,7 @@ mN
 oK
 pk
 qz
-qz
+Bh
 oj
 AO
 vm
@@ -10493,7 +10500,7 @@ mZ
 oO
 pn
 pW
-qz
+ny
 so
 AO
 AO


### PR DESCRIPTION
Which pets are gone?
Renault(captain) Brutus (hos) Lisa(pathfinder)

Added polly to reactor control room, moved Tom and (added) jerry to the engineering area of lavaland/surt instead of the bar area.

What else?
The clown room outside of security maint is replaced with a more normal-looking maint room.

Why?
These 3 pets exist solely to make dirt appear on the floor, or bait for less than desirable actions. Leaving all the other pets that are interesting and/or have unique mechanics (runtime, Ian, Kendrick, ect.)

Polly has unique mechanics, readded.

The clown room left me asking 'why is this here' more times than what's healthy. The answer is probably just "funny tg clown beating, get it?"