### PR TITLE
removes windows build from actions / ci_suite

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -131,34 +131,3 @@ jobs:
           bash tools/ci/run_server.sh
         env:
           CBT_BUILD_MODE: TEST_RUN
-
-  test_windows:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    name: Windows Build
-    runs-on: windows-latest
-    concurrency:
-      group: test_windows-${{ github.ref }}
-      cancel-in-progress: true
-    steps:
-      - uses: actions/checkout@v3
-      - name: Restore Yarn cache
-        uses: actions/cache@v3
-        with:
-          path: tgui/.yarn/cache
-          key: ${{ runner.os }}-yarn-${{ hashFiles('tgui/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - name: Compile
-        run: pwsh tools/ci/build.ps1
-        env:
-          DM_EXE: "C:\\byond\\bin\\dm.exe"
-      - name: Create artifact
-        run: |
-          md deploy
-          bash tools/deploy.sh ./deploy
-      - name: Deploy artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: deploy
-          path: deploy


### PR DESCRIPTION
as it stands we do not actually run integration tests on windows
all it's doing is deploying the server artifact

given we are not tg we really, really do not actually need this
so it's probably better to throw this out and make our CI runs a good deal faster.