### PR TITLE
Gives the tcomms substations starting power

### DIFF
--- a/code/modules/power/smes/smes.dm
+++ b/code/modules/power/smes/smes.dm
@@ -556,6 +556,14 @@ GLOBAL_LIST_EMPTY(smeses)
 	input_level = 100
 	output_level = 200
 
+/obj/machinery/power/smes/buildable/tcomms
+	name = "telecomms smes"
+	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. This is the one dedicated to telecommunications."
+	charge = KWH_TO_KWM(SMES_COIL_STORAGE_BASIC * 1 * 0.25)
+	input_level = 100
+	output_level = 200
+	RCon_tag = "Telecomms"
+
 #define SMES_UI_INPUT 1
 #define SMES_UI_OUTPUT 2
 

--- a/maps/rift/levels/rift-03-underground1.dmm
+++ b/maps/rift/levels/rift-03-underground1.dmm
@@ -1729,9 +1729,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rift/station/fighter_bay/transport_tunnel)
 "dO" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -1740,6 +1737,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/underone)
@@ -1949,8 +1949,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/underone)
@@ -2032,6 +2032,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/underone)
@@ -2139,11 +2142,11 @@
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/underone)
@@ -2752,6 +2755,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
 "hl" = (
@@ -3129,6 +3135,12 @@
 	},
 /turf/simulated/floor/reinforced/airmix,
 /area/engineering/atmos)
+"iP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/underone)
 "iQ" = (
 /obj/item/arrow/rod,
 /obj/effect/decal/remains/tajaran,
@@ -3178,6 +3190,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/underone)
 "ja" = (
@@ -3210,6 +3225,9 @@
 "jg" = (
 /obj/machinery/door/airlock/maintenance/engi{
 	name = "Substation Access"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
@@ -3492,6 +3510,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/rnd/secure_storage/upper)
+"jX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/underone)
 "jY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
@@ -4222,6 +4249,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 6
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/underone)
 "mJ" = (
@@ -4780,6 +4810,9 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
 "pa" = (
@@ -4930,9 +4963,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research/xenobio)
 "pz" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -4941,6 +4971,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
@@ -5821,6 +5854,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/underone)
 "th" = (
@@ -6314,8 +6350,12 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/structure/table/rack/shelf,
+/obj/item/radio/off,
+/obj/item/storage/toolbox/emergency,
+/obj/item/flashlight,
 /obj/structure/cable/green{
-	icon_state = "0-2"
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
@@ -6962,6 +7002,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/underone)
 "xf" = (
@@ -7503,9 +7546,6 @@
 /area/engineering/atmos)
 "yH" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
 "yI" = (
@@ -7554,9 +7594,6 @@
 /turf/simulated/floor/reinforced/airmix,
 /area/engineering/atmos)
 "yX" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
@@ -7571,6 +7608,9 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
 "zb" = (
@@ -8504,6 +8544,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/underone)
 "CE" = (
@@ -9126,7 +9169,10 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
@@ -9139,6 +9185,13 @@
 "Fe" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
@@ -9649,6 +9702,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 10
 	},
+/obj/structure/closet/crate,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/sub_filter,
+/obj/item/stock_parts/subspace/analyzer,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
 "GF" = (
@@ -9837,6 +9901,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
@@ -11070,6 +11137,15 @@
 /obj/effect/alien/weeds/node,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/hallway)
+"LC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/underone)
 "LD" = (
 /obj/structure/table/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -11247,6 +11323,9 @@
 	target_temp = 80;
 	use_power = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
 "Mn" = (
@@ -11273,6 +11352,16 @@
 /area/rift/station/fighter_bay/transport_tunnel)
 "Mt" = (
 /obj/effect/floor_decal/borderfloorblack/corner,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Telecomms Subgrid";
+	name_tag = "Telecomms Subgrid"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
 "Mu" = (
@@ -11538,17 +11627,14 @@
 /area/rift/station/fighter_bay/transport_tunnel)
 "Nt" = (
 /obj/machinery/holopad,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
@@ -12542,6 +12628,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/underone)
 "QP" = (
@@ -12622,6 +12711,11 @@
 /obj/structure/cable/green{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/chamber)
 "Rf" = (
@@ -12695,6 +12789,13 @@
 /obj/effect/paint/pipecyan,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
+"Rr" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/hallway/primary/underone)
 "Rs" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 1
@@ -13066,6 +13167,9 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
@@ -13481,6 +13585,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
 "UL" = (
@@ -13508,19 +13618,14 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/elevator)
 "UP" = (
-/obj/structure/closet/crate,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/subspace/analyzer,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/sub_filter,
-/obj/item/stock_parts/subspace/transmitter,
-/obj/item/stock_parts/subspace/treatment,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 5
+	},
+/obj/machinery/power/breakerbox{
+	RCon_tag = "Telecomms"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
@@ -13820,10 +13925,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/rift/station/fighter_bay/hangar)
 "VU" = (
-/obj/structure/table/rack/shelf,
-/obj/item/storage/toolbox/emergency,
-/obj/item/flashlight,
-/obj/item/radio/off,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -13831,6 +13932,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/power/smes/buildable/tcomms,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
 "VV" = (
@@ -27315,8 +27421,8 @@ aL
 dm
 aG
 cQ
-eg
-rT
+jX
+Rr
 jg
 hk
 cN
@@ -27509,7 +27615,7 @@ aL
 fT
 aG
 cQ
-eg
+LC
 dp
 XQ
 XQ
@@ -27703,7 +27809,7 @@ aL
 aG
 aG
 cS
-eg
+LC
 rT
 XQ
 Ma
@@ -27897,7 +28003,7 @@ aL
 aG
 aT
 cU
-eg
+LC
 Ic
 XQ
 dI
@@ -28091,7 +28197,7 @@ aL
 aG
 aU
 cU
-eg
+LC
 rT
 XQ
 PZ
@@ -28479,7 +28585,7 @@ bi
 aG
 aT
 cU
-eg
+LC
 Ib
 XQ
 CN
@@ -28867,7 +28973,7 @@ aC
 bX
 cw
 cX
-eg
+LC
 rY
 XQ
 Hi
@@ -29061,7 +29167,7 @@ md
 aB
 ca
 de
-eg
+LC
 rT
 XQ
 XQ
@@ -29255,7 +29361,7 @@ bF
 bV
 ae
 df
-eg
+LC
 fQ
 gv
 jv
@@ -29643,7 +29749,7 @@ bI
 rN
 ZS
 dw
-dP
+iP
 dP
 sg
 GP
@@ -29837,7 +29943,7 @@ cA
 ZS
 cA
 du
-dP
+iP
 sd
 eh
 fR
@@ -30031,7 +30137,7 @@ SW
 cl
 cf
 cn
-dP
+iP
 dP
 dP
 cZ
@@ -30225,7 +30331,7 @@ ai
 cy
 dP
 ec
-dP
+iP
 dP
 dP
 cZ
@@ -30419,7 +30525,7 @@ aP
 cz
 dP
 ec
-dP
+iP
 sh
 dP
 cZ
@@ -30613,7 +30719,7 @@ ai
 cC
 dP
 ec
-dP
+iP
 dP
 dP
 cZ
@@ -30807,7 +30913,7 @@ SW
 cD
 cs
 dl
-dP
+iP
 dP
 dP
 cZ
@@ -31001,7 +31107,7 @@ cA
 ZS
 cA
 dv
-dP
+iP
 sk
 cG
 ez

--- a/maps/tether/levels/surface2.dmm
+++ b/maps/tether/levels/surface2.dmm
@@ -3001,8 +3001,8 @@
 /turf/simulated/open/virgo3b,
 /area/tether/surfacebase/outside/outside2)
 "cfW" = (
-/obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Telecomms Substation Bypass"
+/obj/machinery/power/breakerbox{
+	RCon_tag = "Telecomms"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/tcomms)
@@ -8079,7 +8079,7 @@
 /obj/random/maintenance/engineering,
 /obj/effect/floor_decal/rust,
 /obj/item/clothing/suit/storage/vest/hoscoat/jensen{
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0);
+	armor = list("melee"=0,"bullet"=0,"laser"=0,"energy"=0,"bomb"=0,"bio"=0,"rad"=0);
 	desc = "Its an old, dusty trenchcoat... what a shame.";
 	name = "trenchcoat"
 	},
@@ -13843,17 +13843,13 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_two_hall)
 "jDb" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Telecomms";
-	charge = 100;
-	output_attempt = 0
-	},
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
 /obj/structure/cable/green{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/smes/buildable/tcomms,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/tcomms)
 "jDx" = (
@@ -20723,7 +20719,7 @@
 /obj/machinery/vending/cigarette{
 	name = "Cigarette machine";
 	prices = list();
-	products = list(/obj/item/storage/fancy/cigarettes = 10, /obj/item/storage/box/matches = 10, /obj/item/flame/lighter/zippo = 4, /obj/item/clothing/mask/smokable/cigarette/cigar/havana = 2)
+	products = list(/obj/item/storage/fancy/cigarettes=10,/obj/item/storage/box/matches=10,/obj/item/flame/lighter/zippo=4,/obj/item/clothing/mask/smokable/cigarette/cigar/havana=2)
 	},
 /obj/effect/floor_decal/techfloor/hole{
 	dir = 1
@@ -33393,7 +33389,7 @@
 	input_tag = "atmos_out";
 	name = "Atmos Intake Control";
 	output_tag = "atmos_in";
-	sensors = list("atmos_intake" = "Tank")
+	sensors = list("atmos_intake"="Tank")
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/monitoring)

--- a/maps/triumph/levels/deck1.dmm
+++ b/maps/triumph/levels/deck1.dmm
@@ -273,8 +273,11 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "aM" = (
 /obj/structure/table/reinforced,
 /obj/item/rcd/advanced,
@@ -529,11 +532,8 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos/monitoring)
 "bA" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/tcommsat/entrance)
+/turf/simulated/wall/prepainted/engineering,
+/area/engineering/drone_fabrication)
 "bB" = (
 /obj/structure/atmos_tank_segment/o2{
 	icon_state = "1,2"
@@ -729,6 +729,9 @@
 /obj/structure/catwalk,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "ck" = (
@@ -998,8 +1001,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
-/area/tcommsat/entrance)
+/area/tcommsat/powercontrol)
 "dj" = (
 /obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1168,17 +1177,17 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/engineering{
 	name = "Telecomms Control Room"
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "dT" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/spline/fancy/wood,
@@ -1384,6 +1393,15 @@
 /obj/structure/lattice,
 /turf/space,
 /area/engineering/atmos/gas_storage)
+"eL" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/drone_fabrication)
 "eN" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -1592,17 +1610,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engi_engine)
 "fk" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "fm" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 1
@@ -1626,17 +1638,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "fr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
-/area/tcommsat/entrance)
+/area/tcommsat/powercontrol)
 "ft" = (
 /obj/spawner/window/low_wall/borosillicate/full/firelocks,
 /obj/effect/paint_stripe/sun,
@@ -1959,18 +1971,15 @@
 /turf/simulated/floor/airless/ceiling,
 /area/space)
 "gt" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Telecomms";
-	cur_coils = 2
-	},
 /obj/structure/cable/green{
 	icon_state = "0-8"
 	},
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/smes/buildable/tcomms,
 /turf/simulated/floor/plating,
-/area/tcommsat/entrance)
+/area/tcommsat/powercontrol)
 "gu" = (
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/monitoring)
@@ -2312,11 +2321,11 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/trash_pit)
@@ -2344,9 +2353,6 @@
 	},
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2745,6 +2751,15 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
+"je" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
 "jf" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -2863,7 +2878,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "jA" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_airlock)
@@ -2963,7 +2978,8 @@
 	dir = 8;
 	icon_state = "freezer_1";
 	set_temperature = 73;
-	use_power = 1
+	use_power = 1;
+	power_setting_legacy = 25
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tcommsat/computer)
@@ -3008,8 +3024,11 @@
 /area/engineering/hallway/lower)
 "jY" = (
 /obj/structure/closet/firecloset,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
-/area/tcommsat/entrance)
+/area/tcommsat/powercontrol)
 "jZ" = (
 /obj/structure/atmos_tank_segment/air{
 	icon_state = "0,2"
@@ -3391,7 +3410,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "lr" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -3563,14 +3582,14 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "lU" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -3722,7 +3741,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "ms" = (
 /obj/structure/railing{
 	dir = 4
@@ -3748,15 +3767,19 @@
 /area/engineering/atmos/storage)
 "mA" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
+"mB" = (
+/obj/machinery/door/airlock/maintenance/engi,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/tcommsat/powercontrol)
 "mC" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3769,15 +3792,12 @@
 "mD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/plating,
-/area/tcommsat/entrance)
+/area/tcommsat/powercontrol)
 "mE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4907,8 +4927,11 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "qK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4952,11 +4975,8 @@
 /area/engineering/hallway)
 "qP" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "qQ" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 8
@@ -5176,7 +5196,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "rB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -5372,7 +5392,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "sf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5727,7 +5747,7 @@
 "tn" = (
 /obj/structure/sign/department/drones,
 /turf/simulated/wall/prepainted/engineering,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "to" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/holopad,
@@ -6217,16 +6237,16 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/workshop)
 "uL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/maintenance/engi,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "uM" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable{
@@ -6308,7 +6328,7 @@
 	amount = 50
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "vh" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -7050,6 +7070,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/engineering/break_room)
+"xA" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "xB" = (
 /obj/machinery/camera/network/engine,
 /obj/effect/floor_decal/industrial/warning{
@@ -7844,15 +7871,15 @@
 /area/engineering/portnacelle)
 "Ax" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techmaint,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "Ay" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -8363,6 +8390,9 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "Cl" = (
@@ -8773,7 +8803,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/wall/prepainted/engineering,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "DE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/wall/r_wall/prepainted/engineering/atmos,
@@ -8899,16 +8929,13 @@
 /area/maintenance/trash_pit)
 "DY" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "Eb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
@@ -9797,11 +9824,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
@@ -10033,8 +10060,11 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "HV" = (
 /obj/structure/atmos_tank_segment/n2o2{
 	icon_state = "2,0"
@@ -10181,9 +10211,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
 "Ix" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - Telecomms Subgrid";
 	name_tag = "Telecomms Subgrid"
@@ -10191,8 +10218,11 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
-/area/tcommsat/entrance)
+/area/tcommsat/powercontrol)
 "Iz" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/simulated/floor/tiled/dark{
@@ -10763,11 +10793,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
 "Kr" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/techmaint,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "Ks" = (
 /obj/machinery/blackbox_recorder,
 /obj/structure/cable/green{
@@ -10935,7 +10962,7 @@
 /area/engineering/engine_airlock)
 "KX" = (
 /turf/simulated/wall/prepainted/engineering,
-/area/tcommsat/entrance)
+/area/tcommsat/powercontrol)
 "KY" = (
 /obj/effect/floor_decal/techfloor/orange,
 /obj/structure/table/rack{
@@ -11150,7 +11177,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "LD" = (
 /obj/structure/atmos_tank_segment/co2{
 	icon_state = "4,4"
@@ -11365,14 +11392,14 @@
 /turf/simulated/floor/airless/ceiling,
 /area/maintenance/engi_engine)
 "Ms" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
-/area/tcommsat/entrance)
+/area/tcommsat/powercontrol)
 "Mt" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -11646,7 +11673,7 @@
 /area/engineering/engine_smes)
 "Nm" = (
 /turf/simulated/wall/r_wall/prepainted/engineering,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "Nn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 8
@@ -12387,14 +12414,14 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/trash_pit)
@@ -12460,12 +12487,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos/storage)
 "PZ" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
-/area/tcommsat/entrance)
+/area/tcommsat/powercontrol)
 "Qa" = (
 /obj/structure/sign/greencross{
 	pixel_y = 32
@@ -12554,7 +12578,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "Qm" = (
 /obj/structure/railing{
 	dir = 4
@@ -12873,9 +12897,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -12885,17 +12906,23 @@
 /obj/machinery/camera/network/tcomms{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
-/area/tcommsat/entrance)
+/area/tcommsat/powercontrol)
 "Rv" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techmaint,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "Rw" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -12953,10 +12980,10 @@
 "RE" = (
 /obj/machinery/holopad,
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "RG" = (
 /obj/structure/railing,
 /obj/structure/lattice,
@@ -13105,9 +13132,6 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/floor_decal/techfloor/orange,
@@ -13126,11 +13150,17 @@
 	},
 /area/tcommsat/chamber)
 "Sj" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/super;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/tcommsat/entrance)
+/area/tcommsat/powercontrol)
 "Sk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/engineering{
@@ -13494,6 +13524,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/engine_smes)
+"Ty" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "TA" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
@@ -13997,11 +14034,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/power/breakerbox/activated{
+/obj/machinery/power/breakerbox{
 	RCon_tag = "TELECOMMS"
 	},
 /turf/simulated/floor/plating,
-/area/tcommsat/entrance)
+/area/tcommsat/powercontrol)
 "Ve" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
@@ -14369,7 +14406,7 @@
 "Wm" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/techmaint,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "Wn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -15131,6 +15168,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "YJ" = (
@@ -15259,11 +15299,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance/engi,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/trash_pit)
 "Zi" = (
@@ -15343,9 +15383,6 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -15356,8 +15393,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
-/area/tcommsat/entrance)
+/area/tcommsat/powercontrol)
 "Zx" = (
 /obj/machinery/air_alarm{
 	frequency = 1441;
@@ -15502,7 +15545,7 @@
 	light_range = 12
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/tcommsat/entrance)
+/area/engineering/drone_fabrication)
 "ZR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33706,16 +33749,16 @@ Oy
 Oy
 Oy
 Oy
-Oy
-Oy
-Oy
-Oy
-Oy
-Oy
-Oy
-Oy
+xA
+Ty
+Ty
+Ty
+Ty
+Ty
+Ty
+Ty
 cj
-Bl
+je
 YI
 ij
 rv
@@ -33900,7 +33943,7 @@ Oy
 KO
 Eo
 Sd
-yD
+hT
 Ub
 hK
 CN
@@ -34094,15 +34137,15 @@ HW
 Oc
 Oc
 nX
-yD
+hT
 nw
-KX
-KX
-KX
-KX
-KX
-KX
-KX
+bA
+bA
+bA
+bA
+bA
+bA
+bA
 fI
 YA
 dN
@@ -34288,15 +34331,15 @@ BH
 ZC
 zv
 KX
+mB
 KX
-KX
-KX
+bA
 se
 jz
 ZP
 lq
 se
-KX
+bA
 Pm
 AB
 dN
@@ -34489,8 +34532,8 @@ fk
 qP
 Kr
 rA
+fk
 bA
-KX
 Bl
 JP
 dN
@@ -34678,7 +34721,7 @@ zv
 Ix
 di
 jY
-KX
+bA
 lT
 aL
 RE
@@ -34877,7 +34920,7 @@ Rv
 Ax
 DY
 mA
-Rv
+eL
 dR
 Hf
 Se
@@ -35066,7 +35109,7 @@ zv
 Vd
 Ms
 Sj
-KX
+bA
 vg
 LC
 mq


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Give the tcomms substations with power in them to start, as well as breakers that start deactivated. This means that the comms will run for about 1 hour even if nobody starts power immediately. While I did adjust the Tether tcomms, this PR was not actually tested there since it isn't a server we currently run, I just didn't want to leave it behind on this particular change. The power usage (and therefore expected uptime) there should be similar.

## Why It's Good For The Game

People shouldn't be rendered unable to communicate over radio within 5 minutes of roundstart because engineers aren't around or aren't capable of immediately generating power. This gives the facility about an hour of leeway before the comms die, making it still important to get main power running but not something that's going to immediately negatively impact everyone.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: SingingSpock
tweak: Tcomms substations start with a bit of power in them, so they won't die immediately on roundstart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
