### PR TITLE
Follow menu now shows AI and robots/cyborgs

### DIFF
--- a/code/modules/mob/observer/dead/orbit.dm
+++ b/code/modules/mob/observer/dead/orbit.dm
@@ -64,6 +64,10 @@
 				npcs += list(serialized)
 			else
 				players += list(serialized)
+		else if(isrobot(M))
+			players += list(serialized)
+		else if(isAI(M))
+			players += list(serialized)
 
 	data["players"] = players
 	data["simplemobs"] = simplemobs


### PR DESCRIPTION

:cl:
add: Added silicon players to the ghost follow menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
