### PR TITLE
Urgent: Removes space tiles from Atlas

### DIFF
--- a/maps/rift/levels/rift-04-surface1.dmm
+++ b/maps/rift/levels/rift-04-surface1.dmm
@@ -2001,7 +2001,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/space/basic,
+/turf/simulated/floor/plating,
 /area/maintenance/substation/surface_one)
 "brd" = (
 /obj/machinery/light{
@@ -4736,11 +4736,6 @@
 "did" = (
 /turf/simulated/wall/prepainted/cargo,
 /area/maintenance/substation/cargo)
-"die" = (
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
-/turf/space/basic,
-/area/maintenance/security/lower)
 "dix" = (
 /obj/structure/table/rack/shelf,
 /obj/fiftyspawner/hardwood,
@@ -59200,7 +59195,7 @@ cFW
 cFW
 lUJ
 jAY
-die
+jAY
 vaO
 jAY
 dVt

--- a/maps/rift/levels/rift-06-surface3.dmm
+++ b/maps/rift/levels/rift-06-surface3.dmm
@@ -20052,11 +20052,6 @@
 /obj/structure/railing,
 /turf/simulated/open,
 /area/maintenance/station/exploration)
-"fax" = (
-/obj/structure/foamedmetal,
-/obj/structure/grille,
-/turf/space/basic,
-/area/rift/surfacebase/outside/outside3)
 "fbX" = (
 /obj/machinery/door/blast/regular,
 /turf/simulated/floor/reinforced,
@@ -26712,7 +26707,7 @@
 "xUe" = (
 /obj/structure/foamedmetal,
 /obj/structure/grille,
-/turf/space/basic,
+/turf/simulated/floor/plating,
 /area/ai)
 "xVh" = (
 /obj/effect/floor_decal/borderfloor{
@@ -53561,7 +53556,7 @@ hNS
 hNS
 aBL
 bWN
-fax
+iKl
 xUe
 eod
 eod
@@ -53577,7 +53572,7 @@ aTG
 eod
 eod
 eod
-fax
+iKl
 cYF
 afq
 afq

--- a/tgui/packages/tgui/interfaces/PowerMonitor.js
+++ b/tgui/packages/tgui/interfaces/PowerMonitor.js
@@ -7,7 +7,7 @@ import { useBackend, useLocalState } from '../backend';
 import { Box, Button, Chart, ColorBox, Flex, Icon, LabeledList, ProgressBar, Section, Table } from '../components';
 import { Window } from '../layouts';
 
-const PEAK_DRAW = 500000;
+const PEAK_DRAW = 500;
 
 export const powerRank = str => {
   const unit = String(str.split(' ')[1]).toLowerCase();
@@ -130,7 +130,7 @@ export const PowerMonitorFocus = (props, context) => {
                   minValue={0}
                   maxValue={maxValue}
                   color="teal">
-                  {toFixed(supply / 1000) + ' kW'}
+                  {toFixed(supply) + ' kW'}
                 </ProgressBar>
               </LabeledList.Item>
               <LabeledList.Item label="Draw">
@@ -139,7 +139,7 @@ export const PowerMonitorFocus = (props, context) => {
                   minValue={0}
                   maxValue={maxValue}
                   color="pink">
-                  {toFixed(demand / 1000) + ' kW'}
+                  {toFixed(demand) + ' kW'}
                 </ProgressBar>
               </LabeledList.Item>
             </LabeledList>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Pretty sure these are my fault, but there's a few space tiles on Atlas. This removes them.

## Why It's Good For The Game

Space tiles bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: SingingSpock
fix: Atlas no longer has space tiles in its maints
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
