### PR TITLE
Fixes climbing interruptions letting you climb anyway

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -277,7 +277,7 @@
 		. = FALSE
 	LAZYREMOVE(climbing, climber)
 	STOP_INTERACTING_WITH(climber, src, INTERACTING_FOR_CLIMB)
-	if(!allow_climb_on(climber))
+	if(!. || !allow_climb_on(climber))
 		climber.action_feedback(SPAN_WARNING("You couldn't climb onto [src]!"), src)
 		return FALSE
 	do_climb_on(climber)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Hold something in one hand, start climbing, swap hand, you will instantly climb onto the thing you're trying to climb. Any and all interruptions to climbing will cause instant climbing instead of preventing climbing.

## Why It's Good For The Game

Kind of an obviously dumb exploit.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Climbing no longer succeeds if interrupted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
