### PR TITLE
removes automatic material scaling on /obj/item/material

### DIFF
--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -39,12 +39,6 @@
 		qdel(src)
 		return
 
-	materials = material.get_matter()
-	if(materials.len)
-		for(var/material_type in materials)
-			if(!isnull(materials[material_type]))
-				materials[material_type] *= force_divisor // May require a new var instead.
-
 	if(!(material.conductive))
 		src.atom_flags |= NOCONDUCT
 


### PR DESCRIPTION
i don't know who thought this was a good idea but this makes no sense and is shitty, and interferes with a lot of autodetection.