### PR TITLE
Makes more fish count as fish for fishing

### DIFF
--- a/code/__DEFINES/fishing/fishing.dm
+++ b/code/__DEFINES/fishing/fishing.dm
@@ -54,6 +54,8 @@
 #define FISHING_MINIGAME_RULE_WEIGHTED_BAIT "weighted"
 #define FISHING_MINIGAME_RULE_LIMIT_LOSS "limit_loss"
 
+#define isfish(fish_type) (ispath(fish_type, /obj/item/fish) || ispath(fish_type, /mob/living/simple_mob/animal/passive/fish))
+
 /// The default additive value for fishing hook catch weight modifiers.
 #define FISHING_DEFAULT_HOOK_BONUS_ADDITIVE 0
 /// The default multiplicative value for fishing hook catch weight modifiers.

--- a/code/modules/fishing/equipment/hook.dm
+++ b/code/modules/fishing/equipment/hook.dm
@@ -59,7 +59,7 @@
 	// chasm_detritus_type = /obj/item/chasm_detritus/restricted/objects
 
 /obj/item/fishing_hook/magnet/get_hook_bonus_multiplicative(fish_type, datum/fish_source/source)
-	if(fish_type == FISHING_DUD || ispath(fish_type, /obj/item/fish))
+	if(fish_type == FISHING_DUD || isfish(fish_type))
 		return ..()
 	// We multiply the odds by five for everything that's not a fish nor a dud
 	return MAGNET_HOOK_BONUS_MULTIPLIER
@@ -103,7 +103,7 @@
 
 /obj/item/fishing_hook/rescue/get_hook_bonus_multiplicative(fish_type, datum/fish_source/source)
 	// Sorry, you won't catch fish with this.
-	if(ispath(fish_type, /obj/item/fish))
+	if(isfish(fish_type))
 		return RESCUE_HOOK_FISH_MULTIPLIER
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Approximately half of the fish weren't actually being counted as fish.

## Why It's Good For The Game

It makes sense that trout, pike, etc. are fish

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: A few more fish actually count as fish
/:cl: