### PR TITLE
Various changes relating to lunchboxes and species who use them

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -100,7 +100,8 @@
 	throw_force = 0
 
 /obj/item/storage/toolbox/lunchbox
-	max_storage_space = ITEMSIZE_COST_SMALL * 4 //slightly smaller than a toolbox
+	damage_force = 7
+	throw_force = 8
 	name = "rainbow lunchbox"
 	icon_state = "lunchbox_rainbow"
 	item_state_slots = list(SLOT_ID_RIGHT_HAND = "toolbox_pink", SLOT_ID_LEFT_HAND = "toolbox_pink")
@@ -203,10 +204,6 @@
 	icon_state = "lunchbox_survival"
 	item_state_slots = list(SLOT_ID_RIGHT_HAND = "toolbox_syndi", SLOT_ID_LEFT_HAND = "toolbox_syndi")
 	desc = "A little lunchbox. This one seems to be much sturdier than normal, made of a durable steel!"
-	max_storage_space = ITEMSIZE_COST_SMALL * 6
-
-/obj/item/storage/toolbox/lunchbox/survival/zaddat
-	starts_with = list(/obj/item/reagent_containers/hypospray/autoinjector/biginjector/glucose = 6)
 
 /obj/item/storage/toolbox/crystal
 	name = "crystalline toolbox"

--- a/code/modules/species/promethean/promethean.dm
+++ b/code/modules/species/promethean/promethean.dm
@@ -168,6 +168,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 
 	var/obj/item/storage/toolbox/lunchbox/L = new boxtype(get_turf(H))
 	new /obj/item/reagent_containers/food/snacks/candy/proteinbar(L)
+	new /obj/item/tool/prybar/red(L)
 	if(H.backbag == 1)
 		H.equip_to_slot_or_del(L, /datum/inventory_slot_meta/abstract/hand/right)
 	else

--- a/code/modules/species/station/standard/zaddat.dm
+++ b/code/modules/species/station/standard/zaddat.dm
@@ -107,7 +107,14 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/zaddat/(H), SLOT_ID_MASK) // mask has to come first or Shroud helmet will get in the way
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/space/void/zaddat/(H), SLOT_ID_SUIT)
 
-	var/obj/item/storage/toolbox/lunchbox/survival/zaddat/L = new(H)
+	var/obj/item/storage/toolbox/lunchbox/survival/L = new(H)
+	new /obj/item/reagent_containers/hypospray/autoinjector/biginjector/glucose(L)
+	new /obj/item/reagent_containers/hypospray/autoinjector/biginjector/glucose(L)
+	new /obj/item/reagent_containers/hypospray/autoinjector/biginjector/glucose(L)
+	new /obj/item/reagent_containers/hypospray/autoinjector/biginjector/glucose(L)
+	new /obj/item/reagent_containers/hypospray/autoinjector/biginjector/glucose(L)
+	new /obj/item/reagent_containers/hypospray/autoinjector/biginjector/glucose(L)
+	new /obj/item/tool/prybar/red(L)
 
 	if(H.backbag == 1)
 		H.put_in_hands_or_del(L)

--- a/code/modules/species/station/standard/zaddat.dm
+++ b/code/modules/species/station/standard/zaddat.dm
@@ -114,7 +114,6 @@
 	new /obj/item/reagent_containers/hypospray/autoinjector/biginjector/glucose(L)
 	new /obj/item/reagent_containers/hypospray/autoinjector/biginjector/glucose(L)
 	new /obj/item/reagent_containers/hypospray/autoinjector/biginjector/glucose(L)
-	new /obj/item/tool/prybar/red(L)
 
 	if(H.backbag == 1)
 		H.put_in_hands_or_del(L)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- All lunchboxes now have the same storage space as a box/toolbox would. They're boxes. So are the cardboard boxes.
- Lunchbox damage is nerfed to 7 melee, 8 thrown instead of 10/10 like a toolbox would have.
- Fixes a loadout bug relating to lunchboxes where people could obtain the Zaddat lunchbox by simply... removing the Zaddat variant of the lunchbox. Too lazy to make a blacklist.
- Zaddat's received glucose hypopens are relocated to when they get their survival gear equipped instead.
- Prometheans now start with a prybar.

## Why It's Good For The Game

- More storage space at the cost of no longer having a roundstart toolbox-damage weapon, whether it be given through being a specific species or via loadout. Not that that matters much on a server with no antags.
- Fixes good. No powergame shenanigans.
- Prometheans not having a prybar is prejudice. They need to pry open airlocks too after all.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Prometheans now start with a prybar.
balance: Lunchboxes can now fit 7 small items, or 14 tiny items. Same amount as a normal box would.
balance: Lunchboxes, being smaller versions of toolboxes, deal less damage than the robust toolbox would. 7 damage with melee, 8 damage when thrown.
fix: You can no longer select a specific lunchbox in the loadout that starts with 6 glucose hypos on top of the food you selected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
