### PR TITLE
Adds Ability targeting

### DIFF
--- a/citadel.dme
+++ b/citadel.dme
@@ -605,6 +605,7 @@
 #include "code\controllers\subsystem\sound\channel_manager.dm"
 #include "code\controllers\subsystem\sound\soundbyte_manager.dm"
 #include "code\datums\ability.dm"
+#include "code\datums\ability_handler.dm"
 #include "code\datums\access.dm"
 #include "code\datums\action.dm"
 #include "code\datums\ai_law_sets.dm"

--- a/code/__DEFINES/ability.dm
+++ b/code/__DEFINES/ability.dm
@@ -7,6 +7,12 @@
 /// toggle interact, hot-bindable
 #define ABILITY_INTERACT_TOGGLE "toggle"
 
+//? targeting_type - exclusively used for targeted abilities
+
+#define ABILITY_TARGET_ALL "all"
+#define ABILITY_TARGET_MOB "mob"
+#define ABILITY_TARGET_TURF "turf"
+
 //? ability_check_flags - if you add new ones, make sure to modify available_check() and unavailable_reason().
 
 #define ABILITY_CHECK_CONSCIOUS (1<<0)

--- a/code/datums/ability.dm
+++ b/code/datums/ability.dm
@@ -158,8 +158,7 @@
 		if(targeted)
 			if(ishuman(user) && toggling == TRUE)
 				var/mob/living/carbon/human/H = user
-				if(H.ab_handler)
-					H.ab_handler.process_ability(src)
+				H.ab_handler?.process_ability(src)
 	if(!check_trigger(user, toggling, TRUE))
 		return
 	if(windup)
@@ -322,7 +321,8 @@
 /datum/ability/proc/target_check(mob/user, atom/target)
 	if(range)
 		if(get_dist(get_turf(user),get_turf(target)) <= range)
-		else return FALSE
+		else
+			return FALSE
 	if(check_trigger(user))
 		target_trigger(user,target)
 		return TRUE

--- a/code/datums/ability.dm
+++ b/code/datums/ability.dm
@@ -41,6 +41,8 @@
 	var/interact_type = ABILITY_INTERACT_NONE
 	/// currently hidden?
 	var/hidden = FALSE
+	/// targeted?
+	var/targeted = FALSE
 
 	//? ui
 	/// tgui id

--- a/code/datums/ability.dm
+++ b/code/datums/ability.dm
@@ -320,8 +320,7 @@
  */
 /datum/ability/proc/target_check(mob/user, atom/target)
 	if(range)
-		if(get_dist(get_turf(user),get_turf(target)) <= range)
-		else
+		if(get_dist(get_turf(user),get_turf(target)) > range)
 			return FALSE
 	if(check_trigger(user))
 		target_trigger(user,target)

--- a/code/datums/ability.dm
+++ b/code/datums/ability.dm
@@ -42,7 +42,12 @@
 	/// currently hidden?
 	var/hidden = FALSE
 	/// targeted?
+	/// targeted abilities only work with ABILITY_INTERACT_TOGGLE
 	var/targeted = FALSE
+	/// target type? Can be anything (atoms), mobs or turfs
+	var/targeting_type = ABILITY_TARGET_ALL
+	/// range?
+	var/range
 
 	//? ui
 	/// tgui id
@@ -150,6 +155,11 @@
 			return
 		if(isnull(toggling))
 			toggling = !enabled
+		if(targeted)
+			if(ishuman(user) && toggling == TRUE)
+				var/mob/living/carbon/human/H = user
+				if(H.ab_handler)
+					H.ab_handler.process_ability(src)
 	if(!check_trigger(user, toggling, TRUE))
 		return
 	if(windup)
@@ -304,6 +314,18 @@
 	hidden = FALSE
 	if(always_bind)
 		quickbind()
+
+/datum/ability/proc/target_check(mob/user, atom/target)
+	if(range)
+		if(get_dist(get_turf(user),get_turf(target)) <= range)
+		else return FALSE
+	target_trigger(user, target)
+	return TRUE
+
+
+/datum/ability/proc/target_trigger(mob/user, atom/target)
+	//target-related code goes here
+	disable()
 
 /**
  * static data for tgui panel

--- a/code/datums/ability.dm
+++ b/code/datums/ability.dm
@@ -30,7 +30,7 @@
 	/// action button background icon
 	var/background_icon = 'icons/screen/actions/backgrounds.dmi'
 	/// action button background icon state - the _on overlay will be added while active, automatically.
-	var/background_state = "alien"
+	var/background_state = "default"
 	/// currently hotbound?
 	var/bound = FALSE
 	/// automatically hotbound?
@@ -199,12 +199,16 @@
 	enabled = TRUE
 	if(update_action)
 		update_action()
+	action?.background_icon_state += "_on"
+	action?.update_button()
 	on_enable()
 
 /datum/ability/proc/disable(update_action)
 	enabled = FALSE
 	if(update_action)
 		update_action()
+	action?.background_icon_state = background_state
+	action?.update_button()
 	on_disable()
 
 /datum/ability/proc/on_enable()

--- a/code/datums/ability.dm
+++ b/code/datums/ability.dm
@@ -315,14 +315,22 @@
 	if(always_bind)
 		quickbind()
 
+
+/**
+ * checks if the target is within range and the ability is triggerable
+ */
 /datum/ability/proc/target_check(mob/user, atom/target)
 	if(range)
 		if(get_dist(get_turf(user),get_turf(target)) <= range)
 		else return FALSE
-	target_trigger(user, target)
-	return TRUE
+	if(check_trigger(user))
+		target_trigger(user,target)
+		return TRUE
+	return FALSE
 
-
+/**
+ * target-affecting proc
+ */
 /datum/ability/proc/target_trigger(mob/user, atom/target)
 	//target-related code goes here
 	disable()

--- a/code/datums/ability_handler.dm
+++ b/code/datums/ability_handler.dm
@@ -15,6 +15,7 @@
 		else
 			target_type = null
 			return
+	ab.owner.client.mouse_pointer_icon = file("icons/screen/mouse_pointers/standard1.dmi")
 
 ///Is called by a click if there's an ability in 'current'
 /datum/ability_handler/proc/process_click(mob/user, atom/A)
@@ -22,5 +23,6 @@
 		if(istype(A,target_type) && !istype(A,/atom/movable))
 			if(current.target_check(user, A))
 				current = null
+				user.client?.mouse_pointer_icon = initial(user.client.mouse_pointer_icon)
 				return TRUE
 	return FALSE

--- a/code/datums/ability_handler.dm
+++ b/code/datums/ability_handler.dm
@@ -20,7 +20,7 @@
 /datum/ability_handler/proc/process_click(mob/user, atom/A)
 	if(current)
 		if(istype(A,target_type) && !istype(A,/atom/movable))
-			if(current.check_trigger(user, A))
+			if(current.target_check(user, A))
 				current = null
 				return TRUE
 	return FALSE

--- a/code/datums/ability_handler.dm
+++ b/code/datums/ability_handler.dm
@@ -20,9 +20,12 @@
 ///Is called by a click if there's an ability in 'current'
 /datum/ability_handler/proc/process_click(mob/user, atom/A)
 	if(current)
-		if(istype(A,target_type) && !istype(A,/atom/movable))
-			if(current.target_check(user, A))
-				current = null
-				user.client?.mouse_pointer_icon = initial(user.client.mouse_pointer_icon)
-				return TRUE
+		if(target_type && !istype(A, target_type))
+			return FALSE
+		if(A.atom_flags & ATOM_ABSTRACT)
+			return FALSE
+		if(current.target_check(user, A))
+			current = null
+			user.client?.mouse_pointer_icon = initial(user.client.mouse_pointer_icon)
+			return TRUE
 	return FALSE

--- a/code/datums/ability_handler.dm
+++ b/code/datums/ability_handler.dm
@@ -22,4 +22,5 @@
 		if(istype(A,target_type) && !istype(A,/atom/movable))
 			if(current.check_trigger(user, A))
 				current = null
-		else return
+				return TRUE
+	return FALSE

--- a/code/datums/ability_handler.dm
+++ b/code/datums/ability_handler.dm
@@ -1,0 +1,25 @@
+/datum/ability_handler
+    var/datum/ability/current
+    var/target_type
+
+///Is called by the ability
+/datum/ability_handler/proc/process_ability(var/datum/ability/ab)
+	current = ab
+	switch(current?.targeting_type)
+		if(ABILITY_TARGET_ALL)
+			target_type = /atom
+		if(ABILITY_TARGET_MOB)
+			target_type = /mob
+		if(ABILITY_TARGET_TURF)
+			target_type = /turf
+		else
+			target_type = null
+			return
+
+///Is called by a click if there's an ability in 'current'
+/datum/ability_handler/proc/process_click(mob/user, atom/A)
+	if(current)
+		if(istype(A,target_type) && !istype(A,/atom/movable))
+			if(current.check_trigger(user, A))
+				current = null
+		else return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1154,6 +1154,11 @@
 			var/datum/mob_descriptor/descriptor = species.descriptors[desctype]
 			descriptors[desctype] = descriptor.default_value
 
+	if(ispath(species.custom_ability_handler, /datum/ability_handler))
+		ab_handler = new species.custom_ability_handler()
+	else
+		ab_handler = new /datum/ability_handler()
+
 	// dumb shit transformation shit here
 	if(example)
 		if(!(example == src))
@@ -1640,3 +1645,8 @@
 		return
 	// groan
 	. += ((size_multiplier * icon_scale_x) - 1) * ((dir & EAST)? -16 : 16)
+
+/mob/living/carbon/human/ClickOn(var/atom/A)
+	if(ab_handler)
+		ab_handler.process_click(src, A)
+	else ..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1648,5 +1648,6 @@
 
 /mob/living/carbon/human/ClickOn(var/atom/A)
 	if(ab_handler)
-		ab_handler.process_click(src, A)
-	else ..()
+		if(ab_handler.process_click(src, A))
+			return
+	..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1647,7 +1647,6 @@
 	. += ((size_multiplier * icon_scale_x) - 1) * ((dir & EAST)? -16 : 16)
 
 /mob/living/carbon/human/ClickOn(var/atom/A)
-	if(ab_handler)
-		if(ab_handler.process_click(src, A))
-			return
+	if(ab_handler?.process_click(src, A))
+		return
 	..()

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -271,3 +271,5 @@
 	var/hiding_wings = FALSE
 	var/hiding_tail = FALSE
 	var/hiding_horns = FALSE
+
+	var/datum/ability_handler/ab_handler

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -436,6 +436,7 @@
 	var/show_ssd = "fast asleep"
 	/// This allows you to pick up crew
 	var/holder_type = /obj/item/holder/micro
+	var/custom_ability_handler = null
 
 	//? on death drops
 	/// The color of the species flesh.

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -436,7 +436,7 @@
 	var/show_ssd = "fast asleep"
 	/// This allows you to pick up crew
 	var/holder_type = /obj/item/holder/micro
-	var/custom_ability_handler = null
+	var/custom_ability_handler
 
 	//? on death drops
 	/// The color of the species flesh.

--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -98,6 +98,7 @@
 		/datum/ability/species/xenochimera/dissonant_shriek,
 		/datum/ability/species/sonar,
 		/datum/ability/species/toggle_flight,
+		/datum/ability/species/xenochimera/boom,
 	)
 
 	inherent_verbs = list( //Xenochimera get all the special verbs since they can't select traits.
@@ -731,7 +732,7 @@
 	name = "Dissonant Shriek"
 	desc = "We shift our vocal cords to release a high-frequency sound that overloads nearby electronics."
 	action_state = "ling_resonant_shriek"
-	var/range = 8
+	range = 8
 	//Slightly more potent than an EMP grenade
 	var/emp_heavy = 3
 	var/emp_med = 6

--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -98,7 +98,6 @@
 		/datum/ability/species/xenochimera/dissonant_shriek,
 		/datum/ability/species/sonar,
 		/datum/ability/species/toggle_flight,
-		/datum/ability/species/xenochimera/boom,
 	)
 
 	inherent_verbs = list( //Xenochimera get all the special verbs since they can't select traits.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a way for abilities to be targetable, including range.
![dreamseeker_LdiPg2xAvH](https://github.com/Citadel-Station-13/Citadel-Station-13-RP/assets/11361525/9ce5cb7c-c326-4683-ab80-36c65a8aa12a)

Currently works using a carbon/human datum that is used as a middleman between the abilities and the clicks. Currently no ability uses it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ability versatility! 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Ability targeting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
