### PR TITLE
Removes Carpotoxin from Fish-Based Dishes

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -866,7 +866,6 @@
 /obj/item/reagent_containers/food/snacks/fishfingers/Initialize(mapload)
 	. = ..()
 	reagents.add_reagent("protein", 9)
-	reagents.add_reagent("carpotoxin", 3)
 	bitesize = 3
 
 /obj/item/reagent_containers/food/snacks/hugemushroomslice // Buff 3 >> 5
@@ -1089,7 +1088,6 @@
 /obj/item/reagent_containers/food/snacks/fishburger/Initialize(mapload)
 	. = ..()
 	reagents.add_reagent("protein", 15)
-	reagents.add_reagent("carpotoxin", 3)
 	bitesize = 6
 
 /obj/item/reagent_containers/food/snacks/tofuburger // Buff 6 >> 10
@@ -1417,7 +1415,6 @@
 /obj/item/reagent_containers/food/snacks/cubancarp/Initialize(mapload)
 	. = ..()
 	reagents.add_reagent("protein", 9)
-	reagents.add_reagent("carpotoxin", 3)
 	reagents.add_reagent("capsaicin", 3)
 	bitesize = 4
 
@@ -2005,7 +2002,6 @@
 /obj/item/reagent_containers/food/snacks/fishandchips/Initialize(mapload)
 	. = ..()
 	reagents.add_reagent("protein", 5)
-	reagents.add_reagent("carpotoxin", 3)
 	bitesize = 3
 
 /obj/item/reagent_containers/food/snacks/sandwich // Buff 6 >> 11
@@ -3731,7 +3727,6 @@ END CITADEL CHANGE */
 /obj/item/reagent_containers/food/snacks/sashimi/Initialize(mapload)
 	. = ..()
 	reagents.add_reagent("protein", 4)
-	reagents.add_reagent("carpotoxin", 2)
 	bitesize = 3
 
 /obj/item/reagent_containers/food/snacks/benedict // Buff 6 >> 8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. **Removes Carpotoxin from Fish-Based Dishes.**

## Why It's Good For The Game

1. _It's easy to forget about this and poison the crew. Carpotoxin in these foods made sense when we only had poisonous space carp, but now that we have a broad fishing system it doesn't do anything for us to have noob trap food items on the menu._

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removes carpotoxin from fish-based dishes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
