### PR TITLE
Gives Tether/Triumph Sector Holopads

### DIFF
--- a/maps/tether/levels/station1.dmm
+++ b/maps/tether/levels/station1.dmm
@@ -11329,24 +11329,6 @@
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
-"aAx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border,
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
 "aAy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -14661,7 +14643,7 @@
 	frequency = 1443;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	sensors = list("dist_main_meter"="Surface - Distribution Loop","scrub_main_meter"="Surface - Scrubbers Loop","mair_main_meter"="Surface - Mixed Air Tank","dist_aux_meter"="Station - Distribution Loop","scrub_aux_meter"="Station - Scrubbers Loop","mair_aux_meter"="Station - Mixed Air Tank","mair_mining_meter"="Mining Outpost - Mixed Air Tank")
+	sensors = list("dist_main_meter"="Surface  -  Distribution  Loop","scrub_main_meter"="Surface  -  Scrubbers  Loop","mair_main_meter"="Surface  -  Mixed  Air  Tank","dist_aux_meter"="Station  -  Distribution  Loop","scrub_aux_meter"="Station  -  Scrubbers  Loop","mair_aux_meter"="Station  -  Mixed  Air  Tank","mair_mining_meter"="Mining  Outpost  -  Mixed  Air  Tank")
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_monitoring)
@@ -21406,6 +21388,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/machinery/holopad/ship,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/medivac/general)
 "nSf" = (
@@ -21675,9 +21658,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/firedoor/{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/station/docks)
 "ozk" = (
@@ -36210,7 +36190,7 @@ afo
 afo
 ahI
 ais
-aAx
+afW
 aun
 aun
 aun

--- a/maps/tether/levels/station2.dmm
+++ b/maps/tether/levels/station2.dmm
@@ -17526,6 +17526,19 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
+"iKU" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/holopad/ship,
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/excursion/general)
 "iMR" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -39356,7 +39369,7 @@ wOr
 vSZ
 pGy
 vvg
-hfq
+iKU
 ekt
 wPf
 arr

--- a/maps/tether/levels/surface3.dmm
+++ b/maps/tether/levels/surface3.dmm
@@ -13115,28 +13115,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research)
-"axb" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner2{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
 "axc" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
@@ -14877,7 +14855,7 @@
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
 "aAi" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad/ship,
 /turf/simulated/floor/wood,
 /area/library)
 "aAk" = (
@@ -27288,7 +27266,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "aYo" = (
-/obj/machinery/holopad,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27301,6 +27278,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/holopad/ship,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "aYp" = (
@@ -30030,10 +30008,10 @@
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bdw" = (
-/obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/holopad/ship,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bdx" = (
@@ -37259,6 +37237,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/holopad/ship,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/tourbus/general)
 "kdx" = (
@@ -56569,7 +56548,7 @@ aqR
 aZS
 aZZ
 anL
-axb
+vvA
 viF
 vKm
 nlf

--- a/maps/triumph/levels/deck2.dmm
+++ b/maps/triumph/levels/deck2.dmm
@@ -12014,7 +12014,7 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/Dorm_11)
 "Km" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad/ship,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "Ko" = (
@@ -15915,6 +15915,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/holopad/ship,
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/mining_ship/general)
 "We" = (

--- a/maps/triumph/levels/deck3.dmm
+++ b/maps/triumph/levels/deck3.dmm
@@ -4795,6 +4795,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/machinery/holopad/ship,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
 "eeE" = (
@@ -6651,7 +6652,7 @@
 "fJP" = (
 /obj/machinery/camera/network/research{
 	dir = 8;
-	network = list("Research","Toxins Test Area")
+	network = list("Research","Toxins  Test  Area")
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/assembly/robotics/surgery)
@@ -8628,7 +8629,7 @@
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/camera/network/research{
 	dir = 6;
-	network = list("Research","Toxins Test Area")
+	network = list("Research","Toxins  Test  Area")
 	},
 /obj/structure/closet/hydrant{
 	pixel_y = 32
@@ -9053,7 +9054,7 @@
 /obj/machinery/transhuman/synthprinter,
 /obj/machinery/camera/network/research{
 	dir = 8;
-	network = list("Research","Toxins Test Area")
+	network = list("Research","Toxins  Test  Area")
 	},
 /turf/simulated/floor/tiled/old_cargo/purple,
 /area/assembly/robotics)
@@ -9586,7 +9587,7 @@
 "iiV" = (
 /obj/machinery/camera/network/research{
 	dir = 8;
-	network = list("Research","Toxins Test Area")
+	network = list("Research","Toxins  Test  Area")
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -14385,7 +14386,7 @@
 "mrJ" = (
 /obj/machinery/camera/network/research{
 	dir = 8;
-	network = list("Research","Toxins Test Area")
+	network = list("Research","Toxins  Test  Area")
 	},
 /obj/structure/closet/secure_closet/guncabinet/robotics,
 /turf/simulated/floor/tiled/techfloor,
@@ -15077,7 +15078,7 @@
 	},
 /obj/machinery/camera/network/research{
 	dir = 8;
-	network = list("Research","Toxins Test Area")
+	network = list("Research","Toxins  Test  Area")
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/test_area)
@@ -18015,7 +18016,7 @@
 "pmN" = (
 /obj/machinery/camera/network/research{
 	dir = 8;
-	network = list("Research","Toxins Test Area")
+	network = list("Research","Toxins  Test  Area")
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -18982,7 +18983,7 @@
 	name = "Burn Chamber Air Control";
 	output_tag = "burn_out";
 	pressure_setting = 0;
-	sensors = list("burn_sensor"="Burn Chamber")
+	sensors = list("burn_sensor"="Burn  Chamber")
 	},
 /obj/machinery/button/ignition{
 	id = "burn_chamber";
@@ -26137,7 +26138,7 @@
 /obj/item/suit_cooling_unit,
 /obj/machinery/camera/network/research{
 	dir = 8;
-	network = list("Research","Toxins Test Area")
+	network = list("Research","Toxins  Test  Area")
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/anomaly_lab)

--- a/maps/triumph/levels/deck4.dmm
+++ b/maps/triumph/levels/deck4.dmm
@@ -1084,13 +1084,13 @@
 /turf/simulated/floor/tiled,
 /area/security/warden)
 "aTx" = (
-/obj/machinery/holopad,
 /obj/machinery/turretid/lethal{
 	pixel_x = -35
 	},
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/holopad/ship,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "aUx" = (
@@ -2729,6 +2729,13 @@
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"cdE" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad/ship,
+/turf/simulated/floor/tiled,
+/area/shuttle/excursion/general)
 "ceg" = (
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/airless/ceiling,
@@ -16481,7 +16488,7 @@
 "lWJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/holopad,
+/obj/machinery/holopad/ship,
 /turf/simulated/floor/wood,
 /area/library)
 "lXk" = (
@@ -22646,6 +22653,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
+/obj/machinery/holopad/ship,
 /turf/simulated/floor/plating,
 /area/shuttle/courser/cockpit)
 "qpA" = (
@@ -27182,6 +27190,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/holopad/ship,
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
 "tuN" = (
@@ -36711,7 +36720,7 @@ ahf
 nmi
 ieD
 ieD
-qsk
+cdE
 ieD
 nmi
 hBX


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds/Replaces a handful of holopads so now these maps have some Sector Holopads where they'd be expected.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Missing intended features not good.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added Sector Holopads to shuttles;
tweak: Replaced Holopads with Sector Holopads at Bars/Libraries/Bridges.
del: Undefined "/obj/machinery/door/firedoor/" auto-removed in Tether's Station 1 level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
