### PR TITLE
adds a range (3 tiles) to subtle notification message

### DIFF
--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -58,7 +58,7 @@
 			spawn(0)
 				O.see_emote(src, message, 2)
 
-		var/list/other_viewers = get_hearers_in_view(source = src)
+		var/list/other_viewers = get_hearers_in_view(3, source = src)
 		for(var/mob/M in other_viewers - vis_mobs)
 			M.show_message(SPAN_SMALL("<i>[src] does something [pick("subtly", "discreetly", "hidden", "obscured")].</i>"), SAYCODE_TYPE_VISIBLE)
 
@@ -115,7 +115,7 @@
 			var/obj/O = visobj
 			O.see_emote(src, message, 2)
 
-		var/list/other_viewers = get_hearers_in_view(source = src)
+		var/list/other_viewers = get_hearers_in_view(3, source = src)
 		for(var/mob/M in (other_viewers - vis_mobs))
 			if(istype(M, /mob/observer))
 				continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
not everyone has 20 WIS with a perception advantage to notice tiny things happening 7 tiles away

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak:subtler notif now happens at 3 tiles not all of the screen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
