### PR TITLE
Radials no longer resize based on size of atom it's attached to

### DIFF
--- a/code/game/rendering/legacy/radial.dm
+++ b/code/game/rendering/legacy/radial.dm
@@ -9,6 +9,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	icon = 'icons/mob/radial.dmi'
 	layer = HUD_LAYER_ABOVE
 	plane = ABOVE_HUD_PLANE
+	appearance_flags = KEEP_APART|RESET_TRANSFORM
 	var/datum/radial_menu/parent
 
 /atom/movable/screen/radial/slice

--- a/code/game/rendering/legacy/radial.dm
+++ b/code/game/rendering/legacy/radial.dm
@@ -9,7 +9,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	icon = 'icons/mob/radial.dmi'
 	layer = HUD_LAYER_ABOVE
 	plane = ABOVE_HUD_PLANE
-	appearance_flags = KEEP_APART|RESET_TRANSFORM
+	appearance_flags = KEEP_APART|RESET_TRANSFORM|RESET_ALPHA|RESET_COLOR
 	var/datum/radial_menu/parent
 
 /atom/movable/screen/radial/slice

--- a/code/game/rendering/legacy/radial.dm
+++ b/code/game/rendering/legacy/radial.dm
@@ -9,7 +9,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	icon = 'icons/mob/radial.dmi'
 	layer = HUD_LAYER_ABOVE
 	plane = ABOVE_HUD_PLANE
-	appearance_flags = KEEP_APART|RESET_TRANSFORM|RESET_ALPHA|RESET_COLOR
+	appearance_flags = PIXEL_SCALE | NO_CLIENT_COLOR | KEEP_APART |RESET_TRANSFORM | RESET_ALPHA | RESET_COLOR
 	var/datum/radial_menu/parent
 
 /atom/movable/screen/radial/slice

--- a/code/game/rendering/legacy/radial.dm
+++ b/code/game/rendering/legacy/radial.dm
@@ -9,7 +9,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	icon = 'icons/mob/radial.dmi'
 	layer = HUD_LAYER_ABOVE
 	plane = ABOVE_HUD_PLANE
-	appearance_flags = PIXEL_SCALE | NO_CLIENT_COLOR | KEEP_APART |RESET_TRANSFORM | RESET_ALPHA | RESET_COLOR
+	appearance_flags = PIXEL_SCALE | NO_CLIENT_COLOR | KEEP_APART | RESET_TRANSFORM | RESET_ALPHA | RESET_COLOR
 	var/datum/radial_menu/parent
 
 /atom/movable/screen/radial/slice


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

Specifically, this was done so that macro/micros don't have to deal with fucky radials when they're using the switchtool or whatever else. 

I don't think this will break anything. I've tested the switchtool on local testing and it seems fine.

## Why It's Good For The Game

Fix good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Radials no longer resize based on size of atom it's attached to.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
