### PR TITLE
Prometheans can now change hair transparency separate from body transparency.

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -445,8 +445,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		apply_layer(HAIR_LAYER)
 		return
 
-	if(head_organ.transparent)
-		face_standing += rgb(,,,120)
+	face_standing += rgb(,,,head_organ.hair_opacity)
 
 	overlays_standing[HAIR_LAYER] = image(face_standing, layer = BODY_LAYER+HAIR_LAYER)
 	apply_layer(HAIR_LAYER)

--- a/code/modules/organs/external/species/slime.dm
+++ b/code/modules/organs/external/species/slime.dm
@@ -67,3 +67,4 @@
 	encased = 0
 	spread_dam = 1
 	transparent = 1
+	hair_opacity = 160

--- a/code/modules/organs/external/subtypes/standard.dm
+++ b/code/modules/organs/external/subtypes/standard.dm
@@ -258,6 +258,7 @@
 	damage_force = 3
 	throw_force = 7
 
+	var/hair_opacity = 255
 	var/can_intake_reagents = TRUE
 	var/eyes_over_markings = FALSE
 	var/eye_icon = "eyes_s"

--- a/code/modules/species/promethean/promethean.dm
+++ b/code/modules/species/promethean/promethean.dm
@@ -117,7 +117,8 @@ var/datum/species/shapeshifter/promethean/prometheans
 	inherent_verbs = list(
 		/mob/living/proc/eat_trash,
 		/mob/living/proc/set_size,
-		/mob/living/carbon/human/proc/promethean_select_opaqueness,
+		/mob/living/carbon/human/proc/promethean_toggle_body_transparency,
+		/mob/living/carbon/human/proc/promethean_set_hair_transparency,
 		/mob/living/carbon/human/proc/prommie_blobform,
 		/mob/living/carbon/human/proc/regenerate,
 		/mob/living/carbon/human/proc/shapeshifter_select_colour,

--- a/code/modules/species/species_shapeshift.dm
+++ b/code/modules/species/species_shapeshift.dm
@@ -509,9 +509,9 @@ var/list/wrapped_species_by_ref = list()
 
 	update_wing_showing()
 
-/mob/living/carbon/human/proc/promethean_select_opaqueness()
+/mob/living/carbon/human/proc/promethean_toggle_body_transparency()
 
-	set name = "Toggle Transparency"
+	set name = "Toggle Body Opacity" //Opacity is a shorter word than Transparency - the latter word cuts off on the verb button.
 	set category = "Abilities"
 
 	if(stat || world.time < last_special)
@@ -522,8 +522,26 @@ var/list/wrapped_species_by_ref = list()
 	for(var/limb in src.organs)
 		var/obj/item/organ/external/L = limb
 		L.transparent = !L.transparent
-	visible_message(SPAN_NOTICE("\The [src]'s interal composition seems to change."))
+	visible_message(SPAN_NOTICE("\The [src]'s internal composition seems to change."))
 	update_icons_body()
+
+/mob/living/carbon/human/proc/promethean_set_hair_transparency()
+
+	set name = "Set Hair Opacity"
+	set category = "Abilities"
+
+	if(stat || world.time < last_special)
+		return
+
+	last_special = world.time + 50
+
+	var/new_transparency = input("Pick a number between 100 and 255, 255 being no transparency.", "Change Transparency") as num|null
+	if(new_transparency)
+		new_transparency = clamp(new_transparency,100,255)
+		var/obj/item/organ/external/head/H = src.get_organ(BP_HEAD)
+		H.hair_opacity = new_transparency
+		visible_message(SPAN_NOTICE("\The [src]'s \"hair\" composition seems to change."))
+		update_hair()
 
 /datum/species/shapeshifter/handle_environment_special(mob/living/carbon/human/H)
 	// Heal remaining damage.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.
Hair transparency is now configurable from an opacity of 100-255 for prometheans. 
However, body transparency is still a toggle. This is apparently because the transparent body is an actual _sprite_ rather than just changing the transparency of the sprite, and I don't want to bother changing that right now. Maybe in a later PR I will.

## Why It's Good For The Game

Customization good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Prommies can now change their hair transparency separate from body transparency.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
