### PR TITLE
comments out triumph's fission engine until its fixed (it never will be)

### DIFF
--- a/maps/triumph/engines.dm
+++ b/maps/triumph/engines.dm
@@ -21,8 +21,10 @@
 	suffix = "burn.dmm"
 	display_name = list("Toxins Lab", "We Knew You Liked Tether Fires, so we Brought One in a Box", "100 Solarmoths", "Teshari's Bane")
 
+/*
 /datum/map_template/engine/triumph/fission
 	name = "ProcEngine_Triumph_Fission"
 	desc = "The Fission Reactor"
 	suffix = "fission.dmm"
 	display_name = list("Chernobyl", "Not as Cool as the Stormdrive", "Radiation Rework", "Spicy Sticks")
+*/


### PR DESCRIPTION

:cl:
del: Removed fission from triumphs engine rotation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
