### PR TITLE
removes alcoholic root beer (no recipe actually used it) and renames root beer

### DIFF
--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -2225,27 +2225,27 @@
 	glass_special = list(DRINK_FIZZ)
 
 /datum/reagent/drink/soda/sarsaparilla
-	name = "CC's Homemade Sarsaparilla"
+	name = "Sarsaparilla"
 	id = "sarsaparilla"
 	description = "The Cyan Cowgirl rides again!"
 	taste_description = "earthy vanilla and harsh bubbles"
 	color = "#503301"
 	adj_temp = -2
 
-	glass_name = "CC's Homemade Sarsaparilla"
+	glass_name = "Cyan Cowgirl Sarsaparilla"
 	glass_desc = "Real girls drink from the bottle."
 	glass_icon = DRINK_ICON_NOISY
 	glass_special = list(DRINK_FIZZ)
 
 /datum/reagent/drink/soda/sassafras
-	name = "CC's Famous Root Beer"
+	name = "Root Beer"
 	id = "sassafras"
 	description = "Feel nostalgia for a range you never rode."
 	taste_description = "bitter licorice and sweet vanilla"
 	color = "#312003"
 	adj_temp = -2
 
-	glass_name = "CC's Famous Root Beer"
+	glass_name = "Cyan Cowgirl Root Beer"
 	glass_desc = "Wet your whistle!"
 	glass_icon = DRINK_ICON_NOISY
 	glass_special = list(DRINK_FIZZ)
@@ -4043,19 +4043,6 @@
 
 	glass_name = "Fire Punch"
 	glass_desc = "A spicy take on a summer classic."
-
-/datum/reagent/ethanol/alcsassafras
-	name = "CC's Hard Rootbeer"
-	id = "alcsassafras"
-	description = "Doesn't matter if you're drunk when you have a horse to take you home!"
-	taste_description = "bitter vanilla with a sharp burn"
-	strength = 20
-
-	glass_name = "CC's Hard Rootbeer"
-	glass_desc = "You'd better carry two guns if you're gonna keep drinking these!"
-	glass_icon = DRINK_ICON_NOISY
-	glass_special = list(DRINK_FIZZ)
-
 /datum/reagent/ethanol/newsheriff
 	name = "New Sheriff"
 	id = "newsheriff"

--- a/code/modules/reagents/machinery/dispenser/synthesizer.dm
+++ b/code/modules/reagents/machinery/dispenser/synthesizer.dm
@@ -79,7 +79,6 @@
 		/datum/reagent/ethanol/cider,
 		/datum/reagent/ethanol/ale,
 		/datum/reagent/ethanol/mead,
-		/datum/reagent/ethanol/alcsassafras
 	)
 
 /obj/item/reagent_synth/cafe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
renames rootbeer to just 'rootbeer' (soft drink dispenser)
removes the alcoholic one
every recipe already used the non-alco one
removes "CC's Homemade" part from the names, keeps them for when the reagent is actually poured out
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bartender headaches (reduced)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
