### PR TITLE
makes pAIs appear on the api call used by APIs such as the discord bot

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -172,7 +172,12 @@
 		if(SSjob.is_job_in_department(real_rank, DEPARTMENT_OFFDUTY))
 			offduty[name] = rank
 
-	// Synthetics don't have actual records, so we will pull them from here.
+	// Synthetics don't have actual records, so we will pull them from here
+
+	// add pAIs	to the returned manifest, we do this first to just avoid a ghost overwriting a robot or AI name in the list
+	for(var/mob/living/silicon/pai/pai in GLOB.mob_list)
+		silicons[pai.name] = "pAI"
+	.
 	for(var/mob/living/silicon/ai/ai in GLOB.mob_list)
 		silicons[ai.name] = "Artificial Intelligence"
 
@@ -180,11 +185,6 @@
 		// No combat/syndicate cyborgs, no drones, and no AI shells.
 		if(!robot.scrambledcodes && !robot.shell && !(robot.module && robot.module.hide_on_manifest))
 			silicons[robot.name] = "[robot.modtype] [robot.braintype]"
-
-
-	// add pAIs	to the returned manifest
-	for(var/mob/living/silicon/pai/pai in GLOB.mob_list)
-		silicons[pai.name] = "pAI"
 
 	. = list()
 	if(command.len)

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -177,7 +177,7 @@
 	// add pAIs	to the returned manifest, we do this first to just avoid a ghost overwriting a robot or AI name in the list
 	for(var/mob/living/silicon/pai/pai in GLOB.mob_list)
 		silicons[pai.name] = "pAI"
-	.
+
 	for(var/mob/living/silicon/ai/ai in GLOB.mob_list)
 		silicons[ai.name] = "Artificial Intelligence"
 

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -180,6 +180,12 @@
 		// No combat/syndicate cyborgs, no drones, and no AI shells.
 		if(!robot.scrambledcodes && !robot.shell && !(robot.module && robot.module.hide_on_manifest))
 			silicons[robot.name] = "[robot.modtype] [robot.braintype]"
+
+
+	// add pAIs	to the returned manifest
+	for(var/mob/living/silicon/pai/pai in GLOB.mob_list)
+		silicons[pai.name] = "pAI"
+
 	. = list()
 	if(command.len)
 		.["Command"] = command

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -288,6 +288,7 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/paicard)
 	add_overlay("pai-null")
 
 /obj/item/paicard/proc/removePersonality()
+	QDEL_NULL(pai)
 	pai = null
 	cached_holo_image = null
 	cut_overlays()


### PR DESCRIPTION
## About The Pull Request
title

pAIs are still not crew, and not on the crew manifest, this just makes them show up for things like the discord bot

oh also it makes the pAI actually get deleted when you wipe the personality (tested)
## Why It's Good For The Game
makes the manifest a bit more accurate without editing the in-game crew records

## Changelog
:cl:
add: makes pAIs appear on the api call used by APIs such as the discord bot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
