### PR TITLE
makes markings transfer over when ahealed/regenerating + aheals dont remove NIFs

### DIFF
--- a/code/modules/mob/living/carbon/human/health.dm
+++ b/code/modules/mob/living/carbon/human/health.dm
@@ -6,7 +6,7 @@
 	// This is because the logic for being unconscious from damage is, for some reason, in UI. //
 	handle_regular_UI_updates()
 
-/mob/living/carbon/human/rejuvenate(fix_missing, reset_to_slot)
+/mob/living/carbon/human/rejuvenate(fix_missing, reset_to_slot, var/delete_nif = FALSE)
 	. = ..()
 	if(!.)
 		return
@@ -16,7 +16,7 @@
 
 	// todo: this obviously doesn't respect reset_to_slot.
 	if(fix_missing || reset_to_slot)
-		species.create_organs(src)
+		species.create_organs(src, delete_nif)
 		restore_all_organs()
 		client?.prefs?.copy_to(src)
 		if(dna)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -87,22 +87,11 @@
 		owner = loc
 		w_class = max(src.w_class + mob_size_difference(owner.mob_size, MOB_MEDIUM), 1) //smaller mobs have smaller organs.
 		if(internal)
-			if(!LAZYLEN(owner.internal_organs))
-				owner.internal_organs = list()
-			if(!LAZYLEN(owner.internal_organs_by_name))
-				owner.internal_organs_by_name = list()
-
-			owner.internal_organs |= src
-			owner.internal_organs_by_name[organ_tag] = src
-
+			LAZYDISTINCTADD(owner.internal_organs, src)
+			LAZYSET(owner.internal_organs_by_name, organ_tag, src)
 		else
-			if(!LAZYLEN(owner.organs))
-				owner.organs = list()
-			if(!LAZYLEN(owner.organs_by_name))
-				owner.organs_by_name = list()
-
-			owner.organs |= src
-			owner.organs_by_name[organ_tag] = src
+			LAZYDISTINCTADD(owner.organs, src)
+			LAZYSET(owner.organs_by_name, organ_tag, src)
 
 	if(!max_damage)
 		max_damage = min_broken_damage * 2

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -625,6 +625,13 @@ GLOBAL_LIST_INIT(species_oxygen_tank_by_gas, list(
 /datum/species/proc/create_organs(var/mob/living/carbon/human/H) //Handles creation of mob organs.
 	H.mob_size = mob_size
 
+	// store the markings for each limb we have so we can apply them to our new limbs
+	var/list/temporary_marking_store = list()
+	for(var/limb_type in has_limbs)
+		var/obj/item/organ/external/existing_limb = H.organs[limb_type]
+		if(existing_limb && istype(existing_limb))
+			temporary_marking_store[limb_type] = existing_limb.markings
+
 	for(var/obj/item/organ/organ in H.contents)
 		if((organ in H.organs) || (organ in H.internal_organs))
 			qdel(organ)
@@ -648,14 +655,11 @@ GLOBAL_LIST_INIT(species_oxygen_tank_by_gas, list(
 			organ_data = has_limbs[O.parent_organ]
 			organ_data["has_children"] = organ_data["has_children"]+1
 
-	for(var/id in pref.body_marking_ids)
-		var/datum/sprite_accessory/marking/mark_datum = GLOB.sprite_accessory_markings[id]
-		var/mark_color = "[pref.body_marking_ids[id]]"
-
-		for(var/BP in mark_datum.body_parts)
-			var/obj/item/organ/external/O = character.organs_by_name[BP]
-			if(O)
-				O.markings[id] = list("color" = mark_color, "datum" = mark_datum)
+		// check if we had an old limb of the same type that had markings
+		var/obj/item/organ/external/limb = O
+		var/markings_for_limb = temporary_marking_store[limb_type]
+		if(istype(O) && markings_for_limb)
+			limb.markings = markings_for_limb
 
 	for(var/organ_tag in has_organ)
 		var/organ_type = has_organ[organ_tag]

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -622,8 +622,13 @@ GLOBAL_LIST_INIT(species_oxygen_tank_by_gas, list(
  * called to ensure organs are consistent with our species's
  * this is a destructive operation and will erase old organs!
  */
-/datum/species/proc/create_organs(var/mob/living/carbon/human/H) //Handles creation of mob organs.
+/datum/species/proc/create_organs(var/mob/living/carbon/human/H, var/delete_nif = FALSE) //Handles creation of mob organs.
 	H.mob_size = mob_size
+
+	// if we have a NIF, unimplant it before it gets wiped
+	var/obj/item/nif/our_nif = H.nif
+	if(H.nif)
+		H.nif.unimplant(H)
 
 	// store the markings for each limb we have so we can apply them to our new limbs
 	var/list/temporary_marking_store = list()
@@ -669,14 +674,12 @@ GLOBAL_LIST_INIT(species_oxygen_tank_by_gas, list(
 			O.organ_tag = organ_tag
 		H.internal_organs_by_name[organ_tag] = O
 
-	if(H.nif)
-		var/type = H.nif.type
-		var/durability = H.nif.durability
-		var/list/nifsofts = H.nif.nifsofts
-		var/list/nif_savedata = H.nif.save_data.Copy()
-
-		var/obj/item/nif/nif = new type(H,durability,nif_savedata)
-		nif.nifsofts = nifsofts
+	// if we had a NIF, decide if we want to delete it, or put it back
+	if(our_nif)
+		if(delete_nif)
+			QDEL_NULL(our_nif)
+		else
+			our_nif.quick_implant(H)
 
 	if(base_color)
 		H.r_skin = hex2num(copytext(base_color,2,4))

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -623,8 +623,8 @@ GLOBAL_LIST_INIT(species_oxygen_tank_by_gas, list(
  * this is a destructive operation and will erase old organs!
  */
 /datum/species/proc/create_organs(var/mob/living/carbon/human/H) //Handles creation of mob organs.
-
 	H.mob_size = mob_size
+
 	for(var/obj/item/organ/organ in H.contents)
 		if((organ in H.organs) || (organ in H.internal_organs))
 			qdel(organ)
@@ -647,6 +647,15 @@ GLOBAL_LIST_INIT(species_oxygen_tank_by_gas, list(
 		if(O.parent_organ)
 			organ_data = has_limbs[O.parent_organ]
 			organ_data["has_children"] = organ_data["has_children"]+1
+
+	for(var/id in pref.body_marking_ids)
+		var/datum/sprite_accessory/marking/mark_datum = GLOB.sprite_accessory_markings[id]
+		var/mark_color = "[pref.body_marking_ids[id]]"
+
+		for(var/BP in mark_datum.body_parts)
+			var/obj/item/organ/external/O = character.organs_by_name[BP]
+			if(O)
+				O.markings[id] = list("color" = mark_color, "datum" = mark_datum)
 
 	for(var/organ_tag in has_organ)
 		var/organ_type = has_organ[organ_tag]

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -628,7 +628,7 @@ GLOBAL_LIST_INIT(species_oxygen_tank_by_gas, list(
 	// store the markings for each limb we have so we can apply them to our new limbs
 	var/list/temporary_marking_store = list()
 	for(var/limb_type in has_limbs)
-		var/obj/item/organ/external/existing_limb = H.organs[limb_type]
+		var/obj/item/organ/external/existing_limb = H.organs_by_name[limb_type]
 		if(existing_limb && istype(existing_limb))
 			temporary_marking_store[limb_type] = existing_limb.markings
 

--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -691,7 +691,7 @@
 		return
 	var/mob/living/carbon/human/H = owner
 	H.restore_blood()
-	H.species.create_organs(H)
+	H.species.create_organs(H, TRUE)
 	H.restore_all_organs()
 	H.adjustBruteLoss(-healing_amount)
 	H.adjustFireLoss(-healing_amount)


### PR DESCRIPTION
## About The Pull Request
title

regarding NIFs:
xenochimera removing NIFs is intended, nobody ever coded (emergent gameplay!), now it actually removes it instead of sending it to the shadow realm
aheals removing markings and NIFs was never intended so um yes

## Why It's Good For The Game
why would you lose them

## Changelog
:cl:
fix: makes markings transfer over when ahealed/regenerating
/:cl:
