### PR TITLE
Byond lists start at 1

### DIFF
--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -5,10 +5,10 @@
  */
 
 // What each index means:
-#define DNA_OFF_LOWERBOUND 0
-#define DNA_OFF_UPPERBOUND 1
-#define DNA_ON_LOWERBOUND  2
-#define DNA_ON_UPPERBOUND  3
+#define DNA_OFF_LOWERBOUND 1
+#define DNA_OFF_UPPERBOUND 2
+#define DNA_ON_LOWERBOUND  3
+#define DNA_ON_UPPERBOUND  4
 
 // Define block bounds (off-low,off-high,on-low,on-high)
 // Used in setupgame.dm


### PR DESCRIPTION
Genetics DNA bounds were improperly set.
See line 499 for why this is a problem.

This is the reason why toggling genetics powers in the admin player panel sometimes fails to toggle to on, as well as some other grievances.