### PR TITLE
removes precursor tech from the equipment vendors

### DIFF
--- a/code/modules/mining/ore_redemption_machine/engineering_points_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/engineering_points_vendor.dm
@@ -62,7 +62,6 @@
 		new /datum/data/mining_equipment("Special Parts - Fuel compressor Voucher",	/obj/item/engineering_voucher/fuel_compressor, 10),
 		new /datum/data/mining_equipment("Special Parts - Collector Voucher", 		/obj/item/engineering_voucher/collectors, 10),
 		//voucher: Solar crate, Vimur canister
-		new /datum/data/mining_equipment("???", /obj/item/engineering_mystical_tech, 1000)
     )
 
 /obj/machinery/mineral/equipment_vendor/engineering/interact(mob/user)

--- a/code/modules/mining/ore_redemption_machine/survey_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/survey_vendor.dm
@@ -61,7 +61,6 @@
 		new /datum/data/mining_equipment("Bar Shelter Capsule",			/obj/item/survivalcapsule/luxurybar,						1000),
 		new /datum/data/mining_equipment("1000 Thalers",				/obj/item/spacecash/c1000,									1000),
 		new /datum/data/mining_equipment("Defense Equipment - Marksman Box",	/obj/item/gunbox/marksman,							1000),
-		new	/datum/data/mining_equipment("Exploration Component",		/obj/item/engineering_mystical_tech,						1000),
 		)
 /obj/machinery/mineral/equipment_vendor/survey/interact(mob/user)
 	user.set_machine(src)


### PR DESCRIPTION

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed precursor tech item from the equipment vendors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
