### PR TITLE
Makes alcohol "visible" in reagent containers

### DIFF
--- a/code/game/atoms/atom.dm
+++ b/code/game/atoms/atom.dm
@@ -438,14 +438,21 @@
 		if(reagents.reagents_holder_flags & TRANSPARENT)
 			. += "It contains:"
 			if(length(reagents.reagent_list))
+				var/has_alcohol = FALSE
 				if(user.can_see_reagents()) //Show each individual reagent
 					for(var/datum/reagent/current_reagent as anything in reagents.reagent_list)
+						if(!has_alcohol && istype(current_reagent,/datum/reagent/ethanol))
+							has_alcohol = TRUE
 						. += "&bull; [round(current_reagent.volume, 0.01)] units of [current_reagent.name]"
 				else //Otherwise, just show the total volume
 					var/total_volume = 0
 					for(var/datum/reagent/current_reagent as anything in reagents.reagent_list)
+						if(!has_alcohol && istype(current_reagent,/datum/reagent/ethanol))
+							has_alcohol = TRUE
 						total_volume += current_reagent.volume
 					. += "[total_volume] units of various reagents"
+				if(has_alcohol)
+					. += "It smells of alcohol."
 			else
 				. += "Nothing."
 		else if(reagents.reagents_holder_flags & AMOUNT_VISIBLE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Any transparent container, one that allows seeing how many reagents there are, will display if there's any alcoholic ingredients in there.

**This is untested** because my dang computer won't run the build.bat, for some reason, new problems, woo.

## Why It's Good For The Game

Because there's absolutely no way to tell normally.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Alcohol smells
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
