### PR TITLE
Fixes missing survival pod sprites

### DIFF
--- a/code/modules/mining/shelter_atoms.dm
+++ b/code/modules/mining/shelter_atoms.dm
@@ -159,6 +159,9 @@
 	can_reinforce = FALSE
 	can_plate = FALSE
 
+/obj/structure/table/survival_pod/update_icon()
+	icon_state = "table" //this table doesn't care about your material nonsense. just ignore the overlays.
+
 /obj/structure/table/survival_pod/update_icon_state()
 	. = ..()
 	icon_state = "table"
@@ -169,9 +172,15 @@
 	remove_obj_verb(src, /obj/structure/table/proc/do_put)
 	return ..()
 
-/obj/structure/table/survival_pod/dismantle(obj/item/tool/wrench/W, mob/user)
-	to_chat(user, "<span class='warning'>You cannot dismantle \the [src].</span>")
-	return
+/obj/structure/table/survival_pod/attackby(obj/item/W, mob/user)
+	if(W.is_wrench()) //dismantled with one wrench usage
+		dismantle(W, user)
+		return 1
+	return ..()
+
+/obj/structure/table/survival_pod/Destroy()
+	new /obj/item/stack/material/steel(src.loc) //add an additional steel so they can make a new table with two steel if desired
+	return ..()
 
 //Sleeper
 /obj/machinery/sleeper/survival_pod
@@ -180,13 +189,10 @@
 	icon_state = "sleeper"
 	stasis_level = 100 //Just one setting
 
-
-/obj/machinery/sleeper/survival_pod/update_overlays()
-	. = ..()
-	cut_overlays()
+/obj/machinery/sleeper/survival_pod/update_icon()
+	overlays.Cut()
 	if(occupant)
-		. += "sleeper_cover"
-
+		add_overlay("sleeper_cover")
 
 //Computer
 /obj/item/gps/computer
@@ -232,6 +238,7 @@
 	light_color = "#DDFFD3"
 	pixel_y = -4
 	max_n_of_items = 100
+	icon_base = "donkvendor"
 
 /obj/machinery/smartfridge/survival_pod/Initialize(mapload)
 	. = ..()
@@ -241,6 +248,17 @@
 
 /obj/machinery/smartfridge/survival_pod/accept_check(obj/item/O)
 	return isitem(O)
+
+/obj/machinery/smartfridge/survival_pod/update_icon() //survival pod smartfridges don't have the content nonsense, so this is mainly bandaid fix.
+	overlays.Cut()
+	if(inoperable())
+		icon_state = "[icon_base]-off"
+	else
+		icon_state = icon_base
+
+	if(panel_open)
+		icon_state = "[icon_base]_open"
+
 
 /obj/machinery/smartfridge/survival_pod/empty
 	name = "dusty survival pod storage"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Restores:
- Survival pod sleeper
- The special snowflake table
- The survival pod storage

## Why It's Good For The Game

Finally, people will know a sleeper actually exists in there!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Sprites of the sleeper, the table, and the storage in the survival pod have been fixed and are now visible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
