### PR TITLE
half revert of #5564

### DIFF
--- a/code/modules/mining/ore_redemption_machine/engineering_points_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/engineering_points_vendor.dm
@@ -62,6 +62,7 @@
 		new /datum/data/mining_equipment("Special Parts - Fuel compressor Voucher",	/obj/item/engineering_voucher/fuel_compressor, 10),
 		new /datum/data/mining_equipment("Special Parts - Collector Voucher", 		/obj/item/engineering_voucher/collectors, 10),
 		//voucher: Solar crate, Vimur canister
+		new /datum/data/mining_equipment("???", /obj/item/engineering_mystical_tech, 1000)
     )
 
 /obj/machinery/mineral/equipment_vendor/engineering/interact(mob/user)


### PR DESCRIPTION
Lordme clapped it a little too hard. Slightly increases engineering point requirement for precursor tech. Engineers are right. They dont have enough content or goals as it is.