### PR TITLE
Replaces Surt Emergency Double Airlock

### DIFF
--- a/maps/sectors/lavaland_192/levels/lavaland_192.dmm
+++ b/maps/sectors/lavaland_192/levels/lavaland_192.dmm
@@ -894,10 +894,10 @@
 	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	internal_pressure_bound_default = 4000;
+	on = 1;
 	pressure_checks = 2;
 	pressure_checks_default = 2;
-	pump_direction = 0;
-	on = 1
+	pump_direction = 0
 	},
 /turf/simulated/floor/reinforced/airmix,
 /area/lavaland/central/base/common)
@@ -1553,7 +1553,7 @@
 /turf/simulated/wall/r_wall,
 /area/lavaland/central/base/common)
 "Em" = (
-/obj/machinery/door/firedoor/multi_tile{
+/obj/machinery/door/firedoor{
 	req_one_access = list(48)
 	},
 /obj/machinery/door/airlock/multi_tile/glass{
@@ -1906,6 +1906,14 @@
 	},
 /turf/simulated/floor/outdoors/lava/lavaland,
 /area/lavaland/central/explored)
+"Ot" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	req_one_access = list(48)
+	},
+/turf/simulated/floor/tiled,
+/area/lavaland/central/base/common)
 "Ow" = (
 /obj/machinery/button/remote/airlock{
 	id = "mine_orange";
@@ -11865,7 +11873,7 @@ EX
 db
 ZZ
 QR
-QR
+Ot
 QR
 La
 QR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Replaces Surt Emergency Double Airlock.**

## Why It's Good For The Game

1. _These airlocks are no longer using the same sprites as they used to, and that makes the airlock functionally invisible. This removes the double and places in two new shutters._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Replaces Surt emergency double airlock.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
