### PR TITLE
Loam Nutri-Juice no longer poisons Alraune

### DIFF
--- a/code/modules/food/food/cans.dm
+++ b/code/modules/food/food/cans.dm
@@ -324,5 +324,6 @@
 
 /obj/item/reagent_containers/food/drinks/cans/alraune/Initialize(mapload)
 	. = ..()
+	//
 	reagents.add_reagent("diethylamine", 20)
 	reagents.add_reagent("water", 10)

--- a/code/modules/food/food/cans.dm
+++ b/code/modules/food/food/cans.dm
@@ -324,5 +324,5 @@
 
 /obj/item/reagent_containers/food/drinks/cans/alraune/Initialize(mapload)
 	. = ..()
-	reagents.add_reagent("ammonia", 20)
+	reagents.add_reagent("diethylamine", 20)
 	reagents.add_reagent("water", 10)

--- a/code/modules/food/food/cans.dm
+++ b/code/modules/food/food/cans.dm
@@ -324,6 +324,5 @@
 
 /obj/item/reagent_containers/food/drinks/cans/alraune/Initialize(mapload)
 	. = ..()
-	//
 	reagents.add_reagent("diethylamine", 20)
 	reagents.add_reagent("water", 10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces ammonia with diethylamine in the Loam Nutri-Juice can.

This will make it no longer react into space cleaner because ammonia isn't there combining with water anymore.

## Why It's Good For The Game

fixes #5532

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Loam Nutri-Juice is now filled with rich, rich diethylamine instead of ammonia. This also results in no more poisonous space cleaner incidents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
