### PR TITLE
Reduce the amount of mobspawners in trashpiles by 50%

### DIFF
--- a/code/game/objects/structures/trash_pile.dm
+++ b/code/game/objects/structures/trash_pile.dm
@@ -43,12 +43,9 @@
 		"boxfort",
 		"trashbag",
 		"brokecomp")
-	pest_nest = new(src)
+	if(prob(50))
+		pest_nest = new(src)
 
-/obj/structure/trash_pile/Destroy()
-	qdel(pest_nest)
-	pest_nest = null
-	return ..()
 
 /obj/structure/trash_pile/attackby(obj/item/W as obj, mob/user as mob)
 	var/w_type = W.type
@@ -123,6 +120,12 @@
 
 	else
 		return ..()
+
+/obj/structure/trash_pile/proc/create_mob_spawner()
+	if(!pest_nest)
+		pest_nest = new(src)
+	else
+		debug_admins("[src] tried to create pest_nest when pest_nest already existsed([pest_nest])")
 
 //Random lists
 /obj/structure/trash_pile/proc/produce_alpha_item()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
makes it so that trashpiles flip a coin on whether or not to have a mouse spawner.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Honestly mice are hardly any use in game, aside from the rare character eating them, and the occasional griefer throwing tonnes of them into the bar after storing them in backpacks.
Additional I dislike the constant squeeking trying to walk through maint.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: tweaked trash piles to not always spawn mice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
