### PR TITLE
Adjusts Alarms on Shuttles

### DIFF
--- a/maps/templates/shuttles/overmaps/generic/curashuttle.dmm
+++ b/maps/templates/shuttles/overmaps/generic/curashuttle.dmm
@@ -242,12 +242,12 @@
 /obj/machinery/computer/ship/sensors{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -29
-	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 8;
+	pixel_x = -26
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/shuttle/curabitur/curashuttle/cockpit)
@@ -599,16 +599,15 @@
 /area/shuttle/curabitur/curashuttle/med)
 "bi" = (
 /obj/machinery/suit_cycler/medical,
-/obj/machinery/air_alarm{
-	pixel_y = 25
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	layer = 3.3;
-	pixel_y = 26
-	},
-/obj/machinery/light{
-	dir = 1
+	pixel_x = 26
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/curabitur/curashuttle/med)
@@ -985,11 +984,6 @@
 /area/shuttle/curabitur/curashuttle/hangar)
 "bT" = (
 /obj/structure/handrail,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -999,6 +993,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
+/obj/machinery/power/apc/alarms_hidden/north_bump,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/curabitur/curashuttle/eng)
 "bU" = (
@@ -1247,6 +1242,10 @@
 /obj/machinery/computer/ship/engines{
 	dir = 1
 	},
+/obj/machinery/air_alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/curabitur/curashuttle/eng)
 "cy" = (
@@ -1263,20 +1262,17 @@
 /area/shuttle/curabitur/curashuttle/med)
 "cA" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -28
-	},
 /obj/structure/handrail{
 	dir = 1
 	},
+/obj/machinery/power/apc/alarms_hidden/south_bump,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/curabitur/curashuttle/hangar)
 "cB" = (
 /obj/machinery/light,
-/obj/machinery/air_alarm{
+/obj/machinery/air_alarm/alarms_hidden{
 	dir = 1;
-	pixel_y = -32
+	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/curabitur/curashuttle/hangar)

--- a/maps/templates/shuttles/overmaps/generic/mercship.dmm
+++ b/maps/templates/shuttles/overmaps/generic/mercship.dmm
@@ -33,9 +33,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 23
 	},
 /turf/simulated/floor/plating,
 /area/ship/mercenary/engine1)
@@ -520,9 +519,8 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 23
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/barracks)
@@ -604,9 +602,8 @@
 /obj/machinery/button/remote/blast_door{
 	id = "mercblast"
 	},
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 23
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/bridge)
@@ -1305,9 +1302,9 @@
 /area/ship/mercenary/hangar)
 "cL" = (
 /obj/effect/floor_decal/borderfloorblack,
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/med1)
@@ -2089,12 +2086,11 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
 	},
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
+/obj/fiftyspawner/uranium,
+/obj/fiftyspawner/uranium,
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 23
 	},
-/obj/fiftyspawner/uranium,
-/obj/fiftyspawner/uranium,
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/engineeringcntrl)
 "ep" = (
@@ -2650,9 +2646,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -26
 	},
 /turf/simulated/floor/plating,
 /area/ship/mercenary/engine)
@@ -2696,9 +2692,9 @@
 	dir = 9
 	},
 /obj/machinery/meter,
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/atmos)
@@ -3232,9 +3228,8 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 23
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/hall2)
@@ -3357,9 +3352,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack,
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/hall1)
@@ -3379,9 +3374,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack,
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/mercenary/fighter)
@@ -3429,9 +3424,8 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 23
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/engineering)
@@ -3465,9 +3459,9 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/borderfloorblack,
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/mercenary/armoury)
@@ -3621,9 +3615,9 @@
 /area/ship/mercenary/engineering)
 "hp" = (
 /obj/effect/floor_decal/borderfloorblack,
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/hangar)
@@ -3749,9 +3743,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack,
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/mercenary/med)

--- a/maps/templates/shuttles/overmaps/generic/vespa.dmm
+++ b/maps/templates/shuttles/overmaps/generic/vespa.dmm
@@ -16,7 +16,8 @@
 "ac" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/red/border,
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -83,11 +84,10 @@
 /turf/simulated/floor,
 /area/ship/expe/engines)
 "ap" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/atmospherics)
 "aq" = (
@@ -371,9 +371,8 @@
 /turf/simulated/floor,
 /area/ship/expe/maintenancerim)
 "bl" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor,
 /area/ship/expe/maintenancerim)
@@ -535,7 +534,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/firealarm,
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 23
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seccells)
 "bE" = (
@@ -631,9 +632,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/northairlock)
 "bO" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/northairlock)
@@ -767,12 +767,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/northairlock)
 "co" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor,
 /area/ship/expe/maintenance2)
@@ -842,9 +841,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/hangarcontrol)
 "cy" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/hangarcontrol)
@@ -873,12 +871,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/maintenancerim)
 "cC" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/structure/table/woodentable,
 /obj/item/soap/nanotrasen,
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin1)
 "cD" = (
@@ -894,12 +891,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin1)
 "cF" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/structure/table/woodentable,
 /obj/machinery/microwave,
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin2)
 "cG" = (
@@ -915,11 +911,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin2)
 "cI" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/structure/table/woodentable,
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin3)
 "cJ" = (
@@ -935,11 +930,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin3)
 "cL" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/structure/table/woodentable,
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin4)
 "cM" = (
@@ -955,12 +949,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin4)
 "cO" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/structure/table/woodentable,
 /obj/machinery/microwave,
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin5)
 "cP" = (
@@ -976,12 +969,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin5)
 "cR" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/structure/table/woodentable,
 /obj/item/soap/nanotrasen,
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin6)
 "cS" = (
@@ -997,11 +989,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin6)
 "cU" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/structure/table/woodentable,
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin7)
 "cV" = (
@@ -1017,11 +1008,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin7)
 "cX" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/structure/table/woodentable,
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin8)
 "cY" = (
@@ -1037,12 +1027,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin8)
 "da" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/structure/table/woodentable,
 /obj/machinery/microwave,
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin9)
 "db" = (
@@ -1117,12 +1106,11 @@
 /turf/simulated/floor,
 /area/ship/expe/maintenance1)
 "dk" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor,
 /area/ship/expe/maintenance1)
@@ -1505,7 +1493,8 @@
 /turf/simulated/wall/rpshull,
 /area/ship/expe/corridor1)
 "em" = (
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -1524,7 +1513,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin1)
 "ep" = (
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -1542,7 +1532,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin2)
 "es" = (
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -1561,7 +1552,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin3)
 "ev" = (
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -1579,7 +1571,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin4)
 "ey" = (
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -1598,7 +1591,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin5)
 "eB" = (
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -1616,7 +1610,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin6)
 "eE" = (
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -1635,7 +1630,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin7)
 "eH" = (
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -1653,7 +1649,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/cabin8)
 "eK" = (
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2002,12 +1999,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor4)
 "fB" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 1
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor4)
@@ -2057,12 +2053,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor4)
 "fH" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 1
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor6)
@@ -2079,12 +2074,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/bridge)
 "fK" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 1
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/bridge)
@@ -2462,7 +2456,8 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/techfloor,
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2761,7 +2756,8 @@
 /area/ship/expe/corridor3)
 "gW" = (
 /obj/effect/floor_decal/techfloor,
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -3316,7 +3312,8 @@
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/yellow/border,
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -3761,10 +3758,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seceq)
 "iI" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/structure/table/rack/shelf,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
@@ -3773,18 +3766,20 @@
 	dir = 5
 	},
 /obj/item/clothing/suit/storage/vest,
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seceq)
 "iJ" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 9
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/secmain)
@@ -3878,15 +3873,14 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalchem)
 "iR" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalchem)
@@ -4039,10 +4033,6 @@
 /area/ship/expe/medicaleq)
 "jg" = (
 /obj/structure/table/reinforced,
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -4052,6 +4042,9 @@
 /obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/toxin,
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicaleq)
 "jh" = (
@@ -4766,15 +4759,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringpower)
 "kJ" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 1
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringpower)
@@ -5236,10 +5228,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringequipment)
 "lL" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
@@ -5247,6 +5235,9 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringequipment)
 "lM" = (
@@ -5636,12 +5627,12 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
-/obj/machinery/air_alarm{
-	dir = 4;
-	pixel_x = -25
-	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalmain)
@@ -5785,8 +5776,9 @@
 "mL" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/yellow/border,
-/obj/machinery/firealarm{
-	pixel_y = -27
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringpower)
@@ -5798,8 +5790,9 @@
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	pixel_x = -28
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 8;
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/engineeringequipment)
@@ -6197,7 +6190,8 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/techfloor,
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6239,7 +6233,10 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
-/obj/machinery/firealarm,
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 4;
+	pixel_x = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/sechall)
 "nG" = (
@@ -6355,15 +6352,15 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalchem)
 "nS" = (
-/obj/machinery/firealarm{
-	pixel_x = -31;
-	pixel_y = -1
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
+	},
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 8;
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalmain)
@@ -6930,10 +6927,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seclobby2)
 "oZ" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -6945,6 +6938,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seclobby2)
@@ -7023,14 +7019,15 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalmain)
 "pi" = (
-/obj/machinery/firealarm{
-	pixel_x = -28
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
+	},
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 8;
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicaleq)
@@ -7330,15 +7327,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/expedition)
 "pQ" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 1
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/expedition)
@@ -7376,10 +7372,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/hangar)
 "pU" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
 	},
@@ -7388,6 +7380,9 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seccells)
@@ -7435,7 +7430,10 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
-/obj/machinery/firealarm,
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 4;
+	pixel_x = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seclobby)
 "pZ" = (
@@ -7458,7 +7456,10 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 6
 	},
-/obj/machinery/firealarm,
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 4;
+	pixel_x = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seclobby2)
 "qb" = (
@@ -7774,15 +7775,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/captqua)
 "qK" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 1
 	},
 /obj/machinery/photocopier/faxmachine,
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/captqua)
 "qL" = (
@@ -8499,10 +8499,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seclobby)
 "sw" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -8514,6 +8510,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/seclobby)
@@ -8576,16 +8575,15 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medical)
 "sC" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medical)
@@ -8654,10 +8652,6 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalsur)
 "sH" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 8
 	},
@@ -8669,6 +8663,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalsur)
@@ -8698,10 +8695,6 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medical1)
 "sK" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -8710,6 +8703,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medical1)
@@ -8726,10 +8722,6 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medical1)
 "sM" = (
-/obj/machinery/firealarm{
-	pixel_x = -1;
-	pixel_y = 30
-	},
 /obj/structure/bed,
 /obj/structure/curtain/medical,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -8737,6 +8729,9 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
+	},
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 23
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medical1)
@@ -8992,9 +8987,6 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medical)
 "tI" = (
-/obj/machinery/firealarm{
-	pixel_x = -31
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
@@ -9003,6 +8995,10 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/surgery,
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 8;
+	pixel_x = -26
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/expe/medicalsur)
 "tJ" = (
@@ -9664,7 +9660,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/techfloor,
-/obj/machinery/firealarm{
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -10038,9 +10035,8 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor2)
@@ -10299,12 +10295,17 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor2)
 "wS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/techfloor,
-/obj/machinery/firealarm{
-	pixel_y = -26
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 23
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/corridor2)
@@ -10492,9 +10493,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/southairlock)
 "xI" = (
-/obj/machinery/air_alarm{
+/obj/machinery/air_alarm/alarms_hidden{
 	dir = 1;
-	pixel_y = -25
+	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/expe/southairlock)
@@ -10542,9 +10543,8 @@
 /turf/simulated/floor,
 /area/ship/expe/engines)
 "xZ" = (
-/obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22
+/obj/machinery/air_alarm/alarms_hidden{
+	pixel_y = 26
 	},
 /turf/simulated/floor,
 /area/ship/expe/engines)
@@ -16799,7 +16799,7 @@ ss
 tx
 uF
 vC
-wd
+wS
 wP
 aS
 bi
@@ -17226,7 +17226,7 @@ ty
 oS
 vC
 yM
-wS
+wT
 aS
 bi
 bi


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Remaps Alarms on Multiple Shuttle Submaps.**

## Why It's Good For The Game

1. _Some shuttle submaps are not using hidden alarms. This is gonna take a little live testing and stuff._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Replaces shuttle submap alarms with hidden variants.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
