### PR TITLE
Makes air alarms tolerate tiny amounts of phoron

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_types/core.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types/core.dm
@@ -79,4 +79,4 @@
 	gas_flags = GAS_FLAG_FUEL | GAS_FLAG_FUSION_FUEL | GAS_FLAG_CONTAMINANT | GAS_FLAG_FILTERABLE | GAS_FLAG_CORE
 	gas_groups = GAS_GROUP_CORE
 
-	default_tlv = list(0, 0, 0, 0.5)
+	default_tlv = list(0, 0, 0.25, 0.5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Sets the max1 threshold for phoron to 0.25, making air alarms not freak out at the tiniest amount of the gas

## Why It's Good For The Game

Vox breathing and solved air crises won't permanently make a room orange atmos alert

## Changelog

:cl:
fix: Air Alarms no longer freak out at infinitesimally small amounts of phoron
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
