### PR TITLE
Spawned character w/ loadout clothes suit sensor init fix

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -82,11 +82,14 @@
 	// todo: remove this lol
 	if(isnull(snowflake_worn_state))
 		snowflake_worn_state = item_state_slots?[SLOT_ID_UNIFORM] || item_state || icon_state
-	var/mob/living/carbon/human/H = loc
-	if(istype(H))
-		addtimer(CALLBACK(src, PROC_REF(init_sensors), H), 0)
+	addtimer(CALLBACK(src, PROC_REF(init_sensors)), 0)
 
-/obj/item/clothing/under/proc/init_sensors(mob/living/carbon/human/H)
+
+
+/obj/item/clothing/under/proc/init_sensors()
+	var/mob/living/carbon/human/H = loc
+	if(!istype(H))
+		return
 	if(has_sensors == UNIFORM_HAS_LOCKED_SENSORS)
 		return
 	if(istype(H))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Suit sensors are loaded to the player's preference again instead of starting off with none.

## Why It's Good For The Game

was broken since loadout was updated. It's fixed now.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Characters spawned in will now have their preferred suit sensors again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
