### PR TITLE
Re-adds security RIGsuits

### DIFF
--- a/maps/tether/levels/surface2.dmm
+++ b/maps/tether/levels/surface2.dmm
@@ -8079,7 +8079,7 @@
 /obj/random/maintenance/engineering,
 /obj/effect/floor_decal/rust,
 /obj/item/clothing/suit/storage/vest/hoscoat/jensen{
-	armor = list("melee"=0,"bullet"=0,"laser"=0,"energy"=0,"bomb"=0,"bio"=0,"rad"=0);
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0);
 	desc = "Its an old, dusty trenchcoat... what a shame.";
 	name = "trenchcoat"
 	},
@@ -20723,7 +20723,7 @@
 /obj/machinery/vending/cigarette{
 	name = "Cigarette machine";
 	prices = list();
-	products = list(/obj/item/storage/fancy/cigarettes=10,/obj/item/storage/box/matches=10,/obj/item/flame/lighter/zippo=4,/obj/item/clothing/mask/smokable/cigarette/cigar/havana=2)
+	products = list(/obj/item/storage/fancy/cigarettes = 10, /obj/item/storage/box/matches = 10, /obj/item/flame/lighter/zippo = 4, /obj/item/clothing/mask/smokable/cigarette/cigar/havana = 2)
 	},
 /obj/effect/floor_decal/techfloor/hole{
 	dir = 1
@@ -32254,6 +32254,9 @@
 	pixel_y = -28
 	},
 /obj/structure/cable/green,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/hardsuit/hazard/equipped,
+/obj/item/hardsuit/hazard/equipped,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "xnd" = (
@@ -33390,7 +33393,7 @@
 	input_tag = "atmos_out";
 	name = "Atmos Intake Control";
 	output_tag = "atmos_in";
-	sensors = list("atmos_intake"="Tank")
+	sensors = list("atmos_intake" = "Tank")
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/monitoring)

--- a/maps/tether/levels/surface3.dmm
+++ b/maps/tether/levels/surface3.dmm
@@ -881,11 +881,11 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/iaa)
 "atO" = (
-/mob/living/simple_mob/animal/passive/cow,
 /obj/machinery/air_alarm{
 	dir = 8;
 	pixel_x = 24
 	},
+/mob/living/simple_mob/animal/passive/cow,
 /turf/simulated/floor/grass,
 /area/hydroponics/cafegarden)
 "atT" = (
@@ -2409,6 +2409,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/suit/space/void/headofsecurity,
 /obj/item/clothing/head/helmet/space/void/headofsecurity,
+/obj/item/hardsuit/hazard/equipped,
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/security/hos)
 "biw" = (

--- a/maps/triumph/levels/deck4.dmm
+++ b/maps/triumph/levels/deck4.dmm
@@ -7316,13 +7316,13 @@
 /obj/structure/dogbed{
 	name = "pet bed"
 	},
-/mob/living/simple_mob/animal/passive/dog/corgi/Ian,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
 	},
+/mob/living/simple_mob/animal/passive/dog/corgi/Ian,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hop)
 "ePi" = (
@@ -11958,7 +11958,6 @@
 /area/triumph/surfacebase/sauna)
 "ibD" = (
 /obj/structure/dogbed,
-/mob/living/simple_mob/animal/passive/dog/pug/SirPogsley,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -11967,6 +11966,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
+/mob/living/simple_mob/animal/passive/dog/pug/SirPogsley,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
 "ibU" = (
@@ -12182,6 +12182,7 @@
 /obj/machinery/ai_status_display{
 	pixel_y = 32
 	},
+/obj/item/hardsuit/hazard/equipped,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
 "iju" = (
@@ -17152,7 +17153,6 @@
 /turf/simulated/floor/tiled,
 /area/security/hanger)
 "lDa" = (
-/mob/living/simple_mob/animal/passive/mimepet,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -17161,6 +17161,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
+/mob/living/simple_mob/animal/passive/mimepet,
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/mimeoffice)
 "lDo" = (
@@ -30525,19 +30526,12 @@
 	dir = 8
 	},
 /obj/machinery/door/window/northleft{
-	name = "Hardsuit Storage";
+	name = "RIG Storage";
 	req_access = list(1,2,18)
 	},
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/void/security,
-/obj/item/clothing/suit/space/void/security,
-/obj/item/clothing/head/helmet/space/void/security,
-/obj/item/clothing/head/helmet/space/void/security,
 /obj/structure/window/reinforced,
 /obj/machinery/light,
+/obj/item/hardsuit/hazard/equipped,
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "uXy" = (
@@ -34560,6 +34554,22 @@
 /obj/effect/mist,
 /turf/simulated/floor/wood,
 /area/triumph/surfacebase/sauna)
+"xIe" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.6
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/northright{
+	name = "RIG Storage";
+	req_access = list(1,2,18)
+	},
+/obj/structure/window/reinforced,
+/obj/item/hardsuit/hazard/equipped,
+/turf/simulated/floor/tiled,
+/area/security/eva)
 "xIk" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
@@ -43873,7 +43883,7 @@ xDy
 kOM
 arT
 arT
-xmj
+xIe
 xDy
 sAS
 bzE


### PR DESCRIPTION
:cl:
add: Triumph: Removes four security voidsuits from the security EVA storage and replaces them with two hazard rigsuits. Adds one hazard rigsuit to the HoS' EVA storage.
add: Tether: Adds two hazard rigsuits to the level 1 (blue) armoury. Adds one hazard rigsuit to the HoS' EVA storage.
/:cl:
