### PR TITLE
pAI clothing adjustments

### DIFF
--- a/code/modules/mob/living/silicon/pai/defense.dm
+++ b/code/modules/mob/living/silicon/pai/defense.dm
@@ -43,8 +43,8 @@
 				uploaded_snowflake_worn_state = U.snowflake_worn_state
 			uploaded_color = W.get_atom_colour()
 
-			to_chat(user, "<span class='notice'>You successfully upload the clothing item to [src].</span>")
-			to_chat(src, "<span class='notice'>[user] has successfully uploaded the clothing item [W.name] to you.</span>")
+			to_chat(user, "<span class='notice'>You successfully upload the [W.name] to [src].</span>")
+			to_chat(src, "<span class='notice'>[user] has successfully uploaded the [W.name] to you.</span>")
 
 		return
 	else

--- a/code/modules/mob/living/silicon/pai/defense.dm
+++ b/code/modules/mob/living/silicon/pai/defense.dm
@@ -18,25 +18,31 @@
 			return
 	else if(istype(W, /obj/item/clothing))
 		var/obj/item/clothing/C = W
+		var/new_base_uploaded_path
 		if(C.slot_flags & SLOT_HEAD)
-			base_uploaded_path = /obj/item/clothing/head
+			new_uploaded_path = /obj/item/clothing/head
 		if(C.slot_flags & SLOT_ICLOTHING)
-			base_uploaded_path = /obj/item/clothing/under
+			new_uploaded_path = /obj/item/clothing/under
 		if(C.slot_flags & SLOT_EYES)
-			base_uploaded_path = /obj/item/clothing/glasses
+			new_uploaded_path = /obj/item/clothing/glasses
 		if(C.slot_flags & SLOT_GLOVES)
-			base_uploaded_path = /obj/item/clothing/gloves
+			new_uploaded_path = /obj/item/clothing/gloves
 		if(C.slot_flags & SLOT_MASK)
-			base_uploaded_path = /obj/item/clothing/mask
+			new_uploaded_path = /obj/item/clothing/mask
 		if(C.slot_flags & SLOT_FEET)
-			base_uploaded_path = /obj/item/clothing/shoes
+			new_uploaded_path = /obj/item/clothing/shoes
 		if(C.slot_flags & SLOT_OCLOTHING)
-			base_uploaded_path = /obj/item/clothing/suit
-		last_uploaded_path = W.type
+			new_uploaded_path = /obj/item/clothing/suit
 
-		var/obj/item/clothing/under/U = C
-		if(istype(U))
-			uploaded_snowflake_worn_state = U.snowflake_worn_state
+		if(new_base_uploaded_path != null)
+			base_uploaded_path = new_uploaded_path
+			last_uploaded_path = W.type
+
+			var/obj/item/clothing/under/U = C
+			if(istype(U))
+				uploaded_snowflake_worn_state = U.snowflake_worn_state
+
+			to_chat(user, "<span class='notice'>You successfully upload the clothing item to [src].</span>")
 
 		return
 	else

--- a/code/modules/mob/living/silicon/pai/defense.dm
+++ b/code/modules/mob/living/silicon/pai/defense.dm
@@ -20,22 +20,22 @@
 		var/obj/item/clothing/C = W
 		var/new_base_uploaded_path
 		if(C.slot_flags & SLOT_HEAD)
-			new_uploaded_path = /obj/item/clothing/head
+			new_base_uploaded_path = /obj/item/clothing/head
 		if(C.slot_flags & SLOT_ICLOTHING)
-			new_uploaded_path = /obj/item/clothing/under
+			new_base_uploaded_path = /obj/item/clothing/under
 		if(C.slot_flags & SLOT_EYES)
-			new_uploaded_path = /obj/item/clothing/glasses
+			new_base_uploaded_path = /obj/item/clothing/glasses
 		if(C.slot_flags & SLOT_GLOVES)
-			new_uploaded_path = /obj/item/clothing/gloves
+			new_base_uploaded_path = /obj/item/clothing/gloves
 		if(C.slot_flags & SLOT_MASK)
-			new_uploaded_path = /obj/item/clothing/mask
+			new_base_uploaded_path = /obj/item/clothing/mask
 		if(C.slot_flags & SLOT_FEET)
-			new_uploaded_path = /obj/item/clothing/shoes
+			new_base_uploaded_path = /obj/item/clothing/shoes
 		if(C.slot_flags & SLOT_OCLOTHING)
-			new_uploaded_path = /obj/item/clothing/suit
+			new_base_uploaded_path = /obj/item/clothing/suit
 
 		if(new_base_uploaded_path != null)
-			base_uploaded_path = new_uploaded_path
+			base_uploaded_path = new_base_uploaded_path
 			last_uploaded_path = W.type
 
 			var/obj/item/clothing/under/U = C

--- a/code/modules/mob/living/silicon/pai/defense.dm
+++ b/code/modules/mob/living/silicon/pai/defense.dm
@@ -44,6 +44,7 @@
 			uploaded_color = W.get_atom_colour()
 
 			to_chat(user, "<span class='notice'>You successfully upload the clothing item to [src].</span>")
+			to_chat(src, "<span class='notice'>[user] has successfully uploaded the clothing item [W.name] to you.</span>")
 
 		return
 	else

--- a/code/modules/mob/living/silicon/pai/defense.dm
+++ b/code/modules/mob/living/silicon/pai/defense.dm
@@ -41,6 +41,7 @@
 			var/obj/item/clothing/under/U = C
 			if(istype(U))
 				uploaded_snowflake_worn_state = U.snowflake_worn_state
+			uploaded_color = W.get_atom_colour()
 
 			to_chat(user, "<span class='notice'>You successfully upload the clothing item to [src].</span>")
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -252,7 +252,7 @@
 	last_special = world.time + 20
 
 	var/obj/item/new_object = new object_path
-	new_object.name = src.name
+	new_object.name = "[src.name] (pAI)"
 	new_object.desc = src.desc
 	new_object.forceMove(src.loc)
 	switch_shell(new_object)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -84,6 +84,7 @@
 	var/obj/item/clothing/last_uploaded_path
 	var/obj/item/clothing/base_uploaded_path
 	var/uploaded_snowflake_worn_state
+	var/uploaded_color
 
 	/// The cable we produce and use when door or camera jacking.
 	var/obj/item/pai_cable/cable

--- a/code/modules/mob/living/silicon/pai/verbs.dm
+++ b/code/modules/mob/living/silicon/pai/verbs.dm
@@ -135,7 +135,7 @@
 				var/icon = initial(last_uploaded_path.icon)
 				var/obj/item/clothing/new_clothing = new base_uploaded_path
 				new_clothing.forceMove(src.loc)
-				new_clothing.name = src.name
+				new_clothing.name = "[src.name] (pAI)"
 				new_clothing.desc = src.desc
 				new_clothing.icon = icon
 				new_clothing.icon_state = state

--- a/code/modules/mob/living/silicon/pai/verbs.dm
+++ b/code/modules/mob/living/silicon/pai/verbs.dm
@@ -139,7 +139,7 @@
 				new_clothing.desc = src.desc
 				new_clothing.icon = icon
 				new_clothing.icon_state = state
-				copied_atom_colours.atom_colours.add_atom_colour(uploaded_color, colour_priority || FIXED_COLOUR_PRIORITY)
+				new_clothing.add_atom_colour(uploaded_color, FIXED_COLOUR_PRIORITY)
 
 				var/obj/item/clothing/under/U = new_clothing
 				if(istype(U))

--- a/code/modules/mob/living/silicon/pai/verbs.dm
+++ b/code/modules/mob/living/silicon/pai/verbs.dm
@@ -139,6 +139,7 @@
 				new_clothing.desc = src.desc
 				new_clothing.icon = icon
 				new_clothing.icon_state = state
+				copied_atom_colours.atom_colours.add_atom_colour(uploaded_color, colour_priority || FIXED_COLOUR_PRIORITY)
 
 				var/obj/item/clothing/under/U = new_clothing
 				if(istype(U))


### PR DESCRIPTION
## About The Pull Request
1. clothing name now has (pAI) appended to it because i really don't want someone to name their pAI after an item of clothing and be indistinguishable, that's not okay
2. when you use clothing on a pAI, it notifies the person who did so if it was successful, the pAI gets a similar message
3. copied clothing now copies the colour of the item as well

## Why It's Good For The Game
2/3 are some good qol stuff, 1 is because we have a clear rule of "don't be a creep", it's a ghost role, and is easily open for abuse which i would rather not happen

## Changelog
:cl:
tweak: pAI clothing has (pAI) appended to its name, copies colour when copying other clothing items, and notifies the pAI and user when you scan a piece of clothing on a pAI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
