### PR TITLE
Makes the power monitor display supply/draw correctly

### DIFF
--- a/tgui/packages/tgui/interfaces/PowerMonitor.js
+++ b/tgui/packages/tgui/interfaces/PowerMonitor.js
@@ -7,7 +7,7 @@ import { useBackend, useLocalState } from '../backend';
 import { Box, Button, Chart, ColorBox, Flex, Icon, LabeledList, ProgressBar, Section, Table } from '../components';
 import { Window } from '../layouts';
 
-const PEAK_DRAW = 500000;
+const PEAK_DRAW = 500;
 
 export const powerRank = str => {
   const unit = String(str.split(' ')[1]).toLowerCase();
@@ -130,7 +130,7 @@ export const PowerMonitorFocus = (props, context) => {
                   minValue={0}
                   maxValue={maxValue}
                   color="teal">
-                  {toFixed(supply / 1000) + ' kW'}
+                  {toFixed(supply) + ' kW'}
                 </ProgressBar>
               </LabeledList.Item>
               <LabeledList.Item label="Draw">
@@ -139,7 +139,7 @@ export const PowerMonitorFocus = (props, context) => {
                   minValue={0}
                   maxValue={maxValue}
                   color="pink">
-                  {toFixed(demand / 1000) + ' kW'}
+                  {toFixed(demand) + ' kW'}
                 </ProgressBar>
               </LabeledList.Item>
             </LabeledList>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjusts the Javascript to make the power monitoring program display in kW correctly. Additionally, adjusts the default "PEAK_DRAW" to match the change from amounts being displayed in watts to kilowatts, which makes the progress bars actually useful. I hope to also make the number display with our better render_power method, but this is ready to be testmerged and will immediately make the program useful again. Testmerge only until I either figure it out or give up.

## Why It's Good For The Game

Whoever coded the Javascript for the interface decided to make it do math directly rather than make the dm file providing the number do it. This caused the power manager's supply/draw numbers to be divided by 1,000 (and any decimals cut off), which made it pretty useless. This fixes it.

## Changelog


:cl: SingingSpock
fix: The supply/draw numbers on the monitor will now display correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
