### PR TITLE
removes the wood recipe for the (bone) horse post

### DIFF
--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -172,7 +172,6 @@
 	recipes += new/datum/stack_recipe("wooden sandals", /obj/item/clothing/shoes/sandal, 1, pass_stack_color = TRUE)
 	recipes += new/datum/stack_recipe("wood circlet", /obj/item/clothing/head/woodcirclet, 1, pass_stack_color = TRUE)
 	recipes += new/datum/stack_recipe("clipboard", /obj/item/clipboard, 1, pass_stack_color = TRUE)
-	recipes += new/datum/stack_recipe("horse post", /obj/structure/bed/chair/post, 5, time = 20, one_per_turf = 1, on_floor = 1, pass_stack_color = TRUE)
 	recipes += new/datum/stack_recipe("wood floor tile", /obj/item/stack/tile/wood, 1, 4, 20, pass_stack_color = TRUE)
 	recipes += new/datum/stack_recipe("wood roofing tile", /obj/item/stack/tile/roofing/wood, 3, 4, 20)
 	recipes += new/datum/stack_recipe("wooden chair", /obj/structure/bed/chair/wood, 3, time = 10, one_per_turf = 1, on_floor = 1, pass_stack_color = TRUE)


### PR DESCRIPTION
## About The Pull Request
it's a horse post made out of bone and sinew found in the crafting menu intended for ashlanders to make use of
it gets deconstructed into bone still which is what caused it to get reported in bug-triage in the first place

## Why It's Good For The Game
it's um made of bone so you should probably not be able to make it from wood (but someone making a wooden one would be neat!)

## Changelog
:cl:
del: removes the recipe for the horse post that requires wood, because it is made out of bone and sinew
/:cl:
