### PR TITLE
robotic remains now turn to ash when interacted with like all other remains

### DIFF
--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -61,6 +61,3 @@
 	if (istype(F))
 		new /obj/effect/debris/cleanable/ash(F)
 	qdel(src)
-
-/obj/effect/decal/remains/robot/attack_hand(mob/user, list/params)
-	return


### PR DESCRIPTION
## About The Pull Request
title
at whoever did this: want them to not turn into ash? add a different sprite instead of just breaking this item

## Why It's Good For The Game
fixes a bug

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: robotic remains now turn to ash when interacted with like all other remains
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
