### PR TITLE
makes sonar pulses cooldown faster

### DIFF
--- a/code/modules/species/abilites.dm
+++ b/code/modules/species/abilites.dm
@@ -5,7 +5,7 @@
 	name = "Sonar Ping"
 	desc = "You send out a echolocating pulse, briefly showing your environment past the visible"
 	action_state = "shield"
-	cooldown = 8 SECONDS
+	cooldown = 2 SECONDS
 	always_bind = TRUE
 
 /datum/ability/species/sonar/unavailable_reason()


### PR DESCRIPTION
remember that sonar only persists for like a half second
if we boost the image persist time we should make this slower but uh, it's kind of hard to use without