### PR TITLE
TRIUMPH - Secquipment storage fix - slight HoS office edit - sec shuttle replacement

### DIFF
--- a/maps/triumph/levels/deck4.dmm
+++ b/maps/triumph/levels/deck4.dmm
@@ -6334,9 +6334,13 @@
 /area/security/armoury)
 "eGK" = (
 /obj/structure/table/woodentable,
-/obj/item/radio/off,
-/obj/item/megaphone,
-/obj/item/storage/box/glasses/rocks,
+/obj/item/radio/off{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/item/megaphone{
+	pixel_x = 5
+	},
 /obj/item/radio/intercom/department/security{
 	pixel_y = -24
 	},
@@ -8650,8 +8654,8 @@
 "guM" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/flashbangs{
-	pixel_x = -2;
-	pixel_y = -2
+	pixel_x = -4;
+	pixel_y = 8
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -9063,6 +9067,39 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/civilian_hallway_mid)
+"gMk" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = -28
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/storage/box/survival_knife{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/survival_knife{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/storage/box/survival_knife{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/survival_knife{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/storage/box/survival_knife,
+/obj/item/storage/box/survival_knife,
+/turf/simulated/floor/tiled/dark,
+/area/security/security_equiptment_storage)
 "gMx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/skills,
@@ -10640,6 +10677,12 @@
 	},
 /obj/machinery/camera/network/security{
 	dir = 1
+	},
+/obj/item/clothing/accessory/permit/gun{
+	desc = "An example of a card indicating that the owner is allowed to carry a firearm. There's a note saying to fax CentCom if you want to order more blank permits.";
+	name = "sample weapon permit";
+	owner = 1;
+	pixel_y = 10
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
@@ -12899,6 +12942,10 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/item/clothing/under/oricon/utility/fleet/security,
+/obj/item/clothing/under/oricon/utility/fleet/security,
+/obj/item/clothing/under/oricon/utility/marine/security,
+/obj/item/clothing/under/oricon/utility/marine/security,
 /turf/simulated/floor/tiled,
 /area/security/security_lockerroom)
 "jrs" = (
@@ -14024,12 +14071,7 @@
 "khk" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
+	pixel_x = 7;
 	pixel_y = -3
 	},
 /obj/effect/floor_decal/corner/red{
@@ -14039,13 +14081,46 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/clothing/mask/gas/half{
+	pixel_x = -6;
+	pixel_y = -10
+	},
+/obj/item/clothing/mask/gas/half{
+	pixel_x = -6;
+	pixel_y = -9
+	},
+/obj/item/clothing/mask/gas/half{
+	pixel_x = -6;
+	pixel_y = -8
+	},
+/obj/item/clothing/mask/gas/half{
+	pixel_x = -6;
+	pixel_y = -7
+	},
+/obj/item/clothing/mask/gas/half{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/clothing/mask/gas/half{
+	pixel_x = -6;
+	pixel_y = -5
+	},
+/obj/item/clothing/mask/gas/half{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/obj/item/clothing/mask/gas/half{
+	pixel_x = -6;
+	pixel_y = -3
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "khB" = (
@@ -14219,10 +14294,13 @@
 "kor" = (
 /obj/structure/table/woodentable,
 /obj/item/stamp/hos,
-/obj/item/hand_labeler,
+/obj/item/hand_labeler{
+	pixel_x = 11;
+	pixel_y = 7
+	},
 /obj/item/flashlight/lamp/green{
-	pixel_x = -5;
-	pixel_y = 2
+	pixel_x = -14;
+	pixel_y = 1
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
@@ -14390,18 +14468,11 @@
 /area/crew_quarters/mimeoffice)
 "kra" = (
 /obj/structure/table/woodentable,
-/obj/item/paper{
-	desc = "";
-	info = "The Chief of Security at CentCom is debating a new policy. It's not official yet, and probably won't be since it's hard to enforce, but I suggest following it anyway. That policy is, if a security officer claims they need more than two extra magazines (or batteries) to go on routine patrols, fire them. If they cannot subdue a single suspect using all that ammo, they are not competent as Security.\[br]-Jeremiah Acacius";
-	name = "note to the Head of Security"
-	},
-/obj/item/clothing/accessory/permit/gun{
-	desc = "An example of a card indicating that the owner is allowed to carry a firearm. There's a note saying to fax CentCom if you want to order more blank permits.";
-	name = "sample weapon permit";
-	owner = 1
-	},
 /obj/machinery/computer/skills{
 	dir = 1
+	},
+/obj/item/folder/red_hos{
+	pixel_x = 4
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
@@ -14490,13 +14561,15 @@
 /area/bridge)
 "kuS" = (
 /obj/structure/table/woodentable,
-/obj/item/tape_recorder,
+/obj/item/tape_recorder{
+	pixel_x = 10;
+	pixel_y = 3
+	},
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
 	},
 /obj/item/pen/multi,
-/obj/item/folder/red_hos,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
 "kuW" = (
@@ -16207,8 +16280,6 @@
 "lAD" = (
 /obj/structure/closet/secure_closet/hos2,
 /obj/item/storage/box/firingpins,
-/obj/item/storage/belt/security,
-/obj/item/megaphone,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -18407,13 +18478,51 @@
 	pixel_x = -24
 	},
 /obj/structure/table/steel,
-/obj/item/storage/box/nifsofts_security,
-/obj/item/hand_labeler,
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6
+	},
+/obj/item/clothing/accessory/armor/tag/nts{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/clothing/accessory/armor/tag/nts{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/clothing/accessory/armor/tag/nts{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/armor/tag/nts{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/clothing/accessory/armor/tag/nts{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/clothing/accessory/armor/tag/nts{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/item/clothing/accessory/armor/tag/ntc{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/armor/tag/ntc{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/armor/tag/ntbs{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/clothing/accessory/armor/tag/ntbs{
+	pixel_x = 5;
+	pixel_y = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
@@ -18500,22 +18609,6 @@
 /area/hallway/secondary/docking_hallway)
 "nfp" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/suit/armor/vest/alt{
-	pixel_x = -4;
-	pixel_y = -6
-	},
-/obj/item/clothing/suit/armor/vest/alt{
-	pixel_x = 6;
-	pixel_y = -6
-	},
-/obj/item/clothing/suit/armor/vest/alt{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/item/clothing/suit/armor/vest/alt{
-	pixel_x = 6;
-	pixel_y = 6
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -18526,6 +18619,122 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/accessory/armor/armorplate/stab{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/clothing/accessory/armor/armorplate/stab{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/clothing/accessory/armor/armorplate/stab{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/clothing/accessory/armor/armorplate/stab{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/clothing/accessory/armor/armorplate/stab{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/clothing/accessory/armor/armorplate/stab{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/clothing/accessory/armor/armorplate{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/clothing/accessory/armor/armorplate{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/clothing/accessory/armor/armorplate{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/clothing/accessory/armor/armorplate{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/clothing/accessory/armor/armorplate{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/clothing/accessory/armor/armorplate{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/helmet{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/helmet{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/helmet{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/helmet{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/helmet{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/armor/helmetcamera/security{
+	pixel_x = 5;
+	pixel_y = 12
+	},
+/obj/item/clothing/accessory/armor/helmetcamera/security{
+	pixel_x = 5;
+	pixel_y = 11
+	},
+/obj/item/clothing/accessory/armor/helmetcamera/security{
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/obj/item/clothing/accessory/armor/helmetcamera/security{
+	pixel_x = 5;
+	pixel_y = 9
+	},
+/obj/item/clothing/accessory/armor/helmetcamera/security{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/clothing/accessory/armor/helmetcamera/security{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/clothing/accessory/armor/helmetcamera/security{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/clothing/accessory/armor/armorplate/stab{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/clothing/accessory/armor/armorplate{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/clothing/accessory/armor/armorplate/stab{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/clothing/accessory/armor/armorplate{
+	pixel_x = 6;
+	pixel_y = -3
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "nft" = (
@@ -20144,8 +20353,13 @@
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals5,
-/obj/item/storage/box/evidence,
-/obj/item/pen/red,
+/obj/item/storage/box/evidence{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/pen/red{
+	pixel_x = -7
+	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "ooL" = (
@@ -20917,7 +21131,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "oUS" = (
-/obj/structure/table/steel,
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 24
@@ -20928,8 +21141,36 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
-/obj/item/storage/lockbox,
-/obj/item/storage/box/nifsofts_security,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/glasses/sunglasses/sechud{
+	pixel_y = -5;
+	pixel_x = -1
+	},
+/obj/item/clothing/glasses/sunglasses/sechud{
+	pixel_y = -5;
+	pixel_x = -1
+	},
+/obj/item/clothing/glasses/sunglasses/sechud{
+	pixel_y = -5;
+	pixel_x = -1
+	},
+/obj/item/clothing/glasses/sunglasses/sechud{
+	pixel_y = -5;
+	pixel_x = -1
+	},
+/obj/item/gunbox/armor/security{
+	pixel_y = 8
+	},
+/obj/item/gunbox/armor/security{
+	pixel_y = 8
+	},
+/obj/item/gunbox/armor/security{
+	pixel_y = 8
+	},
+/obj/item/gunbox/armor/security{
+	pixel_y = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "oVi" = (
@@ -21621,14 +21862,6 @@
 /area/security/brig)
 "pqd" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/accessory/armor/helmcover/nt,
-/obj/item/clothing/accessory/armor/helmcover/nt,
-/obj/item/clothing/accessory/armor/helmcover/nt,
-/obj/item/clothing/accessory/armor/helmcover/nt,
-/obj/item/clothing/accessory/armor/helmcover/nt,
-/obj/item/clothing/accessory/armor/helmcover/nt,
-/obj/item/clothing/accessory/armor/helmcover/nt,
-/obj/item/clothing/accessory/armor/helmcover/nt,
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
@@ -21636,6 +21869,33 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/accessory/armor/helmcover/nt{
+	pixel_y = -8
+	},
+/obj/item/clothing/accessory/armor/helmcover/nt{
+	pixel_y = -8
+	},
+/obj/item/clothing/accessory/armor/helmcover/nt{
+	pixel_y = -8
+	},
+/obj/item/clothing/accessory/armor/helmcover/nt{
+	pixel_y = -8
+	},
+/obj/item/clothing/accessory/armor/helmcover/nt{
+	pixel_y = -8
+	},
+/obj/item/clothing/accessory/armor/helmcover/nt{
+	pixel_y = -8
+	},
+/obj/item/clothing/accessory/armor/helmcover/nt{
+	pixel_y = -8
+	},
+/obj/item/clothing/accessory/armor/helmcover/navy,
+/obj/item/clothing/accessory/armor/helmcover/navy,
+/obj/item/clothing/accessory/armor/helmcover/navy,
+/obj/item/clothing/accessory/armor/helmcover/navy,
+/obj/item/clothing/accessory/armor/helmcover/navy,
+/obj/item/clothing/accessory/armor/helmcover/navy,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "pqO" = (
@@ -22997,6 +23257,10 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/item/clothing/under/oricon/utility/fleet/security,
+/obj/item/clothing/under/oricon/utility/fleet/security,
+/obj/item/clothing/under/oricon/utility/marine/security,
+/obj/item/clothing/under/oricon/utility/marine/security,
 /turf/simulated/floor/tiled,
 /area/security/security_lockerroom)
 "qkp" = (
@@ -25428,24 +25692,39 @@
 /area/hallway/secondary/civilian_hallway_mid)
 "rUN" = (
 /obj/structure/table/steel,
-/obj/item/tool/crowbar,
-/obj/item/tool/crowbar,
-/obj/item/tool/crowbar,
-/obj/item/tool/crowbar,
-/obj/item/tool/crowbar,
-/obj/item/tool/crowbar,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/retail_scanner/security,
+/obj/item/tool/crowbar{
+	pixel_y = 4;
+	pixel_x = -3
+	},
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6
+	},
+/obj/item/tool/crowbar{
+	pixel_y = 4;
+	pixel_x = -1
+	},
+/obj/item/tool/crowbar{
+	pixel_y = 4;
+	pixel_x = 1
+	},
+/obj/item/tool/crowbar{
+	pixel_y = 4;
+	pixel_x = 3
+	},
+/obj/item/tool/crowbar{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/tool/crowbar{
+	pixel_y = 4;
+	pixel_x = 7
+	},
+/obj/item/retail_scanner/security{
+	pixel_x = 5;
+	pixel_y = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
@@ -26243,16 +26522,23 @@
 /area/security/riot_control)
 "szY" = (
 /obj/structure/table/steel,
-/obj/item/storage/box/evidence,
 /obj/item/storage/box/handcuffs{
-	pixel_x = 6;
-	pixel_y = -2
+	pixel_x = 7;
+	pixel_y = 4
 	},
 /obj/machinery/camera/network/security{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 9
+	},
+/obj/item/storage/box/nifsofts_security{
+	pixel_y = 4;
+	pixel_x = -8
+	},
+/obj/item/storage/box/evidence{
+	pixel_x = -2;
+	pixel_y = 16
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -26283,10 +26569,6 @@
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/sauna)
 "sAq" = (
-/obj/item/clothing/suit/armor/vest/wolftaur{
-	pixel_x = -16;
-	pixel_y = 4
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
@@ -26295,101 +26577,101 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/accessory/armor/armorplate{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/clothing/accessory/armor/armorplate{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/clothing/accessory/armor/armorplate{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/clothing/accessory/armor/armorplate{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/clothing/accessory/armor/armorplate{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/clothing/accessory/armor/armorplate{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/clothing/accessory/armor/armorplate/stab{
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/obj/item/clothing/accessory/armor/armorplate/stab{
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/obj/item/clothing/accessory/armor/armorplate/stab{
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/obj/item/clothing/accessory/armor/armorplate/stab{
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/obj/item/clothing/accessory/armor/armorplate/stab{
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/obj/item/clothing/accessory/armor/armorplate/stab{
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/obj/item/clothing/accessory/armor/tag/nts{
+/obj/item/clothing/suit/armor/pcarrier/navy{
 	pixel_x = -5;
 	pixel_y = 6
 	},
-/obj/item/clothing/accessory/armor/tag/nts{
-	pixel_x = -5;
-	pixel_y = 9
+/obj/item/clothing/suit/armor/pcarrier{
+	pixel_x = 6;
+	pixel_y = 6
 	},
-/obj/item/clothing/accessory/armor/tag/nts{
+/obj/item/clothing/suit/armor/pcarrier/navy{
 	pixel_x = -5;
 	pixel_y = 6
 	},
-/obj/item/clothing/accessory/armor/tag/nts{
+/obj/item/clothing/suit/armor/pcarrier/navy{
 	pixel_x = -5;
 	pixel_y = 6
 	},
-/obj/item/clothing/accessory/armor/tag/nts{
+/obj/item/clothing/suit/armor/pcarrier/navy{
 	pixel_x = -5;
 	pixel_y = 6
 	},
-/obj/item/clothing/accessory/armor/tag/ntc{
+/obj/item/clothing/suit/armor/pcarrier/navy{
 	pixel_x = -5;
-	pixel_y = 3
+	pixel_y = 6
 	},
-/obj/item/clothing/head/helmet{
-	pixel_x = -6;
-	pixel_y = -6
+/obj/item/clothing/suit/armor/pcarrier/navy{
+	pixel_x = -5;
+	pixel_y = 6
 	},
-/obj/item/clothing/head/helmet{
-	pixel_x = -6;
-	pixel_y = -6
+/obj/item/clothing/suit/armor/pcarrier{
+	pixel_x = 6;
+	pixel_y = 6
 	},
-/obj/item/clothing/head/helmet{
-	pixel_x = -6;
-	pixel_y = -6
+/obj/item/clothing/suit/armor/pcarrier{
+	pixel_x = 6;
+	pixel_y = 6
 	},
-/obj/item/clothing/head/helmet{
-	pixel_x = -6;
-	pixel_y = -6
+/obj/item/clothing/suit/armor/pcarrier{
+	pixel_x = 6;
+	pixel_y = 6
 	},
-/obj/item/clothing/head/helmet{
-	pixel_x = -6;
-	pixel_y = -6
+/obj/item/clothing/suit/armor/pcarrier{
+	pixel_x = 6;
+	pixel_y = 6
 	},
-/obj/item/clothing/head/helmet{
-	pixel_x = -6;
-	pixel_y = -6
+/obj/item/clothing/suit/armor/pcarrier{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/clothing/accessory/storage/pouches/navy{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/storage/pouches{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/storage/pouches/navy{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/storage/pouches/navy{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/storage/pouches/navy{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/storage/pouches/navy{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/storage/pouches/navy{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/storage/pouches{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/storage/pouches{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/storage/pouches{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/storage/pouches{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/storage/pouches{
+	pixel_x = 6;
+	pixel_y = -2
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
@@ -27918,20 +28200,6 @@
 /area/maintenance/security/starboard)
 "tBA" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/accessory/holster/waist,
-/obj/item/clothing/accessory/holster/waist,
-/obj/item/clothing/accessory/holster/leg,
-/obj/item/clothing/accessory/holster/leg,
-/obj/item/clothing/accessory/holster/hip,
-/obj/item/clothing/accessory/holster/hip,
-/obj/item/clothing/accessory/holster/armpit,
-/obj/item/clothing/accessory/holster/armpit,
-/obj/item/clothing/accessory/holster/armpit,
-/obj/item/clothing/accessory/holster/armpit,
-/obj/item/clothing/accessory/holster,
-/obj/item/clothing/accessory/holster,
-/obj/item/clothing/accessory/holster,
-/obj/item/clothing/accessory/holster,
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
 	pixel_y = -28
@@ -27943,6 +28211,54 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/accessory/storage/black_drop_pouches{
+	pixel_x = -5
+	},
+/obj/item/clothing/accessory/storage/black_drop_pouches{
+	pixel_x = -3
+	},
+/obj/item/clothing/accessory/storage/black_drop_pouches{
+	pixel_x = -1
+	},
+/obj/item/clothing/accessory/storage/black_drop_pouches{
+	pixel_x = 1
+	},
+/obj/item/clothing/accessory/storage/black_drop_pouches{
+	pixel_x = 3
+	},
+/obj/item/clothing/accessory/storage/black_drop_pouches{
+	pixel_x = 5
+	},
+/obj/item/clothing/accessory/holster/leg{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/item/clothing/accessory/holster/leg{
+	pixel_x = -2;
+	pixel_y = 9
+	},
+/obj/item/clothing/accessory/holster/leg{
+	pixel_y = 9
+	},
+/obj/item/clothing/accessory/holster/leg{
+	pixel_y = 9;
+	pixel_x = 2
+	},
+/obj/item/clothing/accessory/holster/leg{
+	pixel_y = 9;
+	pixel_x = 4
+	},
+/obj/item/clothing/accessory/holster/leg{
+	pixel_y = 9;
+	pixel_x = 6
+	},
+/obj/item/clothing/accessory/holster/leg{
+	pixel_y = 9;
+	pixel_x = 8
+	},
+/obj/item/clothing/accessory/storage/black_drop_pouches{
+	pixel_x = 7
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "tCo" = (
@@ -28231,16 +28547,61 @@
 "tNM" = (
 /obj/structure/table/steel,
 /obj/item/cell/device/weapon{
-	pixel_x = -3
-	},
-/obj/item/cell/device/weapon{
-	pixel_x = 3
+	pixel_x = -9;
+	pixel_y = 4
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/cell/device/weapon{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/cell/device/weapon{
+	pixel_y = 4
+	},
+/obj/item/cell/device/weapon{
+	pixel_y = 4;
+	pixel_x = 1
+	},
+/obj/item/cell/device/weapon{
+	pixel_y = 4;
+	pixel_x = 2
+	},
+/obj/item/hand_labeler{
+	pixel_x = 2;
+	pixel_y = -9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
@@ -29617,9 +29978,6 @@
 /area/exploration/showers)
 "uNX" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/glasses/hud/security,
-/obj/item/clothing/glasses/hud/security,
-/obj/item/clothing/glasses/hud/security,
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -29628,6 +29986,38 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/accessory/holster/hip{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/item/clothing/accessory/holster/hip{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/clothing/accessory/holster/hip{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/clothing/accessory/holster/hip{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/clothing/accessory/holster/hip{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/clothing/accessory/holster/hip{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/clothing/accessory/holster/waist{
+	pixel_y = -7;
+	pixel_x = -4
+	},
+/obj/item/clothing/accessory/holster/waist{
+	pixel_y = -7;
+	pixel_x = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "uOz" = (
@@ -30788,6 +31178,9 @@
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6
+	},
+/obj/item/storage/lockbox{
+	pixel_y = 16
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
@@ -32605,7 +32998,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)
 "wEc" = (
-/obj/mecha/working/hoverpod/shuttlecraft,
 /obj/effect/floor_decal/industrial/danger{
 	dir = 10
 	},
@@ -32613,6 +33005,7 @@
 	dir = 8
 	},
 /obj/machinery/mech_recharger,
+/obj/mecha/combat/fighter/baron/sec/loaded,
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/hanger)
 "wEy" = (
@@ -33272,7 +33665,6 @@
 /area/security/warden)
 "xdv" = (
 /obj/structure/closet/cabinet,
-/obj/item/reagent_containers/food/drinks/bottle/specialwhiskey,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
 "xdx" = (
@@ -34985,11 +35377,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ai)
 "ylF" = (
-/obj/mecha/working/hoverpod/shuttlecraft,
 /obj/effect/floor_decal/industrial/danger{
 	dir = 10
 	},
 /obj/machinery/mech_recharger,
+/obj/mecha/combat/fighter/baron/sec/loaded,
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/hanger)
 "yma" = (
@@ -40649,7 +41041,7 @@ vIl
 sfo
 sfo
 sfo
-sfo
+gMk
 olz
 olz
 nIK


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the security equipment storage once again with hopefully no conflicts this time. It adds plate carriers, helmet cameras, survival knives, ETC, while also removing some uneeded items. 

Removed some unneeded items from the HoS's office

replaced shuttles in the podbay with barons 


## Why It's Good For The Game
good riddance

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
