### PR TITLE
Fixed the erroneous capital A on posture adjustment

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -1061,7 +1061,7 @@
 
 	pose =  sanitize(input(usr, "This is [src]. [T.he]...", "Pose", null)  as text)
 
-	visible_emote("Adjusts [T.his] posture.")
+	visible_emote("adjusts [T.his] posture.")
 
 /mob/living/carbon/human/verb/set_flavor()
 	set name = "Set Flavour Text"

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -286,7 +286,7 @@
 
 	pose =  sanitize(input(usr, "This is [src]. It is...", "Pose", null)  as text)
 
-	visible_emote("Adjusts its posture.")
+	visible_emote("adjusts its posture.")
 
 /mob/living/silicon/verb/set_flavor()
 	set name = "Set Flavour Text"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title, says "**Foo Bar** Adjusted their posture." instead of "**Foo Bar** adjusted their posture" right now. This fixes it.

## Why It's Good For The Game

this is literally the worst thing i have ever added to the game and fixing it will get me into heaven

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: changed a couple "A"s to "a"s
/:cl: