### PR TITLE
Makes the TEG soundloop not go through walls

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -152,6 +152,7 @@ GLOBAL_LIST_EMPTY(all_turbines)
 	// Sounds.
 	if(effective_gen > (max_power * 0.05)) // More than 5% and sounds start.
 		soundloop.start()
+		soundloop.opacity_check = 1
 		soundloop.volume = LERP(1, 40, effective_gen / max_power)
 	else
 		soundloop.stop()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The TEG soundloop now respects opacity and won't make noise through walls and two screens away, making the entire engineering department a low hum.

## Why It's Good For The Game

I want to be able to RP in my department, but that hum gets grating after 20 minutes. 
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: SingingSpock
tweak: The TEG soundloop will no longer play through walls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
