### PR TITLE
Fixes Captain's Spare ID

### DIFF
--- a/code/game/objects/items/id_cards/station_ids.dm
+++ b/code/game/objects/items/id_cards/station_ids.dm
@@ -214,11 +214,15 @@
 	job_access_type = /datum/role/job/station/captain
 
 /obj/item/card/id/gold/captain/spare
-	name = "\improper Facility Director's spare ID"
+	name = "\improper Captain's spare ID"
 	desc = "The spare ID of the High Lord himself."
-	registered_name = "Facility Director"
+	registered_name = "Captain"
 	icon_state = "gold-id-alternate"
 	job_access_type = /datum/role/job/station/captain
+
+/obj/item/card/id/gold/captain/spare/Initialize(mapload)
+	. = ..()
+	access = SSjob.access_ids_of_type(ACCESS_TYPE_STATION)
 
 /obj/item/card/id/synthetic
 	name = "\improper Synthetic ID"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Fixes Captain's Spare ID.**

## Why It's Good For The Game

1. _Restores access to Captain's Spare ID. Still wasn't entirely able to figure out HOW it broke, but it isn't generating access when it spawns. The Captain gets access on spawn, so I've done a similar call for the spare as we have with synth and CC IDs._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes Captain's Spare ID.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
