### PR TITLE
Makes pronoun selection display the actual pronouns the options give you

### DIFF
--- a/code/modules/mob/gender.dm
+++ b/code/modules/mob/gender.dm
@@ -6,8 +6,17 @@ GLOBAL_LIST_INIT(gender_datums, gender_datums())
 		var/datum/gender/G = new path
 		.[G.key] = G
 
+GLOBAL_LIST_INIT(gender_select_list, gender_selection())
+
+/proc/gender_selection()
+	. = list()
+	for(var/path in typesof(/datum/gender))
+		var/datum/gender/G = new path
+		.[G.pronoun_preview] = G.key
+
 /datum/gender
 	var/key		= "plural"
+	var/pronoun_preview = "they/them"
 
 	var/He		= "They"
 	var/he		= "they"
@@ -24,6 +33,7 @@ GLOBAL_LIST_INIT(gender_datums, gender_datums())
 
 /datum/gender/male
 	key		= "male"
+	pronoun_preview = "He/him"
 
 	He		= "He"
 	he		= "he"
@@ -40,6 +50,7 @@ GLOBAL_LIST_INIT(gender_datums, gender_datums())
 
 /datum/gender/female
 	key		= "female"
+	pronoun_preview = "She/her"
 
 	He		= "She"
 	he		= "she"
@@ -56,6 +67,7 @@ GLOBAL_LIST_INIT(gender_datums, gender_datums())
 
 /datum/gender/neuter
 	key		= "neuter"
+	pronoun_preview = "It/its"
 
 	He		= "It"
 	he		= "it"
@@ -72,6 +84,7 @@ GLOBAL_LIST_INIT(gender_datums, gender_datums())
 
 /datum/gender/herm
 	key		= "herm"
+	pronoun_preview = "Shi/hir"
 
 	He		= "Shi"
 	he		= "shi"

--- a/code/modules/preferences/preference_setup/general/01_basic.dm
+++ b/code/modules/preferences/preference_setup/general/01_basic.dm
@@ -133,9 +133,9 @@
 		return PREFERENCES_REFRESH_UPDATE_PREVIEW
 
 	else if(href_list["id_gender"])
-		var/new_gender = tgui_input_list(user, "Choose your character's pronouns:", "Character Preference", all_genders_define_list, pref.identifying_gender)
+		var/new_gender = tgui_input_list(user, "Choose your character's pronouns:", "Character Preference", GLOB.gender_select_list, pref.identifying_gender)
 		if(new_gender && CanUseTopic(user))
-			pref.identifying_gender = new_gender
+			pref.identifying_gender = GLOB.gender_select_list[new_gender]
 		return PREFERENCES_REFRESH
 
 	else if(href_list["age"])


### PR DESCRIPTION
## About The Pull Request
![image](https://github.com/Citadel-Station-13/Citadel-Station-13-RP/assets/6356337/f21f0e5b-b743-479b-95fb-3502a647f834)
Shrimple

## Why It's Good For The Game
The current pronoun selector is incredibly vague. We ended up having to code dive to figure out what pronouns "herm" is associated with, for instance, as there's numerous different sets of pronouns that entails! So this simplifies the pronoun selector: it now displays a preview of the pronouns instead of only displaying the gender label. Self-explanatory

## Changelog

:cl: Bhijn and Myr
tweak: The pronoun selector in chargen now directly displays the pronouns that each given option results in
/:cl:

