### PR TITLE
Fixes Openable Snack Traits Passing to Fruit

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -16,6 +16,7 @@
 	var/nutriment_amt = 0
 	var/list/nutriment_desc = list("food" = 1)
 	var/datum/reagent/nutriment/coating/coating = null
+	var/sealed = 0
 	var/custom_open_sound
 	var/open_message = "You peel open the can! It looks ready to eat!"
 	var/opened_icon = 0
@@ -51,7 +52,7 @@
 	. = ..()
 	if(.)
 		return
-	if(!is_open_container())
+	if(sealed)
 		open(user)
 
 /obj/item/reagent_containers/food/snacks/proc/open(mob/user)
@@ -65,7 +66,7 @@
 		update_icon()
 
 	to_chat(user, "<span class='notice'>[open_message]</span>")
-	atom_flags |= OPENCONTAINER
+	sealed = 0
 
 /obj/item/reagent_containers/food/snacks/attack_mob(mob/target, mob/user, clickchain_flags, list/params, mult, target_zone, intent)
 	if(user.a_intent == INTENT_HARM)
@@ -81,7 +82,7 @@
 		qdel(src)
 		return 0
 
-	if(!is_open_container())
+	if(sealed)
 		to_chat(user, "<span class='notice'>You need to open [src]!</span>")
 		return 0
 
@@ -3646,7 +3647,7 @@ END CITADEL CHANGE */
 	trash = /obj/item/trash/liquidfood
 	filling_color = "#A8A8A8"
 	survivalfood = TRUE
-	atom_flags = NONE //starts closed
+	sealed = 1
 	center_of_mass = list("x"=16, "y"=15)
 	nutriment_amt = 30
 	bitesize = 4
@@ -3752,7 +3753,7 @@ END CITADEL CHANGE */
 	icon_state = "beans"
 	nutriment_amt = 4
 	nutriment_desc = list("beans" = 4)
-	atom_flags = NONE //starts closed
+	sealed = 1
 	opened_icon = 1
 
 /obj/item/reagent_containers/food/snacks/beans/Initialize(mapload)
@@ -6596,7 +6597,7 @@ END CITADEL CHANGE */
 	filling_color = "#015f01"
 	nutriment_amt = 5
 	nutriment_desc = list("mossy fungus" = 5)
-	atom_flags = NONE //starts closed
+	sealed = 1
 	opened_icon = 1
 
 /obj/item/reagent_containers/food/snacks/cavemoss_can/Initialize(mapload)
@@ -6611,7 +6612,7 @@ END CITADEL CHANGE */
 	filling_color = "#64482d"
 	nutriment_amt = 5
 	nutriment_desc = list("mushroom" = 1, "carrot" = 1, "bugflesh" = 3)
-	atom_flags = NONE //starts closed
+	sealed = 1
 	opened_icon = 1
 
 /obj/item/reagent_containers/food/snacks/diggerstew_can/Initialize(mapload)
@@ -6626,7 +6627,7 @@ END CITADEL CHANGE */
 	filling_color = "#759c75"
 	nutriment_amt = 5
 	nutriment_desc = list("mushroom" = 2, "bugflesh" = 3)
-	atom_flags = NONE //starts closed
+	sealed = 1
 	opened_icon = 1
 
 /obj/item/reagent_containers/food/snacks/canned_beetles/Initialize(mapload)
@@ -6641,7 +6642,7 @@ END CITADEL CHANGE */
 	filling_color = "#7a3f07"
 	nutriment_amt = 5
 	nutriment_desc = list(MAT_IRON = 3, "water" = 2)
-	atom_flags = NONE //starts closed
+	sealed = 1
 	opened_icon = 1
 
 /obj/item/reagent_containers/food/snacks/rust_can/Initialize(mapload)
@@ -6657,7 +6658,7 @@ END CITADEL CHANGE */
 	filling_color = "#331f0c"
 	nutriment_amt = 5
 	nutriment_desc = list("bugflesh" = 3, "soil" = 1, "dirt" = 1)
-	atom_flags = NONE //starts closed
+	sealed = 1
 
 /obj/item/reagent_containers/food/snacks/wrapped/alraune_bar/Initialize(mapload)
 	. = ..()
@@ -6741,7 +6742,7 @@ END CITADEL CHANGE */
 	filling_color = "#FC6F28"
 	nutriment_amt = 4
 	nutriment_desc = list("beans" = 4)
-	atom_flags = NONE //starts closed
+	sealed = 1
 	opened_icon = 1
 
 /obj/item/reagent_containers/food/snacks/baschbeans/Initialize(mapload)
@@ -6756,7 +6757,7 @@ END CITADEL CHANGE */
 	filling_color = "#FFFAD4"
 	nutriment_amt = 5
 	nutriment_desc = list("corn" = 5)
-	atom_flags = NONE //starts closed
+	sealed = 1
 	opened_icon = 1
 
 /obj/item/reagent_containers/food/snacks/creamcorn/Initialize(mapload)
@@ -6770,7 +6771,7 @@ END CITADEL CHANGE */
 	trash = /obj/item/trash/brainsnaxtrash
 	nutriment_amt = 5
 	nutriment_desc = list("protein" = 3, "iron" = 2)
-	atom_flags = NONE //starts closed
+	sealed = 1
 	opened_icon = 1
 
 /obj/item/reagent_containers/food/snacks/brainsnax/Initialize(mapload)
@@ -6792,7 +6793,7 @@ END CITADEL CHANGE */
 	filling_color = "#7D5F46"
 	nutriment_amt = 3
 	nutriment_desc = list("candy" = 1)
-	atom_flags = NONE //starts closed
+	sealed = 1
 	custom_open_sound = 'sound/effects/pageturn2.ogg'
 	open_message = "You peel back the wrapping!"
 
@@ -6910,7 +6911,7 @@ END CITADEL CHANGE */
 	filling_color = "#E8C31E"
 	nutriment_amt = 5
 	nutriment_desc = list("salt" = 1, "chips" = 2)
-	atom_flags = NONE //starts closed
+	sealed = 1
 	custom_open_sound = 'sound/bureaucracy/papercrumple.ogg'
 	open_message = "You pull the package open!"
 
@@ -6970,7 +6971,7 @@ END CITADEL CHANGE */
 	filling_color = "#343834"
 	nutriment_amt = 12
 	nutriment_desc = list("dried raisins" = 6)
-	atom_flags = NONE //starts closed
+	sealed = 1
 	custom_open_sound = 'sound/misc/boxopen.ogg'
 	open_message = "You pop open the box!"
 
@@ -7002,7 +7003,7 @@ END CITADEL CHANGE */
 	center_of_mass = list("x"=17, "y"=16)
 	nutriment_amt = 6
 	nutriment_desc = list("bread" = 2, "sweetness" = 3)
-	atom_flags = NONE //starts closed
+	sealed = 1
 	custom_open_sound = 'sound/weapons/grenade_launcher.ogg'
 	open_message = "You pop open the tube!"
 

--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -16,7 +16,7 @@
 	var/nutriment_amt = 0
 	var/list/nutriment_desc = list("food" = 1)
 	var/datum/reagent/nutriment/coating/coating = null
-	var/sealed = 0
+	var/sealed = FALSE
 	var/custom_open_sound
 	var/open_message = "You peel open the can! It looks ready to eat!"
 	var/opened_icon = 0
@@ -66,7 +66,7 @@
 		update_icon()
 
 	to_chat(user, "<span class='notice'>[open_message]</span>")
-	sealed = 0
+	sealed = FALSE
 
 /obj/item/reagent_containers/food/snacks/attack_mob(mob/target, mob/user, clickchain_flags, list/params, mult, target_zone, intent)
 	if(user.a_intent == INTENT_HARM)
@@ -3647,7 +3647,7 @@ END CITADEL CHANGE */
 	trash = /obj/item/trash/liquidfood
 	filling_color = "#A8A8A8"
 	survivalfood = TRUE
-	sealed = 1
+	sealed = TRUE
 	center_of_mass = list("x"=16, "y"=15)
 	nutriment_amt = 30
 	bitesize = 4
@@ -3753,7 +3753,7 @@ END CITADEL CHANGE */
 	icon_state = "beans"
 	nutriment_amt = 4
 	nutriment_desc = list("beans" = 4)
-	sealed = 1
+	sealed = TRUE
 	opened_icon = 1
 
 /obj/item/reagent_containers/food/snacks/beans/Initialize(mapload)
@@ -6597,7 +6597,7 @@ END CITADEL CHANGE */
 	filling_color = "#015f01"
 	nutriment_amt = 5
 	nutriment_desc = list("mossy fungus" = 5)
-	sealed = 1
+	sealed = TRUE
 	opened_icon = 1
 
 /obj/item/reagent_containers/food/snacks/cavemoss_can/Initialize(mapload)
@@ -6612,7 +6612,7 @@ END CITADEL CHANGE */
 	filling_color = "#64482d"
 	nutriment_amt = 5
 	nutriment_desc = list("mushroom" = 1, "carrot" = 1, "bugflesh" = 3)
-	sealed = 1
+	sealed = TRUE
 	opened_icon = 1
 
 /obj/item/reagent_containers/food/snacks/diggerstew_can/Initialize(mapload)
@@ -6627,7 +6627,7 @@ END CITADEL CHANGE */
 	filling_color = "#759c75"
 	nutriment_amt = 5
 	nutriment_desc = list("mushroom" = 2, "bugflesh" = 3)
-	sealed = 1
+	sealed = TRUE
 	opened_icon = 1
 
 /obj/item/reagent_containers/food/snacks/canned_beetles/Initialize(mapload)
@@ -6642,7 +6642,7 @@ END CITADEL CHANGE */
 	filling_color = "#7a3f07"
 	nutriment_amt = 5
 	nutriment_desc = list(MAT_IRON = 3, "water" = 2)
-	sealed = 1
+	sealed = TRUE
 	opened_icon = 1
 
 /obj/item/reagent_containers/food/snacks/rust_can/Initialize(mapload)
@@ -6658,7 +6658,7 @@ END CITADEL CHANGE */
 	filling_color = "#331f0c"
 	nutriment_amt = 5
 	nutriment_desc = list("bugflesh" = 3, "soil" = 1, "dirt" = 1)
-	sealed = 1
+	sealed = TRUE
 
 /obj/item/reagent_containers/food/snacks/wrapped/alraune_bar/Initialize(mapload)
 	. = ..()
@@ -6742,7 +6742,7 @@ END CITADEL CHANGE */
 	filling_color = "#FC6F28"
 	nutriment_amt = 4
 	nutriment_desc = list("beans" = 4)
-	sealed = 1
+	sealed = TRUE
 	opened_icon = 1
 
 /obj/item/reagent_containers/food/snacks/baschbeans/Initialize(mapload)
@@ -6757,7 +6757,7 @@ END CITADEL CHANGE */
 	filling_color = "#FFFAD4"
 	nutriment_amt = 5
 	nutriment_desc = list("corn" = 5)
-	sealed = 1
+	sealed = TRUE
 	opened_icon = 1
 
 /obj/item/reagent_containers/food/snacks/creamcorn/Initialize(mapload)
@@ -6771,7 +6771,7 @@ END CITADEL CHANGE */
 	trash = /obj/item/trash/brainsnaxtrash
 	nutriment_amt = 5
 	nutriment_desc = list("protein" = 3, "iron" = 2)
-	sealed = 1
+	sealed = TRUE
 	opened_icon = 1
 
 /obj/item/reagent_containers/food/snacks/brainsnax/Initialize(mapload)
@@ -6793,7 +6793,7 @@ END CITADEL CHANGE */
 	filling_color = "#7D5F46"
 	nutriment_amt = 3
 	nutriment_desc = list("candy" = 1)
-	sealed = 1
+	sealed = TRUE
 	custom_open_sound = 'sound/effects/pageturn2.ogg'
 	open_message = "You peel back the wrapping!"
 
@@ -6911,7 +6911,7 @@ END CITADEL CHANGE */
 	filling_color = "#E8C31E"
 	nutriment_amt = 5
 	nutriment_desc = list("salt" = 1, "chips" = 2)
-	sealed = 1
+	sealed = TRUE
 	custom_open_sound = 'sound/bureaucracy/papercrumple.ogg'
 	open_message = "You pull the package open!"
 
@@ -6971,7 +6971,7 @@ END CITADEL CHANGE */
 	filling_color = "#343834"
 	nutriment_amt = 12
 	nutriment_desc = list("dried raisins" = 6)
-	sealed = 1
+	sealed = TRUE
 	custom_open_sound = 'sound/misc/boxopen.ogg'
 	open_message = "You pop open the box!"
 
@@ -7003,7 +7003,7 @@ END CITADEL CHANGE */
 	center_of_mass = list("x"=17, "y"=16)
 	nutriment_amt = 6
 	nutriment_desc = list("bread" = 2, "sweetness" = 3)
-	sealed = 1
+	sealed = TRUE
 	custom_open_sound = 'sound/weapons/grenade_launcher.ogg'
 	open_message = "You pop open the tube!"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Adjusts Openable Snack Traits.**

## Why It's Good For The Game

1. _Somehow, Palpatine came back. I mean, uh, somehow fruits and grown snacks were being affected by the openable trait. I'm not exactly sure how that happened, since I didn't subtype them at all. However upon review and discussion with Kev, we decided not to tie Opening into the open container flag for foods at all. So I've reworked the proc to just check for a sealed variable._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes Openable Snack Traits Passing to Fruit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
