### PR TITLE
stops mob holders being buggy when placing a held mob onto a table

### DIFF
--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -141,6 +141,9 @@
 			//Clamp it so that the icon never moves more than 16 pixels in either direction (thus leaving the table turf)
 			W.pixel_x = clamp(text2num(params["icon-x"]) - 16, -(world.icon_size/2), world.icon_size/2)
 			W.pixel_y = clamp(text2num(params["icon-y"]) - 16, -(world.icon_size/2), world.icon_size/2)
+		if(istype(W, /obj/item/holder))
+			var/obj/item/holder/holder = W
+			holder.update_state()
 		return
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request
instead of waiting for the automatic process to handle it, we tell it to update the moment it is placed on a table

## Why It's Good For The Game
boy i sure love seeing two sprites when i place something on a table just for one to magically disappear a second later

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: stops mob holders being buggy when placing a held mob onto a table
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
