### PR TITLE
Reverts 6056's changes to Facility Director

### DIFF
--- a/code/modules/jobs/job_types/station/command/captain.dm
+++ b/code/modules/jobs/job_types/station/command/captain.dm
@@ -2,7 +2,7 @@ var/datum/legacy_announcement/minor/captain_announcement = new(do_newscast = 1)
 
 /datum/role/job/station/captain
 	id = JOB_ID_CAPTAIN
-	title = "Captain"
+	title = "Facility Director"
 	economy_payscale = ECONOMY_PAYSCALE_JOB_CAPTAIN
 	flag = CAPTAIN
 	disallow_jobhop = TRUE
@@ -25,12 +25,14 @@ var/datum/legacy_announcement/minor/captain_announcement = new(do_newscast = 1)
 	ideal_character_age = 70 // Old geezer captains ftw
 
 	outfit_type = /datum/outfit/job/station/captain
-	desc = "The Captain manages the other Command Staff, and through them the rest of the station. Though they have access to everything, \
-						they do not understand everything, and are expected to delegate tasks to the appropriate crew member. The Captain is expected to \
+	desc = "The Facility Director manages the other Command Staff, and through them the rest of the station. Though they have access to everything, \
+						they do not understand everything, and are expected to delegate tasks to the appropriate crew member. The Facility Director is expected to \
 						have an understanding of Standard Operating Procedure, and is subject to it, and legal action, in the same way as every other crew member."
 	alt_titles = list(
 		"Overseer"= /datum/prototype/struct/alt_title/overseer,
-		"Facility Director" = /datum/prototype/struct/alt_title/captain/fd
+		"Site Manager" = /datum/prototype/struct/alt_title/captain/site,
+		"Director of Operations" = /datum/prototype/struct/alt_title/captain/director,
+		"Captain" = /datum/prototype/struct/alt_title/captain/captain
 	)
 
 /datum/role/job/station/captain/get_access()
@@ -39,8 +41,14 @@ var/datum/legacy_announcement/minor/captain_announcement = new(do_newscast = 1)
 /datum/prototype/struct/alt_title/overseer
 	title = "Overseer"
 
-/datum/prototype/struct/alt_title/captain/fd
-	title = "Facility Director"
+/datum/prototype/struct/alt_title/captain/site
+	title = "Site Manager"
+
+/datum/prototype/struct/alt_title/captain/director
+	title = "Director of Operations"
+
+/datum/prototype/struct/alt_title/captain/captain
+	title = "Captain"
 
 /datum/outfit/job/station/captain
 	name = OUTFIT_JOB_NAME("Captain")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR directly reverts #6056's changes to the Facility Director (i.e. renaming the default title to Captain, among a couple other things). This fixes a bug where none of the FD-specific loadout items could be equipped even as the Captain, as those items were checking for the "Facility Director" title, not the "Captain" title. (Alt-titles don't count toward this.) This same bug may be present in other jobs that have had their default titles changed, but that is beyond the scope of this PR.

This PR has been tested locally.

## Why It's Good For The Game

Nothing else in the community (i.e. the wiki or other parts of the code) have been updated to reflect this sudden change to the default title of the head of the facility, so I think that should be taken care of first/at the same time. In addition, the bug that I am directly fixing is rather egregious and probably should have been caught earlier.

In any case, there is nothing wrong with continuing to call the head of the installation the Facility Director, and players who wish to continue being called Captain can simply change their alt title.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Renamed Captain to Facility Director by default, which should fix a bug where FD-specific items could not be equipped even as the Captain.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
