### PR TITLE
Backpacks in Loadout

### DIFF
--- a/code/modules/loadout/loadout_role_restricted.dm
+++ b/code/modules/loadout/loadout_role_restricted.dm
@@ -478,6 +478,12 @@
 	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Detective", "Talon Guard")
 	cost = 2
 
+/datum/loadout_entry/restricted/security/back/backpack
+	name = "Security - Backpack"
+	path = /obj/item/storage/backpack/security
+	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Detective", "Talon Guard")
+	cost = 2
+
 //Suit
 /datum/loadout_entry/restricted/security/suit/forensics
 	name = "Detective Forensics - Red"

--- a/code/modules/loadout/loadout_utility.dm
+++ b/code/modules/loadout/loadout_utility.dm
@@ -206,21 +206,42 @@ modular computers
 	..()
 	tweaks += new /datum/loadout_tweak/laptop()
 
+//Backpacks//
+
+/datum/loadout_entry/utility/backpack
+	name = "Backpack"
+	path = /obj/item/storage/backpack
+	slot = SLOT_ID_BACK
+
+/datum/loadout_entry/utility/messanger
+	name = "Messanger Bag"
+	path = /obj/item/storage/backpack/messenger
+	slot = SLOT_ID_BACK
+
+/datum/loadout_entry/utility/satchel
+	name = "Satchel"
+	path = /obj/item/storage/backpack/satchel/norm
+	slot = SLOT_ID_BACK
+
+/datum/loadout_entry/utility/satchelleather
+	name = "Leather Satchel"
+	path = /obj/item/storage/backpack/satchel
+	slot = SLOT_ID_BACK
+
 /datum/loadout_entry/utility/dufflebag
 	name = "Dufflebag"
 	path = /obj/item/storage/backpack/dufflebag
 	slot = SLOT_ID_BACK
-	cost = 2
 
 /datum/loadout_entry/utility/dufflebag/black
 	name = "Dufflebag - Black"
 	path = /obj/item/storage/backpack/dufflebag/fluff
+	slot = SLOT_ID_BACK
 
 /datum/loadout_entry/utility/rigbag
 	name = "Rig Storage Unit"
 	path = /obj/item/storage/backpack/rig
 	slot = SLOT_ID_BACK
-	cost = 0
 
 /datum/loadout_entry/utility/welding_helmet
 	name = "Welding Helmet"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Puts all the missing backpacks (default versions) into the utility tab for matrix recoloring. Equipping a backpack from the loadout and setting yourself to spawn with the same backpack in the main screen will overwrite, and autoequip the backpack+equipment.

Adds security backpack to role restricted section.

## Why It's Good For The Game

You can now matrix default backpacks automatically at round start.


I would have just made it a selection for all types, but there are some that aren't meant to be accessed based on role and faction. I don't want to bloat the role restricted section THAT much, yet.