### PR TITLE
Finally fixes the encryption reinforcing heater

### DIFF
--- a/code/modules/power/crypto_miner.dm
+++ b/code/modules/power/crypto_miner.dm
@@ -1,5 +1,5 @@
 /*******
- * Crypto miner, turns power into points for engineering
+ * Crypto miner, or cryptominer turns power into points for engineering
  * Basicly a glorified power sink
  * Heats either atmos in the connector below or atmos in the environment
  * Reduced efficency the warmer it gets
@@ -30,6 +30,7 @@ GLOBAL_VAR_INIT(power_per_point, 1000 KILOWATTS)
 
 /obj/machinery/power/crypto_miner/examine(mob/user)
     . = ..()
+    . += "An indicator on [src]'s controll panel indicates that [src] is in a [(check_right_atmos() ? "sufficent" : "insufficent")] amount of helium to function."
     if(GLOB.points_mined)//Only show this if someone actually mined
         . += "[src] is [power_level? "on":"off"]. Current Power Level reads [power_level]."
         . += "Progress to next Point: [(power_drawn/GLOB.power_per_point) *100] %"
@@ -47,6 +48,10 @@ GLOBAL_VAR_INIT(power_per_point, 1000 KILOWATTS)
     if(temperature_damage >= 100)//Once the circuit is fried, turn off
         power_level = 0
         return
+
+    if(!check_right_atmos())
+        temperature_damage++
+        src.visible_message(SPAN_NOTICE("[src] beeps as it is unable to work in this atmosphere."))
 
     var/new_power_drawn = draw_power(power_level * 0.001) * 1000
     power_drawn += new_power_drawn
@@ -128,4 +133,17 @@ GLOBAL_VAR_INIT(power_per_point, 1000 KILOWATTS)
                 to_chat(user, SPAN_NOTICE("You completely restore the [src]'s circuit"))
     else
         to_chat(user, SPAN_NOTICE("There is no damage on the [src]'s circuit"))
+
+/obj/machinery/power/crypto_miner/proc/check_right_atmos()
+	var/datum/gas_mixture/env = loc.return_air()
+	var/non_helium = 0
+	var/helium = 0
+	for(var/diff_gasses in env.gas)
+		if(ispath(diff_gasses, /datum/gas/helium))
+			helium = env.gas[diff_gasses]
+		else
+			non_helium += env.gas[diff_gasses]
+	return helium > non_helium
+
+
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
the encryption reinforcing heater was supposed to be an additional challenge for engineers, not a, lets put it outside and forget about it machine, this pullrequest makes it so that it requires to be in at least 50% helium atmosphere to function
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
makes the ERH more that just a, who can build the largest power output engine challenge
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Cryptominer cant be run in standard atmosphere anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
