### PR TITLE
Makes Mecha Components Recyclable

### DIFF
--- a/code/game/mecha/components/actuators.dm
+++ b/code/game/mecha/components/actuators.dm
@@ -5,6 +5,7 @@
 	icon_state = "motor"
 	w_class = ITEMSIZE_HUGE
 	origin_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
+	materials = list(MAT_STEEL = 2500, MAT_GLASS = 1200)
 
 	component_type = MECH_ACTUATOR
 

--- a/code/game/mecha/components/armor.dm
+++ b/code/game/mecha/components/armor.dm
@@ -5,6 +5,7 @@
 	icon_state = "armor"
 	w_class = ITEMSIZE_HUGE
 	origin_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 2)
+	materials = list(MAT_STEEL = 5000, MAT_GLASS = 1000)
 
 	component_type = MECH_ARMOR
 

--- a/code/game/mecha/components/electrical.dm
+++ b/code/game/mecha/components/electrical.dm
@@ -5,6 +5,7 @@
 	icon_state = "board"
 	w_class = ITEMSIZE_HUGE
 	origin_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
+	materials = list(MAT_STEEL = 2500, MAT_GLASS = 1000)
 
 	component_type = MECH_ELECTRIC
 

--- a/code/game/mecha/components/hull.dm
+++ b/code/game/mecha/components/hull.dm
@@ -5,6 +5,7 @@
 	icon_state = "hull"
 	w_class = ITEMSIZE_HUGE
 	origin_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
+	materials = list(MAT_STEEL = 3500, MAT_GLASS = 200)
 
 	component_type = MECH_HULL
 

--- a/code/game/mecha/components/lifesupport.dm
+++ b/code/game/mecha/components/lifesupport.dm
@@ -5,6 +5,7 @@
 	icon_state = "lifesupport"
 	w_class = ITEMSIZE_HUGE
 	origin_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
+	materials = list(MAT_STEEL = 1000, MAT_GLASS = 1500)
 
 	component_type = MECH_GAS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Mecha Components Can Now Be Recycled via Autolathe.**

## Why It's Good For The Game

1. _I'm tired of mecha components just taking up space as total junk. Now they can be recycled via the Autolathe for 50% value._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Makes Mecha Components Recyclable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
