### PR TITLE
Gives xenochimeras set_size

### DIFF
--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -109,6 +109,7 @@
 		/mob/living/carbon/human/proc/hide_horns,
 		/mob/living/carbon/human/proc/hide_wings,
 		/mob/living/carbon/human/proc/hide_tail,
+		/mob/living/proc/set_size,
 		/mob/living/proc/shred_limb,
 		/mob/living/proc/eat_trash,
 		/mob/living/proc/glow_toggle,


### PR DESCRIPTION

## About The Pull Request

Gives xenochimeras the /mob/living/proc/set_size verb, allowing them to switch sizes as if they had the Sizeshift trait.

## Why It's Good For The Game

It definitely feels like something that can be reasonably explained in the lore, as chimeras can manipulate their own mass pretty competently already. I would've liked to implement a nutrition cost system on positive size alteration, but I'm not skilled enough to pull that off.

## Changelog

:cl:
tweak: Added set_size to xenochimeras
/:cl: