### PR TITLE
Replaces the RnG of electric shocks with a more sane calculation

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -255,33 +255,20 @@
 	return
 
 /obj/item/cell/proc/get_electrocute_damage()
-	switch (charge)
-/*		if (9000 to INFINITY)
-			return min(rand(90,150),rand(90,150))
-		if (2500 to 9000-1)
-			return min(rand(70,145),rand(70,145))
-		if (1750 to 2500-1)
-			return min(rand(35,110),rand(35,110))
-		if (1500 to 1750-1)
-			return min(rand(30,100),rand(30,100))
-		if (750 to 1500-1)
-			return min(rand(25,90),rand(25,90))
-		if (250 to 750-1)
-			return min(rand(20,80),rand(20,80))
-		if (100 to 250-1)
-			return min(rand(20,65),rand(20,65))*/
-		if (1000000 to INFINITY)
-			return min(rand(50,160),rand(50,160))
-		if (200000 to 1000000-1)
-			return min(rand(25,80),rand(25,80))
-		if (100000 to 200000-1)//Ave powernet
-			return min(rand(20,60),rand(20,60))
-		if (50000 to 100000-1)
-			return min(rand(15,40),rand(15,40))
-		if (1000 to 50000-1)
-			return min(rand(10,20),rand(10,20))
-		else
-			return 0
+	//1kW = 5
+	//10kW = 24
+	//100kW = 45
+	//250kW = 53
+	//1MW = 66
+	//10MW = 88
+	//100MW = 110
+	//1GW = 132
+	if(charge >= 1000)
+		var/damage = log(1.1,charge)
+		damage = damage - (log(1.1,damage)*1.5)
+		return round(damage)
+	else
+		return 0
 
 /obj/item/cell/suicide_act(mob/user)
 	var/datum/gender/TU = GLOB.gender_datums[user.get_visible_gender()]

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -131,19 +131,20 @@
 	newavail = 0
 
 /datum/powernet/proc/get_electrocute_damage()
-	switch(avail)
-		if (1000 to INFINITY)
-			return min(rand(50,160),rand(50,160))
-		if (200 to 1000)
-			return min(rand(25,80),rand(25,80))
-		if (100 to 200)//Ave powernet
-			return min(rand(20,60),rand(20,60))
-		if (50 to 100)
-			return min(rand(15,40),rand(15,40))
-		if (1 to 50)
-			return min(rand(10,20),rand(10,20))
-		else
-			return 0
+	//1kW = 5
+	//10kW = 24
+	//100kW = 45
+	//250kW = 53
+	//1MW = 66
+	//10MW = 88
+	//100MW = 110
+	//1GW = 132
+	if(avail >= 1000)
+		var/damage = log(1.1,avail)
+		damage = damage - (log(1.1,damage)*1.5)
+		return round(damage)
+	else
+		return 0
 
 /datum/powernet/proc/drain_energy_handler(datum/actor, amount, flags)
 	// amount is in kj so no conversion needed


### PR DESCRIPTION
TL;DR
Shock damage being an RnG value hard capped at 1MW with "jumps" in damage at certain breakpoints was weird so I smoothed out the math. Overall, damage is uncapped but does a little less damage.

Extended answer:
The old method returns burn damage to the victim in a series of five "tiers" based on the available power at the time.
These tiers roll a random with disadvantage, the thresholds in question were as follows:
Note that these values are rolled with disadvantage.
1kW to 50kw = 10-20
50kW to 100kW = 15-40
100kW to 200kW = 20-60
200kW to 1MW = 25-80
1MW+ = 50-160

I've replaced the math with a logarithmic that looks like this
burn damage = log(1.1, power) - log(1.1, (log(1.1, power)*1.5))
which results in a smoothed out damage curve with a plateau around 1MW, as follows:
1kW = 5
10kW = 24
100kW = 45
250kW = 53
1MW = 66
10MW = 88
100MW = 110
1GW = 132