### PR TITLE
Adds plantpeople physiologies, buffs alraune in snow and water turfs, turf slowdown fixes & additions

### DIFF
--- a/code/__DEFINES/inventory/carry_weight.dm
+++ b/code/__DEFINES/inventory/carry_weight.dm
@@ -22,6 +22,8 @@
 #define CARRY_STRENGTH_ADD_TESHARI 0
 #define CARRY_STRENGTH_ADD_XENOCHIMERA 2.5
 #define CARRY_STRENGTH_ADD_XENOHYBRID 2.5
+#define CARRY_STRENGTH_ADD_ALRAUNE 3
+#define CARRY_STRENGTH_ADD_DIONA 3
 
 //? Carry factor - multiplier for penalizing over-limit weight; higher is worse.
 
@@ -36,6 +38,8 @@
 #define CARRY_FACTOR_MOD_PROTEAN 1.12
 #define CARRY_FACTOR_MOD_XENOCHIMERA 0.88
 #define CARRY_FACTOR_MOD_XENOHYBRID 0.88
+#define CARRY_FACTOR_MOD_ALRAUNE 0.25
+#define CARRY_FACTOR_MOD_DIONA 0.1
 
 //? Carry equation constants
 

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -141,6 +141,7 @@
 	encumbrance = ITEM_ENCUMBRANCE_SHOES_FINS
 	flat_encumbrance = ITEM_FLAT_ENCUMBRANCE_SHOES_FINS
 	species_restricted = null
+	water_speed = -3
 
 /obj/item/clothing/shoes/flipflop
 	name = "flip flops"

--- a/code/modules/mob/living/carbon/human/movement.dm
+++ b/code/modules/mob/living/carbon/human/movement.dm
@@ -115,7 +115,7 @@
 				turf_move_cost = clamp(HUMAN_LOWEST_SLOWDOWN, turf_move_cost + species.snow_movement, 15)
 			if(shoes)
 				var/obj/item/clothing/shoes/feet = shoes
-				if(feet.water_speed)
+				if(feet.snow_speed)
 					turf_move_cost = clamp(HUMAN_LOWEST_SLOWDOWN, turf_move_cost + feet.snow_speed, 15)
 			. += turf_move_cost
 

--- a/code/modules/species/station/alraune.dm
+++ b/code/modules/species/station/alraune.dm
@@ -1,8 +1,13 @@
+/datum/physiology_modifier/intrinsic/species/alraune
+	carry_strength_add = CARRY_STRENGTH_ADD_ALRAUNE
+	carry_strength_factor = CARRY_FACTOR_MOD_ALRAUNE
+
 /datum/species/alraune
 	uid = SPECIES_ID_ALRAUNE
 	id = SPECIES_ID_ALRAUNE
 	name = SPECIES_ALRAUNE
 	name_plural = "Alraunes"
+	mob_physiology_modifier = /datum/physiology_modifier/intrinsic/species/alraune
 
 	icobase = 'icons/mob/species/human/body_greyscale.dmi'
 	deform  = 'icons/mob/species/human/deformed_body_greyscale.dmi'
@@ -12,7 +17,7 @@
 	traits with other humanoid beings, occasionally mimicking their forms to lure in prey.
 
 	Most Alraune are rather opportunistic in nature, being primarily self-serving; however, this does not mean they
-	are selfish or unable to empathise with others.
+	are selfish or unable to empathize with others.
 
 	They are highly adaptable both mentally and physically, but tend to have a collecting intra-species mindset.
 	"}
@@ -21,6 +26,8 @@
 	intrinsic_languages = LANGUAGE_ID_VERNAL
 
 	slowdown = 1 //slow, they're plants. Not as slow as full diona.
+	snow_movement  = -1 // Alraune can still wear shoes. Combined with winter boots, negates light snow slowdown but still slowed on ice.
+	water_movement = -1 // Combined with swimming fins, negates shallow water slowdown.
 	total_health = 100 //standard
 	metabolic_rate = 0.75 // slow metabolism
 

--- a/code/modules/species/station/diona.dm
+++ b/code/modules/species/station/diona.dm
@@ -1,3 +1,6 @@
+/datum/physiology_modifier/intrinsic/species/diona
+	carry_strength_add = CARRY_STRENGTH_ADD_DIONA
+	carry_strength_factor = CARRY_FACTOR_MOD_DIONA
 
 /datum/species/diona
 	uid = SPECIES_ID_DIONA
@@ -5,6 +8,7 @@
 	name = SPECIES_DIONA
 	name_plural = "Dionaea"
 	//primitive_form = "Nymph"
+	mob_physiology_modifier = /datum/physiology_modifier/intrinsic/species/diona
 
 	icobase      = 'icons/mob/species/diona/body.dmi'
 	deform       = 'icons/mob/species/diona/deformed_body.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Alraune and Diona are given physiologies that improves their carrying strength and reduces their penalty for items they're carrying. This is mostly consistent with the item_slowdown_mod mechanic that they used to have.
- Alraune now have a reduced penalty for moving in water and snow. Combined with winter boots or swimming fins, this penalty is negated in light snow, and shallow water. This is consistent with how the diona's penalties are negated in these same areas.
- Winter boots were meant to reduce slowdown when walking in snow. However, someone fucked up somewhere. This PR fixes that.
- Additionally, the swimming fins have been buffed to reduce slowdown in water. They're fucking flippers. Yes, this also means the Skrell and Akula, who have reduced slowdown in water, outright gets a speed boost when swimming and wearing flippers. Water generally is situational and infrequent and is unlikely to come up much currently, so I don't think that'll cause any major balancing issues. Turf modifier slowdowns are capped at -3 for human mobs anyways.

## Why It's Good For The Game

Playing a naturally slow species is already unfun. Let's not make it even more unfun.
Otherwise, fixes good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Alraune and Diona now have physiologies that greatly reduce their slowdown in regards to item encumbrance, to compensate for how slow they are. This was a thing before item encumbrance, but it's now fixed.
fix: Winter boots will actually reduce slowdown when walking in snow like they're intended to.
balance: Swimming fins will reduce slowdown when moving in water.
balance: Alraune now have a reduced speed penalty for moving in water and snow.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
