### PR TITLE
adds a component for putting a mob in an object

### DIFF
--- a/citadel.dme
+++ b/citadel.dme
@@ -722,6 +722,7 @@
 #include "code\datums\components\gps_signal.dm"
 #include "code\datums\components\horror_aura.dm"
 #include "code\datums\components\jousting.dm"
+#include "code\datums\components\object_transform.dm"
 #include "code\datums\components\orbiter.dm"
 #include "code\datums\components\simple_access.dm"
 #include "code\datums\components\slaved_atom_to_loc.dm"

--- a/code/datums/components/object_transform.dm
+++ b/code/datums/components/object_transform.dm
@@ -1,0 +1,21 @@
+/datum/component/object_transform
+	var/transformed_object
+
+/datum/component/object_transform/Initialize(_transformed_object)
+	transformed_object = _transformed_object
+	put_in_object()
+
+/datum/component/object_transform/proc/swap_object(new_object)
+	if(parent in transformed_object.contents)
+		parent.forceMove(transformed_object.loc)
+	qdel(transformed_object)
+	transformed_object = new_object
+	put_in_object()
+
+/datum/component/object_transform/proc/put_in_object
+	transformed_object.forceMove(parent.loc)
+	parent.forceMove(transformed_object)
+
+/datum/component/object_transform/proc/put_in_mob
+	parent.forceMove(transformed_object.loc)
+	transformed_object.forceMove(parent)

--- a/code/modules/mob/living/silicon/pai/mobility.dm
+++ b/code/modules/mob/living/silicon/pai/mobility.dm
@@ -29,8 +29,8 @@
 		forceMove(get_turf(src))
 
 	// Move us into the card and move the card to the ground.
-	card.forceMove(loc)
-	forceMove(card)
+	transform_component.put_in_object()
+
 	update_perspective()
 	set_resting(FALSE)
 	update_mobility()
@@ -63,8 +63,9 @@
 		var/obj/item/pda/holder = card.loc
 		holder.pai = null
 
-	forceMove(card.loc)
-	card.forceMove(src)
+	// handle the actual object stuffing via the component
+	transform_component.put_in_mob()
+
 	update_perspective()
 
 	card.screen_loc = null

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -105,12 +105,16 @@
 	// space movement related
 	var/last_space_movement = 0
 
+	// transformation component
+	var/datum/component/object_transform/transform_component
+
 /mob/living/silicon/pai/Initialize(mapload)
 	. = ..()
 	card = loc
 	sradio = new(src)
 	communicator = new(src)
 	if(card)
+		transform_component = new(card)
 		if(!card.radio)
 			card.radio = new /obj/item/radio(src.card)
 		radio = card.radio


### PR DESCRIPTION
## About The Pull Request
title

currently just swaps object stuffing for pAIs going in their card and has support for changing the object too

## Why It's Good For The Game
it's better to have this done in one spot rather than having object stuffing repeated whenever we want to do it
future use is some holosphere stuff and also some more pAI stuff

## Changelog

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
tweak: tweaked a few things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
