### PR TITLE
Nightshift Color/Brightness

### DIFF
--- a/code/__DEFINES/color/lights.dm
+++ b/code/__DEFINES/color/lights.dm
@@ -34,4 +34,4 @@
 #define LIGHT_COLOR_INCANDESCENT_TUBE       "#E0EFF0" // rgb(224, 239, 240) Slightly blueish white.
 #define LIGHT_COLOR_INCANDESCENT_BULB       "#FFFEB8" // rgb(255, 254, 184) Slightly yellowish white.
 #define LIGHT_COLOR_INCANDESCENT_FLASHLIGHT "#FFCC66" // rgb(255, 204, 102) Slightly yellowish white.
-#define LIGHT_COLOR_NIGHTSHIFT              "#EFCC86" // rgb(239, 204, 134) Slightly yellowish white.
+#define LIGHT_COLOR_NIGHTSHIFT              "#616191" // rgb(134, 162, 239) Blueish white.

--- a/code/__DEFINES/color/lights.dm
+++ b/code/__DEFINES/color/lights.dm
@@ -34,4 +34,4 @@
 #define LIGHT_COLOR_INCANDESCENT_TUBE       "#E0EFF0" // rgb(224, 239, 240) Slightly blueish white.
 #define LIGHT_COLOR_INCANDESCENT_BULB       "#FFFEB8" // rgb(255, 254, 184) Slightly yellowish white.
 #define LIGHT_COLOR_INCANDESCENT_FLASHLIGHT "#FFCC66" // rgb(255, 204, 102) Slightly yellowish white.
-#define LIGHT_COLOR_NIGHTSHIFT              "#616191" // rgb(134, 162, 239) Blueish white.
+#define LIGHT_COLOR_NIGHTSHIFT              "#616191" // rgb(97, 97, 145) Dark blue.

--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -56,9 +56,9 @@ SUBSYSTEM_DEF(nightshift)
 	nightshift_active = active
 	if(announce)
 		if(active)
-			announce("Good evening, crew. To reduce power consumption and stimulate the circadian rhythms of some species, all of the lights aboard the station have been dimmed for the night.")
+			announce("Good evening, crew. To reduce power consumption and stimulate the circadian rhythms of some species, all of the non-essential lights have been dimmed for the night.")
 		else
-			announce("Good morning, crew. As it is now day time, all of the lights aboard the station have been restored to their former brightness.")
+			announce("Good morning, crew. As it is now day time, all of the non-essential lights have been restored to their former brightness.")
 
 	SSlighting.pause_instant()
 

--- a/code/modules/power/lighting/lights.dm
+++ b/code/modules/power/lighting/lights.dm
@@ -26,7 +26,7 @@
 	var/brightness_color = LIGHT_COLOR_HALOGEN
 
 	var/nightshift_range = 6
-	var/nightshift_power = 0.4
+	var/nightshift_power = 0.5
 	var/nightshift_color = LIGHT_COLOR_NIGHTSHIFT
 
 /obj/item/light/tube
@@ -41,7 +41,7 @@
 	brightness_color = LIGHT_COLOR_HALOGEN
 
 	nightshift_range = 6
-	nightshift_power = 0.4
+	nightshift_power = 0.5
 
 /obj/item/light/tube/large
 	w_class = ITEMSIZE_SMALL
@@ -109,7 +109,7 @@
 	brightness_range = 4
 
 	nightshift_range = 4
-	nightshift_power = 0.4
+	nightshift_power = 0.5
 
 /obj/item/light/bulb/strong
 	name = "light bulb"
@@ -122,8 +122,9 @@
 
 	brightness_range = 8
 
-	nightshift_range = 8
+	nightshift_range = 8 //Basically just a no-nightshift light.
 	nightshift_power = 0.8
+	nightshift_color = LIGHT_COLOR_TUNGSTEN
 
 /obj/item/light/throw_impact(atom/hit_atom)
 	..()

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -674,6 +674,9 @@
 	dir = 2
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/sleep)
 "awp" = (
@@ -11284,6 +11287,9 @@
 	name = "note from CentCom";
 	pixel_x = -6;
 	pixel_y = -4
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
@@ -35528,9 +35534,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/morgue{
 	dir = 2
 	},

--- a/maps/rift/levels/rift-06-surface3.dmm
+++ b/maps/rift/levels/rift-06-surface3.dmm
@@ -5058,19 +5058,6 @@
 	},
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/shuttle/emt/cockpit)
-"amG" = (
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel,
-/area/hallway/primary/surfacethree)
 "amH" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -15582,9 +15569,6 @@
 /area/exploration/courser_dock)
 "aNw" = (
 /obj/machinery/disposal,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
@@ -17838,6 +17822,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/bcarpet,
@@ -22780,7 +22767,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/commandmaint)
 "ilt" = (
-/obj/machinery/camera/network/civilian,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/beehive,
 /turf/simulated/floor/grass,
@@ -23190,6 +23176,7 @@
 "jLq" = (
 /obj/machinery/beehive,
 /obj/structure/flora/ausbushes/stalkybush,
+/obj/machinery/camera/network/civilian,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "jLR" = (
@@ -27165,10 +27152,6 @@
 "xlc" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 6
-	},
-/obj/machinery/light{
-	dir = 8;
-	light_range = 12
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/smartfridge/drinks,
@@ -40585,7 +40568,7 @@ kps
 axr
 aIa
 ask
-amG
+axr
 jIg
 cqj
 aXu


### PR DESCRIPTION
## About The Pull Request

brightens nightshift lighting from 0.4 to 0.6 (dayshift is 0.8)

## Why It's Good For The Game


Nightshift was too dark, and blue adds atmosphere (It overwhelmingly won the vote too)

## Changelog

:cl:
tweak: Changes nightshift color to blueish
tweak: Changes nightshift brightness from 0.4 to 0.6
/:cl:

![5-0 6](https://github.com/Citadel-Station-13/Citadel-Station-13-RP/assets/86886852/ae020e11-0b2b-4330-bc8e-4950dace9413)