### PR TITLE
Character Profile Tweaks

### DIFF
--- a/code/datums/character_profile.dm
+++ b/code/datums/character_profile.dm
@@ -28,16 +28,16 @@ GLOBAL_LIST_EMPTY(cached_previews)
 	data["vore_tag"] = H?.client?.prefs?.directory_tag || "Unset"
 	data["erp_tag"] = H?.client?.prefs?.directory_erptag || "Unset"
 	data["species_name"] = H?.species?.name
-	data["species_text"] = replacetext(H?.species?.blurb, "<br/>", "\n")
-	data["flavortext_general"] = replacetext(H?.flavor_texts["general"], "\n", "<BR>") || ""
-	data["flavortext_head"] = replacetext(H?.flavor_texts["head"], "\n", "<BR>") || ""
-	data["flavortext_face"] = replacetext(H?.flavor_texts["face"], "\n", "<BR>") || ""
-	data["flavortext_eyes"] = replacetext(H?.flavor_texts["eyes"], "\n", "<BR>") || ""
-	data["flavortext_torso"] = replacetext(H?.flavor_texts["torso"], "\n", "<BR>") || ""
-	data["flavortext_arms"] = replacetext(H?.flavor_texts["arms"], "\n", "<BR>") || ""
-	data["flavortext_hands"] = replacetext(H?.flavor_texts["hands"], "\n", "<BR>") || ""
-	data["flavortext_legs"] = replacetext(H?.flavor_texts["legs"], "\n", "<BR>") || ""
-	data["flavortext_feet"] = replacetext(H?.flavor_texts["feet"], "\n", "<BR>") || ""
+	data["species_text"] = html_decode(replacetext(H?.species?.blurb, "<br/>", "\n"))
+	data["flavortext_general"] = html_decode(replacetext(H?.flavor_texts["general"], "\n", "<BR>") || "")
+	data["flavortext_head"] = html_decode(replacetext(H?.flavor_texts["head"], "\n", "<BR>") || "")
+	data["flavortext_face"] = html_decode(replacetext(H?.flavor_texts["face"], "\n", "<BR>") || "")
+	data["flavortext_eyes"] = html_decode(replacetext(H?.flavor_texts["eyes"], "\n", "<BR>") || "")
+	data["flavortext_torso"] = html_decode(replacetext(H?.flavor_texts["torso"], "\n", "<BR>") || "")
+	data["flavortext_arms"] = html_decode(replacetext(H?.flavor_texts["arms"], "\n", "<BR>") || "")
+	data["flavortext_hands"] = html_decode(replacetext(H?.flavor_texts["hands"], "\n", "<BR>") || "")
+	data["flavortext_legs"] = html_decode(replacetext(H?.flavor_texts["legs"], "\n", "<BR>") || "")
+	data["flavortext_feet"] = html_decode(replacetext(H?.flavor_texts["feet"], "\n", "<BR>") || "")
 
 	return data
 

--- a/code/datums/character_profile.dm
+++ b/code/datums/character_profile.dm
@@ -29,15 +29,15 @@ GLOBAL_LIST_EMPTY(cached_previews)
 	data["erp_tag"] = H?.client?.prefs?.directory_erptag || "Unset"
 	data["species_name"] = H?.species?.name
 	data["species_text"] = html_decode(replacetext(H?.species?.blurb, "<br/>", "\n"))
-	data["flavortext_general"] = html_decode(replacetext(H?.flavor_texts["general"], "\n", "<BR>") || "")
-	data["flavortext_head"] = html_decode(replacetext(H?.flavor_texts["head"], "\n", "<BR>") || "")
-	data["flavortext_face"] = html_decode(replacetext(H?.flavor_texts["face"], "\n", "<BR>") || "")
-	data["flavortext_eyes"] = html_decode(replacetext(H?.flavor_texts["eyes"], "\n", "<BR>") || "")
-	data["flavortext_torso"] = html_decode(replacetext(H?.flavor_texts["torso"], "\n", "<BR>") || "")
-	data["flavortext_arms"] = html_decode(replacetext(H?.flavor_texts["arms"], "\n", "<BR>") || "")
-	data["flavortext_hands"] = html_decode(replacetext(H?.flavor_texts["hands"], "\n", "<BR>") || "")
-	data["flavortext_legs"] = html_decode(replacetext(H?.flavor_texts["legs"], "\n", "<BR>") || "")
-	data["flavortext_feet"] = html_decode(replacetext(H?.flavor_texts["feet"], "\n", "<BR>") || "")
+	data["flavortext_general"] = html_decode(H?.flavor_texts["general"] || "")
+	data["flavortext_head"] = html_decode(H?.flavor_texts["head"] || "")
+	data["flavortext_face"] = html_decode(H?.flavor_texts["face"] || "")
+	data["flavortext_eyes"] = html_decode(H?.flavor_texts["eyes"] || "")
+	data["flavortext_torso"] = html_decode(H?.flavor_texts["torso"] || "")
+	data["flavortext_arms"] = html_decode(H?.flavor_texts["arms"] || "")
+	data["flavortext_hands"] = html_decode(H?.flavor_texts["hands"] || "")
+	data["flavortext_legs"] = html_decode(H?.flavor_texts["legs"] || "")
+	data["flavortext_feet"] = html_decode(H?.flavor_texts["feet"] || "")
 
 	return data
 

--- a/code/datums/character_profile.dm
+++ b/code/datums/character_profile.dm
@@ -19,28 +19,25 @@ GLOBAL_LIST_EMPTY(cached_previews)
 	. = ..()
 	var/data[0]
 	var/mob/living/carbon/human/H = host.resolve()
-	var/image/ingame_preview
-	var/preview_name = "preview_[rand(1,9999)]_[H.name].png" //nobody should ever be named the same in a round, but just in case, a little randomness to prevent collisions.
 
-	if (!(H.name in GLOB.cached_previews))
-		ingame_preview = get_flat_icon(H)
-		if(!ingame_preview) //flat icon fails for whatever reason, this should probably throw an error.
-			ingame_preview = image('icons/404_profile_not_found.dmi')
-		GLOB.cached_previews[H.name] = ingame_preview
-	else
-		ingame_preview = GLOB.cached_previews[H.name]
-
-	user << browse_rsc(ingame_preview, preview_name)
-
-	data["flavortext"] = H?.flavor_text || ""
 	data["oocnotes"] = H?.ooc_notes || ""
-	data["headshot_url"] = H?.client?.prefs?.headshot_url || ""
-	data["preview_name"] = preview_name
+	data["headshot_url"] = H?.client?.prefs?.headshot_url
+	data["fullref_url"] = H?.client?.prefs?.full_ref_url
+	data["fullref_toggle"] = H?.client?.prefs?.full_ref_toggle
 	data["directory_visible"] = H?.client?.prefs?.show_in_directory
 	data["vore_tag"] = H?.client?.prefs?.directory_tag || "Unset"
 	data["erp_tag"] = H?.client?.prefs?.directory_erptag || "Unset"
 	data["species_name"] = H?.species?.name
 	data["species_text"] = replacetext(H?.species?.blurb, "<br/>", "\n")
+	data["flavortext_general"] = replacetext(H?.flavor_texts["general"], "\n", "<BR>") || ""
+	data["flavortext_head"] = replacetext(H?.flavor_texts["head"], "\n", "<BR>") || ""
+	data["flavortext_face"] = replacetext(H?.flavor_texts["face"], "\n", "<BR>") || ""
+	data["flavortext_eyes"] = replacetext(H?.flavor_texts["eyes"], "\n", "<BR>") || ""
+	data["flavortext_torso"] = replacetext(H?.flavor_texts["torso"], "\n", "<BR>") || ""
+	data["flavortext_arms"] = replacetext(H?.flavor_texts["arms"], "\n", "<BR>") || ""
+	data["flavortext_hands"] = replacetext(H?.flavor_texts["hands"], "\n", "<BR>") || ""
+	data["flavortext_legs"] = replacetext(H?.flavor_texts["legs"], "\n", "<BR>") || ""
+	data["flavortext_feet"] = replacetext(H?.flavor_texts["feet"], "\n", "<BR>") || ""
 
 	return data
 

--- a/code/datums/character_profile.dm
+++ b/code/datums/character_profile.dm
@@ -38,6 +38,13 @@ GLOBAL_LIST_EMPTY(cached_previews)
 	data["flavortext_hands"] = html_decode(H?.flavor_texts["hands"] || "")
 	data["flavortext_legs"] = html_decode(H?.flavor_texts["legs"] || "")
 	data["flavortext_feet"] = html_decode(H?.flavor_texts["feet"] || "")
+	data["vore_digestable"] = "[H?.digestable ? "Enabled" : "Disabled"]"
+	data["vore_devourable"] = "[H?.devourable ? "Enabled" : "Disabled"]"
+	data["vore_feedable"] = "[H?.feeding ? "Enabled" : "Disabled"]"
+	data["vore_leaves_remains"] = "[H?.digest_leave_remains ? "Enabled" : "Disabled"]"
+	data["vore_healbelly"] = "[H?.permit_healbelly ? "Allowed" : "Disallowed"]"
+	data["vore_spontaneous_prey"] = "[H?.can_be_drop_prey ? "Enabled" : "Disabled"]"
+	data["vore_spontaneous_pred"] = "[H?.can_be_drop_pred ? "Enabled" : "Disabled"]"
 
 	return data
 

--- a/code/game/machinery/holopad.dm
+++ b/code/game/machinery/holopad.dm
@@ -1258,9 +1258,7 @@ GLOBAL_VAR_INIT(holopad_connectivity_rebuild_queued, FALSE)
 /obj/effect/overlay/hologram/holopad/ai/examine(mob/user, dist)
 	. = ..()
 	//If you need an ooc_notes copy paste, this is NOT the one to use.
-	var/ooc_notes = owner.ooc_notes
-	if(ooc_notes)
-		. += SPAN_BOLDNOTICE("OOC Notes: <a href='?src=\ref[owner];ooc_notes=1'>\[View\]</a>\n")
+	. += SPAN_BOLDNOTICE("Character Profile: <a href='?owner=\ref[src];character_profile=1'>\[View\]</a>")
 	if(vored)
 		. += SPAN_WARNING("It seems to have [vored] inside of it!")
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -111,7 +111,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/revokebunkerbypass,
 	/client/proc/toggle_AI_interact,
 	/client/proc/list_event_volunteers,
-	/client/proc/set_headshot_for_user
+	/client/proc/set_headshot_for_user,
+	/client/proc/set_fullref_for_user
 	)
 
 var/list/admin_verbs_ban = list(

--- a/code/modules/admin/verbs/admin_set_headshot.dm
+++ b/code/modules/admin/verbs/admin_set_headshot.dm
@@ -24,12 +24,12 @@
 		return
 
 	var/list/mob_list = GLOB.clients
-	var/client/selection = input(usr, "Select a player to set a headshot for.", "Headshot Selection") as anything in mob_list
-	var input_link = input(usr, "Enter the URL for the headshot image.", "Headshot Selection") as text
+	var/client/selection = input(usr, "Select a player to set a full reference for  for.", "Full Reference Selection") as anything in mob_list
+	var input_link = input(usr, "Enter the URL for the Full Reference image.", "Full Reference Selection") as text
 	if(!selection || !input_link || !selection.prefs)
 		to_chat(usr, SPAN_BOLDWARNING("Your selection was either invalid, or the link was blank."))
 		return
 	selection.prefs.full_ref_url = input_link
-	to_chat(usr, SPAN_NOTICE("[selection]'s headshot URL for [selection.prefs.real_name] has been set."))
-	to_chat(selection, SPAN_BOLDNOTICE("Your headshot URL for your currently selected character, [selection.prefs.real_name], has been set by an admin."))
+	to_chat(usr, SPAN_NOTICE("[selection]'s Full Reference URL for [selection.prefs.real_name] has been set."))
+	to_chat(selection, SPAN_BOLDNOTICE("Your Full Reference URL for your currently selected character, [selection.prefs.real_name], has been set by an admin."))
 	SScharacters.queue_preferences_save(selection.prefs)

--- a/code/modules/admin/verbs/admin_set_headshot.dm
+++ b/code/modules/admin/verbs/admin_set_headshot.dm
@@ -15,3 +15,21 @@
 	to_chat(usr, SPAN_NOTICE("[selection]'s headshot URL for [selection.prefs.real_name] has been set."))
 	to_chat(selection, SPAN_BOLDNOTICE("Your headshot URL for your currently selected character, [selection.prefs.real_name], has been set by an admin."))
 	SScharacters.queue_preferences_save(selection.prefs)
+
+/client/proc/set_fullref_for_user()
+	set category = "Admin"
+	set name = "Set Full Reference For User"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	var/list/mob_list = GLOB.clients
+	var/client/selection = input(usr, "Select a player to set a headshot for.", "Headshot Selection") as anything in mob_list
+	var input_link = input(usr, "Enter the URL for the headshot image.", "Headshot Selection") as text
+	if(!selection || !input_link || !selection.prefs)
+		to_chat(usr, SPAN_BOLDWARNING("Your selection was either invalid, or the link was blank."))
+		return
+	selection.prefs.full_ref_url = input_link
+	to_chat(usr, SPAN_NOTICE("[selection]'s headshot URL for [selection.prefs.real_name] has been set."))
+	to_chat(selection, SPAN_BOLDNOTICE("Your headshot URL for your currently selected character, [selection.prefs.real_name], has been set by an admin."))
+	SScharacters.queue_preferences_save(selection.prefs)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -480,8 +480,7 @@
 	if(print_flavor_text())
 		. += "[print_flavor_text()]"
 
-	if(ooc_notes)
-		. += SPAN_BOLDNOTICE("OOC Notes: <a href='?src=\ref[src];ooc_notes=1'>\[View\]</a>")
+	. += SPAN_BOLDNOTICE("Character Profile: <a href='?src=\ref[src];character_profile=1'>\[View\]</a>")
 
 	. += SPAN_BOLDNOTICE("<a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a>")
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -480,8 +480,6 @@
 	if(print_flavor_text())
 		. += "[print_flavor_text()]"
 
-	. += SPAN_BOLDNOTICE("Character Profile: <a href='?src=\ref[src];character_profile=1'>\[View\]</a>")
-
 	. += SPAN_BOLDNOTICE("<a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a>")
 
 	. += applying_pressure
@@ -502,7 +500,7 @@
 		effect.on_examine(.)
 
 	// send signal last so everything else prioritizes above
-	. += SPAN_BOLDNOTICE("<a href='?src=\ref[src];character_profile=1'>\[View Character Profile\]</a>")
+	. += SPAN_BOLDNOTICE("Character Profile: <a href='?src=\ref[src];character_profile=1'>\[View\]</a>")
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .) //This also handles flavor texts now
 
 //Helper procedure. Called by /mob/living/carbon/human/examine() and /mob/living/carbon/human/Topic() to determine HUD access to security and medical records.

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -480,8 +480,6 @@
 	if(print_flavor_text())
 		. += "[print_flavor_text()]"
 
-	. += SPAN_BOLDNOTICE("<a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a>")
-
 	. += applying_pressure
 
 	var/show_descs = show_descriptors_to(user)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -503,6 +503,10 @@ var/list/ai_verbs_default = list(
 			ai_actual_track(target)
 		else
 			to_chat(src, "<font color='red'>System error. Cannot locate [html_decode(href_list["trackname"])].</font>")
+	if(href_list["character_profile"])
+		if(!profile)
+			profile = new(src)
+		profile.ui_interact(usr)
 
 /mob/living/silicon/ai/reset_perspective(datum/perspective/P, apply = TRUE, forceful = TRUE, no_optimizations)
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -50,14 +50,13 @@
 			. += SPAN_DEADSAY("It looks like its system is corrupted and requires a reset.")
 
 	. += attempt_vr(src,"examine_bellies_borg",args)
-	if(ooc_notes)
-		. += SPAN_BOLDNOTICE("Character Profile: <a href='?src=\ref[src];character_profile=1'>\[View\]</a>")
 
 	if(showvoreprefs && ckey) //ckey so non-controlled mobs don't display it.
 		. += SPAN_BOLDNOTICE("<a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a>")
 
 	if(print_flavor_text())
 		. += "\n[print_flavor_text()]\n"
+	. += SPAN_BOLDNOTICE("Character Profile: <a href='?src=\ref[src];character_profile=1'>\[View\]</a>")
 
 	if(pose)
 		if(findtext(pose, ".", length(pose)) == 0 && findtext(pose, "!", length(pose)) == 0 && findtext(pose, "?", length(pose)) == 0)

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -51,7 +51,7 @@
 
 	. += attempt_vr(src,"examine_bellies_borg",args)
 	if(ooc_notes)
-		. += SPAN_BOLDNOTICE("\nOOC Notes: <a href='?src=\ref[src];ooc_notes=1'>\[View\]</a>")
+		. += SPAN_BOLDNOTICE("Character Profile: <a href='?src=\ref[src];character_profile=1'>\[View\]</a>")
 
 	if(showvoreprefs && ckey) //ckey so non-controlled mobs don't display it.
 		. += SPAN_BOLDNOTICE("<a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a>")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1071,6 +1071,12 @@
 			to_chat(src, "Module isn't activated")
 		installed_modules()
 		return 1
+		
+	if(href_list["character_profile"])
+		if(!profile)
+			profile = new(src)
+		profile.ui_interact(usr)
+
 	return
 
 /mob/living/silicon/robot/proc/radio_menu()

--- a/code/modules/preferences/_preferences.dm
+++ b/code/modules/preferences/_preferences.dm
@@ -191,6 +191,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 //! ## OOC Metadata
 	var/metadata = ""
 	var/headshot_url = ""
+	var/full_ref_url = ""
+	var/full_ref_toggle = FALSE
 	var/list/ignored_players = list()
 
 	var/client/client = null

--- a/code/modules/preferences/preference_setup/general/01_basic.dm
+++ b/code/modules/preferences/preference_setup/general/01_basic.dm
@@ -20,6 +20,8 @@
 	S["spawnpoint"]				>> pref.spawnpoint
 	S["OOC_Notes"]				>> pref.metadata
 	S["Headshot_URL"]           >> pref.headshot_url
+	S["Full_Ref_URL"]			>> pref.full_ref_url
+	S["Ref_Toggle"]				>> pref.full_ref_toggle
 
 /datum/category_item/player_setup_item/general/basic/save_character(var/savefile/S)
 	S["real_name"]				<< pref.real_name
@@ -31,6 +33,8 @@
 	S["spawnpoint"]				<< pref.spawnpoint
 	S["OOC_Notes"]				<< pref.metadata
 	S["Headshot_URL"]           << pref.headshot_url
+	S["Full_Ref_URL"]			<< pref.full_ref_url
+	S["Ref_Toggle"]				<< pref.full_ref_toggle
 
 /datum/category_item/player_setup_item/general/basic/sanitize_character()
 	var/species_name = pref.real_species_name()
@@ -84,7 +88,9 @@
 	. += "<b>Age:</b> <a href='?src=\ref[src];age=1'>[pref.age]</a><br>"
 	. += "<b>Spawn Point</b>: <a href='?src=\ref[src];spawnpoint=1'>[pref.spawnpoint]</a><br>"
 	. += "<b>OOC Notes:</b> <a href='?src=\ref[src];metadata=1'> Edit </a><br>"
-	. += "<b>Headshot:</b> <a href='?src=\ref[src];headshot=1'>[pref.headshot_url ? "Set" : "Not Set"]</a><br>"
+	. += "<b>Profile Headshot:</b> <a href='?src=\ref[src];headshot=1'>[pref.headshot_url ? "Set" : "Not Set"]</a><br>"
+	. += "<b>Profile Full Ref:</b> <a href='?src=\ref[src];fullref=1'>[pref.full_ref_url ? "Set" : "Not Set"]</a><br>"
+	. += "<b>Profile Reference:</b> <a href='?src=\ref[src];fullref_toggle=1'>[pref.full_ref_toggle ? "Full Reference" : "Headshot"]</a><br>"
 	. = jointext(., null)
 
 /datum/category_item/player_setup_item/general/basic/OnTopic(var/href,var/list/href_list, var/mob/user)
@@ -159,6 +165,20 @@
 				pref.headshot_url = null
 		else
 			to_chat(user, SPAN_BOLDWARNING("You must join the Discord and open a ticket in order to have your headshot URL set!"))
+		return PREFERENCES_REFRESH
+
+	else if(href_list["fullref"])
+		if(pref.full_ref_url)
+			if(alert(user, "Do you want to unset your headshot URL? An admin must set it again.", "Unset Headshot", "No", "Yes") == "Yes")
+				pref.headshot_url = null
+		else
+			to_chat(user, SPAN_BOLDWARNING("You must join the Discord and open a ticket in order to have your full reference URL set!"))
+		return PREFERENCES_REFRESH
+
+	else if(href_list["fullref_toggle"])
+		pref.full_ref_toggle = !pref.full_ref_toggle
+		to_chat(user, SPAN_NOTICE("Now showing your [pref.full_ref_toggle ? "full reference": "headshot"] in your character profile."))
+		return PREFERENCES_REFRESH
 
 	return ..()
 

--- a/code/modules/preferences/preference_setup/general/01_basic.dm
+++ b/code/modules/preferences/preference_setup/general/01_basic.dm
@@ -170,7 +170,7 @@
 	else if(href_list["fullref"])
 		if(pref.full_ref_url)
 			if(alert(user, "Do you want to unset your headshot URL? An admin must set it again.", "Unset Headshot", "No", "Yes") == "Yes")
-				pref.headshot_url = null
+				pref.full_ref_url = null
 		else
 			to_chat(user, SPAN_BOLDWARNING("You must join the Discord and open a ticket in order to have your full reference URL set!"))
 		return PREFERENCES_REFRESH

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -726,9 +726,6 @@
 /mob/living/examine(mob/user, dist)
 	. = ..()
 
-	if(ooc_notes)
-		. += SPAN_BOLDNOTICE("OOC Notes: <a href='?src=\ref[src];ooc_notes=1'>\[View\]</a>")
-
 	if(print_flavor_text())
 		. += "\n[print_flavor_text()]"
 

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -731,9 +731,6 @@
 
 	. += attempt_vr(src,"examine_bellies",args)
 
-	if(showvoreprefs && ckey) //ckey so non-controlled mobs don't display it.
-		. += SPAN_BOLDNOTICE("<a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a>")
-
 /mob/living/Topic(href, href_list)	//Can't find any instances of Topic() being overridden by /mob/living in polaris' base code, even though /mob/living/carbon/human's Topic() has a ..() call
 	if(href_list["vore_prefs"])
 		display_voreprefs(usr)

--- a/tgui/packages/tgui/interfaces/CharacterProfile.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterProfile.tsx
@@ -1,4 +1,4 @@
-import { Section, Flex, Divider, Table, Box } from "../components";
+import { Section, Stack, Divider, Table, Collapsible, Box, Flex } from "../components";
 import { Window } from "../layouts";
 import { useBackend, useLocalState } from "../backend";
 import { Tabs } from "../components";
@@ -18,16 +18,28 @@ const getTagColor = (erptag) => {
   }
 };
 
+// I am aware that the following context with all these vars is messy, but this isn't particularly
+// 'hot' code given it's static data.
+
 interface CharacterProfileContext {
-  oocnotes: String;
-  flavortext: String;
+  oocnotes: string;
   headshot_url: string;
-  preview_name: string;
+  fullref_url: string;
+  fullref_toggle: boolean;
   directory_visible: boolean;
   erp_tag: string;
   vore_tag: string;
   species_name: string;
   species_text: string;
+  flavortext_general: string;
+  flavortext_head: string;
+  flavortext_face: string;
+  flavortext_eyes: string;
+  flavortext_torso: string;
+  flavortext_arms: string;
+  flavortext_hands: string;
+  flavortext_legs: string;
+  flavortext_feet: string;
 }
 
 export const CharacterProfile = (props, context) => {
@@ -37,71 +49,95 @@ export const CharacterProfile = (props, context) => {
     "selectedTab",
     1
   );
-  const preview_image = data.preview_name;
+  let combinedspeciesname : string = "";
+  combinedspeciesname = combinedspeciesname.concat("Species - ", data.species_name);
 
   return (
-    <Window resizable width={800} height={700}>
-      <Tabs>
-        <Tabs.Tab onClick={() => setSelectedTab(1)}>
-          Visual Overview/Description
-        </Tabs.Tab>
-        <Tabs.Tab onClick={() => setSelectedTab(2)}>
-          Character Directory
-        </Tabs.Tab>
-      </Tabs>
-      {selectedTab === 1 && (
-        <Flex height="620px" scrollable>
-          <Flex.Item width="35%" pl="10px">
-            {data.headshot_url !== "" ? (
-              <Section title="Headshot" pb="12" textAlign="center">
-                <img src={data.headshot_url} height="256px" width="256px" />
-              </Section>) : (<Box height="0" width="0" />)}
-            <Section title="Character Preview" pt="12" textAlign="center">
-              <img
-                src={preview_image}
-                height="250px"
-                width="250px"
-                style={{ "-ms-interpolation-mode": "nearest-neighbor" }}
-              />
-            </Section>
-          </Flex.Item>
-          <Flex.Item width="65%" flex-direction="column" pl="10px">
-            <Section title={data.species_name} scrollable height="33%">
-              {data.species_text}
-            </Section>
-            <Section title="Flavor Text" scrollable height="33%">
-              {data.flavortext}
-            </Section>
-            <Section title="OOC Notes" scrollable height="33%">
-              {data.oocnotes}
-            </Section>
-          </Flex.Item>
-        </Flex>
-      )}
-      {selectedTab === 2 && (
-        <Flex>
-          <Divider vertical />
-          <Flex.Item>
-            {data.directory_visible ? (
-              <Section title="Character Directory Info" width="100%">
-                <Table backgroundColor={getTagColor(data.erp_tag)}>
-                  <Table.Row>
-                    <Table.Cell>ERP Tag -</Table.Cell>
-                    <Table.Cell>{data.erp_tag}</Table.Cell>
-                  </Table.Row>
-                  <Table.Row>
-                    <Table.Cell>Vore Tag -</Table.Cell>
-                    <Table.Cell>{data.vore_tag}</Table.Cell>
-                  </Table.Row>
-                </Table>
-              </Section>
-            ) : (
-              <Divider vertical />
-            )}
-          </Flex.Item>
-          <Divider vertical />
-        </Flex>
-      )}
+    <Window resizable width={950} height={800}>
+      <Window.Content scrollable>
+        <Tabs>
+          <Tabs.Tab onClick={() => setSelectedTab(1)}>
+            Visual Overview/Description
+          </Tabs.Tab>
+          <Tabs.Tab onClick={() => setSelectedTab(2)}>
+            Character Directory
+          </Tabs.Tab>
+        </Tabs>
+        {selectedTab === 1 && (
+          <Stack>
+            <Stack.Item pl="10px">
+              <CharacterProfileImageElement />
+            </Stack.Item>
+            <Stack.Item Stack-direction="column" pl="10px" width="65%">
+              <Collapsible title={combinedspeciesname}>
+                <Section>
+                  {data.species_text}
+                </Section>
+              </Collapsible>
+              <Collapsible title="Flavor Text">
+                <Section>
+                  <CharacterProfileDescElement />
+                </Section>
+              </Collapsible>
+              <Collapsible title="OOC Notes">
+                <Section>
+                  {data.oocnotes}
+                </Section>
+              </Collapsible>
+            </Stack.Item>
+          </Stack>
+        )}
+        {selectedTab === 2 && (
+          <Stack>
+            <Divider vertical />
+            <Stack.Item>
+              {data.directory_visible ? (
+                <Section title="Character Directory Info" width="100%">
+                  <Table backgroundColor={getTagColor(data.erp_tag)}>
+                    <Table.Row>
+                      <Table.Cell>ERP Tag -</Table.Cell>
+                      <Table.Cell>{data.erp_tag}</Table.Cell>
+                    </Table.Row>
+                    <Table.Row>
+                      <Table.Cell>Vore Tag -</Table.Cell>
+                      <Table.Cell>{data.vore_tag}</Table.Cell>
+                    </Table.Row>
+                  </Table>
+                </Section>
+              ) : (
+                <Divider vertical />
+              )}
+            </Stack.Item>
+            <Divider vertical />
+          </Stack>
+        )}
+      </Window.Content>
     </Window>
   );
 };
+
+const CharacterProfileImageElement = (props, context) => {
+  const { act, data } = useBackend<CharacterProfileContext>(context);
+
+  if (data.fullref_toggle && data.fullref_url) return (<Section title="Full Reference" pb="12" textAlign="center"><img src={data.fullref_url} style={{ "max-width": "500px", "max-height": "900px" }} /></Section>);
+  if (!data.fullref_toggle && data.headshot_url) return (<Section title="Headshot Reference" pb="12" textAlign="center"><img src={data.headshot_url} height="256px" width="256px" /></Section>);
+  return (<Box />);
+};
+
+
+const CharacterProfileDescElement = (props, context) => {
+  const { act, data } = useBackend<CharacterProfileContext>(context);
+
+  return (
+    <Flex flex-direction="column">
+      {data.flavortext_general !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_general}<Divider /></Flex.Item>): (<Box />) }
+      {data.flavortext_head !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_head}<Divider /></Flex.Item>): (<Box />) }
+      {data.flavortext_face !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_face}<Divider /></Flex.Item>): (<Box />) }
+      {data.flavortext_eyes !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_eyes}<Divider /></Flex.Item>): (<Box />) }
+      {data.flavortext_torso !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_torso}<Divider /></Flex.Item>): (<Box />) }
+      {data.flavortext_arms !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_arms}<Divider /></Flex.Item>): (<Box />) }
+      {data.flavortext_hands !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_hands}<Divider /></Flex.Item>): (<Box />) }
+      {data.flavortext_legs !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_legs}<Divider /></Flex.Item>): (<Box />) }
+      {data.flavortext_feet !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_feet}<Divider /></Flex.Item>): (<Box />) }
+    </Flex>
+  ); };

--- a/tgui/packages/tgui/interfaces/CharacterProfile.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterProfile.tsx
@@ -68,7 +68,7 @@ export const CharacterProfile = (props, context) => {
             <Stack.Item pl="10px">
               <CharacterProfileImageElement />
             </Stack.Item>
-            <Stack.Item Stack-direction="column" pl="10px" width="65%">
+            <Stack.Item Stack-direction="column" pl="10px">
               <Collapsible title={combinedspeciesname}>
                 <Section>
                   {data.species_text}

--- a/tgui/packages/tgui/interfaces/CharacterProfile.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterProfile.tsx
@@ -1,4 +1,4 @@
-import { Section, Stack, Divider, Table, Collapsible, Box, Flex } from "../components";
+import { Section, Flex, Divider, Table, Collapsible, Box } from "../components";
 import { Window } from "../layouts";
 import { useBackend, useLocalState } from "../backend";
 import { Tabs } from "../components";
@@ -64,13 +64,13 @@ export const CharacterProfile = (props, context) => {
           </Tabs.Tab>
         </Tabs>
         {selectedTab === 1 && (
-          <Stack>
-            <Stack.Item pl="10px">
+          <Flex>
+            <Flex.Item pl="10px">
               <CharacterProfileImageElement />
-            </Stack.Item>
-            <Stack.Item Stack-direction="column" pl="10px" width="100%">
+            </Flex.Item>
+            <Flex.Item Flex-direction="column" pl="10px" width="100%">
               <Collapsible title={combinedspeciesname}>
-                <Section>
+                <Section style={{ "white-space": "pre-line" }}>
                   {data.species_text}
                 </Section>
               </Collapsible>
@@ -80,17 +80,17 @@ export const CharacterProfile = (props, context) => {
                 </Section>
               </Collapsible>
               <Collapsible title="OOC Notes">
-                <Section>
+                <Section style={{ "white-space": "pre-line" }}>
                   {data.oocnotes}
                 </Section>
               </Collapsible>
-            </Stack.Item>
-          </Stack>
+            </Flex.Item>
+          </Flex>
         )}
         {selectedTab === 2 && (
-          <Stack>
+          <Flex>
             <Divider vertical />
-            <Stack.Item>
+            <Flex.Item>
               {data.directory_visible ? (
                 <Section title="Character Directory Info" width="100%">
                   <Table backgroundColor={getTagColor(data.erp_tag)}>
@@ -107,9 +107,9 @@ export const CharacterProfile = (props, context) => {
               ) : (
                 <Divider vertical />
               )}
-            </Stack.Item>
+            </Flex.Item>
             <Divider vertical />
-          </Stack>
+          </Flex>
         )}
       </Window.Content>
     </Window>
@@ -129,15 +129,15 @@ const CharacterProfileDescElement = (props, context) => {
   const { act, data } = useBackend<CharacterProfileContext>(context);
 
   return (
-    <Flex flex-direction="column">
-      {data.flavortext_general !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_general}<Divider /></Flex.Item>): (<Box />) }
-      {data.flavortext_head !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_head}<Divider /></Flex.Item>): (<Box />) }
-      {data.flavortext_face !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_face}<Divider /></Flex.Item>): (<Box />) }
-      {data.flavortext_eyes !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_eyes}<Divider /></Flex.Item>): (<Box />) }
-      {data.flavortext_torso !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_torso}<Divider /></Flex.Item>): (<Box />) }
-      {data.flavortext_arms !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_arms}<Divider /></Flex.Item>): (<Box />) }
-      {data.flavortext_hands !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_hands}<Divider /></Flex.Item>): (<Box />) }
-      {data.flavortext_legs !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_legs}<Divider /></Flex.Item>): (<Box />) }
-      {data.flavortext_feet !== "" ? (<Flex.Item><Divider /><b>General</b><br />{data.flavortext_feet}<Divider /></Flex.Item>): (<Box />) }
+    <Flex direction="column">
+      {data.flavortext_general !== "" ? (<Flex.Item style={{ "white-space": "pre-line" }}><Divider /><b>General</b><br />{data.flavortext_general}</Flex.Item>): (<Box />) }
+      {data.flavortext_head !== "" ? (<Flex.Item style={{ "white-space": "pre-line" }}><Divider /><b>Head</b><br />{data.flavortext_head}</Flex.Item>): (<Box />) }
+      {data.flavortext_face !== "" ? (<Flex.Item style={{ "white-space": "pre-line" }}><Divider /><b>Face</b><br />{data.flavortext_face}</Flex.Item>): (<Box />) }
+      {data.flavortext_eyes !== "" ? (<Flex.Item style={{ "white-space": "pre-line" }}><Divider /><b>Eyes</b><br />{data.flavortext_eyes}</Flex.Item>): (<Box />) }
+      {data.flavortext_torso !== "" ? (<Flex.Item style={{ "white-space": "pre-line" }}><Divider /><b>Torso</b><br />{data.flavortext_torso}</Flex.Item>): (<Box />) }
+      {data.flavortext_arms !== "" ? (<Flex.Item style={{ "white-space": "pre-line" }}><Divider /><b>Arms</b><br />{data.flavortext_arms}</Flex.Item>): (<Box />) }
+      {data.flavortext_hands !== "" ? (<Flex.Item style={{ "white-space": "pre-line" }}><Divider /><b>Hands</b><br />{data.flavortext_hands}</Flex.Item>): (<Box />) }
+      {data.flavortext_legs !== "" ? (<Flex.Item style={{ "white-space": "pre-line" }}><Divider /><b>Legs</b><br />{data.flavortext_legs}</Flex.Item>): (<Box />) }
+      {data.flavortext_feet !== "" ? (<Flex.Item style={{ "white-space": "pre-line" }}><Divider /><b>Feet</b><br />{data.flavortext_feet}</Flex.Item>): (<Box />) }
     </Flex>
   ); };

--- a/tgui/packages/tgui/interfaces/CharacterProfile.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterProfile.tsx
@@ -40,6 +40,13 @@ interface CharacterProfileContext {
   flavortext_hands: string;
   flavortext_legs: string;
   flavortext_feet: string;
+	vore_digestable: string;
+	vore_devourable: string;
+	vore_feedable: string;
+	vore_leaves_remains: string;
+	vore_healbelly: string;
+	vore_spontaneous_prey: string;
+	vore_spontaneous_pred: string;
 }
 
 export const CharacterProfile = (props, context) => {
@@ -57,10 +64,10 @@ export const CharacterProfile = (props, context) => {
       <Window.Content scrollable>
         <Tabs>
           <Tabs.Tab onClick={() => setSelectedTab(1)}>
-            Visual Overview/Description
+            Visual Overview / Description
           </Tabs.Tab>
           <Tabs.Tab onClick={() => setSelectedTab(2)}>
-            Character Directory
+            Character Directory / Vore Preferences
           </Tabs.Tab>
         </Tabs>
         {selectedTab === 1 && (
@@ -69,17 +76,17 @@ export const CharacterProfile = (props, context) => {
               <CharacterProfileImageElement />
             </Flex.Item>
             <Flex.Item Flex-direction="column" pl="10px" width="100%">
-              <Collapsible title={combinedspeciesname}>
+              <Collapsible title={combinedspeciesname} open>
                 <Section style={{ "white-space": "pre-line" }}>
                   {data.species_text}
                 </Section>
               </Collapsible>
-              <Collapsible title="Flavor Text">
+              <Collapsible title="Flavor Text" open>
                 <Section>
                   <CharacterProfileDescElement />
                 </Section>
               </Collapsible>
-              <Collapsible title="OOC Notes">
+              <Collapsible title="OOC Notes" open>
                 <Section style={{ "white-space": "pre-line" }}>
                   {data.oocnotes}
                 </Section>
@@ -109,7 +116,19 @@ export const CharacterProfile = (props, context) => {
               )}
             </Flex.Item>
             <Divider vertical />
+            <Section title="Mechanical Vore Preferences">
+              <Flex.Item direction="column">
+                <Flex.Item>Digestable: {data.vore_digestable}</Flex.Item>
+                <Flex.Item>Devourable: {data.vore_devourable}</Flex.Item>
+                <Flex.Item>Feedable: {data.vore_feedable}</Flex.Item>
+                <Flex.Item>Leaves Remains: {data.vore_leaves_remains}</Flex.Item>
+                <Flex.Item>Belly Healing: {data.vore_healbelly}</Flex.Item>
+                <Flex.Item>Drop Vore Prey: {data.vore_spontaneous_prey}</Flex.Item>
+                <Flex.Item>Drop Vore Pred: {data.vore_spontaneous_pred}</Flex.Item>
+              </Flex.Item>
+            </Section>
           </Flex>
+
         )}
       </Window.Content>
     </Window>

--- a/tgui/packages/tgui/interfaces/CharacterProfile.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterProfile.tsx
@@ -68,7 +68,7 @@ export const CharacterProfile = (props, context) => {
             <Stack.Item pl="10px">
               <CharacterProfileImageElement />
             </Stack.Item>
-            <Stack.Item Stack-direction="column" pl="10px">
+            <Stack.Item Stack-direction="column" pl="10px" width="100%">
               <Collapsible title={combinedspeciesname}>
                 <Section>
                   {data.species_text}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tidies up character profiles considerably.
Adds options for either a headshot, or a full-sized reference (portrait only, limitations of max width 500px and max height 1000px)
Makes flavor text work. Turns text boxes into collapsible sections.
Adds character profile link to AI holograms.
Replaces the 'OOC Notes' link in examine, rolling that functionality into the profile. Vore prefs and flavor text viewing are untouched, for the moment.

## Why It's Good For The Game

I have more experience with tgui now so it's a good time for me to clean up my mess.

## Changelog


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
