### PR TITLE
Fixes and creates variants of the Opaque Gas Mask

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -146,7 +146,7 @@
 
 /obj/item/clothing/mask/gas/opaque_nitrogen
 	name = "Opaque Mask - Oxygen Filter"
-	desc = "A face-covering mask with an opaque faceplate that can be connected to an air supply, often used by various alien races to filter out oxygen.""
+	desc = "A face-covering mask with an opaque faceplate that can be connected to an air supply, often used by various alien races to filter out oxygen."
 	icon_state = "opaque_mask"
 	inv_hide_flags = null
 	filtered_gases = list(GAS_ID_PHORON, GAS_ID_NITROUS_OXIDE, GAS_ID_OXYGEN)

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -140,11 +140,16 @@
 
 /obj/item/clothing/mask/gas/opaque
 	name = "Opaque Mask"
-	desc = "A face-covering mask with an opaque faceplate that can be connected to an air supply, often used by various alien races to filter out oxygen."
+	desc = "A face-covering mask with an opaque faceplate that can be connected to an air supply. Despite being stripped of all advanced technolgy, it still seems airtight."
 	icon_state = "opaque_mask"
 	inv_hide_flags = null
-	filtered_gases = list(/datum/gas/phoron, /datum/gas/nitrous_oxide, /datum/gas/oxygen)
 
+/obj/item/clothing/mask/gas/opaque_nitrogen
+	name = "Opaque Mask - Oxygen Filter"
+	desc = "A face-covering mask with an opaque faceplate that can be connected to an air supply, often used by various alien races to filter out oxygen.""
+	icon_state = "opaque_mask"
+	inv_hide_flags = null
+	filtered_gases = list(GAS_ID_PHORON, GAS_ID_NITROUS_OXIDE, GAS_ID_OXYGEN)
 
 /obj/item/clothing/mask/gas/syndicate
 	name = "tactical mask"

--- a/code/modules/loadout/loadout_mask.dm
+++ b/code/modules/loadout/loadout_mask.dm
@@ -57,3 +57,7 @@
 /datum/loadout_entry/mask/opaque
 	name = "Opaque Mask"
 	path = /obj/item/clothing/mask/gas/opaque
+
+/datum/loadout_entry/mask/opaque_nitrogen
+	name = "Opaque Mask - Oxygen Filter"
+	path = /obj/item/clothing/mask/gas/opaque_nitrogen


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Finally splits the opaque gas mask into one without any gas being filtered out, and one which is designed for nitrogen breathers.

## Why It's Good For The Game

People requested the opaque mask be given a no-filter version for a long while but nobody even tried to do it. Also brings the filter list up to date.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: New variant of the Opaque Mask
fix: Fixes gas paths for the Filtered version
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
