### PR TITLE
transcore talks about missed backups again

### DIFF
--- a/code/controllers/subsystem/transcore_vr.dm
+++ b/code/controllers/subsystem/transcore_vr.dm
@@ -33,7 +33,7 @@ SUBSYSTEM_DEF(transcore)
 	var/timer = TICK_USAGE
 
 	INTERNAL_PROCESS_STEP(SSTRANSCORE_IMPLANTS,TRUE,process_implants,cost_implants,SSTRANSCORE_BACKUPS)
-//	INTERNAL_PROCESS_STEP(SSTRANSCORE_BACKUPS,FALSE,process_backups,cost_backups,SSTRANSCORE_IMPLANTS)
+	INTERNAL_PROCESS_STEP(SSTRANSCORE_BACKUPS,FALSE,process_backups,cost_backups,SSTRANSCORE_IMPLANTS)
 
 /datum/controller/subsystem/transcore/proc/process_implants(resumed = 0)
 	if (!resumed)
@@ -139,9 +139,8 @@ SUBSYSTEM_DEF(transcore)
 			MR.nif_durability = null
 			MR.nif_software = null
 			MR.nif_savedata = null
-
-
-	MR = new(mind, mind.current, add_to_db = FALSE, one_time = one_time)
+	else
+		MR = new(mind, mind.current, add_to_db = TRUE, one_time = one_time)
 
 	return MR
 

--- a/code/modules/resleeving/mirror.dm
+++ b/code/modules/resleeving/mirror.dm
@@ -43,6 +43,7 @@
 		icon_state = "mirror_implant"
 		human = H
 		human.mirror = src
+		LAZYADD(SStranscore.implants, src)
 
 /obj/item/implant/mirror/afterattack(atom/target, mob/user, clickchain_flags, list/params)
 	var/obj/machinery/computer/transhuman/resleeving/comp = target


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Why transcore should detect missed backups:

1. Unless we changed it, Mirror lore had backup stations that do regular backups
2. (1.) means that it has more than system wide reach, so transcore has to have the reach to detect the crew out there
3. People where complaining about their life crystals, we can also buff death alarms in return, I just think life crystals shouldnt be the solution to interplanetary death notifications

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: tweaked the transcore subsystem to send reminders for people missing their mind backups
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
