### PR TITLE
Connects Lower Medbay Maint, adds CE/CMO request consoles

### DIFF
--- a/maps/rift/levels/rift-02-underground2.dmm
+++ b/maps/rift/levels/rift-02-underground2.dmm
@@ -11565,6 +11565,12 @@
 /obj/item/storage/single_use/med_pouch/radiation,
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engine_room)
+"Nk" = (
+/obj/machinery/requests_console/preset/ce{
+	pixel_y = -30
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/chief)
 "Nm" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -31043,7 +31049,7 @@ he
 ol
 mE
 me
-mE
+Nk
 aA
 aA
 aa

--- a/maps/rift/levels/rift-04-surface1.dmm
+++ b/maps/rift/levels/rift-04-surface1.dmm
@@ -11687,6 +11687,9 @@
 	desc = "A bed made especially for cats, or other similarly sized pets.";
 	name = "Runtime's Bed"
 	},
+/obj/machinery/requests_console/preset/cmo{
+	pixel_y = -30
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/cmo)
 "hDN" = (
@@ -16603,21 +16606,15 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/rift/trade_shop)
 "kAd" = (
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/catwalk,
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "kBr" = (
@@ -53962,7 +53959,7 @@ oOT
 gWs
 mUU
 mUU
-kAd
+kjp
 eBp
 uOt
 qQo
@@ -55309,7 +55306,7 @@ wUo
 qwF
 qwF
 qwF
-qwF
+kAd
 qwF
 dyA
 qwF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves the APC for lower medbay maints to where there's actually a power line and gives it a wire node. Additionally gives the CE and CMO offices a request console so they can make announcements from their respective desks.

## Why It's Good For The Game

Fixes a couple minor issues with Atlas

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: SingingSpock
Fix: Lower Medbay Maints has power now on Atlas
Add: CE and CMO have request consoles in their office now on Atlas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
