### PR TITLE
Replaces "capsaicin" with "wasabi" in wasabi peas' taste description

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -412,7 +412,7 @@
 	desc = "Freeze Dried peas covered in a very spicy substance!"
 	icon_state = "wasabi_peas"
 	nutriment_amt = 4
-	nutriment_desc = list("capsaicin" = 2, "protein" = 2)
+	nutriment_desc = list("wasabi" = 2, "protein" = 2)
 
 /obj/item/reagent_containers/food/snacks/bagged/wpeas/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Wasabi contains no capsaicin. Its heat-inducing ingredient is [allyl isothiocyanate](https://en.wikipedia.org/wiki/Allyl_isothiocyanate).

We don't have that, so I'm keeping capsaicin as the literal ingredient for the pain-causing. But still. It shouldn't be explicitly listed as a taste.

## Why It's Good For The Game

My immersion !

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Wasabi peas no longer taste like "capsaicin"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
