### PR TITLE
life crystals are no longer unlimited range

### DIFF
--- a/code/modules/vore/fluffstuff/custom_items.dm
+++ b/code/modules/vore/fluffstuff/custom_items.dm
@@ -463,7 +463,8 @@
 	//He's dead, jim
 	if(state != 1)
 		return
-	if(owner && (in_range_of(src, owner,7)) && owner.stat == DEAD)
+	var/list/connected_z_levels = GetConnectedZlevels(get_z(src))
+	if(owner && (owner.z in connected_z_levels) && owner.stat == DEAD)
 		update_state(2)
 		audible_message("<span class='warning'>The [name] begins flashing red.</span>")
 		sleep(30)

--- a/code/modules/vore/fluffstuff/custom_items.dm
+++ b/code/modules/vore/fluffstuff/custom_items.dm
@@ -463,7 +463,7 @@
 	//He's dead, jim
 	if(state != 1)
 		return
-	if(owner && (owner in src.view) && owner.stat == DEAD)
+	if(owner && (in_range_of(src, owner,7)) && owner.stat == DEAD)
 		update_state(2)
 		audible_message("<span class='warning'>The [name] begins flashing red.</span>")
 		sleep(30)

--- a/code/modules/vore/fluffstuff/custom_items.dm
+++ b/code/modules/vore/fluffstuff/custom_items.dm
@@ -461,7 +461,9 @@
 
 /obj/item/clothing/accessory/collar/vmcrystal/proc/check_owner()
 	//He's dead, jim
-	if((state == 1) && owner && (owner.stat == DEAD))
+	if(state != 1)
+		return
+	if(owner && (owner in src.view) && owner.stat == DEAD)
 		update_state(2)
 		audible_message("<span class='warning'>The [name] begins flashing red.</span>")
 		sleep(30)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
why life crystals should be nerfed:

1. Funny crystal rubbing and its able to detect your death from planets away is stupid
2. So far the lore (ingame description) suggests that its used to inform a thrid party(veymed) about the death of their customer, it should be worn on the customer, not left somewhere.
3. Currently its a loadout item for 1(one) loadout point, while practically an infinit range death alarm, death alarm implants are, opposed to that, a supply crate, that costs 40 points for 7, and death alarms work only while someone is in radio range of you

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: tweaked life crystals working over unlimited range
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
