### PR TITLE
Visible emote on setting pose

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -1061,6 +1061,8 @@
 
 	pose =  sanitize(input(usr, "This is [src]. [T.he]...", "Pose", null)  as text)
 
+	visible_emote("Adjusts [T.his] posture.")
+
 /mob/living/carbon/human/verb/set_flavor()
 	set name = "Set Flavour Text"
 	set desc = "Sets an extended description of your character's features."

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -286,6 +286,8 @@
 
 	pose =  sanitize(input(usr, "This is [src]. It is...", "Pose", null)  as text)
 
+	visible_emote("Adjusts its posture.")
+
 /mob/living/silicon/verb/set_flavor()
 	set name = "Set Flavour Text"
 	set desc = "Sets an extended description of your character's features."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Just says "adjusts their posture" when pose is changed.

## Why It's Good For The Game

Set pose feels a bit underused, I dunno? Because it's awkward to manually /me "sets their pose" or LOOCing or whatever.

## Changelog

:cl:
tweak: Setting pose shows a visible message.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
