### PR TITLE
when loading into a pAI card you can now choose to use a saved name and description

### DIFF
--- a/code/game/click/observer.dm
+++ b/code/game/click/observer.dm
@@ -99,26 +99,3 @@
 
 */
 
-//! ## VR FILE MERGE ## !//
-/obj/item/paicard/attack_ghost(mob/user)
-	. = ..()
-	if(src.pai != null) //Have a person in them already?
-		user.examinate(src)
-		return
-	var/choice = input(user, "You sure you want to inhabit this PAI?") in list("Yes", "No")
-	var/pai_name = input(user, "Choose your character's name", "Character Name") as text
-	var/actual_pai_name = sanitize_species_name(pai_name)
-	var/pai_key
-	if (isnull(pai_name))
-		return
-	if(choice == "Yes")
-		pai_key = user.key
-	else
-		return
-	var/turf/location = get_turf(src)
-	var/obj/item/paicard/card = new(location)
-	var/mob/living/silicon/pai/pai = new(card)
-	qdel(src)
-	pai.key = pai_key
-	card.setPersonality(pai)
-	pai.SetName(actual_pai_name)

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -392,7 +392,7 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/paicard)
 		user.examinate(src)
 		return
 
-	var/datum/category_item/player_setup_item/player_global/pai/pai_pref = user.client.prefs.preference_by_type["pAI"]
+	var/datum/category_item/player_setup_item/player_global/pai/pai_pref = user.client.prefs.preference_by_type[/datum/category_item/player_setup_item/player_global/pai]
 	var/datum/paiCandidate/prefs = pai_pref?.candidate
 	var/has_pAI_data = !isnull(prefs) && !isnull(prefs.name)
 	var/options = (has_pAI_data ? list("Yes (As [prefs.name])") : list()) + list("Yes (Pick Name)", "No")

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -392,7 +392,7 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/paicard)
 		user.examinate(src)
 		return
 
-	var/datum/paiCandidate/prefs = user.client.prefs.preferences_by_type["pAI"].candidate
+	var/datum/paiCandidate/prefs = user.client.prefs.preference_by_type["pAI"].candidate
 	var/has_pAI_data = !isnull(prefs) && !isnull(prefs.name)
 	var/options = (has_pAI_data ? list("Yes (As [prefs.name])") : list()) + list("Yes (Pick Name)", "No")
 

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -392,7 +392,7 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/paicard)
 		user.examinate(src)
 		return
 
-	var/prefs = user.client.prefs.preferences_by_type["pAI"].candidate
+	var/datum/paiCandidate/prefs = user.client.prefs.preferences_by_type["pAI"].candidate
 	var/has_pAI_data = !isnull(prefs) && !isnull(prefs.name)
 	var/options = (has_pAI_data ? list("Yes (As [prefs.name])") : list()) + list("Yes (Pick Name)", "No")
 

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -418,7 +418,7 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/paicard)
 	var/mob/living/silicon/pai/pai = new(card)
 	qdel(src)
 
-	if(!(has_pAI_data && options[choice] == 1))
+	if((has_pAI_data && options[choice] == 1))
 		pai.desc = prefs.description
 
 	pai.key = pai_key

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -392,7 +392,8 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/paicard)
 		user.examinate(src)
 		return
 
-	var/datum/paiCandidate/prefs = user.client.prefs.preference_by_type["pAI"]?.candidate
+	var/_prefs = user.client.prefs.preference_by_type["pAI"]?.candidate
+	var/datum/paiCandidate/prefs = _prefs
 	var/has_pAI_data = !isnull(prefs) && !isnull(prefs.name)
 	var/options = (has_pAI_data ? list("Yes (As [prefs.name])") : list()) + list("Yes (Pick Name)", "No")
 

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -383,3 +383,44 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/paicard)
 /obj/item/paicard/proc/stop_displaying_hologram()
 	displaying_hologram = FALSE
 	update_icons()
+
+/// Handling for ghosts going into empty pAI cards
+/obj/item/paicard/attack_ghost(mob/user)
+	. = ..()
+
+	if(src.pai != null) //Have a person in them already?
+		user.examinate(src)
+		return
+
+	var/prefs = user.client.prefs.preferences_by_type["pAI"].candidate
+	var/has_pAI_data = !isnull(prefs) && !isnull(prefs.name)
+	var/options = (has_pAI_data ? list("Yes (As [prefs.name])") : list()) + list("Yes (Pick Name)", "No")
+
+	var/choice = input(user, "Do you wish to inhabit this PAI?") in options
+	if(choice == "No" || isnull(choice))
+		return
+
+	var/pai_name
+	var/actual_pai_name
+
+	if(!(has_pAI_data && options[choice] == 1))
+		pai_name = input(user, "Choose your character's name", "Character Name") as text
+		actual_pai_name = sanitize_species_name(pai_name)
+	else
+		actual_pai_name = sanitize_species_name(prefs.name)
+
+	if(isnull(actual_pai_name))
+		return
+
+	var/pai_key = user.key
+	var/turf/location = get_turf(src)
+	var/obj/item/paicard/card = new(location)
+	var/mob/living/silicon/pai/pai = new(card)
+	qdel(src)
+
+	if(!(has_pAI_data && options[choice] == 1))
+		pai.desc = prefs.description
+
+	pai.key = pai_key
+	card.setPersonality(pai)
+	pai.SetName(actual_pai_name)

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -404,7 +404,7 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/paicard)
 	var/pai_name
 	var/actual_pai_name
 
-	if(!(has_pAI_data && options[choice] == 1))
+	if(choice == "Yes (Pick Name)")
 		pai_name = input(user, "Choose your character's name", "Character Name") as text
 		actual_pai_name = sanitize_species_name(pai_name)
 	else
@@ -419,7 +419,7 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/paicard)
 	var/mob/living/silicon/pai/pai = new(card)
 	qdel(src)
 
-	if((has_pAI_data && options[choice] == 1))
+	if(choice != "Yes (Pick Name)")
 		pai.desc = prefs.description
 
 	pai.key = pai_key

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -392,7 +392,7 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/paicard)
 		user.examinate(src)
 		return
 
-	var/datum/paiCandidate/prefs = user.client.prefs.preference_by_type["pAI"].candidate
+	var/datum/paiCandidate/prefs = user.client.prefs.preference_by_type["pAI"]?.candidate
 	var/has_pAI_data = !isnull(prefs) && !isnull(prefs.name)
 	var/options = (has_pAI_data ? list("Yes (As [prefs.name])") : list()) + list("Yes (Pick Name)", "No")
 

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -392,8 +392,8 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/paicard)
 		user.examinate(src)
 		return
 
-	var/_prefs = user.client.prefs.preference_by_type["pAI"]?.candidate
-	var/datum/paiCandidate/prefs = _prefs
+	var/datum/category_item/player_setup_item/player_global/pai/pai_pref = user.client.prefs.preference_by_type["pAI"]
+	var/datum/paiCandidate/prefs = pai_pref?.candidate
 	var/has_pAI_data = !isnull(prefs) && !isnull(prefs.name)
 	var/options = (has_pAI_data ? list("Yes (As [prefs.name])") : list()) + list("Yes (Pick Name)", "No")
 


### PR DESCRIPTION
## About The Pull Request
the role you can set in character setup doesn't seem like it has a real use but if anyone badly wants it to show on examine i can do that

## Why It's Good For The Game
ease of use, plus having descriptions on pAIs is nice as you can give a bit of a visual description to differentiate them

## Changelog

:cl:
add: when loading into a pAI card you can now choose to use a saved name and description
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
