### PR TITLE
Hypokit placeable on Belt Slot

### DIFF
--- a/code/game/objects/items/storage/medical/hypokit.dm
+++ b/code/game/objects/items/storage/medical/hypokit.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/items/storage/firstaid_small.dmi'
 	inhand_icon = 'icons/items/storage/firstaid.dmi'
 	icon_state = "normal"
+	slot_flags = SLOT_BELT
 	max_storage_space = INVENTORY_BOX_SPACE
 	can_hold = list(
 		/obj/item/reagent_containers/glass/hypovial,


### PR DESCRIPTION
## About The Pull Request

Makes hypokits able to be put on the belt slot

## Why It's Good For The Game

First aid kits already do this. If we were worried about abuse via belt storage we'd prevent kits from accepting vials.
