### PR TITLE
Rearranges Surt Jump Pads For Accessibility

### DIFF
--- a/maps/rift/levels/rift-02-underground2.dmm
+++ b/maps/rift/levels/rift-02-underground2.dmm
@@ -644,11 +644,6 @@
 /obj/machinery/camera/network/engineering,
 /turf/simulated/floor,
 /area/maintenance/substation/engineering)
-"bF" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
 "bG" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/rift/turbolift/maint)
@@ -705,6 +700,15 @@
 "bQ" = (
 /turf/simulated/wall/r_wall/prepainted/engineering,
 /area/engineering/engine_core)
+"bR" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/miningdock)
 "bT" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/paper_bin,
@@ -1050,6 +1054,13 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_room)
+"cZ" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "da" = (
 /turf/simulated/wall/prepainted/engineering,
 /area/engineering/engine_smes)
@@ -1600,6 +1611,13 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/heads/chief)
+"eA" = (
+/obj/machinery/door/airlock/glass/mining{
+	name = "Mining Operations";
+	req_one_access = list(1,5,31,38,47,48)
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/miningdock)
 "eB" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 10
@@ -1721,6 +1739,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor,
 /area/engineering/engine_room)
+"eS" = (
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/turf/simulated/floor/plating,
+/area/quartermaster/miningdock)
 "eT" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -2074,6 +2096,15 @@
 /area/crew_quarters/public_bunker)
 "fY" = (
 /obj/effect/floor_decal/borderfloor,
+/turf/simulated/floor/tiled/steel,
+/area/hallway/primary/undertwo)
+"fZ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/undertwo)
 "ga" = (
@@ -3128,8 +3159,8 @@
 	icon_state = "map_vent_in";
 	id_tag = "cooling_out";
 	initialize_directions = 4;
-	pump_direction = 0;
-	on = 1
+	on = 1;
+	pump_direction = 0
 	},
 /turf/simulated/floor/reinforced/nitrogen{
 	initial_gas_mix = "n2=82.1472;TEMP=293.15"
@@ -3219,6 +3250,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel,
+/area/quartermaster/miningdock)
+"jx" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/miningdock)
 "jy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -3438,6 +3475,9 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
 	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/undertwo)
 "jT" = (
@@ -3600,9 +3640,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/undertwo)
 "ki" = (
-/obj/machinery/camera/network/engineering{
-	dir = 2
-	},
+/obj/machinery/camera/network/engineering,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -4144,9 +4182,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/camera/network/engineering{
-	dir = 2
-	},
+/obj/machinery/camera/network/engineering,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -4230,15 +4266,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/hallway/primary/undertwo)
-"mb" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel,
@@ -4714,6 +4741,12 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/hallway)
+"nh" = (
+/obj/effect/floor_decal/rust,
+/obj/random/trash_pile,
+/obj/structure/railing,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "ni" = (
 /obj/machinery/door/airlock{
 	name = "Cryogenics Access"
@@ -5069,7 +5102,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloor/corner2{
-	dir = 5
+	dir = 6
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/undertwo)
@@ -5123,7 +5156,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/toilet,
@@ -5274,6 +5306,14 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/undertwo)
+"oA" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/floor_decal/rust,
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "oG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -6165,42 +6205,28 @@
 /turf/simulated/floor/tiled,
 /area/rnd/secure_storage/critical)
 "rp" = (
-/obj/structure/girder,
-/obj/effect/overlay/snow/floor/pointy{
+/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/miningdock)
 "rq" = (
-/obj/effect/overlay/snow/floor/edges{
-	dir = 5
-	},
-/obj/effect/overlay/snow/floor,
-/obj/item/reagent_containers/syringe/drugs{
-	pixel_x = -12;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/syringe/steroid{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
-"rr" = (
-/obj/effect/overlay/snow/floor/edges{
-	dir = 4
-	},
-/obj/effect/overlay/snow/floor,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
-"rs" = (
-/obj/structure/girder/displaced,
-/obj/effect/overlay/snow/wall{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/effect/overlay/snow/wall{
-	dir = 8
+/obj/machinery/camera/network/mining{
+	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/miningdock)
+"rs" = (
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
 "rt" = (
@@ -6210,13 +6236,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering/pumpstation)
-"ru" = (
-/obj/structure/girder,
-/obj/effect/overlay/snow/wall{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
 "rv" = (
 /turf/simulated/mineral,
 /area/rift/surfacebase/underground/under2)
@@ -6361,6 +6380,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rift/station/stairs_one)
+"rT" = (
+/obj/effect/overlay/snow/floor/surround,
+/obj/effect/overlay/snow/floor,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "rU" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/steel_grid,
@@ -6396,7 +6420,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/bed/padded,
@@ -6417,9 +6440,6 @@
 	},
 /obj/effect/floor_decal/borderfloor/corner2,
 /obj/machinery/disposal,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -6465,7 +6485,6 @@
 "se" = (
 /obj/machinery/power/emitter,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
@@ -6561,6 +6580,11 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_airlock)
+"sy" = (
+/obj/effect/overlay/snow/floor,
+/obj/structure/girder/displaced,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "sz" = (
 /obj/spawner/window/low_wall/borosillicate/reinforced/full/firelocks,
 /obj/effect/paint/sun,
@@ -6926,11 +6950,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/secure_storage/lower)
 "tL" = (
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Operations";
-	req_access = list(31);
-	req_one_access = list()
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -6938,6 +6957,22 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/cargo{
+	req_access = list(50);
+	req_one_access = list(48)
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/miningdock)
+"tM" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningdock)
 "tN" = (
@@ -7009,13 +7044,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/chapel/office)
-"uc" = (
-/obj/effect/overlay/snow/floor,
-/obj/effect/overlay/snow/floor/edges{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/rift/surfacebase/underground/under2)
 "ud" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -7088,8 +7116,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/miningdock)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "us" = (
 /turf/simulated/wall/prepainted/engineering,
 /area/engineering/locker_room)
@@ -7160,6 +7189,13 @@
 "uG" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/belterdock/gear)
+"uH" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/rift/surfacebase/underground/under2)
 "uI" = (
 /obj/structure/railing{
 	dir = 4
@@ -7222,9 +7258,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/miningdock)
-"uT" = (
-/obj/effect/overlay/snow/floor/pointy{
-	dir = 4
+"uS" = (
+/obj/structure/closet/crate,
+/obj/random/maintenance,
+/obj/random/maintenance/engineering,
+/obj/structure/railing{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
@@ -7377,13 +7416,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"vH" = (
-/obj/machinery/door/airlock/maintenance/cargo{
-	req_access = list(50);
-	req_one_access = list(48)
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/miningdock)
 "vI" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -7435,6 +7467,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/secure_storage/lower)
+"vR" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/miningdock)
 "vT" = (
 /obj/effect/floor_decal/chapel{
 	dir = 4
@@ -7526,6 +7567,13 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/railing,
 /turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/mining)
+"wk" = (
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
 "wm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7845,13 +7893,6 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
-"xv" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
 "xw" = (
 /obj/structure/railing{
 	dir = 8
@@ -7870,6 +7911,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_eva)
+"xy" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "xz" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -7881,7 +7928,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/glass{
-	dir = 2;
 	req_one_access = list(18,47)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8138,12 +8184,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "yl" = (
-/obj/structure/railing,
-/obj/structure/closet/crate,
-/obj/random/maintenance/engineering,
-/obj/random/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/fire{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/storage/firstaid{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/miningdock)
 "ym" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -8409,7 +8463,6 @@
 	dir = 5
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8589,6 +8642,7 @@
 /obj/structure/railing,
 /obj/structure/table/rack,
 /obj/random/maintenance/cargo,
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
 "AD" = (
@@ -8656,6 +8710,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/chapel/observation)
+"AP" = (
+/obj/machinery/vending/sovietsoda,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "AS" = (
 /turf/simulated/floor/lythios43c,
 /area/engineering/engine_room)
@@ -8695,7 +8759,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/railing,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8726,6 +8789,16 @@
 /obj/item/bone/arm,
 /turf/simulated/floor/outdoors/snow/lythios43c,
 /area/rift/surfacebase/underground/under2)
+"Bf" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance/cargo{
+	req_access = list(50);
+	req_one_access = list(48)
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/miningdock)
 "Bg" = (
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
@@ -8763,22 +8836,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/storage)
-"Bn" = (
-/obj/random/trash_pile,
-/obj/effect/overlay/snow/wall{
-	dir = 8
-	},
-/obj/effect/overlay/snow/floor/pointy{
-	dir = 4
-	},
-/obj/effect/overlay/snow/floor/pointy{
-	dir = 1
-	},
-/obj/effect/overlay/snow/wall{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
 "Bo" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -9062,11 +9119,6 @@
 "CC" = (
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/miningdock)
-"CF" = (
-/obj/structure/table/rack/shelf,
-/obj/item/storage/box/lights/mixed,
-/turf/simulated/floor/tiled,
-/area/quartermaster/miningdock)
 "CH" = (
 /obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks,
 /obj/effect/paint/sun,
@@ -9331,9 +9383,16 @@
 /obj/structure/flora/grass/brown,
 /turf/simulated/floor/outdoors/snow/lythios43c,
 /area/rift/surfacebase/underground/under2)
+"DE" = (
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "DF" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/techfloor{
@@ -9412,6 +9471,17 @@
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_waste)
+"DU" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/floor_decal/rust,
+/obj/structure/closet,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "DV" = (
 /obj/structure/railing,
 /obj/effect/floor_decal/rust,
@@ -9470,15 +9540,19 @@
 "Ec" = (
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/belterdock/gear)
-"Eg" = (
+"Ef" = (
+/obj/effect/overlay/snow/floor,
+/obj/effect/overlay/snow/floor/pointy{
+	dir = 1
+	},
+/obj/effect/overlay/snow/floor/pointy,
 /obj/effect/overlay/snow/floor/pointy{
 	dir = 4
 	},
-/obj/effect/overlay/snow/floor/pointy{
-	dir = 8
-	},
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
+"Eg" = (
+/obj/effect/floor_decal/industrial/halfstair,
 /turf/simulated/floor/plating,
 /area/maintenance/atmos)
 "Eh" = (
@@ -9514,6 +9588,13 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/atmos/hallway)
+"Er" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/rift/surfacebase/underground/under2)
 "Et" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -9566,7 +9647,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/bed/padded,
@@ -9689,6 +9769,11 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining)
+"EV" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/maintenance/atmos)
 "EW" = (
 /obj/machinery/floodlight,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -9852,9 +9937,7 @@
 	dir = 4;
 	name = "Radiation Prep - Cleanup"
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 2
-	},
+/obj/machinery/door/firedoor/multi_tile,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
@@ -9879,6 +9962,8 @@
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 4
 	},
+/obj/structure/table/rack/shelf,
+/obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/miningdock)
 "FM" = (
@@ -9897,9 +9982,7 @@
 /obj/machinery/door/airlock/multi_tile/metal{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 2
-	},
+/obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "FU" = (
@@ -9964,7 +10047,6 @@
 /area/maintenance/chapel)
 "Gc" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -10240,10 +10322,6 @@
 "Hp" = (
 /turf/simulated/wall/prepainted/engineering,
 /area/engineering/engine_eva)
-"Hq" = (
-/obj/effect/floor_decal/industrial/halfstair,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
 "Hr" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/firealarm{
@@ -10507,13 +10585,6 @@
 "Ir" = (
 /turf/simulated/wall/prepainted/engineering,
 /area/engineering/atmos/hallway)
-"Iu" = (
-/obj/effect/overlay/snow/floor,
-/obj/effect/overlay/snow/floor/edges{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/rift/surfacebase/underground/under2)
 "Iv" = (
 /obj/machinery/door/window/southright{
 	dir = 4;
@@ -10787,9 +10858,7 @@
 	name = "General Storage";
 	req_one_access = list(47)
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 2
-	},
+/obj/machinery/door/firedoor/multi_tile,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
@@ -11023,13 +11092,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/miningdock)
-"Ks" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
 "Kt" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -11203,11 +11265,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/hallway)
-"Ln" = (
-/obj/structure/girder,
-/obj/effect/overlay/snow/floor,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
 "Lp" = (
 /obj/structure/flora/grass/green,
 /turf/simulated/floor/outdoors/snow/lythios43c,
@@ -11301,6 +11358,10 @@
 /obj/structure/sign/mining,
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/turbolift/rmine/under2)
+"LH" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled,
+/area/quartermaster/miningdock)
 "LJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11377,8 +11438,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/miningdock)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "LX" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -11496,9 +11558,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/machinery/camera/network/engineering{
-	dir = 2
-	},
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/hallway)
 "Mm" = (
@@ -11609,12 +11669,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"MF" = (
-/obj/effect/overlay/snow/floor/pointy{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
 "MH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -11640,6 +11694,18 @@
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/plating,
 /area/maintenance/atmos)
+"MO" = (
+/obj/effect/overlay/snow/floor,
+/obj/item/reagent_containers/syringe/drugs{
+	pixel_x = -12;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/syringe/steroid{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "MP" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/clean,
@@ -11757,15 +11823,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engine_room)
 "Nk" = (
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Operations";
-	req_access = list(31);
-	req_one_access = list()
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/cargo{
+	req_access = list(50);
+	req_one_access = list(48)
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/refinery)
 "Nm" = (
@@ -11989,11 +12054,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
-"NT" = (
-/obj/effect/overlay/snow/floor,
-/obj/effect/overlay/snow/floor/surround,
-/turf/simulated/floor/plating,
-/area/rift/surfacebase/underground/under2)
 "NU" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
@@ -12164,13 +12224,18 @@
 /turf/simulated/floor/tiled/steel,
 /area/engineering/atmos/locker_room)
 "OR" = (
-/obj/structure/railing,
-/obj/structure/railing{
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/vending/sovietsoda,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/miningdock)
 "OT" = (
 /obj/item/geiger_counter,
 /obj/item/geiger_counter,
@@ -12274,16 +12339,14 @@
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "Pl" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/quartermaster/miningdock)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "Pm" = (
 /obj/structure/table/woodentable,
 /obj/item/flashlight/lamp,
@@ -12294,10 +12357,8 @@
 /turf/simulated/floor/lino,
 /area/chapel/office)
 "Pq" = (
-/obj/effect/overlay/snow/floor/pointy{
-	dir = 1
-	},
-/obj/effect/overlay/snow/floor/pointy{
+/obj/effect/floor_decal/rust,
+/obj/structure/railing{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -12340,12 +12401,9 @@
 "Py" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
-/obj/machinery/camera/network/engineering{
-	dir = 2
-	},
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/locker_room)
 "Pz" = (
@@ -12677,14 +12735,6 @@
 /obj/effect/decal/remains/tajaran,
 /turf/simulated/floor/outdoors/snow/lythios43c,
 /area/rift/surfacebase/underground/under2)
-"Rb" = (
-/obj/structure/railing,
-/obj/structure/closet/crate,
-/obj/random/maintenance/engineering,
-/obj/random/maintenance,
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
 "Rd" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/yellowdouble,
@@ -12712,6 +12762,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/engineering/atmos/locker_room)
+"Rj" = (
+/obj/structure/closet/largecardboard,
+/obj/random/contraband,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "Rk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -12974,9 +13029,6 @@
 /turf/simulated/floor,
 /area/engineering/engine_room)
 "Sx" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
@@ -12986,8 +13038,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/miningdock)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "Sz" = (
 /obj/machinery/camera/network/civilian{
 	dir = 1
@@ -13056,7 +13109,6 @@
 "SL" = (
 /obj/structure/bed/chair/bay/chair/padded/yellow,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -13134,16 +13186,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
 "Ti" = (
-/obj/machinery/door/airlock/maintenance/cargo{
-	req_access = list(50);
-	req_one_access = list(48)
-	},
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/glass/mining{
+	name = "Mining Operations";
+	req_access = list(31);
+	req_one_access = list()
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/miningdock)
 "Tj" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -13184,6 +13239,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/secure_storage/lower)
+"Tp" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled,
+/area/quartermaster/miningdock)
 "Tq" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -13224,9 +13283,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/foyer)
-"Tw" = (
-/turf/simulated/wall/prepainted/cargo,
-/area/maintenance/lower/mining)
 "Tx" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
@@ -13347,6 +13403,13 @@
 /obj/structure/curtain/open/shower/engineering,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/chief)
+"TR" = (
+/obj/random/trash_pile,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "TU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -13586,6 +13649,13 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/heads/chief)
+"UX" = (
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "UZ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -13973,21 +14043,25 @@
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
 "Ws" = (
-/obj/machinery/door/airlock/maintenance/cargo{
-	req_access = list(50);
-	req_one_access = list(48)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/quartermaster/miningdock)
+/area/maintenance/lower/mining)
 "Wt" = (
 /obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_monitoring)
+"Ww" = (
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/miningdock)
 "Wx" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -14087,6 +14161,19 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/atmos/hallway)
+"WH" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/miningdock)
 "WJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
@@ -14108,14 +14195,6 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
-"WO" = (
-/obj/structure/closet/largecardboard,
-/obj/random/contraband,
-/obj/effect/overlay/snow/floor/pointy{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
 "WT" = (
 /turf/simulated/floor/carpet/bcarpet,
 /area/chapel/observation)
@@ -14181,6 +14260,15 @@
 	icon_state = "icerock-dark"
 	},
 /area/rift/surfacebase/underground/under2)
+"Xi" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "Xj" = (
 /obj/machinery/vending/snack{
 	dir = 8
@@ -14497,7 +14585,6 @@
 	dir = 1
 	},
 /obj/machinery/computer/guestpass{
-	dir = 2;
 	pixel_y = 26
 	},
 /obj/structure/disposalpipe/segment{
@@ -14576,7 +14663,6 @@
 "YK" = (
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -14691,12 +14777,13 @@
 /turf/simulated/floor/plating,
 /area/rift/station/stairs_one)
 "Zk" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/structure/railing,
 /obj/structure/closet/crate,
-/turf/simulated/floor/tiled,
-/area/quartermaster/miningdock)
+/obj/random/maintenance,
+/obj/random/maintenance/engineering,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "Zl" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -14797,11 +14884,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/hallway)
-"ZH" = (
-/obj/random/trash_pile,
-/obj/structure/railing,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
 "ZM" = (
 /turf/simulated/wall/prepainted,
 /area/engineering/break_room)
@@ -34159,9 +34241,9 @@ ux
 DO
 OD
 jS
-mb
-nZ
 qC
+nZ
+fZ
 sb
 gJ
 ea
@@ -34350,14 +34432,14 @@ Wy
 CC
 Aq
 Aq
-Tw
-JP
-JP
-JP
-JP
-bF
-JP
-JP
+Aq
+Aq
+eS
+eA
+eS
+Aq
+Aq
+gJ
 rt
 gJ
 gJ
@@ -34532,8 +34614,8 @@ Aj
 tR
 wL
 xI
-Aq
-CF
+JP
+Uf
 Zk
 LW
 Sj
@@ -34544,19 +34626,19 @@ Vc
 Sp
 Sj
 Sj
-Tw
+Aq
 yl
-Tg
-Hq
+Ww
+Mj
+Tp
+Tp
+Aq
 Ze
 Ze
 Ze
-Ze
-Ze
-MF
 Eg
-wG
-wG
+ks
+EV
 wG
 wG
 wG
@@ -34726,9 +34808,9 @@ Ze
 Mc
 JP
 JP
-Aq
-Mj
-Mj
+JP
+rs
+wk
 ur
 Sj
 MU
@@ -34738,16 +34820,16 @@ FW
 MU
 Xm
 AB
-Tw
+Aq
 OR
-Tg
-JP
-JP
+tM
+bR
+bR
 rp
-uT
-WO
-ru
-Bn
+Aq
+Ze
+JP
+JP
 zy
 zy
 zy
@@ -34933,14 +35015,14 @@ Nw
 Bh
 Fi
 Ti
-RV
-xv
-JP
-aa
+WH
+Uw
+Uw
+Uw
 rq
-rr
+Aq
 rs
-aa
+JP
 aa
 aa
 aa
@@ -35114,10 +35196,10 @@ JP
 JP
 JP
 JP
-Aq
-Uw
-Uw
-Uw
+JP
+JP
+Tg
+Xi
 Sj
 FX
 YQ
@@ -35126,15 +35208,15 @@ An
 EP
 De
 DZ
-Tw
+Aq
+LH
+Uw
+RD
+Uw
+vR
+Aq
+Ze
 JP
-Ks
-JP
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -35308,10 +35390,10 @@ JP
 aO
 aU
 cj
-Aq
-Uw
-RD
-Uw
+Ze
+JP
+Tg
+oA
 Sj
 Kc
 Qr
@@ -35320,15 +35402,15 @@ tD
 CB
 Qr
 Pu
-Sj
-ZH
-Xk
+Aq
+LH
+Uw
+jx
+Uw
+vR
+Aq
+Ze
 JP
-Iu
-NT
-aa
-aa
-aa
 aa
 aa
 aa
@@ -35502,10 +35584,10 @@ JP
 aR
 Ze
 ek
-Aq
-Uw
-Uw
-Uw
+Ze
+JP
+Tg
+DU
 Sj
 Yz
 Qr
@@ -35514,15 +35596,15 @@ FY
 LQ
 Qr
 vN
-Sj
-Cl
-Xk
-MF
-uc
-aa
-aa
-aa
-aa
+Aq
+Aq
+Aq
+Aq
+Aq
+Bf
+Aq
+Ze
+JP
 aa
 aa
 aa
@@ -35696,10 +35778,10 @@ JP
 aT
 Ze
 ft
-Aq
-Aq
-vH
-Aq
+Ze
+JP
+Tg
+xy
 Sj
 XR
 RU
@@ -35709,15 +35791,15 @@ Nx
 RU
 vN
 Sj
-Cl
-Xk
+nh
+Ze
 Pq
-aa
-aa
-aa
-aa
-aa
-aa
+uH
+Er
+Ze
+Ze
+MO
+rT
 aa
 aa
 aa
@@ -35891,7 +35973,7 @@ JP
 wJ
 JP
 JP
-Rb
+JP
 OJ
 La
 Sj
@@ -35903,14 +35985,14 @@ Qr
 Qr
 vN
 Sj
+rs
+UX
+cZ
+cZ
+DE
 Ze
-Xk
-Ln
-aa
-aa
-aa
-aa
-aa
+rs
+sy
 aa
 aa
 aa
@@ -36099,12 +36181,12 @@ IS
 Sj
 AC
 Xk
+AP
+TR
+Rj
+rs
+uS
 JP
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -36294,11 +36376,11 @@ Sj
 ye
 Xk
 JP
-aa
-aa
-aa
-aa
-aa
+JP
+JP
+Ef
+JP
+JP
 aa
 aa
 aa

--- a/maps/sectors/lavaland_140/levels/lavaland_140.dmm
+++ b/maps/sectors/lavaland_140/levels/lavaland_140.dmm
@@ -10,7 +10,6 @@
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "aN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -292,7 +291,6 @@
 	name = "Mining Engine Room";
 	req_access = list(48)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -325,8 +323,11 @@
 /turf/simulated/mineral/triumph/lavaland,
 /area/lavaland/central/explored)
 "hr" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
@@ -357,7 +358,6 @@
 /turf/simulated/floor/wood,
 /area/lavaland/central/base/common)
 "ia" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -366,12 +366,6 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/lavaland/central/base/common)
-"ib" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "ig" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
@@ -436,9 +430,6 @@
 	dir = 4;
 	layer = 3.3;
 	pixel_x = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
@@ -508,21 +499,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
-"lX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/lavaland/central/base/common)
 "mm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "mq" = (
@@ -600,23 +582,16 @@
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "nx" = (
-/obj/machinery/door/firedoor{
-	req_one_access = list(48)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/machinery/atmospheric_field_generator/perma,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/access_button{
-	dir = 4;
-	frequency = 1384;
-	master_tag = "mining_outpost";
-	pixel_x = -10;
-	pixel_y = 25;
-	req_one_access = list(48)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/map_helper/airlock/door/int_door,
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(48)
+/obj/machinery/door/blast/regular{
+	id = "surtstage";
+	name = "Staging Area Blast Door"
 	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
@@ -731,12 +706,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "pv" = (
@@ -809,10 +779,6 @@
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "pW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
@@ -844,9 +810,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -1012,15 +975,7 @@
 	id_tag = "mining_outpost";
 	pixel_y = -25
 	},
-/obj/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
-	dir = 1;
-	frequency = 1384;
-	id_tag = "mining_outpost";
-	power_rating = 20000
-	},
-/obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "sQ" = (
@@ -1095,10 +1050,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "uE" = (
@@ -1121,12 +1072,6 @@
 	req_one_access = list(48)
 	},
 /turf/simulated/floor/tiled,
-/area/lavaland/central/base/common)
-"vz" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "vA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1323,9 +1268,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/air_alarm/alarms_hidden{
 	pixel_y = 22;
 	req_one_access = list(48)
@@ -1372,10 +1314,10 @@
 	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	internal_pressure_bound_default = 4000;
+	on = 1;
 	pressure_checks = 2;
 	pressure_checks_default = 2;
-	pump_direction = 0;
-	on = 1
+	pump_direction = 0
 	},
 /turf/simulated/floor/reinforced/airmix,
 /area/lavaland/central/base/common)
@@ -1402,21 +1344,6 @@
 "Bf" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood,
-/area/lavaland/central/base/common)
-"Bp" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "Bs" = (
 /obj/structure/extinguisher_cabinet{
@@ -1471,12 +1398,18 @@
 /turf/simulated/floor/wood,
 /area/lavaland/central/base/common)
 "Cr" = (
-/obj/machinery/door/firedoor{
+/obj/machinery/access_button{
+	dir = 4;
+	frequency = 1384;
+	master_tag = "mining_outpost";
+	pixel_x = -10;
+	pixel_y = -25;
 	req_one_access = list(48)
 	},
-/obj/map_helper/airlock/door/int_door,
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(48)
+/obj/machinery/atmospheric_field_generator/perma,
+/obj/machinery/door/blast/regular{
+	id = "surtstage";
+	name = "Staging Area Blast Door"
 	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
@@ -1508,7 +1441,7 @@
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Transit";
-	req_access = list(48)
+	req_access = list(1,5,31,38,47,48)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1618,6 +1551,10 @@
 	},
 /turf/simulated/floor/plating/lavaland,
 /area/lavaland/central/base/common)
+"Fh" = (
+/obj/spawner/window/reinforced/full/firelocks,
+/turf/simulated/floor/plating,
+/area/lavaland/central/base/common)
 "Fq" = (
 /obj/machinery/vending/snack,
 /obj/machinery/light/small{
@@ -1636,7 +1573,7 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4;
 	name = "Dorms";
-	req_access = list(48)
+	req_access = list(1,5,31,38,47,48)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1675,9 +1612,6 @@
 "Ga" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "Gj" = (
@@ -1687,8 +1621,8 @@
 	pixel_y = 25;
 	req_one_access = list(48)
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
@@ -1738,7 +1672,7 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4;
 	name = "Lounge";
-	req_access = list(48)
+	req_access = list(1,5,31,38,47,48)
 	},
 /turf/simulated/floor/wood,
 /area/lavaland/central/base/common)
@@ -1805,7 +1739,6 @@
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "Iq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "IR" = (
@@ -1909,7 +1842,6 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/lavaland/central/base/common)
 "KB" = (
-/obj/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1384;
@@ -1938,9 +1870,6 @@
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "KX" = (
-/obj/machinery/door/firedoor{
-	req_one_access = list(48)
-	},
 /obj/machinery/access_button{
 	dir = 8;
 	frequency = 1384;
@@ -1949,9 +1878,10 @@
 	pixel_y = -25;
 	req_one_access = list(48)
 	},
-/obj/map_helper/airlock/door/ext_door,
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(48)
+/obj/machinery/atmospheric_field_generator/perma,
+/obj/machinery/door/blast/regular{
+	id = "surtstage";
+	name = "Staging Area Blast Door"
 	},
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
@@ -2054,7 +1984,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Lounge";
-	req_one_access = list(48)
+	req_one_access = list(1,5,31,38,47,48)
 	},
 /turf/simulated/floor/wood,
 /area/lavaland/central/base/common)
@@ -2142,7 +2072,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Logistics";
-	req_one_access = list(48)
+	req_one_access = list(1,5,31,38,47,48)
 	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
@@ -2168,18 +2098,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
-"PZ" = (
-/obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
-	dir = 1;
-	frequency = 1384;
-	id_tag = "mining_outpost";
-	power_rating = 20000
-	},
-/obj/map_helper/airlock/atmos/chamber_pump,
-/turf/simulated/floor/tiled,
-/area/lavaland/central/base/common)
 "Qo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "surtstage";
+	name = "Staging Area Shutters";
+	pixel_x = 26;
+	pixel_y = 26;
+	req_one_access = list(1,5,31,38,47,48)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -2203,7 +2134,7 @@
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "QC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
@@ -2265,9 +2196,6 @@
 /turf/simulated/mineral/triumph/lavaland,
 /area/lavaland/central/unexplored)
 "Sa" = (
-/obj/machinery/atmospherics/pipe/tank/air{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -2337,15 +2265,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
-"Ty" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/lavaland/central/base/common)
 "TA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -2382,18 +2301,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/purcarpet,
-/area/lavaland/central/base/common)
-"TW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "Ui" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -2461,7 +2368,6 @@
 /turf/simulated/floor/wood,
 /area/lavaland/central/base/common)
 "VX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2479,18 +2385,6 @@
 	req_one_access = list(48)
 	},
 /turf/simulated/floor/wood,
-/area/lavaland/central/base/common)
-"Wb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 "Wd" = (
 /obj/structure/catwalk,
@@ -2561,12 +2455,10 @@
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "WV" = (
-/obj/machinery/door/firedoor{
-	req_one_access = list(48)
-	},
-/obj/map_helper/airlock/door/ext_door,
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(48)
+/obj/machinery/atmospheric_field_generator/perma,
+/obj/machinery/door/blast/regular{
+	id = "surtstage";
+	name = "Staging Area Blast Door"
 	},
 /turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
@@ -2613,17 +2505,11 @@
 "Yb" = (
 /obj/machinery/door/airlock/glass/medical{
 	name = "Triage";
-	req_one_access = list(48)
+	req_one_access = list(1,5,31,38,47,48)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/lavaland/central/base/common)
-"Yn" = (
-/obj/machinery/atmospherics/pipe/tank/air{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
 /area/lavaland/central/base/common)
 "YJ" = (
 /obj/machinery/meter,
@@ -2693,9 +2579,6 @@
 "ZZ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
 
@@ -8207,7 +8090,7 @@ km
 EE
 bJ
 RJ
-Yn
+Iq
 Sa
 uA
 eT
@@ -8349,8 +8232,8 @@ CX
 gR
 qc
 tU
-vz
-lX
+Iq
+Iq
 Iq
 ig
 AO
@@ -8493,7 +8376,7 @@ UV
 WR
 pW
 pi
-ig
+Iq
 vA
 AO
 AO
@@ -8782,7 +8665,7 @@ AO
 AO
 AO
 AO
-Bp
+Ll
 ew
 db
 JM
@@ -8924,7 +8807,7 @@ cY
 ZG
 OB
 db
-Wb
+or
 ew
 db
 db
@@ -9492,10 +9375,10 @@ AO
 Jx
 EX
 db
-TW
-ib
-ib
-ib
+Jl
+nE
+nE
+nE
 pn
 nE
 nE
@@ -9638,7 +9521,7 @@ Ll
 ew
 db
 ZO
-Ty
+Wv
 VD
 ew
 zm
@@ -9780,7 +9663,7 @@ bs
 ew
 db
 ZI
-Qo
+or
 ew
 ND
 AO
@@ -9922,7 +9805,7 @@ VA
 Au
 db
 zk
-Qo
+or
 ew
 Mc
 AO
@@ -10347,10 +10230,10 @@ gy
 gy
 gy
 gy
-ip
+Fh
 hr
 KB
-xF
+Fh
 gy
 ip
 Vw
@@ -10631,10 +10514,10 @@ MX
 MX
 MX
 gy
-ip
+Fh
 QC
-PZ
-xF
+VD
+Fh
 gy
 gy
 gy

--- a/maps/sectors/lavaland_192/levels/lavaland_192.dmm
+++ b/maps/sectors/lavaland_192/levels/lavaland_192.dmm
@@ -72,7 +72,8 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4;
 	name = "Dorms";
-	req_access = list(1,5,31,38,47,48)
+	req_access = null;
+	req_one_access = list(1,5,31,38,47,48)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1467,7 +1468,8 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4;
 	name = "Lounge";
-	req_access = list(1,5,31,38,47,48)
+	req_access = null;
+	req_one_access = list(1,5,31,38,47,48)
 	},
 /turf/simulated/floor/wood,
 /area/lavaland/central/base/common)
@@ -2328,7 +2330,8 @@
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Transit";
-	req_access = list(1,5,31,38,47,48)
+	req_access = null;
+	req_one_access = list(1,5,31,38,47,48)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,

--- a/maps/sectors/lavaland_192/levels/lavaland_192.dmm
+++ b/maps/sectors/lavaland_192/levels/lavaland_192.dmm
@@ -72,7 +72,7 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4;
 	name = "Dorms";
-	req_access = list(48)
+	req_access = list(1,5,31,38,47,48)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1467,7 +1467,7 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4;
 	name = "Lounge";
-	req_access = list(48)
+	req_access = list(1,5,31,38,47,48)
 	},
 /turf/simulated/floor/wood,
 /area/lavaland/central/base/common)
@@ -1558,7 +1558,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Logistics";
-	req_one_access = list(48)
+	req_one_access = list(1,5,31,38,47,48)
 	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)
@@ -1732,7 +1732,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Lounge";
-	req_one_access = list(48)
+	req_one_access = list(1,5,31,38,47,48)
 	},
 /turf/simulated/floor/wood,
 /area/lavaland/central/base/common)
@@ -2328,7 +2328,7 @@
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Transit";
-	req_access = list(48)
+	req_access = list(1,5,31,38,47,48)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2444,7 +2444,7 @@
 "Yb" = (
 /obj/machinery/door/airlock/glass/medical{
 	name = "Triage";
-	req_one_access = list(48)
+	req_one_access = list(1,5,31,38,47,48)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2568,7 +2568,7 @@
 	name = "Staging Area Shutters";
 	pixel_x = 26;
 	pixel_y = 26;
-	req_one_access = list(48)
+	req_one_access = list(1,5,31,38,47,48)
 	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)

--- a/maps/triumph/levels/deck2.dmm
+++ b/maps/triumph/levels/deck2.dmm
@@ -7,8 +7,11 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
 "ac" = (
-/obj/structure/sign/department/cargo_dock,
-/turf/simulated/wall/prepainted/cargo,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass/mining{
+	name = "Cargo Bay"
+	},
+/turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "ad" = (
 /obj/machinery/light/small{
@@ -805,14 +808,11 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/requests_console/preset/cargo{
-	pixel_x = 30
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -1701,12 +1701,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_10)
 "eS" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "eU" = (
@@ -1824,6 +1818,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"fm" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass/mining{
+	id_tag = "cargodoor";
+	name = "Cargo Office";
+	req_access = list(31);
+	req_one_access = list()
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "fn" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3020,6 +3029,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
+"iU" = (
+/obj/machinery/light_switch{
+	pixel_x = 25;
+	pixel_y = 7
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "iV" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -3369,6 +3385,13 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
+"jY" = (
+/obj/machinery/air_alarm{
+	dir = 8;
+	pixel_x = 25
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/foyer)
 "jZ" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -3692,6 +3715,12 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
 "kY" = (
@@ -3767,8 +3796,12 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_9)
 "lh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
 "li" = (
@@ -4297,9 +4330,6 @@
 /area/triumph/surfacebase/mining_main/storage)
 "nf" = (
 /obj/item/radio/beacon,
-/obj/structure/bed/chair{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
@@ -4776,14 +4806,6 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/port)
-"oE" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
 "oF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/stool/padded,
@@ -5005,20 +5027,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/sleep/cryo)
-"pk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/window{
-	dir = 1;
-	req_one_access = list(31)
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
 "pl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6171,12 +6179,12 @@
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/refinery)
 "sz" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /obj/machinery/station_map{
 	dir = 4;
 	pixel_x = -32
+	},
+/obj/machinery/computer/supplycomp{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
@@ -6301,6 +6309,10 @@
 "sN" = (
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
+"sP" = (
+/obj/structure/sign/department/cargo_dock,
+/turf/simulated/wall/prepainted/cargo,
+/area/quartermaster/warehouse)
 "sQ" = (
 /turf/simulated/wall/prepainted/civilian,
 /area/janitor)
@@ -6422,6 +6434,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
+"tf" = (
+/obj/machinery/requests_console/preset/cargo{
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "tg" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/toilet)
@@ -6574,6 +6592,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/bed/chair{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
 "tD" = (
@@ -6621,12 +6642,14 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/fitness)
 "tL" = (
+/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/mining{
-	id_tag = "cargodoor";
-	name = "Cargo Office";
-	req_access = list(31);
-	req_one_access = list()
+/obj/machinery/door/window{
+	dir = 1;
+	req_one_access = list(31)
+	},
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -6807,13 +6830,9 @@
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
 "up" = (
-/obj/machinery/air_alarm{
-	pixel_y = 22
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/vending/snack,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "uq" = (
@@ -6940,19 +6959,6 @@
 "uN" = (
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/hallway/primary/port)
-"uO" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/glass/mining{
-	id_tag = "cargodoor";
-	name = "Cargo Office";
-	req_access = list(31);
-	req_one_access = list()
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
 "uP" = (
 /obj/machinery/status_display/supply_display{
 	pixel_y = 32
@@ -7774,14 +7780,6 @@
 /obj/machinery/gear_painter,
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
-"wW" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/closet/crate/engineering,
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
 "wX" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -8284,9 +8282,7 @@
 /turf/simulated/floor/airless,
 /area/shuttle/mining_ship/general)
 "yq" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "yr" = (
@@ -8381,11 +8377,10 @@
 /area/maintenance/dormitory)
 "yC" = (
 /obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/computer/supplycomp{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "yD" = (
@@ -9414,9 +9409,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
 "BE" = (
-/obj/machinery/computer/supplycomp/control{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "BH" = (
@@ -9757,6 +9754,10 @@
 /obj/structure/ladder/up,
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
+"CO" = (
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "CQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -10812,13 +10813,10 @@
 /turf/simulated/floor/crystal,
 /area/station/stairs_two)
 "Gj" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/machinery/holopad,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "Gk" = (
@@ -11132,15 +11130,15 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "Hh" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/machinery/status_display/supply_display{
 	mode = 99;
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -11510,6 +11508,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"It" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate/engineering,
+/turf/simulated/floor/tiled,
+/area/quartermaster/storage)
 "Iv" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -11530,6 +11533,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/storage)
+"Ix" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass/mining{
+	id_tag = "cargodoor";
+	name = "Cargo Office";
+	req_access = list(31);
+	req_one_access = list()
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "IA" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -11692,9 +11705,19 @@
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/refinery)
 "IX" = (
-/obj/structure/bed/chair/office/dark,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table/reinforced,
+/obj/item/pen{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/item/paper_bin{
+	pixel_x = 5;
+	pixel_y = 12
+	},
+/obj/item/stamp/cargo,
+/obj/item/stamp/denied{
+	pixel_x = 7
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "IY" = (
@@ -11788,6 +11811,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
+"Jk" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "Jm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -11881,17 +11910,6 @@
 /obj/structure/bed/chair/sofa/black/left,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
-"JD" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/item/radio/beacon/anchored,
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
 "JE" = (
 /obj/item/stool/padded,
 /obj/item/toy/plushie/deer,
@@ -12061,23 +12079,14 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/structure/table/reinforced,
-/obj/item/stamp/cargo,
-/obj/item/stamp/denied{
-	pixel_x = 7
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
-/obj/item/paper_bin{
-	pixel_x = 5;
-	pixel_y = 12
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/item/pen{
-	pixel_x = -6;
-	pixel_y = 7
-	},
-/obj/machinery/light_switch{
-	pixel_x = 25;
-	pixel_y = 7
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "Kd" = (
@@ -12184,6 +12193,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/stairs_two)
+"Kr" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "Ks" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 4
@@ -12425,8 +12438,8 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "Lb" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/computer/supplycomp/control{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -14198,6 +14211,9 @@
 /area/maintenance/dormitory)
 "QG" = (
 /obj/landmark/spawnpoint/job/cargo_technician,
+/obj/machinery/camera/network/cargo{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "QI" = (
@@ -15696,6 +15712,9 @@
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/bed/chair{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/quartermaster/foyer)
 "UX" = (
@@ -15850,6 +15869,7 @@
 /obj/structure/closet/hydrant{
 	pixel_x = 32
 	},
+/obj/machinery/vending/snack,
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
 "Vq" = (
@@ -15991,9 +16011,13 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/item/radio/beacon/anchored,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "VP" = (
@@ -36226,7 +36250,7 @@ fM
 jj
 Gj
 Lb
-uO
+fM
 sz
 NY
 Fr
@@ -36419,10 +36443,10 @@ OS
 fM
 jj
 ED
-dP
+CO
 tL
 yq
-Pk
+Kr
 Fr
 lT
 wZ
@@ -36612,11 +36636,11 @@ YH
 YH
 NH
 Hh
-oE
+ED
 IX
-pk
+fM
 eS
-JD
+Pk
 lh
 XV
 bR
@@ -36808,7 +36832,7 @@ Ci
 cl
 Kb
 BE
-fM
+fm
 yC
 VO
 kW
@@ -36999,16 +37023,16 @@ hf
 hf
 Qh
 ac
-NH
-NH
-Tn
-Tn
-Tn
+tf
+iU
+eS
+Ix
+Jk
 up
 Fr
-Mq
-Mq
 wZ
+Mq
+Mq
 sY
 wZ
 uo
@@ -37192,15 +37216,15 @@ MO
 jL
 jL
 nj
-av
-NA
+sP
+wr
 wl
-Si
-sd
+wl
+wl
 Tn
 Ef
 Vo
-il
+jY
 il
 tC
 yw
@@ -37387,10 +37411,10 @@ GY
 Xj
 nj
 QG
-fq
+NA
 wl
-wW
-Zq
+Si
+sd
 wl
 wl
 wl
@@ -37780,8 +37804,8 @@ fl
 zt
 IY
 LG
-RE
-RE
+It
+Zq
 VE
 wl
 EP
@@ -38357,7 +38381,7 @@ YM
 tA
 Cn
 Xj
-Xj
+fq
 wl
 Zq
 ca

--- a/maps/triumph/levels/deck2.dmm
+++ b/maps/triumph/levels/deck2.dmm
@@ -142,26 +142,6 @@
 "ar" = (
 /turf/simulated/wall/prepainted/civilian,
 /area/triumph/surfacebase/bar_backroom)
-"as" = (
-/obj/structure/table/standard,
-/obj/item/coin/silver,
-/obj/item/coin/silver,
-/obj/machinery/air_alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/light,
-/obj/item/cartridge/quartermaster{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/cartridge/quartermaster{
-	pixel_x = -4;
-	pixel_y = 7
-	},
-/obj/item/cartridge/quartermaster,
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
 "at" = (
 /obj/structure/bed/padded,
 /obj/machinery/newscaster{
@@ -443,6 +423,20 @@
 /obj/machinery/vending/fitness,
 /turf/simulated/floor/wood,
 /area/crew_quarters/fitness)
+"bj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "bk" = (
 /obj/machinery/atmospherics/component/binary/passive_gate/on{
 	dir = 8;
@@ -653,12 +647,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area_hallway)
-"bJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar/lower)
 "bK" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -905,6 +893,19 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/airless,
 /area/shuttle/mining_ship/general)
+"cz" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/structure/closet,
+/obj/item/storage/backpack/dufflebag,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -28
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "cA" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -1187,17 +1188,6 @@
 /obj/item/tool/crowbar,
 /turf/simulated/floor/tiled,
 /area/hydroponics)
-"dj" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "Quartermaster-Office"
-	},
-/obj/structure/table/standard,
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
 "dk" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -1508,14 +1498,14 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_11)
 "ej" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -1545,13 +1535,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
 "eo" = (
-/obj/machinery/hyperpad/centre{
-	map_pad_id = "lavaland_station";
-	map_pad_link_id = "lavaland_away";
-	newcolor = "#fcba03"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/triumph/surfacebase/mining_main/refinery)
+/area/triumph/surfacebase/mining_main/eva)
 "ep" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -1943,9 +1931,7 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
-/obj/machinery/suit_storage_unit/mining{
-	boots_stored_TYPE = /obj/item/clothing/shoes/magboots
-	},
+/obj/machinery/suit_storage_unit/mining,
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/storage)
 "fA" = (
@@ -2129,9 +2115,26 @@
 /obj/machinery/smartfridge,
 /turf/simulated/wall/prepainted/civilian,
 /area/crew_quarters/kitchen)
+"gd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/cargo)
 "ge" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/substation/civilian)
+"gf" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "gg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2261,6 +2264,26 @@
 /obj/structure/flora/pottedplant/smallcactus,
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
+"gy" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 8
+	},
+/obj/machinery/door/airlock/mining{
+	name = "Quartermaster";
+	req_access = list(41);
+	req_one_access = list()
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "gA" = (
 /turf/simulated/wall/prepainted/cargo,
 /area/triumph/surfacebase/mining_main/uxstorage)
@@ -2307,6 +2330,12 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
+"gM" = (
+/obj/machinery/computer/security/mining{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "gN" = (
 /obj/machinery/air_alarm{
 	dir = 8;
@@ -2553,19 +2582,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar/lower)
-"hz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
 "hB" = (
@@ -2910,12 +2926,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"iH" = (
-/obj/machinery/computer/supplycomp/control{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
 "iI" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -3292,12 +3302,6 @@
 "jN" = (
 /turf/simulated/floor/carpet/sblucarpet,
 /area/crew_quarters/sleep/Dorm_3)
-"jO" = (
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
 "jP" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -3319,9 +3323,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/door/firedoor{
-	dir = 2
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/station/stairs_two)
 "jT" = (
@@ -3441,14 +3443,14 @@
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/sleep/Dorm_1)
 "kj" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/turf/simulated/floor/tiled,
-/area/triumph/surfacebase/mining_main/eva)
+/turf/simulated/floor/carpet/sblucarpet,
+/area/quartermaster/qm)
 "kl" = (
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/sleep/Dorm_9)
@@ -3516,6 +3518,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
+"kz" = (
+/obj/machinery/door/firedoor{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/bar/lower)
 "kA" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /obj/structure/sign/directions/roomnum{
@@ -3547,12 +3566,12 @@
 	dir = 8;
 	pixel_x = -26
 	},
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
+/obj/structure/table/standard,
+/obj/machinery/photocopier/faxmachine{
+	department = "Quartermaster-Office"
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled,
-/area/triumph/surfacebase/mining_main/eva)
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "kF" = (
 /obj/structure/cryofeed{
 	dir = 4
@@ -3623,6 +3642,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
+"kN" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/camera/network/cargo{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "kO" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -3715,9 +3743,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/freezer)
 "ld" = (
-/obj/machinery/door/firedoor{
-	dir = 2
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/station/stairs_two)
 "le" = (
@@ -3895,11 +3921,17 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_10)
 "lM" = (
+/obj/machinery/door/firedoor{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass/mining{
-	name = "Magmatic Rift Leap Pad"
+	name = "Mining Airlock Storage"
 	},
 /turf/simulated/floor/tiled,
-/area/triumph/surfacebase/mining_main/refinery)
+/area/triumph/surfacebase/mining_main/eva)
 "lO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -3912,18 +3944,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
-"lP" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/mob/living/simple_mob/animal/sif/fluffy,
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
 "lQ" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -4000,9 +4020,6 @@
 /obj/machinery/vending/fitness,
 /turf/simulated/floor/wood,
 /area/station/stairs_two)
-"me" = (
-/turf/simulated/floor/tiled,
-/area/triumph/surfacebase/mining_main/eva)
 "mf" = (
 /obj/machinery/light{
 	dir = 4
@@ -4094,11 +4111,11 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_9)
 "mz" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/triumph/surfacebase/mining_main/refinery)
+/area/triumph/surfacebase/mining_main/eva)
 "mA" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -4186,13 +4203,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
-"mN" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/quartermaster/foyer)
 "mO" = (
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -4239,22 +4249,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/freezer)
-"mW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/bar/lower)
 "mX" = (
 /obj/machinery/newscaster{
 	layer = 3.3;
@@ -4325,10 +4319,14 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/coffee_shop)
 "nm" = (
-/obj/structure/closet,
-/obj/item/storage/backpack/dufflebag,
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "no" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -4407,6 +4405,8 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/obj/structure/closet/secure_closet/cargotech,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "nB" = (
@@ -4541,13 +4541,6 @@
 /obj/structure/sign/deck/second,
 /turf/simulated/wall/prepainted,
 /area/station/stairs_two)
-"nY" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate,
-/obj/fiftyspawner/glass,
-/obj/fiftyspawner/rods,
-/turf/simulated/floor/tiled,
-/area/maintenance/cargo)
 "nZ" = (
 /obj/machinery/air_alarm{
 	dir = 4;
@@ -4665,9 +4658,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/suit_storage_unit/mining{
-	boots_stored_TYPE = /obj/item/clothing/shoes/magboots
-	},
+/obj/machinery/suit_storage_unit/mining,
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/storage)
 "ol" = (
@@ -4799,11 +4790,11 @@
 /turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
 "oG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/triumph/surfacebase/mining_main/eva)
+/turf/simulated/floor/carpet/sblucarpet,
+/area/quartermaster/qm)
 "oI" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4850,6 +4841,14 @@
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
+"oO" = (
+/obj/structure/closet/secure_closet/quartermaster,
+/obj/item/clothing/accessory/poncho/roles/cloak/qm,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "oP" = (
 /obj/machinery/mineral/output,
 /obj/structure/window/reinforced,
@@ -4950,6 +4949,14 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/port)
+"pd" = (
+/obj/machinery/light_switch{
+	pixel_x = 25
+	},
+/obj/structure/dogbed,
+/mob/living/simple_mob/animal/sif/fluffy,
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "pf" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -5053,17 +5060,21 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "pr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/quartermaster/foyer)
+"ps" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "pt" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/sleep/cryo)
@@ -5098,9 +5109,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_1)
 "py" = (
-/obj/machinery/door/firedoor{
-	dir = 2
-	},
+/obj/machinery/door/firedoor,
 /obj/machinery/door/blast/shutters{
 	dir = 2;
 	id = "cafe";
@@ -5283,11 +5292,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
 "qa" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled/monotile,
-/area/triumph/surfacebase/mining_main/refinery)
+/area/triumph/surfacebase/mining_main/eva)
 "qb" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5300,6 +5310,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area_hallway)
+"qc" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/air_alarm{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "qd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -5366,9 +5389,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area_hallway)
 "ql" = (
-/obj/machinery/door/firedoor{
-	dir = 2
-	},
+/obj/machinery/door/firedoor,
 /obj/machinery/door/blast/shutters{
 	dir = 2;
 	id = "cafe";
@@ -5384,6 +5405,12 @@
 /obj/structure/stairs/spawner/west,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
+"qp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/triumph/surfacebase/mining_main/refinery)
 "qq" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -5402,9 +5429,7 @@
 	layer = 3.3;
 	name = "Kitchen Service Shutters"
 	},
-/obj/machinery/door/firedoor{
-	dir = 2
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/kitchen)
 "qt" = (
@@ -5634,19 +5659,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
-"rd" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/bar/lower)
 "re" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5792,6 +5804,22 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
+"rw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar/lower)
 "rx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6276,6 +6304,14 @@
 "sQ" = (
 /turf/simulated/wall/prepainted/civilian,
 /area/janitor)
+"sR" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/rods,
+/obj/fiftyspawner/glass,
+/turf/simulated/floor/tiled,
+/area/maintenance/cargo)
 "sS" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6329,6 +6365,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/refinery)
+"sY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/quartermaster/foyer)
 "sZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -6522,6 +6570,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
+"tC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/foyer)
 "tD" = (
 /obj/random/trash_pile,
 /obj/machinery/light/small,
@@ -6941,19 +6995,25 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "uT" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/mining{
-	name = "Quartermaster";
-	req_access = list(41);
-	req_one_access = list()
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "uX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
@@ -7051,16 +7111,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/station/stairs_two)
-"vh" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/random/trash_pile,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar/lower)
 "vi" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/door/firedoor{
@@ -7241,14 +7291,13 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "vB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/hyperpad/centre{
+	map_pad_id = "lavaland_station";
+	map_pad_link_id = "lavaland_away";
+	newcolor = "#fcba03"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/qm)
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/office)
 "vC" = (
 /obj/structure/bed/padded,
 /obj/machinery/computer/ship/navigation/telescreen{
@@ -7258,12 +7307,11 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_4)
 "vD" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
+/obj/machinery/keycard_auth{
+	pixel_y = -28
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled,
-/area/triumph/surfacebase/mining_main/eva)
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "vF" = (
 /obj/machinery/light{
 	dir = 4
@@ -7277,12 +7325,6 @@
 /obj/item/pen,
 /turf/simulated/floor/wood,
 /area/triumph/surfacebase/bar_backroom)
-"vH" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/triumph/surfacebase/mining_main/refinery)
 "vJ" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -7332,14 +7374,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
 "vQ" = (
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/bed/chair/comfy/beige{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/qm)
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/office)
 "vR" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /turf/simulated/floor/plating,
@@ -7382,8 +7421,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock{
-	name = "Restroom";
-	id_tag = "restroom ad"
+	id_tag = "restroom ad";
+	name = "Restroom"
 	},
 /turf/simulated/floor/tiled/white,
 /area/station/stairs_two)
@@ -7427,12 +7466,6 @@
 "wb" = (
 /turf/simulated/wall/prepainted/civilian,
 /area/crew_quarters/barrestroom)
-"wc" = (
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/quartermaster/foyer)
 "wd" = (
 /obj/structure/stairs/spawner/east,
 /obj/structure/railing{
@@ -7535,6 +7568,12 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
+"ww" = (
+/obj/structure/bed/chair/comfy/beige{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/quartermaster/qm)
 "wx" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/super;
@@ -7684,19 +7723,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/station/stairs_two)
+"wM" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "wP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/air_alarm{
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/simulated/floor/tiled,
-/area/triumph/surfacebase/mining_main/eva)
+/obj/machinery/computer/roguezones{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "wQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -7952,11 +7994,11 @@
 	dir = 10
 	},
 /obj/machinery/button/remote/airlock{
+	dir = 8;
 	id = "mine_black";
 	name = "Door Lock";
-	specialfunctions = 4;
-	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	specialfunctions = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/station/stairs_two)
@@ -7965,9 +8007,7 @@
 	dir = 8;
 	pixel_x = 25
 	},
-/obj/machinery/door/firedoor{
-	dir = 2
-	},
+/obj/machinery/door/firedoor,
 /obj/machinery/door/blast/shutters{
 	dir = 2;
 	id = "cafe";
@@ -7978,13 +8018,6 @@
 /obj/item/storage/box/donut,
 /turf/simulated/floor/lino,
 /area/crew_quarters/coffee_shop)
-"xz" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled,
-/area/triumph/surfacebase/mining_main/eva)
 "xA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -8122,8 +8155,16 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "xX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
 "xY" = (
@@ -8403,14 +8444,14 @@
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/storage)
 "yH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+	icon_state = "2-4"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -8429,19 +8470,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/belter)
 "yL" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/mining{
-	name = "Quartermaster";
-	req_access = list(41);
-	req_one_access = list()
-	},
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/turf/simulated/floor/plating,
+/area/quartermaster/office)
 "yO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8716,6 +8747,18 @@
 /obj/structure/girder/displaced,
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
+"zw" = (
+/obj/machinery/camera/network/cargo,
+/obj/structure/table/standard,
+/obj/item/stamp/cargo,
+/obj/item/stamp/denied{
+	pixel_x = 7
+	},
+/obj/item/stamp/qm{
+	pixel_x = -6
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "zy" = (
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/sleep/Dorm_4)
@@ -8958,6 +9001,9 @@
 /obj/item/duct_tape_roll,
 /turf/simulated/floor/airless,
 /area/shuttle/mining_ship/general)
+"Ai" = (
+/turf/simulated/wall/r_wall/prepainted/cargo,
+/area/quartermaster/qm)
 "Aj" = (
 /obj/landmark{
 	name = "carpspawn"
@@ -9010,20 +9056,11 @@
 /obj/machinery/air_alarm{
 	pixel_y = 22
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled,
 /area/maintenance/cargo)
 "Aq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9095,9 +9132,6 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/Dorm_11)
 "AB" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
@@ -9602,14 +9636,11 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/Dorm_11)
 "Ct" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
-/turf/simulated/floor/tiled,
-/area/triumph/surfacebase/mining_main/eva)
+/turf/simulated/floor/carpet/sblucarpet,
+/area/quartermaster/qm)
 "Cu" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -9646,15 +9677,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
-"Cz" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/qm)
 "CA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9898,14 +9920,12 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "Dm" = (
-/obj/structure/closet/secure_closet/quartermaster,
-/obj/item/clothing/accessory/poncho/roles/cloak/qm,
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
-"Dn" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
-/area/maintenance/cargo)
+/area/quartermaster/office)
 "Do" = (
 /obj/machinery/ai_status_display{
 	pixel_y = -32
@@ -10268,6 +10288,15 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/mining_ship/general)
+"Ew" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/computer/supplycomp/control{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "Ex" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -10284,9 +10313,7 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
-/obj/machinery/suit_storage_unit/mining{
-	boots_stored_TYPE = /obj/item/clothing/shoes/magboots
-	},
+/obj/machinery/suit_storage_unit/mining,
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/storage)
 "EA" = (
@@ -10431,17 +10458,17 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_9)
 "Fa" = (
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Airlock Storage"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "Fb" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -10558,15 +10585,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_office)
-"Fu" = (
-/obj/machinery/computer/security/mining{
-	dir = 4
-	},
-/obj/machinery/camera/network/cargo{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
 "Fv" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -10610,14 +10628,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
-"Fy" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = -28;
-	req_access = list()
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
 "Fz" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/structure/catwalk,
@@ -10636,12 +10646,8 @@
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/refinery)
 "FF" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/obj/machinery/camera/network/cargo,
-/turf/simulated/floor/tiled,
-/area/triumph/surfacebase/mining_main/eva)
+/turf/simulated/floor/carpet/sblucarpet,
+/area/quartermaster/qm)
 "FH" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -10937,11 +10943,24 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/mining,
 /turf/simulated/floor/plating,
-/area/triumph/surfacebase/mining_main/eva)
+/area/quartermaster/qm)
 "GE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/freezer)
+"GF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/cargo)
 "GG" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -10978,12 +10997,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
-"GL" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/triumph/surfacebase/mining_main/refinery)
 "GM" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood,
@@ -11023,10 +11036,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
-"GQ" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/monotile,
-/area/triumph/surfacebase/mining_main/refinery)
 "GR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11146,9 +11155,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/network/cargo,
-/obj/machinery/suit_storage_unit/mining{
-	boots_stored_TYPE = /obj/item/clothing/shoes/magboots
-	},
+/obj/machinery/suit_storage_unit/mining,
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/storage)
 "Hk" = (
@@ -11198,12 +11205,8 @@
 /turf/simulated/floor/tiled,
 /area/station/stairs_two)
 "Hp" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/office)
 "Hq" = (
 /obj/machinery/camera/network/civilian{
 	dir = 1
@@ -11253,6 +11256,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
+"HA" = (
+/turf/simulated/floor/tiled,
+/area/maintenance/cargo)
 "HB" = (
 /obj/structure/table/marble,
 /obj/item/hand_labeler,
@@ -11344,6 +11350,18 @@
 "HO" = (
 /turf/simulated/wall/prepainted/civilian,
 /area/maintenance/bar/lower)
+"HP" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "HQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -11492,12 +11510,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"It" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/triumph/surfacebase/mining_main/refinery)
 "Iv" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -11518,12 +11530,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/storage)
-"Iw" = (
-/obj/machinery/air_alarm{
-	pixel_y = 22
-	},
-/turf/simulated/wall/prepainted/cargo,
-/area/quartermaster/qm)
 "IA" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -11610,6 +11616,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
 "IM" = (
@@ -11830,6 +11839,12 @@
 /obj/machinery/holopad,
 /turf/simulated/floor/wood,
 /area/vacant/vacant_shop)
+"Jw" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "Jx" = (
 /obj/machinery/camera/network/civilian{
 	dir = 4
@@ -12088,14 +12103,9 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "Ki" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/computer/ship/navigation/telescreen{
-	pixel_y = -37
-	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "Kj" = (
 /obj/spawner/window/reinforced/full/firelocks,
 /obj/structure/curtain/open/bed{
@@ -12226,6 +12236,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
+"KA" = (
+/obj/structure/table/standard,
+/obj/item/coin/silver,
+/obj/item/coin/silver,
+/obj/item/cartridge/quartermaster{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/cartridge/quartermaster{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/cartridge/quartermaster,
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "KB" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/warning{
@@ -12558,17 +12583,6 @@
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
-"LE" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/camera/network/cargo,
-/turf/simulated/floor/tiled,
-/area/triumph/surfacebase/mining_main/eva)
 "LG" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 8
@@ -12645,18 +12659,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_7)
-"LO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/quartermaster/foyer)
 "LP" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/item/suit_cooling_unit,
@@ -12811,9 +12813,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
 	},
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/refinery)
@@ -13002,20 +13001,6 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/port)
-"MY" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/cargo)
 "MZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -13214,12 +13199,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_4)
-"Ny" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate,
-/obj/fiftyspawner/steel,
-/turf/simulated/floor/tiled,
-/area/maintenance/cargo)
 "Nz" = (
 /obj/landmark/spawnpoint/latejoin/station/cryogenics,
 /obj/structure/extinguisher_cabinet{
@@ -13258,6 +13237,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
+"NG" = (
+/obj/machinery/door/firedoor{
+	dir = 8
+	},
+/obj/machinery/door/airlock/glass/mining{
+	name = "Magmatic Rift Leap Pad";
+	req_one_access = list(1,5,31,38,47,48)
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "NH" = (
 /turf/simulated/wall/prepainted/cargo,
 /area/quartermaster/office)
@@ -13499,12 +13488,10 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "Ox" = (
@@ -13701,6 +13688,17 @@
 /obj/item/duct_tape_roll,
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/storage)
+"OV" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/camera/network/cargo{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "OW" = (
 /obj/structure/cable/green{
 	icon_state = "0-8"
@@ -13742,6 +13740,13 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/showers)
+"Pf" = (
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -37
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "Pg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/glass{
@@ -13785,9 +13790,7 @@
 	req_access = list(25);
 	req_one_access = list(25)
 	},
-/obj/machinery/door/firedoor{
-	dir = 2
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "Pm" = (
@@ -13800,20 +13803,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
-"Pn" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/turf/simulated/floor/tiled,
-/area/triumph/surfacebase/mining_main/eva)
 "Po" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13907,8 +13896,14 @@
 /turf/simulated/floor/airless,
 /area/space)
 "Py" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 8
+	},
+/obj/machinery/door/airlock/glass/mining{
+	name = "Magmatic Rift Leap Pad"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "PA" = (
@@ -13932,23 +13927,21 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/bar)
-"PD" = (
-/obj/structure/table/standard,
-/obj/structure/cable/green{
-	icon_state = "1-4"
+"PE" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/keycard_auth{
-	pixel_y = -28
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/stamp/cargo,
-/obj/item/stamp/denied{
-	pixel_x = 7
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/item/stamp/qm{
-	pixel_x = -6
-	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/cargo)
 "PF" = (
 /obj/machinery/door/firedoor{
 	dir = 8
@@ -14137,6 +14130,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/showers)
+"Qm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/triumph/surfacebase/mining_main/refinery)
 "Qn" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -14176,20 +14175,11 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/fitness)
 "Qw" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/atmospherics/portables_connector{
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/triumph/surfacebase/mining_main/eva)
-"Qy" = (
-/obj/item/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/carpet/sblucarpet,
+/area/quartermaster/qm)
 "Qz" = (
 /obj/structure/table/marble,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -14469,12 +14459,29 @@
 	dir = 1;
 	pixel_y = -25
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
 "Rt" = (
 /obj/machinery/scale,
 /turf/simulated/floor/wood,
 /area/crew_quarters/fitness)
+"Rv" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/turf/simulated/floor/tiled,
+/area/maintenance/cargo)
 "Rw" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -14585,6 +14592,12 @@
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/sleep/Dorm_5)
+"RN" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "RO" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -14660,11 +14673,9 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "RT" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/tiled/monotile,
-/area/triumph/surfacebase/mining_main/refinery)
+/area/triumph/surfacebase/mining_main/eva)
 "RU" = (
 /obj/machinery/meter{
 	frequency = 1443;
@@ -14698,13 +14709,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
-"RY" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/obj/machinery/lathe/autolathe,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
 "RZ" = (
 /obj/structure/table/woodentable,
 /obj/structure/flora/pottedplant/shoot,
@@ -14795,7 +14799,7 @@
 	pixel_y = -24
 	},
 /obj/machinery/recipe_lookup/drinks{
-	pixel_x = -32;
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
@@ -14819,13 +14823,11 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "Sq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/quartermaster/foyer)
@@ -15090,10 +15092,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/dormitory)
-"Tf" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled,
-/area/triumph/surfacebase/mining_main/eva)
 "Tg" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -15204,6 +15202,10 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/belter)
+"TC" = (
+/obj/machinery/lathe/autolathe,
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "TD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15576,13 +15578,6 @@
 "UG" = (
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
-"UH" = (
-/obj/machinery/camera/network/cargo{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/cargotech,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
 "UI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15800,6 +15795,21 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/sleep/cryo)
+"Vj" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/storage/firstaid{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "Vk" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -16234,6 +16244,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/stairs_two)
+"WB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/foyer)
 "WC" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
@@ -16246,11 +16268,11 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/lounge/kitchen_freezer)
 "WE" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/triumph/surfacebase/mining_main/refinery)
+/area/triumph/surfacebase/mining_main/eva)
 "WF" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -16301,17 +16323,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
 "WN" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/computer/roguezones{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "WO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16543,9 +16559,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/station/stairs_two)
-"XB" = (
-/turf/simulated/wall/prepainted/cargo,
-/area/triumph/surfacebase/mining_main/eva)
 "XC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16807,7 +16820,17 @@
 	dir = 1;
 	pixel_y = -25
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/maintenance/cargo)
 "Yw" = (
 /obj/structure/sink{
@@ -16889,12 +16912,13 @@
 /area/station/stairs_two)
 "YG" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Airlock Storage"
+/obj/machinery/door/airlock/mining{
+	name = "Quartermaster";
+	req_access = list(41);
+	req_one_access = list()
 	},
 /turf/simulated/floor/tiled,
-/area/triumph/surfacebase/mining_main/eva)
+/area/quartermaster/qm)
 "YH" = (
 /turf/simulated/wall/prepainted/cargo,
 /area/triumph/surfacebase/mining_main/storage)
@@ -16931,14 +16955,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
 "YO" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/quartermaster/foyer)
@@ -16962,11 +16985,9 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/fitness)
 "YU" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/triumph/surfacebase/mining_main/eva)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/quartermaster/qm)
 "YW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17250,11 +17271,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
-"ZN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
 "ZO" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -17287,22 +17303,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_10)
-"ZS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar/lower)
 "ZU" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -17327,14 +17327,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
-"ZZ" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/closet/secure_closet/cargotech,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
 
 (1,1,1) = {"
 cW
@@ -33318,10 +33310,10 @@ on
 kd
 eK
 eK
-mZ
-mZ
-mZ
-mZ
+Lm
+Lm
+Lm
+DT
 cW
 HY
 BI
@@ -33512,11 +33504,11 @@ nB
 Bn
 BS
 eK
-It
 qa
-vH
-mZ
-oj
+qa
+Lm
+DT
+cW
 HY
 vj
 vU
@@ -33708,13 +33700,13 @@ pN
 eK
 WE
 eo
-GQ
-mZ
-cW
 Lm
-XB
-XB
-XB
+Ai
+Ai
+Ai
+sb
+sb
+sb
 he
 xY
 Rx
@@ -33902,13 +33894,13 @@ mA
 eK
 mz
 RT
-GL
-mZ
-cW
 Lm
+KA
+gM
+Ew
 wP
 kE
-XB
+sb
 he
 xY
 Lx
@@ -34095,14 +34087,14 @@ Nl
 mZ
 mZ
 lM
-mZ
 Lm
 Lm
-Lm
-Lm
+zw
+FF
+ww
 FF
 vD
-XB
+sb
 he
 xY
 xY
@@ -34288,20 +34280,20 @@ nC
 vT
 kJ
 ol
-pD
+qp
 Mt
-XB
-LE
+hI
+rb
 Qw
-xz
+UA
 oG
-me
+rb
 GC
 ej
 IL
 IL
 uX
-JK
+hv
 CM
 hB
 NJ
@@ -34482,20 +34474,20 @@ pD
 bs
 sy
 jA
-jA
-jA
+Qm
+pD
 YG
-Pn
+rb
 kj
 YU
 Ct
-Tf
-XB
-vh
-bJ
-bJ
-rd
-tq
+rb
+sb
+UG
+UG
+UG
+UG
+he
 CM
 zk
 CL
@@ -34678,18 +34670,18 @@ tr
 xV
 sZ
 fX
-NH
-NH
+sb
+pd
 Fa
-NH
-NH
+Jw
+oO
+cz
 sb
-sb
-sb
-sb
-sb
-hz
+BI
+JK
+tq
 UG
+Bk
 EK
 sh
 sh
@@ -34873,17 +34865,17 @@ ne
 ne
 YH
 NH
-Qy
-ED
-Fy
-UH
-hI
-iH
-Fu
-dj
-Iw
-hz
-UG
+NH
+gy
+yL
+NH
+NH
+NH
+NH
+NH
+NH
+NH
+Bk
 CM
 II
 sk
@@ -35068,16 +35060,16 @@ cS
 lR
 NH
 nA
-dQ
-dP
-ZZ
-sb
-rb
+ps
+OV
+NH
+gf
+Hp
 vQ
 Hp
-sb
-mW
-op
+wM
+NH
+rw
 CM
 wF
 Bl
@@ -35266,12 +35258,12 @@ Ow
 Lk
 Py
 uT
-ZN
+Hp
 vB
-as
-sb
-hz
-UG
+Hp
+wM
+NH
+Bk
 CM
 uP
 Bl
@@ -35455,16 +35447,16 @@ Ll
 AE
 gR
 NH
-jj
+bj
 nr
-dP
 vV
-sb
-lP
-Cz
-PD
-sb
-hz
+NH
+qc
+Hp
+Hp
+Hp
+kN
+NH
 Rq
 CM
 KQ
@@ -35651,15 +35643,15 @@ gJ
 NH
 HF
 dQ
-dP
 hD
-hI
+yL
+HP
 nm
-UA
 WN
-sb
-hz
-UG
+WN
+RN
+NH
+Bk
 CM
 iZ
 Bl
@@ -35845,15 +35837,15 @@ Qg
 NH
 fW
 KK
-dP
-RY
-sb
+TC
+yL
+Vj
 Dm
-jO
+dP
 Ki
-sb
-hz
-UG
+Pf
+NH
+Bk
 CM
 Ra
 Bl
@@ -36041,13 +36033,13 @@ jj
 nr
 IG
 NH
-sb
-hI
-hI
+NH
 yL
-sb
-ZS
-xY
+NG
+yL
+NH
+NH
+kz
 CM
 Ao
 WU
@@ -36240,8 +36232,8 @@ NY
 Fr
 AB
 pS
-LO
 Fr
+WB
 CM
 CM
 CM
@@ -36435,7 +36427,7 @@ Fr
 lT
 wZ
 pr
-wc
+yw
 RJ
 mt
 HQ
@@ -36822,8 +36814,8 @@ VO
 kW
 nf
 hj
-dW
 UW
+dW
 wZ
 Fr
 HQ
@@ -37016,8 +37008,8 @@ up
 Fr
 Mq
 Mq
-dW
 wZ
+sY
 wZ
 uo
 BT
@@ -37210,8 +37202,8 @@ Ef
 Vo
 il
 il
+tC
 yw
-mN
 XF
 iD
 BT
@@ -37404,8 +37396,8 @@ wl
 wl
 wl
 wl
-MY
 ph
+PE
 BT
 BT
 BT
@@ -37598,8 +37590,8 @@ xW
 cM
 Zq
 wl
-zU
 Pr
+gd
 BT
 nl
 rV
@@ -37792,8 +37784,8 @@ RE
 RE
 VE
 wl
-zU
 EP
+GF
 BT
 GI
 rV
@@ -37986,7 +37978,7 @@ zt
 zt
 Sy
 wl
-zU
+HA
 Yu
 BT
 FR
@@ -38181,7 +38173,7 @@ Zq
 EE
 wl
 Ap
-Dn
+GF
 BT
 MM
 oU
@@ -38374,8 +38366,8 @@ Zq
 CI
 Zq
 wl
-zU
-Ny
+Rv
+GF
 BT
 yF
 HN
@@ -38568,8 +38560,8 @@ wl
 wl
 wl
 wl
-zU
-nY
+sR
+GF
 BT
 Wh
 xL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Triumph and Atlas Jump Pads Made Accessible By Other Departments.**

## Why It's Good For The Game

1. _I have recieved a very reasonable request to make the telepad to Surt more accessible to respond to emergencies. I have rearranged both departments to allow for Security, Medical, and Science access to Surt proper._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Triumph and Atlas Jump Pads Made Accessible By Other Departments.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
