### PR TITLE
Take 2: Some fixes and QoL

### DIFF
--- a/code/game/objects/items/circuitboards/machinery/mining_drill.dm
+++ b/code/game/objects/items/circuitboards/machinery/mining_drill.dm
@@ -19,4 +19,7 @@
 	build_path = /obj/machinery/mining/brace
 	board_type = new /datum/frame/frame_types/machine
 	origin_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
-	req_components = list()
+	req_components = list(
+		/obj/item/stock_parts/manipulator = 1
+		)
+

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -247,7 +247,7 @@
 		if(supports.len >= braces_needed)
 			supported = 1
 		else for(var/obj/machinery/mining/brace/check in supports)
-			if(check.brace_tier > 3)
+			if(check.brace_tier >= 3)
 				supported = 1
 
 	update_icon()
@@ -311,12 +311,12 @@
 
 /obj/machinery/mining/brace/examine(mob/user)
 	. = ..()
-	if(brace_tier > 3)
+	if(brace_tier >= 3)
 		. += SPAN_NOTICE("The internals of the brace look resilient enough to support a drill by itself.")
 
 /obj/machinery/mining/brace/Initialize()
 	. = ..()
-	default_apply_parts()
+
 
 /obj/machinery/mining/brace/RefreshParts()
 	..()

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -11,7 +11,7 @@
 	icon_state = "mining_drill"
 	circuit = /obj/item/circuitboard/miningdrill
 	var/braces_needed = 2
-	var/list/supports = list()
+	var/list/obj/machinery/mining/brace/supports = list()
 	var/supported = 0
 	var/active = 0
 	var/list/resource_field = list()
@@ -243,8 +243,12 @@
 	else
 		anchored = 1
 
-	if(supports && supports.len >= braces_needed)
-		supported = 1
+	if(supports)
+		if(supports.len >= braces_needed)
+			supported = 1
+		else for(var/obj/machinery/mining/brace/check in supports)
+			if(check.brace_tier > 3)
+				supported = 1
 
 	update_icon()
 
@@ -302,11 +306,23 @@
 	desc = "A machinery brace for an industrial drill. It looks easily two feet thick."
 	icon_state = "mining_brace"
 	circuit = /obj/item/circuitboard/miningdrillbrace
+	var/brace_tier = 1
 	var/obj/machinery/mining/drill/connected
 
-/obj/machinery/mining/brace/Initialize(mapload, newdir)
+/obj/machinery/mining/brace/examine(mob/user)
 	. = ..()
-	component_parts = list()
+	if(brace_tier > 3)
+		. += SPAN_NOTICE("The internals of the brace look resilient enough to support a drill by itself.")
+
+/obj/machinery/mining/brace/Initialize()
+	. = ..()
+	default_apply_parts()
+
+/obj/machinery/mining/brace/RefreshParts()
+	..()
+	brace_tier = 0
+	for(var/obj/item/stock_parts/manipulator/M in component_parts)
+		brace_tier += M.rating
 
 /obj/machinery/mining/brace/attackby(obj/item/W as obj, mob/user as mob)
 	if(connected && connected.active)
@@ -316,6 +332,8 @@
 	if(default_deconstruction_screwdriver(user, W))
 		return
 	if(default_deconstruction_crowbar(user, W))
+		return
+	if(default_part_replacement(user,W))
 		return
 
 	if(W.is_wrench())

--- a/code/modules/mining/ore_datum.dm
+++ b/code/modules/mining/ore_datum.dm
@@ -185,6 +185,7 @@ GLOBAL_LIST_INIT(ore_data, initialize_ore_data())
 	name = MAT_COPPER
 	display_name = "raw copper"
 	smelts_to = "copper"
+	alloy = 1
 	result_amount = 4
 	spread_chance = 20
 	ore = /obj/item/ore/copper

--- a/code/modules/research/designs/xenobio_toys.dm
+++ b/code/modules/research/designs/xenobio_toys.dm
@@ -28,3 +28,21 @@
 	materials = list(MAT_STEEL = 500, MAT_GLASS = 500)
 	build_path = /obj/item/slime_scanner
 	sort_string = "HBAAA"
+
+/datum/design/item/xenobio/gene_disk
+	name = "genetics disk"
+	desc = "A disk designed to retain humanoid genetic information."
+	id = "gene_disk"
+	req_tech = list(TECH_DATA = 3, TECH_BIO = 3)
+	materials = list(MAT_STEEL = 300, MAT_GLASS = 300)
+	build_path = /obj/item/disk/data
+	sort_string = "HAAHA"
+
+/datum/design/item/xenobio/botany_disk
+	name = "flora data disk"
+	desc = "A small disk used for carrying data on plant genetics."
+	id = "plant_disk"
+	req_tech = list(TECH_DATA = 3, TECH_BIO = 3)
+	materials = list(MAT_STEEL = 300, MAT_GLASS = 300)
+	build_path = /obj/item/disk/botany
+	sort_string = "HAHAB"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Would you believe me if I hadn't updated my git in about 400 years, and had to blow the old version of my repo up?
Yes? No? It doesn't matter.

Anyways! Meat and potatoes of this:
Allows players to make gene and plant discs freely in the protolathe. Since we do not have a dedicated genetics, this will help the pains of actually doing genetics by giving us storage solutions for genes.

Fixes a problem with brass also creating slag when compressing, by setting the copper alloy flag to 1.

And finally: Allows you to upgrade the braces! If your brace has T3 or better, a single brace can hold an entire drill. All credit goes to Hatterhat for this one, as I pretty much wholesale ripped it from his buff of the big drill™ on Virgo.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Not making slag is ALWAYS good. It saves on material, too.
Having more discs for a cheap cost is also good, it means you can reduce headaches while scoping out for genes, because there are many, and the ability to track them are currently few.
And honestly, the less lugging a person has to do with the mining drill, the more likely people might stop blowing up an already unstable planet with miniature hydrogen bombs.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: The0bserver
add: Discs are able to be produced in the protolathe now. Go nuts, or don't. I'm not your guardian.
balance: Mining Drills can finally be operated with just one brace with the requisite parts. Thank you, Hatterhat!
fix: Copper no longer smelts slag when set to "Alloying."
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
