### PR TITLE
Fixes RCD and Sprinter hardsuit modules

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -385,7 +385,7 @@
 
 // Infinite use RCD for debugging/adminbuse.
 /obj/item/rcd/debug
-	name = "self-repleshing rapid construction device"
+	name = "self-replenishing rapid construction device"
 	desc = "An RCD that appears to be plated with gold. For some reason it also seems to just \
 	be vastly superior to all other RCDs ever created, possibly due to it being colored gold."
 	icon_state = "debug_rcd"

--- a/code/modules/hardsuits/_rig.dm
+++ b/code/modules/hardsuits/_rig.dm
@@ -114,6 +114,8 @@
 	var/trapDelay = 300 //in deciseconds
 	var/warn = 1 //If the suit will warn you if it can't deploy a part. Will always end back at 1.
 
+	var/sprint_slowdown_modifier = 0					      // Sprinter module modifier.
+
 /obj/item/hardsuit/get_cell()
 	return cell
 
@@ -578,7 +580,7 @@
 			last_online = TRUE
 		if(istype(wearer) && !wearer.wearing_rig)
 			wearer.wearing_rig = src
-		slowdown = initial(slowdown)
+		slowdown = initial(slowdown) + sprint_slowdown_modifier
 
 	if(cell && cell.charge > 0 && electrified > 0)
 		electrified--

--- a/code/modules/hardsuits/modules/utility.dm
+++ b/code/modules/hardsuits/modules/utility.dm
@@ -121,9 +121,9 @@
 	if(istype(T) && !T.Adjacent(get_turf(src)))
 		return 0
 
-	var/resolved = target.attackby(device,holder.wearer)
-	if(!resolved && device && target)
-		device.afterattack(target,holder.wearer,1)
+	var/obj/item/rcd/electric/mounted/hardsuit/R = device
+	R.use_rcd(target, holder.wearer)
+
 	return 1
 
 
@@ -652,6 +652,7 @@
 	to_chat(H, "<font color=#4F49AF><b>You activate the suit's sprint mode.</b></font>")
 
 	holder.slowdown -= sprint_speed
+	holder.sprint_slowdown_modifier = -sprint_speed
 
 /obj/item/hardsuit_module/sprinter/deactivate()
 
@@ -663,6 +664,7 @@
 	to_chat(H, "<span class='danger'>Your hardsuit returns to normal speed.</span>")
 
 	holder.slowdown += sprint_speed
+	holder.sprint_slowdown_modifier = 0
 
 /obj/item/hardsuit_module/device/hand_defib
 	name = "\improper Hand-mounted Defibrillator"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. 
Cause of Sprinter bug: 
- The hardsuit process constantly changed the slowdown to its default value.

Solution:
- I added the sprinter modifier to the value.

Cause of RCD bug:
- attackby doesn't seem to work for it.

Solution:
- I made it use use_rcd instead. I don't think anyone plans to bash someone with the mounted RCD.

## Why It's Good For The Game

Fix good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The Sprinter and RCD modules for the hardsuit/RIG are now functional again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
