### PR TITLE
Fixes a runtime in powered atmos machines

### DIFF
--- a/code/modules/atmospherics/machinery/portable/powered.dm
+++ b/code/modules/atmospherics/machinery/portable/powered.dm
@@ -77,8 +77,10 @@
 	..()
 
 /obj/machinery/portable_atmospherics/powered/use_power(amount, chan, dt)
-	if(!use_cell || !cell)
+	if(!use_cell)
 		return ..()
+	else if(!cell)
+		return 0
 	. = cell.use(DYNAMIC_W_TO_CELL_UNITS(amount, dt))
 	if(!cell.charge)
 		power_change()

--- a/code/modules/atmospherics/machinery/portable/powered.dm
+++ b/code/modules/atmospherics/machinery/portable/powered.dm
@@ -77,7 +77,7 @@
 	..()
 
 /obj/machinery/portable_atmospherics/powered/use_power(amount, chan, dt)
-	if(!use_cell)
+	if(!use_cell || !cell)
 		return ..()
 	. = cell.use(DYNAMIC_W_TO_CELL_UNITS(amount, dt))
 	if(!cell.charge)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It didn't check for if there's actually a cell.

## Why It's Good For The Game

runtimes bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Powered atmos machines now check if there's a cell before trying to drain it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
