### PR TITLE
Speedfix for Puzzle Doors

### DIFF
--- a/maps/submaps/level_specific/class_p/archaictemple.dmm
+++ b/maps/submaps/level_specific/class_p/archaictemple.dmm
@@ -399,11 +399,6 @@
 "tc" = (
 /obj/machinery/door/blast/puzzle{
 	color = "#CBA713";
-	icon_state = "metal";
-	icon_state_closed = "metal";
-	icon_state_closing = "metalclosing";
-	icon_state_open = "metalopen";
-	icon_state_opening = "metalopening";
 	lockID = "bchar";
 	name = "The Tomb of the Forgotten One"
 	},
@@ -620,11 +615,6 @@
 "Dy" = (
 /obj/machinery/door/blast/puzzle{
 	color = "#1F1A04";
-	icon_state = "metal";
-	icon_state_closed = "metal";
-	icon_state_closing = "metalclosing";
-	icon_state_open = "metalopen";
-	icon_state_opening = "metalopening";
 	lockID = "dmirr";
 	name = "enchanted door"
 	},
@@ -902,11 +892,6 @@
 "Nk" = (
 /obj/machinery/door/blast/puzzle{
 	color = "#4D4D4D";
-	icon_state = "metal";
-	icon_state_closed = "metal";
-	icon_state_closing = "metalclosing";
-	icon_state_open = "metalopen";
-	icon_state_opening = "metalopening";
 	lockID = "anak";
 	name = "Vault of B'Chardamz"
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Removes Varedited Icon State from Wizard College Puzzle Doors.**

## Why It's Good For The Game

1. _When door icons were redone whatever these were originally supposed to look like was removed. This is a band-aid until I can pick a new sprite._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Speedfix for Puzzle Doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
