### PR TITLE
Completely changes how DCS types works

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -14,6 +14,9 @@
 	 * Defines how duplicate existing components are handled when added to a datum
 	 *
 	 * See [COMPONENT_DUPE_*][COMPONENT_DUPE_ALLOWED] definitions for available options
+	 *
+	 * Dupe detection operates on registered_type. If you use components with subtypes,
+	 * you shouldn't be relying on dupe_mode or argument passing at all.
 	 */
 	var/dupe_mode = COMPONENT_DUPE_HIGHLANDER
 
@@ -28,6 +31,10 @@
 
 	/// The datum this components belongs to
 	var/datum/parent
+
+	/// the type we register at in the datum_components list; null = exact type
+	/// this is also the type used for detection with dupe_mode.
+	var/registered_type
 
 	/**
 	 * Only set to true if you are able to properly transfer this component
@@ -88,34 +95,18 @@
 	var/datum/P = parent
 	//lazy init the parent's dc list
 	var/list/dc = P.datum_components
-	if(!dc)
+	if(isnull(dc))
 		P.datum_components = dc = list()
 
 	//set up the typecache
-	var/our_type = type
-	for(var/I in _GetInverseTypeList(our_type))
-		var/test = dc[I]
-		if(test) //already another component of this type here
-			var/list/components_of_type
-			if(!length(test))
-				components_of_type = list(test)
-				dc[I] = components_of_type
-			else
-				components_of_type = test
-			if(I == our_type) //exact match, take priority
-				var/inserted = FALSE
-				for(var/J in 1 to components_of_type.len)
-					var/datum/component/C = components_of_type[J]
-					if(C.type != our_type) //but not over other exact matches
-						components_of_type.Insert(J, I)
-						inserted = TRUE
-						break
-				if(!inserted)
-					components_of_type += src
-			else //indirect match, back of the line with ya
-				components_of_type += src
-		else //only component of this type, no list
-			dc[I] = src
+	var/our_type = isnull(registered_type)? type : registered_type
+	var/list/existing = dc[our_type]
+	if(length(existing))
+		existing += src
+	else if(!isnull(existing))
+		dc[our_type] = list(existing, src)
+	else
+		dc[our_type] = src
 
 	RegisterWithParent()
 
@@ -125,21 +116,17 @@
 /datum/component/proc/_RemoveFromParent()
 	var/datum/parent = src.parent
 	var/list/parents_components = parent.datum_components
-	for(var/I in _GetInverseTypeList())
-		var/list/components_of_type = parents_components[I]
+	var/our_type = isnull(registered_type)? type : registered_type
+	var/list/existing = parents_components[our_type]
+	if(length(existing))
+		existing -= src
+		if(length(existing) == 1)
+			parents_components[our_type] = existing[1]
+		// we don't check for 0 because joinwithparent only makes a list if len >= 2
+	else
+		parents_components -= our_type
 
-		if(length(components_of_type)) //
-			var/list/subtracted = components_of_type - src
-
-			if(subtracted.len == 1) //only 1 guy left
-				parents_components[I] = subtracted[1] //make him special
-			else
-				parents_components[I] = subtracted
-
-		else //just us
-			parents_components -= I
-
-	if(!parents_components.len)
+	if(!length(parents_components))
 		parent.datum_components = null
 
 	UnregisterFromParent()
@@ -310,18 +297,6 @@
 	return COMPONENT_INCOMPATIBLE //Do not support transfer by default as you must properly support it
 
 /**
- * Internal proc to create a list of our type and all parent types
- */
-/datum/component/proc/_GetInverseTypeList(our_type = type)
-	//we can do this one simple trick
-	var/current_type = parent_type
-	. = list(our_type, current_type)
-	//and since most components are root level + 1, this won't even have to run
-	while (current_type != /datum/component)
-		current_type = type2parent(current_type)
-		. += current_type
-
-/**
  * Internal proc to handle most all of the signaling procedure
  *
  * Will runtime if used on datums with an empty component list
@@ -347,43 +322,15 @@
 /**
  * Return any component assigned to this datum of the given type
  *
- * This will throw an error if it's possible to have more than one component of that type on the parent
+ * If it has a registered type, that'll be used instead!
  *
  * Arguments:
- * * datum/component/c_type The typepath of the component you want to get a reference to
+ * * datum/component/c_type The type of the component you want to get a reference to. It will be overridden with the type of its [registered_type] if it's set.
  */
 /datum/proc/GetComponent(datum/component/c_type)
 	RETURN_TYPE(c_type)
-	//? Don't use the cycles to check; assume they aren't going to screw up.
-	//? If you're screwing up and you're reading this, please reevaluate why you're using GetComponent.
-	// if(initial(c_type.dupe_mode) == COMPONENT_DUPE_ALLOWED || initial(c_type.dupe_mode) == COMPONENT_DUPE_SELECTIVE)
-	// 	stack_trace("GetComponent was called to get a component of which multiple copies could be on an object. This can easily break and should be changed. Type: \[[c_type]\]")
-	. = datum_components?[c_type]
+	. = datum_components?[initial(c_type.registered_type)]
 	return . && (length(.) ? .[1] : .)
-
-// The type arg is casted so initial works, you shouldn't be passing a real instance into this
-/**
- * Return any component assigned to this datum of the exact given type
- *
- * This will throw an error if it's possible to have more than one component of that type on the parent
- *
- * Arguments:
- * * datum/component/c_type The typepath of the component you want to get a reference to
- */
-/datum/proc/GetExactComponent(datum/component/c_type)
-	RETURN_TYPE(c_type)
-	if(initial(c_type.dupe_mode) == COMPONENT_DUPE_ALLOWED || initial(c_type.dupe_mode) == COMPONENT_DUPE_SELECTIVE)
-		stack_trace("GetComponent was called to get a component of which multiple copies could be on an object. This can easily break and should be changed. Type: \[[c_type]\]")
-	var/list/dc = datum_components
-	if(!dc)
-		return null
-	var/datum/component/C = dc[c_type]
-	if(C)
-		if(length(C))
-			C = C[1]
-		if(C.type == c_type)
-			return C
-	return null
 
 /**
  * Get all components of a given type that are attached to this datum
@@ -414,11 +361,13 @@
 	var/new_type = raw_args[1]
 	var/datum/component/nt = new_type
 
+	// todo: rewrite this proc; we already horribly changed component behavior
+	// e.g. dupe behavior is entirely changed and needs to be rethought, probably.
+
 	if(QDELING(src))
 		CRASH("Attempted to add a new component of type \[[nt]\] to a qdeleting parent of type \[[type]\]!")
 
 	var/dm = initial(nt.dupe_mode)
-	var/dt = initial(nt.dupe_type)
 
 	var/datum/component/old_comp
 	var/datum/component/new_comp
@@ -433,10 +382,7 @@
 	raw_args[1] = src
 
 	if(dm != COMPONENT_DUPE_ALLOWED && dm != COMPONENT_DUPE_SELECTIVE)
-		if(!dt)
-			old_comp = GetExactComponent(nt)
-		else
-			old_comp = GetComponent(dt)
+		old_comp = GetComponent(nt)
 		if(old_comp)
 			switch(dm)
 				if(COMPONENT_DUPE_UNIQUE)
@@ -464,7 +410,7 @@
 		var/list/arguments = raw_args.Copy()
 		arguments[1] = new_comp
 		var/make_new_component = TRUE
-		for(var/datum/component/existing_component as anything in GetComponents(new_type))
+		for(var/datum/component/existing_component as anything in GetComponents(initial(nt.registered_type)))
 			if(existing_component.CheckDupeComponent(arglist(arguments)))
 				make_new_component = FALSE
 				QDEL_NULL(new_comp)
@@ -494,25 +440,29 @@
 		return _AddComponent(arguments)
 
 /**
- * qdels a component of given type, or exact
+ * qdels a component of given registered type,
+ * optionally filtering to a subtype to make sure it's the right one
  */
-/datum/proc/DelComponent(path, exact)
-	var/list/L = datum_components[path]
-	var/datum/component/C
-	if(!L)
+/datum/proc/DelComponent(registered_type, filter_type)
+	var/list/val = datum_components?[registered_type]
+	if(isnull(val))
 		return FALSE
-	if(!islist(L))
-		C = L
-		if(exact && C.type != path)
-			return FALSE
+	var/datum/component/potential
+	if(length(val))
+		for(potential as anything in val)
+			if(isnull(filter_type))
+				qdel(potential)
+				return TRUE
+			else if(istype(potential, filter_type))
+				qdel(potential)
+				return TRUE
+		return FALSE
 	else
-		for(var/datum/component/C2 as anything in L)
-			if(exact? (C2.type == path) : istype(C2, path))
-				C = C2
-	if(!C)
-		return FALSE
-	qdel(C)
-	return TRUE
+		potential = val
+		if(!isnull(filter_type) && !istype(potential, filter_type))
+			return FALSE
+		qdel(potential)
+		return TRUE
 
 /**
  * Removes the component from parent, ends up with a null parent
@@ -561,17 +511,17 @@
  */
 /datum/proc/TransferComponents(datum/target)
 	var/list/dc = datum_components
-	if(!dc)
+	if(isnull(dc))
 		return
-	var/comps = dc[/datum/component]
-	if(islist(comps))
-		for(var/datum/component/I in comps)
-			if(I.can_transfer)
-				target.TakeComponent(I)
-	else
-		var/datum/component/C = comps
-		if(C.can_transfer)
-			target.TakeComponent(comps)
+	for(var/key in dc)
+		if(length(key))
+			for(var/datum/component/thing as anything in dc[key])
+				if(thing.can_transfer)
+					target.TakeComponent(thing)
+		else
+			var/datum/component/val = dc[key]
+			if(val.can_transfer)
+				target.TakeComponent(val)
 
 /**
  * Return the object that is the host of any UI's that this component has

--- a/code/datums/components/atoms/fishing_spot.dm
+++ b/code/datums/components/atoms/fishing_spot.dm
@@ -1,5 +1,7 @@
 // A thing you can fish in
 /datum/component/fishing_spot
+	registered_type = /datum/component/fishing_spot
+	
 	/// Defines the probabilities and fish availibilty
 	var/datum/fish_source/fish_source
 

--- a/code/datums/components/atoms/radioactive.dm
+++ b/code/datums/components/atoms/radioactive.dm
@@ -5,6 +5,7 @@
 
 /datum/component/radioactive
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+	registered_type = /datum/component/radioactive
 
 	/// half life in deciseconds
 	var/hl3_release_date

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -15,6 +15,8 @@
 	RegisterSignal(C, COMSIG_CLICK, PROC_REF(component_ui_interact))
 
 /datum/component/personal_crafting
+	registered_type = /datum/component/personal_crafting
+
 	var/busy
 	var/viewing_category = 1 //typical powergamer starting on the Weapons tab
 	var/viewing_subcategory = 1

--- a/code/datums/components/gps_signal.dm
+++ b/code/datums/components/gps_signal.dm
@@ -34,6 +34,7 @@ GLOBAL_LIST_EMPTY(gps_transmitters)
  */
 /datum/component/gps_signal
 	dupe_mode = COMPONENT_DUPE_ALLOWED
+	registered_type = /datum/component/gps_signal
 	/// our gps tag
 	var/gps_tag
 	/// disabled

--- a/code/datums/components/items/wielding.dm
+++ b/code/datums/components/items/wielding.dm
@@ -1,5 +1,7 @@
 // todo: can element this by usign 3 signals instead of 2, one to receive a keybind signal.
 /datum/component/wielding
+	registered_type = /datum/component/wielding
+	
 	/// hands needed
 	var/hands
 	/// lazylist

--- a/code/datums/components/movable/aquarium.dm
+++ b/code/datums/components/movable/aquarium.dm
@@ -1,5 +1,7 @@
 /// Allows movables to be inserted/displayed in aquariums.
 /datum/component/aquarium_content
+	registered_type = /datum/component/aquarium_content
+	
 	/// Keeps track of our current aquarium.
 	var/obj/structure/aquarium/current_aquarium
 

--- a/code/datums/components/riding/riding_filter.dm
+++ b/code/datums/components/riding/riding_filter.dm
@@ -25,7 +25,7 @@
 	//? disabled as we don't have dupe handling
 	can_transfer = FALSE
 	dupe_mode = COMPONENT_DUPE_UNIQUE
-	dupe_type = /datum/component/riding_filter
+	registered_type = /datum/component/riding_filter
 	/// filter flags
 	var/riding_filter_flags = CF_RIDING_FILTER_AUTO_BUCKLE_TOGGLE
 	/// expected typepath of what we're to be filtering for

--- a/code/datums/components/riding/riding_handler.dm
+++ b/code/datums/components/riding/riding_handler.dm
@@ -10,7 +10,7 @@
 	//? disabled as we don't have dupe handling
 	can_transfer = FALSE
 	dupe_mode = COMPONENT_DUPE_UNIQUE
-	dupe_type = /datum/component/riding_handler
+	registered_type = /datum/component/riding_handler
 	//! main
 	/// expected typepath of what we're handling for
 	var/expected_typepath = /atom/movable

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -24,8 +24,7 @@
 
 	/**
 	 * Components attached to this datum
-	 *
-	 * Lazy associated list in the structure of `type:component/list of components`
+	 * Lazy assoclist of type -> component reference or list of component references
 	 */
 	var/list/datum_components
 	/**
@@ -111,17 +110,16 @@
 	#endif
 
 	//BEGIN: ECS SHIT
-	var/list/dc = datum_components
-	if(dc)
-		var/all_components = dc[/datum/component]
-		if(length(all_components))
-			for(var/datum/component/component as anything in all_components)
-				qdel(component, FALSE, TRUE)
-		else
-			var/datum/component/C = all_components
-			qdel(C, FALSE, TRUE)
-		dc.Cut()
-
+	if(!isnull(datum_components))
+		var/list/dc = datum_components
+		for(var/path in dc)
+			var/list/what = dc[path]
+			if(length(what))
+				for(var/thing in what)
+					qdel(thing, FALSE, TRUE)
+			else
+				qdel(what)
+		datum_components = null
 	clear_signal_refs()
 	//END: ECS SHIT
 	return QDEL_HINT_QUEUE

--- a/code/modules/mob/living/simple_mob/subtypes/lavaland/gutshank.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/lavaland/gutshank.dm
@@ -210,7 +210,7 @@
 	if(istype(O, /obj/item/tool/wirecutters) && rideable)
 		to_chat(user, "<span class='danger'>You nip the straps of the [O]! It falls off of the [src].</span>")
 		rideable = 0
-		DelComponent(/datum/component/riding_handler/shank)
+		DelComponent(/datum/component/riding_handler, /datum/component/riding_handler/shank)
 		var/turf/T = get_turf(src)
 		new /obj/item/saddle/shank(T)
 	if(istype(O, /obj/item/pen/charcoal) && rideable)

--- a/code/modules/mob/living/simple_mob/subtypes/lavaland/stormdrifter.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/lavaland/stormdrifter.dm
@@ -160,7 +160,7 @@
 		to_chat(user, "<span class='danger'>You nip the straps of the [O]! It falls off of the [src].</span>")
 		rideable = 0
 		buckle_allowed = FALSE
-		DelComponent(/datum/component/riding_handler/stormdrifter_bull)
+		DelComponent(/datum/component/riding_handler, /datum/component/riding_handler/stormdrifter_bull)
 		var/turf/T = get_turf(src)
 		new /obj/item/saddle/stormdrifter(T)
 	if(istype(O, /obj/item/pen/charcoal) && rideable)

--- a/code/modules/mob/living/simple_mob/subtypes/vore/corrupt_hounds.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/corrupt_hounds.dm
@@ -109,7 +109,7 @@
 
 /mob/living/simple_mob/vore/aggressive/corrupthound/Logout()
 	. = ..()
-	DelComponent(/datum/component/riding_filter/mob/animal, exact = TRUE)
+	DelComponent(/datum/component/riding_filter, /datum/component/riding_filter/mob/animal)
 
 /mob/living/simple_mob/vore/aggressive/corrupthound/MouseDroppedOnLegacy(mob/living/M, mob/living/user)
 	return

--- a/code/modules/mob/living/simple_mob/subtypes/vore/horse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/horse.dm
@@ -86,7 +86,7 @@
 	if(istype(O, /obj/item/tool/wirecutters) && rideable)
 		to_chat(user, "<span class='danger'>You nip the straps of the [O]! It falls off of the [src].</span>")
 		rideable = 0
-		DelComponent(/datum/component/riding_handler/horse)
+		DelComponent(/datum/component/riding_handler, /datum/component/riding_handler/horse)
 		var/turf/T = get_turf(src)
 		new /obj/item/saddle/horse(T)
 	update_icon()

--- a/code/modules/mob/living/simple_mob/subtypes/vore/otie.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/otie.dm
@@ -266,7 +266,7 @@
 
 /mob/living/simple_mob/otie/Logout()
 	. = ..()
-	DelComponent(/datum/component/riding_filter/mob/animal)
+	DelComponent(/datum/component/riding_filter, /datum/component/riding_filter/mob/animal)
 
 /mob/living/simple_mob/otie/MouseDroppedOnLegacy(mob/living/M, mob/living/user)
 	return


### PR DESCRIPTION
DCS now registers based on its registered type, as opposed to at every subtype.
Dupe mode is no longer considered realistically usable unless if-and-only-if all var pre-setting behavior is considered - which is not the case on the majority of citrp-made components outside of /datum/component/radioactive

## Why?

Components are a generic way to attach datums to things.
The common practices included:
- No getcomponent
- Use signals for all interaction
- Don't subtype, set vars on initialization

This resulted in components, while being quite stable, being also quite rigid, in my opinion. Given we don't use components for the same things, and probably never will, I think it's better for us to get the optimizations from not supporting what's honestly behavior that we shouldn't rely on in the first place - if something needs to be applied multiple times (e.g. radiation) it should rely on the old behavior and this new system still allows it. If it doesn't, the author should either not be adding the component multiple times, or **making** their component functional under this system. InheritComponent still has all the tools necessary to properly do component inheritance, it's just now we default to all components only being considered the same if it's the exact subtype - which from what I could see, is also the previous case (as if you add a subtype, uh, bad shit's going to happen if the base type is registered but not the subtype anyways!)