### PR TITLE
Makes the Tcomms SMES start with input on

### DIFF
--- a/code/modules/power/smes/smes.dm
+++ b/code/modules/power/smes/smes.dm
@@ -560,6 +560,7 @@ GLOBAL_LIST_EMPTY(smeses)
 	name = "telecomms smes"
 	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. This is the one dedicated to telecommunications."
 	charge = KWH_TO_KWM(SMES_COIL_STORAGE_BASIC * 1 * 0.25)
+	input_attempt = 1
 	input_level = 100
 	output_level = 200
 	RCon_tag = "Telecomms"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Exactly what it says on the tin. Makes the tcomms SMES start with input turned on so that it can utilize secondary power sources without engineering being present. This will increase the time before tcomms runs out of power but decrease the time for the rest of the station (since it's pulling in a consistent 100kW)

## Why It's Good For The Game

Apparently folks on shifts without engineering were having power in tcomms run out before the rest of the station because the SMES wasn't charging and tcomms was segregated from the rest of the grid.

## Changelog

:cl:
tweak: tcomms SMESes now start with input toggled on
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
