### PR TITLE
changes emag orion trail reward from a 1,2,4 explosion to a 0,0,2 explosion

### DIFF
--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -527,7 +527,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 	src.audible_message("<b>\The [src]</b> says, 'Oh, God! Code Eight! CODE EIGHT! IT'S GONNA BL-'")
 	sleep(3.6)
 	src.visible_message(SPAN_DANGER("[src] explodes!"))
-	explosion(src.loc, 1,2,4)
+	explosion(src.loc, 0,0,2)
 	qdel(src)
 
 #undef ORION_TRAIL_WINTURN


### PR DESCRIPTION
## About The Pull Request
title

## Why It's Good For The Game
don't blow the bar up by accident with an item you can find in maintenance

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: changes emag orion trail reward from a 1,2,4 explosion to a 0,0,2 explosion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
