### PR TITLE
Makes radiation wave decay inverse square instead of exponential

### DIFF
--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -140,7 +140,7 @@
 	var/dir
 	var/spread
 	var/existing
-	var/inverse_square_factor = 1 / (2 ** (falloff_modifier * cycles))
+	var/inverse_square_factor = (falloff_modifier * cycles)**-2
 
 	for(i in length(turfs) to 1 step -1)
 		T = turfs[i]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Right now it decays exponentially instead of through an inverse square law.

## Why It's Good For The Game

It... makes radiation stronger, actually. Not sure this is better. But engineers should be wearing rad suits when there's radiation anyway, so, y'know. Probably good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: "Inverse square factor" for radiation now actually inverse square instead of exponential decay
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
