### PR TITLE
experimental: 3-phase Z-Mimic

### DIFF
--- a/code/__DEFINES/controllers/_subsystems.dm
+++ b/code/__DEFINES/controllers/_subsystems.dm
@@ -115,13 +115,12 @@ DEFINE_BITFIELD(runlevels, list(
 #define INIT_ORDER_OVERMAPS       -20
 #define INIT_ORDER_TICKER         -30
 #define INIT_ORDER_LIGHTING       -40
-#define INIT_ORDER_ZMIMIC         -45
 #define INIT_ORDER_AMBIENT_LIGHT  -46
 #define INIT_ORDER_XENOARCH       -50
 #define INIT_ORDER_CIRCUIT        -60
 #define INIT_ORDER_AI             -70
 #define INIT_ORDER_PATH           -98
-#define INIT_ORDER_OPENSPACE      -99
+#define INIT_ORDER_ZMIMIC         -99
 #define INIT_ORDER_CHAT           -100  //! Should be last to ensure chat remains smooth during init.
 
 

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -195,6 +195,10 @@ SUBSYSTEM_DEF(overlays)
 
 // The same as the above, but with ZM_AUTOMANGLE.
 /atom/movable/build_appearance_list(atom/new_overlays)
+	// If the atom has explicitly opted into mangling, don't bother scanning for automangle.
+	if (zmm_flags & ZMM_MANGLE_PLANES)
+		return ..()
+
 	var/static/image/appearance_bro = new
 	if (islist(new_overlays))
 		new_overlays = new_overlays:Copy()

--- a/code/game/atoms/movable/movable.dm
+++ b/code/game/atoms/movable/movable.dm
@@ -176,6 +176,8 @@
 	if (bound_overlay)
 		QDEL_NULL(bound_overlay)
 
+	zm_discovery_pending = 0
+
 	. = ..()
 
 	moveToNullspace()

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -103,7 +103,7 @@ GLOBAL_LIST_INIT(multiz_hole_baseturfs, typecacheof(list(
 
 	if(!GLOB.use_preloader && path == type && !(flags & CHANGETURF_FORCEOP) && (baseturfs == new_baseturfs)) // Don't no-op if the map loader requires it to be reconstructed, or if this is a new set of baseturfs
 		return src
-	if(flags & CHANGETURF_SKIP)
+	if(!(atom_flags & ATOM_INITIALIZED) || (flags & CHANGETURF_SKIP))
 		return new path(src)
 
 	// store lighting

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -181,6 +181,9 @@
 	return INITIALIZE_HINT_NORMAL
 
 /turf/Destroy(force)
+	if (!(atom_flags & ATOM_INITIALIZED))
+		crash_with("Turf destroyed without initializing.")
+
 	. = QDEL_HINT_IWILLGC
 	if(!changing_turf)
 		stack_trace("Incorrect turf deletion")

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -138,6 +138,9 @@ GLOBAL_LIST_EMPTY(dirty_vars)
 
 var/list/debug_verbs = list (
 	/client/proc/analyze_openturf,
+	/client/proc/zms_display_turf,
+	/client/proc/zms_display_discovery,
+	/client/proc/zms_display_mimic,
 	/client/proc/atmos_toggle_debug,
 	/client/proc/atmosscan,
 	/client/proc/camera_view,

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -1,6 +1,7 @@
 /atom/movable
 	/// The mimic (if any) that's *directly* copying us.
 	var/tmp/atom/movable/openspace/mimic/bound_overlay
+	var/tmp/zm_discovery_pending = FALSE
 	/// Movable-level Z-Mimic flags. This uses ZMM_* flags, not ZM_* flags.
 	var/zmm_flags = NONE
 
@@ -206,6 +207,11 @@
 /atom/movable/openspace/mimic/proc/owning_turf_changed()
 	if (!destruction_timer)
 		destruction_timer = addtimer(CALLBACK(src, /datum/.proc/qdel_self), 10 SECONDS, TIMER_STOPPABLE)
+
+/atom/movable/openspace/mimic/proc/get_root()
+	. = associated_atom
+	while ((.):type == /atom/movable/openspace/mimic)
+		. = (.):associated_atom
 
 // -- TURF PROXY --
 

--- a/code/modules/multiz/zmimic/mimic_turf.dm
+++ b/code/modules/multiz/zmimic/mimic_turf.dm
@@ -68,6 +68,9 @@
 /// Cleans up Z-mimic objects for this turf. You shouldn't call this directly 99% of the time.
 /turf/proc/cleanup_zmimic()
 	SSzmimic.openspace_turfs -= 1
+	if (SSzmimic.openspace_turfs < 0)
+		stack_trace("Z-Turf count is insane.")
+
 	// Don't remove ourselves from the queue, the subsystem will explode. We'll naturally fall out of the queue.
 	z_queued = 0
 
@@ -89,7 +92,8 @@
 		below = null
 
 /turf/Entered(atom/movable/thing, atom/oldLoc)
-	..()
-	if (thing.bound_overlay || (thing.zmm_flags & ZMM_IGNORE) || thing.invisibility == INVISIBILITY_ABSTRACT || !TURF_IS_MIMICKING(above))
+	. = ..()
+	if ((thing.bound_overlay && !thing.bound_overlay.destruction_timer) || (thing.zmm_flags & ZMM_IGNORE) || thing.invisibility == INVISIBILITY_ABSTRACT || !TURF_IS_MIMICKING(above))
 		return
-	above.update_mimic()
+	SSzmimic.queued_discovery += thing
+	thing.zm_discovery_pending += 1


### PR DESCRIPTION
- It is no longer possible to outrun Z-Mimic. Z-Mimic will find you.
- Movables can now be independently discovered by ZM without requiring an expensive turf update as well.
- Fixes some issues with broken comparisons in the Z-Mimic eligibility macros.
- Z-Mimic now has a performance profiler.
- Z-Mimic now attempts to copy vis_contents, though not very efficiently.
- Fixes some issues where reclaimed mimics may not have their destruction timer halted.
- Adds support for ZMM_LOOKBESIDE, which is ZMM_LOOKAHEAD but for left/right instead.
- Minor automangle efficiency weak.
- Fixes a double-init issue with turf init.