### PR TITLE
Doors/airlocks added to list of things airlocks will autorotate to (fixes Triumph hallway airlocks)

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -17,8 +17,9 @@ GLOBAL_REAL_VAR(airlock_typecache) = typecacheof(list(
 	/obj/structure/window/basic/full,
 	/obj/structure/window/reinforced/polarized/full,
 	/obj/structure/wall_frame,
-	/obj/spawner/window
-	)) //the spawner is there specifically because doors are initializing weird.
+	/obj/spawner/window, //the spawner is there specifically because doors are initializing weird.
+	/obj/machinery/door //specific maps sometimes have airlocks adjacent to other airlocks in rows and columns of 3.
+	))
 
 #define AIRLOCK_PAINTABLE 1
 #define AIRLOCK_STRIPABLE 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.
BEFORE:
![image](https://cdn.discordapp.com/attachments/472887611757953034/1136821685677473902/dreamseeker_2023-08-03_18-42-36.png)
AFTER:
![image](https://cdn.discordapp.com/attachments/472887611757953034/1136821695555051571/image.png)

This PR does not modify the Triumph map files.

## Why It's Good For The Game

No more funny misrotated airlocks.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Roundstart-airlocks will be rotated respectively to nearby airlocks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
