### PR TITLE
Fixes Mapped Directional Sprites, Adds Pet, General Mapping Bug Fixes

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/racoon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/racoon.dm
@@ -349,4 +349,4 @@
 /mob/living/simple_mob/animal/sif/sakimm/dexter
 	name = "Dexter"
 	desc = "A tame, oversized rodent with hands. It seems really friendly."
-	faction = "station"
+	faction = "neutral"

--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/racoon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/racoon.dm
@@ -345,3 +345,8 @@
 
 /datum/ai_holder/simple_mob/intentional/sakimm/special_flee_check()
 	return holder.get_active_held_item()
+
+/mob/living/simple_mob/animal/sif/sakimm/dexter
+	name = "Dexter"
+	desc = "A tame, oversized rodent with hands. It seems really friendly."
+	faction = "station"

--- a/code/modules/tables/presets.dm
+++ b/code/modules/tables/presets.dm
@@ -306,6 +306,21 @@
 	material = SSmaterials.get_material(/datum/material/bone)
 	return ..()
 
+/obj/structure/table/carbon
+	icon_state = "plain_preview"
+
+/obj/structure/table/carbon/Initialize(mapload)
+	material = SSmaterials.get_material(/datum/material/carbon)
+	return ..()
+
+/obj/structure/table/carbon/reinforced
+	icon_state = "plain_preview"
+
+/obj/structure/table/carbon/reinforced/Initialize(mapload)
+	material = SSmaterials.get_material(/datum/material/carbon)
+	reinforced = SSmaterials.get_material(/datum/material/marble)
+	return ..()
+
 /*
 /obj/structure/table/bench/holotable
 	icon_state = "holo_preview"

--- a/maps/rift/levels/rift-04-surface1.dmm
+++ b/maps/rift/levels/rift-04-surface1.dmm
@@ -7186,10 +7186,10 @@
 /area/maintenance/engineering/pumpstation)
 "eDQ" = (
 /obj/machinery/power/apc{
+	alarms_hidden = 1;
 	dir = 4;
 	name = "east bump";
-	pixel_x = 24;
-	alarms_hidden = 1
+	pixel_x = 24
 	},
 /obj/structure/cable/green{
 	icon_state = "0-8"
@@ -18895,10 +18895,6 @@
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_breakroom)
-"mbD" = (
-/obj/random/mob/mouse,
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/xenobiology/outpost_breakroom)
 "mbJ" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/outdoors/grass/heavy/interior,
@@ -26783,8 +26779,8 @@
 "qHS" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Research Southwest Wing Subgrid";
-	output_attempt = 0;
-	cur_coils = 2
+	cur_coils = 2;
+	output_attempt = 0
 	},
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -27489,9 +27485,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/office)
 "rdW" = (
-/obj/machinery/vending/cola{
-	dir = 4
-	},
+/obj/machinery/vending/cola,
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_breakroom)
 "rer" = (
@@ -28435,6 +28429,10 @@
 	},
 /obj/machinery/light,
 /obj/structure/cable/green,
+/obj/structure/dogbed{
+	name = "pet bed"
+	},
+/mob/living/simple_mob/animal/sif/sakimm/dexter,
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_breakroom)
 "rJv" = (
@@ -47420,7 +47418,7 @@ wPH
 mLf
 jPz
 pdl
-mbD
+dee
 nYD
 srP
 eZh

--- a/maps/rift/levels/rift-04-surface1.dmm
+++ b/maps/rift/levels/rift-04-surface1.dmm
@@ -18664,10 +18664,6 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -18676,6 +18672,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/hallway)

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -289,6 +289,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "ang" = (
@@ -4815,6 +4818,18 @@
 "ddZ" = (
 /turf/simulated/floor/outdoors/gravsnow/lythios43c/indoors,
 /area/rift/surfacebase/outside/outside2)
+"dek" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/hallway/primary/surfacetwo)
 "dep" = (
 /turf/simulated/wall/prepainted/security,
 /area/security/range)
@@ -10898,11 +10913,11 @@
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/recreation_area)
 "gZt" = (
+/obj/machinery/cryopod/robot,
 /obj/machinery/firealarm{
-	dir = 8;
+	dir = 4;
 	pixel_x = 24
 	},
-/obj/machinery/cryopod/robot,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/assembly/chargebay)
 "gZC" = (
@@ -12054,6 +12069,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
 	},
+/obj/structure/bed/chair/sofa/black/corner,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "hMP" = (
@@ -14489,6 +14505,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
 	},
+/obj/structure/bed/chair/sofa/black/right,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "jmn" = (
@@ -14657,6 +14674,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
+	},
+/obj/structure/bed/chair/sofa/black/corner{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
@@ -20436,6 +20456,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
+	},
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
@@ -27283,6 +27306,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "rib" = (
@@ -28235,6 +28261,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "rMB" = (
@@ -28814,6 +28843,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
 	},
+/obj/structure/bed/chair/sofa/black/left,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "sfC" = (
@@ -30139,6 +30169,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/structure/table/carbon/reinforced,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "teZ" = (
@@ -31854,6 +31885,7 @@
 /obj/effect/floor_decal/corner/purple/bordercorner2{
 	dir = 9
 	},
+/obj/machinery/media/jukebox,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "unz" = (
@@ -33062,6 +33094,7 @@
 	},
 /obj/effect/floor_decal/borderfloor/corner2,
 /obj/effect/floor_decal/corner/purple/bordercorner2,
+/obj/structure/table/carbon/reinforced,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "uZq" = (
@@ -34584,6 +34617,10 @@
 /obj/effect/overlay/snow/floor,
 /turf/simulated/floor/plating,
 /area/rift/surfacebase/outside/outside2)
+"weh" = (
+/obj/structure/table/carbon/reinforced,
+/turf/simulated/floor/glass/reinforced,
+/area/hallway/primary/surfacetwo)
 "wek" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/wood,
@@ -36223,6 +36260,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/structure/table/carbon/reinforced,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "xpI" = (
@@ -36326,6 +36364,18 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/sleep)
+"xqT" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/hallway/primary/surfacetwo)
 "xrI" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -53037,7 +53087,7 @@ xUe
 xUe
 emT
 jru
-xLE
+dek
 mDz
 bgP
 bgP
@@ -53231,7 +53281,7 @@ rCo
 rCo
 xUe
 sfB
-bgP
+weh
 bgP
 bgP
 bgP
@@ -53619,7 +53669,7 @@ rCo
 rCo
 xUe
 jmj
-bgP
+weh
 bgP
 bgP
 bgP
@@ -53813,7 +53863,7 @@ xUe
 xUe
 emT
 hLX
-sJl
+xqT
 iru
 bgP
 bgP

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -289,9 +289,6 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/bed/chair/sofa/black/right{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "ang" = (
@@ -4818,18 +4815,6 @@
 "ddZ" = (
 /turf/simulated/floor/outdoors/gravsnow/lythios43c/indoors,
 /area/rift/surfacebase/outside/outside2)
-"dek" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/structure/bed/chair/sofa/black/right{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/hallway/primary/surfacetwo)
 "dep" = (
 /turf/simulated/wall/prepainted/security,
 /area/security/range)
@@ -12069,7 +12054,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
 	},
-/obj/structure/bed/chair/sofa/black/corner,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "hMP" = (
@@ -14505,7 +14489,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
 	},
-/obj/structure/bed/chair/sofa/black/right,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "jmn" = (
@@ -14674,9 +14657,6 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
-	},
-/obj/structure/bed/chair/sofa/black/corner{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
@@ -20456,9 +20436,6 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
-	},
-/obj/structure/bed/chair/sofa/black/left{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
@@ -27306,9 +27283,6 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/bed/chair/sofa/black/left{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "rib" = (
@@ -28261,9 +28235,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/structure/bed/chair/sofa/black/right{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "rMB" = (
@@ -28843,7 +28814,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
 	},
-/obj/structure/bed/chair/sofa/black/left,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "sfC" = (
@@ -30169,7 +30139,6 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/table/carbon/reinforced,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "teZ" = (
@@ -31885,7 +31854,6 @@
 /obj/effect/floor_decal/corner/purple/bordercorner2{
 	dir = 9
 	},
-/obj/machinery/media/jukebox,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "unz" = (
@@ -33094,7 +33062,6 @@
 	},
 /obj/effect/floor_decal/borderfloor/corner2,
 /obj/effect/floor_decal/corner/purple/bordercorner2,
-/obj/structure/table/carbon/reinforced,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "uZq" = (
@@ -34617,10 +34584,6 @@
 /obj/effect/overlay/snow/floor,
 /turf/simulated/floor/plating,
 /area/rift/surfacebase/outside/outside2)
-"weh" = (
-/obj/structure/table/carbon/reinforced,
-/turf/simulated/floor/glass/reinforced,
-/area/hallway/primary/surfacetwo)
 "wek" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/wood,
@@ -36260,7 +36223,6 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/table/carbon/reinforced,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "xpI" = (
@@ -36364,18 +36326,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/sleep)
-"xqT" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/structure/bed/chair/sofa/black/left{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel,
-/area/hallway/primary/surfacetwo)
 "xrI" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -53087,7 +53037,7 @@ xUe
 xUe
 emT
 jru
-dek
+xLE
 mDz
 bgP
 bgP
@@ -53281,7 +53231,7 @@ rCo
 rCo
 xUe
 sfB
-weh
+bgP
 bgP
 bgP
 bgP
@@ -53669,7 +53619,7 @@ rCo
 rCo
 xUe
 jmj
-weh
+bgP
 bgP
 bgP
 bgP
@@ -53863,7 +53813,7 @@ xUe
 xUe
 emT
 hLX
-xqT
+sJl
 iru
 bgP
 bgP

--- a/maps/rift/levels/rift-06-surface3.dmm
+++ b/maps/rift/levels/rift-06-surface3.dmm
@@ -12357,9 +12357,6 @@
 /turf/simulated/floor/plating,
 /area/shuttle/courser/cockpit)
 "aIC" = (
-/obj/machinery/vending/coffee{
-	dir = 4
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
 	},
@@ -12369,6 +12366,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 10
 	},
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway)
 "aID" = (

--- a/maps/rift/levels/rift-06-surface3.dmm
+++ b/maps/rift/levels/rift-06-surface3.dmm
@@ -401,9 +401,7 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/captain)
 "abq" = (
-/obj/machinery/camera/network/exploration{
-	dir = 6
-	},
+/obj/machinery/camera/network/exploration,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/courser_dock)
 "abr" = (
@@ -5230,7 +5228,7 @@
 /area/shuttle/excursion/general)
 "aoV" = (
 /obj/machinery/camera/network/exploration{
-	dir = 10
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/courser_dock)
@@ -7447,6 +7445,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/steel,
 /area/exploration/explorer_prep)
 "auU" = (
@@ -8455,6 +8456,10 @@
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -25
 	},
 /turf/simulated/floor/tiled/steel,
 /area/exploration)
@@ -10216,9 +10221,7 @@
 "aCt" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/exploration{
-	dir = 6
-	},
+/obj/machinery/camera/network/exploration,
 /turf/simulated/floor/tiled/steel,
 /area/exploration/courser_dock)
 "aCu" = (
@@ -10640,6 +10643,10 @@
 	},
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -25
 	},
 /turf/simulated/floor/tiled/steel,
 /area/exploration/pathfinder_office)
@@ -11351,6 +11358,11 @@
 	},
 /obj/effect/floor_decal/corner/beige/bordercorner2{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/steel,
 /area/exploration)
@@ -12625,11 +12637,11 @@
 "aJm" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/beige/border,
-/obj/machinery/camera/network/exploration{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/camera/network/exploration{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel,
 /area/exploration)
@@ -15826,6 +15838,9 @@
 /area/bridge/bridge_hallway)
 "aSj" = (
 /obj/effect/floor_decal/spline/plain,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/wood,
 /area/exploration/meeting)
 "aSk" = (
@@ -16619,7 +16634,7 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/item/multitool/ai_detector,
+/obj/item/multitool,
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "aUr" = (
@@ -17863,6 +17878,10 @@
 	},
 /obj/effect/floor_decal/corner/beige/bordercorner2{
 	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/steel,
 /area/exploration/excursion_dock)
@@ -21483,6 +21502,13 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
+"jew" = (
+/obj/structure/table/bench/standard,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/exploration/courser_dock)
 "jil" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
@@ -23330,6 +23356,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway2)
+"orx" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/exploration/courser_dock)
 "oti" = (
 /obj/structure/bed/chair/bay/chair{
 	dir = 1
@@ -25363,6 +25395,25 @@
 /obj/effect/paint/commandblue,
 /turf/simulated/wall/r_wall/prepainted/command,
 /area/bridge)
+"uAA" = (
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled,
+/area/exploration/explorer_prep)
 "uCG" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -44658,7 +44709,7 @@ qnv
 pnT
 jNZ
 dIa
-asy
+uAA
 aTd
 aTd
 aTd
@@ -46029,7 +46080,7 @@ cvI
 aJN
 aVX
 cvI
-aYe
+orx
 aNv
 aHS
 aHp
@@ -46409,7 +46460,7 @@ aQr
 asV
 ahq
 hXj
-axm
+jew
 axm
 ciu
 mXd


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Fixes Directional Sprites for Cameras, Vendors, and Fire Alarms.**
2. **Adds Dexter, the Xenobio Pet.**
3. **Adds Carbon Table Presets.**

## Why It's Good For The Game

1. _These off-direction sprites have been driving me crazy.._
2. _This cute little guy got spawned from a gold slime just today, and everyone loved him so much I decided to make him a permanent pet for Xenobio._
3. _Adds carbon table presets because I like the black on white look._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes mislaid directional sprites.
add: Adds Dexter, a pet for Xenobio.
add: Adds carbon table presets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
