### PR TITLE
makes it so you can always move through ghosts

### DIFF
--- a/code/modules/mob/observer/mobility.dm
+++ b/code/modules/mob/observer/mobility.dm
@@ -1,2 +1,5 @@
 /mob/observer/update_mobility()
 	return
+
+/mob/observer/CanAllowThrough(atom/movable/mover, turf/target)
+	return TRUE


### PR DESCRIPTION
## About The Pull Request
>be a ghost
>pixelshift
>living people cant go past you now

there's no actual reason anything should be stopped by a ghost so it's better to let this always return true

## Why It's Good For The Game
fixes a bug

## Changelog
:cl:
fix: makes it so you can always move through ghosts
/:cl: