### PR TITLE
Allows negative traits to be available for everyone (+ makes a few disabilities available to all + related tweaks)

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -601,13 +601,13 @@ var/global/list/remainless_species = list(SPECIES_ID_PROMETHEAN,
 		var/cost = instance.cost
 		traits_costs[path] = cost
 		all_traits[path] = instance
+		if(!instance.custom_only && instance.cost <= 0)
+			everyone_traits[path] = instance
 		switch(cost)
 			if(-INFINITY to -0.1)
 				negative_traits[path] = instance
 			if(0)
 				neutral_traits[path] = instance
-				if(!(instance.custom_only))
-					everyone_traits[path] = instance
 			if(0.1 to INFINITY)
 				positive_traits[path] = instance
 

--- a/code/modules/mob/living/carbon/human/traits/negative.dm
+++ b/code/modules/mob/living/carbon/human/traits/negative.dm
@@ -140,6 +140,7 @@
 	name = "Colorblindness (Monochromancy)"
 	desc = "You simply can't see colors at all, period. You are 100% colorblind."
 	cost = -1
+	custom_only = FALSE
 
 /datum/trait/negative/colorblind/mono/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
@@ -181,6 +182,7 @@
 	name = "Blind"
 	desc = "You're blind. Permanently."
 	cost = -3
+	custom_only = FALSE
 	traits = list(
 		TRAIT_BLIND
 	)
@@ -193,6 +195,7 @@
 	name = "Deaf"
 	desc = "You're deaf. Permanently."
 	cost = -2
+	custom_only = FALSE
 	traits = list(
 		TRAIT_DEAF
 	)
@@ -209,6 +212,7 @@
 	name = "Mute"
 	desc = "You're mute. Permanently."
 	cost = 0			// TTS bypasses this instantly, no powergaming mute ass explo characters
+	custom_only = FALSE
 	traits = list(
 		TRAIT_MUTE
 	)


### PR DESCRIPTION
## About The Pull Request
![image](https://github.com/Citadel-Station-13/Citadel-Station-13-RP/assets/6356337/84656b88-e499-4482-8708-0463e924161c)

Self-explanatory PR. Ya no longer need to be a custom species to take negative traits!

There's a few extra changes in here, as well. Notably, the trait selector will no longer show you traits that are exclusive to certain species if you are not that species (like the shadekin traits, for instance). Additionally, being a non-custom species will simplify the "neutral traits" button to just "traits", with the selector having both neutral and negative traits merged together.

As a treat, we've also gone the extra mile and made four negative traits available to all: monochromancy, blindness, deafness, and muteness.

## Why It's Good For The Game
Some negative traits, especially notably the disabilities, can make for genuinely interesting RP in some cases! So this makes a few directly available, and makes it *much* easier to add more in the future.

## Changelog

:cl: Bhijn and Myr
add: Some negative traits are now available to all species, not just custom species! Non-custom species have a trait selector with all traits available to them merged together.
tweak: Monochromancy, blindness, deafness, and muteness, are now available to all species
qol: The trait selector will no longer show you traits that you are unable to take.
/:cl:
