### PR TITLE
Gives the Triumph SMES room expansion wires

### DIFF
--- a/maps/triumph/levels/deck1.dmm
+++ b/maps/triumph/levels/deck1.dmm
@@ -3572,7 +3572,8 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tcommsat/entrance)
 "lU" = (
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "lV" = (
 /obj/structure/closet/radiation,
@@ -3906,7 +3907,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "nk" = (
 /obj/structure/atmos_tank_segment/phoron{
@@ -5123,7 +5128,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "rs" = (
 /obj/structure/bed/chair,
@@ -5725,7 +5731,14 @@
 "to" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/holopad,
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "tq" = (
 /obj/structure/disposalpipe/segment{
@@ -6416,7 +6429,11 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera/network/engine,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "vI" = (
 /obj/structure/railing{
@@ -6813,7 +6830,8 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "wV" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
@@ -6891,7 +6909,11 @@
 /area/engineering/hallway/lower)
 "xh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "xi" = (
 /obj/machinery/door/blast/regular{
@@ -7732,7 +7754,8 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "Al" = (
 /obj/machinery/power/terminal,
@@ -8990,7 +9013,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "Ev" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9165,7 +9189,8 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "EY" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -10325,7 +10350,8 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "IY" = (
 /turf/simulated/wall/prepainted,
@@ -11069,7 +11095,11 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "Lx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13461,7 +13491,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "TA" = (
 /obj/effect/floor_decal/techfloor/orange{
@@ -14435,7 +14466,11 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "WD" = (
 /obj/machinery/door/firedoor,
@@ -14513,7 +14548,11 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "WT" = (
 /obj/structure/cable{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives the SMES room in engineering on the Triumph the wiring needed to more easily add more SMESes, like the Atlas does. Also makes that flooring catwalks so the wiring is more visible.
![image](https://github.com/Citadel-Station-13/Citadel-Station-13-RP/assets/29682682/018ad9bd-a1ee-4de2-87a0-ab0da6fa95e0)


## Why It's Good For The Game

The setup of the engine room makes it a pain to add more SMESes, especially if someone else first built a single SMES and you want to add a second. This makes it easier.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Make the wiring in the SMES room on Triumph easier for adding additional SMESEs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
