### PR TITLE
Tradeport mapfixes and rotations.

### DIFF
--- a/maps/sectors/tradeport_140/levels/tradeport_140.dmm
+++ b/maps/sectors/tradeport_140/levels/tradeport_140.dmm
@@ -16,7 +16,8 @@
 	req_access = list(160)
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "trade";
@@ -502,7 +503,8 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
@@ -617,6 +619,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/shuttle/trade_ship/general)
 "cq" = (
@@ -625,16 +630,29 @@
 	},
 /turf/simulated/floor/tiled/old_tile/blue,
 /area/tradeport)
-"cu" = (
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
+"cs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/trade_ship/cockpit)
+"cu" = (
 /obj/machinery/door/airlock/multi_tile/glass/polarized{
 	id_tint = "traderportdoor";
 	req_access = list(160)
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
@@ -703,14 +721,14 @@
 /area/shuttle/trade_ship/general)
 "cF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
 "cH" = (
@@ -790,7 +808,8 @@
 	req_one_access = null
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -960,7 +979,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access = list(160);
@@ -1337,11 +1357,11 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
 /turf/simulated/floor/tiled/old_cargo/red,
 /area/shuttle/trade_ship/general)
 "eV" = (
@@ -1475,6 +1495,17 @@
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
+"fy" = (
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	id = "storeshutter2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tradeport/facility)
 "fB" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/wood,
@@ -1509,7 +1540,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -1586,7 +1618,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Hydroponics"
@@ -1892,7 +1925,8 @@
 	},
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/trade_ship/general)
@@ -1960,8 +1994,7 @@
 /turf/simulated/floor/wood,
 /area/tradeport/cyndi)
 "hw" = (
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 8;
+/obj/machinery/door/firedoor{
 	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/neutral,
@@ -2197,6 +2230,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
+	},
 /turf/simulated/floor/tiled/old_tile/red,
 /area/tradeport)
 "iB" = (
@@ -2288,7 +2325,8 @@
 	},
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/trade_ship/general)
@@ -2565,10 +2603,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1;
-	req_one_access = list(160)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -2579,6 +2613,10 @@
 	dir = 1;
 	name = "Nebula Gas - Engineering";
 	req_access = list(160)
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/engineering)
@@ -3017,6 +3055,12 @@
 /obj/random/energy,
 /turf/simulated/floor/tiled/dark,
 /area/tradeport/facility)
+"lx" = (
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/tradeport/commons)
 "ly" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -3752,7 +3796,8 @@
 	req_one_access = null
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
@@ -4537,7 +4582,8 @@
 	req_access = list(160)
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/atmospherics)
@@ -4546,7 +4592,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -4839,7 +4886,8 @@
 	name = "Sleeping"
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/shuttle/trade_ship/general)
@@ -5154,7 +5202,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/silver{
 	id_tag = "tradedorm2";
@@ -5344,6 +5393,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
+	},
 /turf/simulated/floor/tiled/old_tile/red,
 /area/tradeport/commhall)
 "tU" = (
@@ -5409,6 +5462,9 @@
 "uc" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/cafeteria)
@@ -5684,7 +5740,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -5882,7 +5939,8 @@
 	id = "storeshutter1"
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/tradeport/facility)
@@ -6058,7 +6116,8 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/shuttle/floor/white,
 /area/tradeport/commons)
@@ -6221,7 +6280,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -6347,10 +6407,6 @@
 /turf/simulated/floor/tiled/old_tile/blue,
 /area/tradeport)
 "xu" = (
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1;
-	req_one_access = list(160)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -6366,6 +6422,10 @@
 	req_access = list(160)
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -7021,7 +7081,8 @@
 	req_one_access = null
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/cockpit)
@@ -7102,6 +7163,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
+"zZ" = (
+/obj/machinery/door/firedoor/glass{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/tradeport/cafeteria)
 "Ab" = (
 /obj/effect/mist,
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -7149,6 +7218,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
@@ -7288,7 +7360,8 @@
 /area/tradeport/pads)
 "Bj" = (
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -7469,9 +7542,9 @@
 	name = "Nebula Commercial District";
 	req_access = null
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1;
-	req_one_access = list(160)
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/old_tile/blue,
 /area/tradeport)
@@ -7975,15 +8048,15 @@
 /turf/simulated/floor/plating,
 /area/tradeport/atmospherics)
 "DS" = (
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /obj/machinery/door/airlock/multi_tile/glass/polarized{
 	id_tint = "traderstardoor";
 	req_access = list(160)
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/shuttle/trade_ship/general)
@@ -8031,6 +8104,12 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/old_tile/purple,
 /area/tradeport/spine)
+"Eg" = (
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/tradeport)
 "Ej" = (
 /turf/simulated/floor,
 /area/tradeport/pads)
@@ -8270,6 +8349,13 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/tradeport)
+"Fi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/trade_ship/general)
 "Fj" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -8688,7 +8774,7 @@
 	name = "Nebula Gas - Atmospherics";
 	req_access = list(160)
 	},
-/obj/machinery/door/firedoor/multi_tile{
+/obj/machinery/door/firedoor{
 	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/neutral,
@@ -8749,6 +8835,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/atmospherics)
 "Ht" = (
@@ -8772,7 +8861,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Restrooms"
@@ -9121,7 +9211,8 @@
 /area/tradeport/commons)
 "IT" = (
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/command{
 	name = "Managers Office";
@@ -9148,6 +9239,10 @@
 /area/shuttle/trade_ship/general)
 "Ja" = (
 /obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -9408,9 +9503,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1;
-	req_one_access = list(160)
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/cockpit)
@@ -9424,7 +9519,7 @@
 	id = "tradebridgeshutters";
 	name = "remote shutter control";
 	pixel_x = 30;
-	req_access = list(150)
+	req_access = list(160)
 	},
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-09";
@@ -9572,7 +9667,8 @@
 /area/tradeport/facility)
 "KF" = (
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -9904,7 +10000,8 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -10079,7 +10176,8 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/old_cargo/red,
 /area/shuttle/trade_ship/general)
@@ -10212,7 +10310,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/silver{
 	name = "Women"
@@ -10353,7 +10452,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -10441,7 +10541,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/silver{
 	id_tag = "tradedorm1";
@@ -10526,7 +10627,8 @@
 /area/tradeport/cyndishow)
 "Og" = (
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
@@ -10953,7 +11055,8 @@
 	req_one_access = null
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/tradeport/medical)
@@ -11052,6 +11155,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/facility)
 "Qm" = (
@@ -11122,6 +11228,7 @@
 	name = "Beruang";
 	pixel_x = 32
 	},
+/obj/machinery/holopad/ship/starts_inactive,
 /turf/simulated/floor/tiled/old_cargo/red,
 /area/shuttle/trade_ship/cockpit)
 "QF" = (
@@ -11264,6 +11371,20 @@
 /obj/machinery/power/solar,
 /turf/simulated/floor/airless,
 /area/space)
+"QX" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/tradeport/facility)
 "QY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -11627,6 +11748,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
+"Sy" = (
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/tradeport/commons)
 "SB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -11647,7 +11775,8 @@
 /area/tradeport/cafeteria)
 "SD" = (
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -11691,7 +11820,8 @@
 	req_one_access = null
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -11810,9 +11940,6 @@
 /turf/simulated/mineral/vacuum,
 /area/tradeport/exterior)
 "Tl" = (
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/multi_tile/glass{
@@ -11823,6 +11950,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport)
@@ -11922,9 +12052,9 @@
 	name = "Nebula Commercial District";
 	req_access = null
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1;
-	req_one_access = list(160)
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/old_tile/blue,
 /area/tradeport/commhall)
@@ -12093,14 +12223,14 @@
 /turf/simulated/floor/wood,
 /area/tradeport/commons)
 "Ur" = (
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
-	},
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Nebula Gas - Warehouse";
 	req_access = list(160)
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
 "Uv" = (
@@ -12118,9 +12248,6 @@
 /area/tradeport/medical)
 "Uw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -12131,6 +12258,9 @@
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/cafeteria)
@@ -12232,7 +12362,8 @@
 	},
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/trade_ship/general)
@@ -12253,7 +12384,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/silver{
 	name = "Men"
@@ -12360,7 +12492,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -12382,7 +12515,8 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/cash_register/trader{
 	desc = "Swipe your ID card to make purchases electronically. There is a note at the bottom. Press Custom Order. Enter reason and cost. Then have customer swipe their card. ";
@@ -12436,6 +12570,17 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating,
 /area/tradeport/facility)
+"VP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/tradeport/facility)
 "VR" = (
 /obj/landmark/spawnpoint/latejoin/tradeport,
 /obj/machinery/computer/cryopod/robot{
@@ -12445,7 +12590,8 @@
 /area/tradeport/commons)
 "VS" = (
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access = list(160);
@@ -12457,7 +12603,8 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -12607,7 +12754,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
@@ -12647,7 +12795,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Kitchen"
@@ -12712,11 +12861,11 @@
 /area/tradeport/engineering)
 "WN" = (
 /obj/machinery/door/airlock/multi_tile/glass,
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
 /turf/simulated/floor/tiled/old_cargo/red,
 /area/shuttle/trade_ship/general)
 "WO" = (
@@ -12793,6 +12942,10 @@
 /turf/simulated/floor/plating,
 /area/tradeport/atmospherics)
 "Xd" = (
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/engineering)
 "Xe" = (
@@ -13173,12 +13326,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1;
-	req_one_access = list(160)
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
@@ -13262,7 +13415,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/item/deskbell{
 	pixel_x = -7;
@@ -13547,6 +13701,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
 "ZZ" = (
@@ -27213,7 +27370,7 @@ WY
 WY
 WY
 WY
-xP
+cs
 JZ
 Lp
 Jn
@@ -28788,8 +28945,8 @@ XM
 BK
 ZM
 Zv
-OW
-OW
+zZ
+zZ
 Zv
 Zv
 Zv
@@ -28936,7 +29093,7 @@ Wd
 cg
 cg
 cg
-Vy
+Sy
 Yy
 cg
 TB
@@ -29198,12 +29355,12 @@ lM
 ST
 cP
 Pd
-qq
+Fi
 qq
 iy
 Dg
 LW
-qq
+Fi
 JY
 Dg
 MH
@@ -29222,7 +29379,7 @@ Vy
 dy
 JH
 Ox
-Vy
+lx
 Vy
 Vy
 IS
@@ -29232,7 +29389,7 @@ Dw
 IS
 Vy
 Vy
-Dr
+Eg
 tS
 kP
 mm
@@ -31321,13 +31478,13 @@ nG
 cB
 xN
 lo
-lo
+QX
 tD
 iC
 zr
 oq
 rr
-xv
+VP
 vl
 Xi
 xv
@@ -31474,7 +31631,7 @@ bA
 bA
 pQ
 Nu
-pQ
+fy
 Vx
 bA
 bA

--- a/maps/sectors/tradeport_192/levels/tradeport_192.dmm
+++ b/maps/sectors/tradeport_192/levels/tradeport_192.dmm
@@ -63,10 +63,6 @@
 /turf/simulated/floor/wood,
 /area/tradeport/cyndi)
 "av" = (
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1;
-	req_one_access = list(160)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -82,6 +78,10 @@
 	req_access = list(160)
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -100,7 +100,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Restrooms"
@@ -118,6 +119,23 @@
 "az" = (
 /turf/simulated/floor/outdoors/beach/sand/desert,
 /area/tradeport/cyndishow)
+"aA" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "trade-ship-secure";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/trade_ship/general)
 "aC" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 1
@@ -183,15 +201,15 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/tradeport/cafeteria)
 "aM" = (
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
-	},
 /obj/machinery/door/airlock/multi_tile/glass/polarized{
 	id_tint = "traderportdoor";
 	req_access = list(160)
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
@@ -246,9 +264,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1;
-	req_one_access = list(160)
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/cockpit)
@@ -293,6 +311,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/old_tile/red,
 /area/tradeport/commhall)
 "bi" = (
@@ -533,11 +552,11 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
 /turf/simulated/floor/tiled/old_cargo/red,
 /area/shuttle/trade_ship/general)
 "ci" = (
@@ -570,7 +589,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Hydroponics"
@@ -699,7 +719,8 @@
 	req_one_access = null
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
@@ -773,7 +794,8 @@
 /area/tradeport)
 "cZ" = (
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -1285,7 +1307,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/item/deskbell{
 	pixel_x = -7;
@@ -1303,6 +1326,17 @@
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/tradeport/medical)
+"fa" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/tradeport/facility)
 "fc" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/reagent_containers/spray/cleaner,
@@ -1541,7 +1575,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
@@ -1574,7 +1609,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Kitchen"
@@ -1614,7 +1650,8 @@
 	req_one_access = null
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1655,6 +1692,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/tradeport/pads)
+"gr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/trade_ship/general)
 "gs" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
 	frequency = 1380;
@@ -1713,9 +1757,6 @@
 /turf/simulated/floor/wood,
 /area/tradeport/cyndi)
 "gH" = (
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/multi_tile/glass{
@@ -1726,6 +1767,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport)
@@ -2215,7 +2259,8 @@
 	req_access = list(160)
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "trade";
@@ -2557,7 +2602,7 @@
 	id = "tradebridgeshutters";
 	name = "remote shutter control";
 	pixel_x = 30;
-	req_access = list(150)
+	req_access = list(160)
 	},
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-09";
@@ -2566,6 +2611,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/cockpit)
+"jG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/tradeport/facility)
 "jJ" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/wood,
@@ -2787,14 +2843,14 @@
 /turf/simulated/floor/tiled/old_tile/beige,
 /area/tradeport/commhall)
 "kG" = (
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
-	},
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Nebula Gas - Warehouse";
 	req_access = list(160)
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
 "kH" = (
@@ -2846,13 +2902,20 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tradeport/engineering)
+"kL" = (
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/tradeport)
 "kQ" = (
 /obj/machinery/door/blast/shutters{
 	dir = 8;
 	id = "storeshutter1"
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/tradeport/facility)
@@ -3003,6 +3066,12 @@
 	},
 /turf/simulated/floor/wmarble,
 /area/tradeport/cafeteria)
+"lr" = (
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
+/turf/simulated/floor/tiled/old_tile/red,
+/area/tradeport)
 "lv" = (
 /obj/structure/table/steel_reinforced,
 /obj/fiftyspawner/glass,
@@ -3215,10 +3284,7 @@
 	name = "Nebula Commercial District";
 	req_access = null
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1;
-	req_one_access = list(160)
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/old_tile/blue,
 /area/tradeport)
 "mg" = (
@@ -3236,7 +3302,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -3278,7 +3345,8 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/cash_register/trader{
 	desc = "Swipe your ID card to make purchases electronically. There is a note at the bottom. Press Custom Order. Enter reason and cost. Then have customer swipe their card. ";
@@ -3523,7 +3591,8 @@
 	},
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/trade_ship/general)
@@ -3876,6 +3945,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/shuttle/trade_ship/general)
@@ -4235,6 +4307,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/tradeport/commons)
+"qy" = (
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/tradeport/commons)
 "qA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -4363,7 +4442,8 @@
 	req_one_access = null
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/tradeport/medical)
@@ -5425,7 +5505,8 @@
 	req_one_access = null
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/cockpit)
@@ -5494,7 +5575,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -5536,7 +5618,8 @@
 	req_access = list(160)
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/atmospherics)
@@ -5566,10 +5649,8 @@
 	name = "Nebula Commercial District";
 	req_access = null
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1;
-	req_one_access = list(160)
-	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/old_tile/blue,
 /area/tradeport/commhall)
 "vF" = (
@@ -5645,7 +5726,8 @@
 /area/tradeport/safarizoo)
 "vY" = (
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/command{
 	name = "Managers Office";
@@ -5686,9 +5768,6 @@
 /area/shuttle/trade_ship/general)
 "wd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -5699,6 +5778,9 @@
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/cafeteria)
@@ -5921,7 +6003,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/silver{
 	id_tag = "tradedorm2";
@@ -6012,7 +6095,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/silver{
 	id_tag = "tradedorm1";
@@ -6054,14 +6138,14 @@
 /area/tradeport/cyndishow)
 "xp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
 "xq" = (
@@ -6164,6 +6248,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
 "xG" = (
@@ -6265,7 +6352,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access = list(160);
@@ -6667,7 +6755,8 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/old_cargo/red,
 /area/shuttle/trade_ship/general)
@@ -6946,7 +7035,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -6956,7 +7046,8 @@
 /area/tradeport/facility)
 "AU" = (
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
@@ -7030,10 +7121,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1;
-	req_one_access = list(160)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -7044,6 +7131,10 @@
 	dir = 1;
 	name = "Nebula Gas - Engineering";
 	req_access = list(160)
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/engineering)
@@ -7461,7 +7552,8 @@
 /area/shuttle/trade_ship/general)
 "Cw" = (
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -7504,8 +7596,7 @@
 /turf/simulated/floor/wood,
 /area/tradeport/commons)
 "CE" = (
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 8;
+/obj/machinery/door/firedoor{
 	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/neutral,
@@ -7697,7 +7788,8 @@
 	name = "Sleeping"
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/shuttle/trade_ship/general)
@@ -7989,7 +8081,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tradeport/commons)
@@ -8874,6 +8967,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
+"HX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/trade_ship/cockpit)
 "HZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -9009,6 +9115,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/atmospherics)
 "Iu" = (
@@ -9051,7 +9160,8 @@
 /area/shuttle/trade_ship/general)
 "IE" = (
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -9465,7 +9575,8 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -10173,6 +10284,10 @@
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/shuttle/trade_ship/cockpit)
 "MY" = (
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/engineering)
 "MZ" = (
@@ -10198,7 +10313,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -10208,7 +10324,8 @@
 /area/tradeport/facility)
 "Nb" = (
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -10389,7 +10506,8 @@
 	},
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/trade_ship/general)
@@ -10430,7 +10548,8 @@
 	},
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/trade_ship/general)
@@ -10782,6 +10901,12 @@
 /obj/structure/dispenser,
 /turf/simulated/floor/tiled/techmaint,
 /area/tradeport/engineering)
+"Pn" = (
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/tradeport/commons)
 "Po" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -10818,12 +10943,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1;
-	req_one_access = list(160)
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
@@ -11072,12 +11197,19 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160);
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/tradeport/commons)
 "Qx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
@@ -11281,6 +11413,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/old_tile/red,
 /area/tradeport)
 "Rm" = (
@@ -11678,9 +11811,6 @@
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/facility)
 "SH" = (
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/multi_tile/glass{
@@ -11689,6 +11819,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/old_tile/blue,
 /area/tradeport)
@@ -11990,7 +12123,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -12022,7 +12156,8 @@
 	req_one_access = null
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -12114,6 +12249,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tradeport/engineering)
+"Ur" = (
+/obj/machinery/door/firedoor/glass{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/tradeport/cafeteria)
 "Ut" = (
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
@@ -12279,7 +12422,8 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
@@ -12339,6 +12483,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/facility)
@@ -12550,15 +12697,15 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/tradeport/commons)
 "We" = (
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /obj/machinery/door/airlock/multi_tile/glass/polarized{
 	id_tint = "traderstardoor";
 	req_access = list(160)
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/shuttle/trade_ship/general)
@@ -13115,7 +13262,7 @@
 	name = "Nebula Gas - Atmospherics";
 	req_access = list(160)
 	},
-/obj/machinery/door/firedoor/multi_tile{
+/obj/machinery/door/firedoor{
 	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/neutral,
@@ -13262,11 +13409,11 @@
 /area/tradeport/atmospherics)
 "YV" = (
 /obj/machinery/door/airlock/multi_tile/glass,
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = list(160)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
+	},
 /turf/simulated/floor/tiled/old_cargo/red,
 /area/shuttle/trade_ship/general)
 "YW" = (
@@ -13364,7 +13511,8 @@
 /area/tradeport/atmospherics)
 "Zk" = (
 /obj/machinery/door/firedoor{
-	req_one_access = list(160)
+	req_one_access = list(160);
+	dir = 8
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access = list(160);
@@ -13437,6 +13585,9 @@
 "Zy" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/cafeteria)
@@ -37081,7 +37232,7 @@ PJ
 PJ
 PJ
 PJ
-jC
+HX
 aZ
 Su
 sO
@@ -39209,18 +39360,18 @@ Jv
 PJ
 PJ
 PJ
-ol
-ol
-ol
+aA
+aA
+aA
 Su
 Ax
 NC
 NC
 BG
 Su
+aA
 ol
-ol
-ol
+aA
 PJ
 PJ
 PJ
@@ -39229,7 +39380,7 @@ FS
 dA
 tW
 pr
-pr
+Ur
 tW
 tW
 tW
@@ -39428,7 +39579,7 @@ gv
 tu
 tu
 tu
-IX
+qy
 Pq
 tu
 Ez
@@ -39794,12 +39945,12 @@ Rf
 wR
 iK
 ck
-Cd
+gr
 Cd
 cV
 ri
 YK
-Cd
+gr
 OV
 ri
 ic
@@ -39818,7 +39969,7 @@ IX
 bP
 is
 DD
-IX
+Pn
 IX
 IX
 tR
@@ -39828,7 +39979,7 @@ ya
 tR
 IX
 IX
-rb
+kL
 YW
 ft
 RN
@@ -39838,7 +39989,7 @@ hQ
 Ge
 wW
 mn
-wW
+lr
 lT
 Wz
 sW
@@ -42697,13 +42848,13 @@ rY
 hV
 XD
 XM
-XM
+fa
 dv
 ea
 Go
 CL
 tl
-tU
+jG
 LL
 dS
 tU


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Modifies both tradeport_140 and tradeport_192
-Replaces all multi-tile firelocks with single tile firelocks. --Multi-tile firelocks are invisible ingame and potentially defunct.

-Rotates all firelocks to be the correct direction for baywall effects.

-Headbashes the Baruang bridge shutter control button to no longer be loyal to the syndicate (Access id change from 150 to 160)

-Mirrors the Beruang bridge 'sector holopad' to the tradeport_140 version, it was on the 192 version only before.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
-Buffs trader
-Fixes nasty visual bugs in emergency equipment
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
-Replaces all multi-tile firelocks with single tile firelocks on tradeport_192 & tradeport_140
-Rotates all firelocks to be the correct direction on tradeport_192 & tradeport_140
-Adds a sector holopad to the bridge of the Beruang on tradeport_140. tradeport_192 already has one.
-Adjusts the Bridge shutter control button on the Beruang to use trader access instead of syndicate access

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Sector holopad to all Beruang bridges
fix: fixed Beruang firelocks being invisible
fix: fixed Beruang firelocks being rotated the wrong way
fix: fixed Beruang bridge shutter control button requiring wrong id access
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
