### PR TITLE
makes the wings box sprite point to food.dmi instead of storage.dmi

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -5900,6 +5900,7 @@ END CITADEL CHANGE */
 /obj/item/storage/box/wings //This is kinda like the donut box.
 	name = "wing basket"
 	desc = "A basket of chicken wings! Get some before they're all gone! Or maybe you're too late..."
+	icon = 'icons/obj/food.dmi'
 	icon_state = "wings5"
 	var/startswith = 5
 	max_storage_space = ITEMSIZE_COST_SMALL * 5


### PR DESCRIPTION
## About The Pull Request
title

## Why It's Good For The Game
fixes missing sprite

## Changelog
:cl:
fix: makes the wings box sprite point to food.dmi instead of storage.dmi
/:cl:
