### PR TITLE
Removes wolfgirl crates from Cargo

### DIFF
--- a/code/modules/cargo/supplypacks/contraband.dm
+++ b/code/modules/cargo/supplypacks/contraband.dm
@@ -140,13 +140,6 @@
 	contraband = 1
 	group = "Supplies"
 
-/datum/supply_pack/supply/wolfgirl
-	name = "Wolfgirl Crate"
-	cost = 200 //I mean, it's a whole wolfgirl
-	container_type = /obj/structure/largecrate/animal/wolfgirl
-	container_name = "Wolfgirl crate"
-	contraband = 1
-
 /datum/supply_pack/supply/medieval
 	name = "Knight set crate"
 	contains = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

no more awoo.

Specifically this just removes the wolfgirl crate from being orderable by Cargo. It doesn't remove wolfgirls from the code, so maybe admemes can spawn them still.

## Why It's Good For The Game

you can debate the ethics of orderable humanoids in a different world. It ain't happening here, even if it's contraband.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: The wolfgirl crate is no longer orderable from Cargo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
