### PR TITLE
Gives senior engineer access to some loadout entries

### DIFF
--- a/code/modules/loadout/loadout_role_restricted.dm
+++ b/code/modules/loadout/loadout_role_restricted.dm
@@ -874,22 +874,22 @@
 /datum/loadout_entry/restricted/engineering/uniform/jeans/atmos
 	name = "Atmospheric Technicians Jumpjeans"
 	path = /obj/item/clothing/under/rank/atmospheric_technician/jeans
-	allowed_roles = list("Chief Engineer", "Atmospheric Technician")
+	allowed_roles = list("Chief Engineer", "Atmospheric Technician", "Senior Engineer")
 
 /datum/loadout_entry/restricted/engineering/uniform/fem_jeans/atmos
 	name = "Atmospheric Technicians Jumpjeans - Female"
 	path = /obj/item/clothing/under/rank/atmospheric_technician/fem_jeans
-	allowed_roles = list("Chief Engineer", "Atmospheric Technician")
+	allowed_roles = list("Chief Engineer", "Atmospheric Technician", "Senior Engineer")
 
 /datum/loadout_entry/restricted/engineering/uniform/atmos_skirt
 	name = "Atmospherics Skirt"
 	path = /obj/item/clothing/under/rank/atmospheric_technician/skirt
-	allowed_roles = list("Chief Engineer", "Atmospheric Technician")
+	allowed_roles = list("Chief Engineer", "Atmospheric Technician", "Senior Engineer")
 
 /datum/loadout_entry/restricted/engineering/uniform/atmos_pleated_skirt
 	name = "Atmospherics Pleated Skirt"
 	path = /obj/item/clothing/under/rank/atmospheric_technician/skirt_pleated
-	allowed_roles = list("Chief Engineer", "Atmospheric Technician")
+	allowed_roles = list("Chief Engineer", "Atmospheric Technician", "Senior Engineer")
 
 /datum/loadout_entry/restricted/engineering/uniform/jeans
 	name = "Engineering Jumpjeans"
@@ -943,7 +943,7 @@
 /datum/loadout_entry/restricted/engineering/suit/wintercoat/atmos
 	name = "Atmospherics Winter Coat"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/engineering/atmos
-	allowed_roles = list("Chief Engineer", "Atmospheric Technician")
+	allowed_roles = list("Chief Engineer", "Atmospheric Technician", "Senior Engineer")
 
 /datum/loadout_entry/restricted/engineering/suit/wintercoat/ce
 	name = "Chief Engineers Winter Coat"
@@ -987,7 +987,7 @@
 /datum/loadout_entry/restricted/engineering/shoes/winterboots/atmos
 	name = "Atmospherics Winter Boots"
 	path = /obj/item/clothing/shoes/boots/winter/atmos
-	allowed_roles = list("Chief Engineer", "Atmospheric Technician")
+	allowed_roles = list("Chief Engineer", "Atmospheric Technician", "Senior Engineer")
 
 
 

--- a/code/modules/loadout/loadout_xeno.dm
+++ b/code/modules/loadout/loadout_xeno.dm
@@ -263,7 +263,7 @@
 /datum/loadout_entry/xeno/tajaran/eyes/veil/mesons
 	name = "Tajaran - Optical Meson Veil"
 	path = /obj/item/clothing/glasses/meson/prescription/tajblind
-	allowed_roles = list("Station Engineer", "Chief Engineer", "Atmospheric Technician", "Research Director", "Scientist", "Roboticist", "Xenobiologist", "Explorer", "Pathfinder")
+	allowed_roles = list("Station Engineer", "Chief Engineer", "Atmospheric Technician", "Senior Engineer", "Research Director", "Scientist", "Roboticist", "Xenobiologist", "Explorer", "Pathfinder")
 
 /datum/loadout_entry/xeno/tajaran/eyes/veil/material_scanners
 	name = "Tajaran - Material Scanning Veil"
@@ -392,7 +392,7 @@
 /datum/loadout_entry/xeno/vox/uniform/engineer
 	name = "Vox - Engineering - Pressure Suit"
 	path = /obj/item/clothing/under/pressuresuit/voxcivengineer
-	allowed_roles = list("Station Engineer", "Chief Engineer", "Atmospheric Technician")
+	allowed_roles = list("Station Engineer", "Chief Engineer", "Atmospheric Technician", "Senior Engineer")
 
 /datum/loadout_entry/xeno/vox/uniform/engineer/ce
 	name = "Vox - Chief Engineer - Pressure Suit"
@@ -656,12 +656,12 @@
 /datum/loadout_entry/xeno/teshari/uniform/role_undercoat/engineer
 	name = "Teshari - Engineering Undercoat"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/engineer
-	allowed_roles = list("Chief Engineer", "Station Engineer")
+	allowed_roles = list("Chief Engineer", "Station Engineer", "Senior Engineer")
 
 /datum/loadout_entry/xeno/teshari/uniform/role_undercoat/atmos
 	name = "Teshari - Atmospherics Undercoat"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/atmos
-	allowed_roles = list("Chief Engineer","Atmospheric Technician")
+	allowed_roles = list("Chief Engineer","Atmospheric Technician", "Senior Engineer")
 
 /datum/loadout_entry/xeno/teshari/uniform/role_undercoat/research
 	name = "Teshari - Scientist Undercoat"
@@ -785,12 +785,12 @@
 /datum/loadout_entry/xeno/teshari/suit/role_cloak/engineer
 	name = "Teshari - Engineering Cloak"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/eningeer
-	allowed_roles = list("Chief Engineer","Station Engineer")
+	allowed_roles = list("Chief Engineer","Station Engineer", "Senior Engineer")
 
 /datum/loadout_entry/xeno/teshari/suit/role_cloak/atmos
 	name = "Teshari - Atmospherics Cloak"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/atmos
-	allowed_roles = list("Chief Engineer","Atmospheric Technician")
+	allowed_roles = list("Chief Engineer","Atmospheric Technician", "Senior Engineer")
 
 /datum/loadout_entry/xeno/teshari/suit/role_cloak/research
 	name = "Teshari - Scientist Cloak"
@@ -1023,7 +1023,7 @@
 /datum/loadout_entry/xeno/shoes/moth/workboots
 	name = "Moth - Workboots"
 	path = /obj/item/clothing/shoes/boots/moth
-	allowed_roles = list("Station Engineer", "Chief Engineer", "Atmospheric Technician", "Research Director", "Scientist", "Roboticist", "Xenobiologist", "Explorer", "Pathfinder")
+	allowed_roles = list("Station Engineer", "Chief Engineer", "Atmospheric Technician", "Senior Engineer", "Research Director", "Scientist", "Roboticist", "Xenobiologist", "Explorer", "Pathfinder")
 
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Senior engineer isn't allowed any station engineer/atmos tech-specific items (that is, items specific to just those two); this fixes that

## Why It's Good For The Game

This was probably intended in the first place, so I'll say "bug fix"

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Gives senior engineers access to some missing engineer loadout entries
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
