### PR TITLE
Toggle cover verb for borgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -495,6 +495,13 @@
 	set name = "Emit Sparks"
 	spark_system.start()
 
+/mob/living/silicon/robot/verb/toggle_cover()
+	set category = "Robot Commands"
+	set name = "Toggle Cover"
+	locked = !locked
+	to_chat(src, "You [ locked ? "lock" : "unlock"] your interface.")
+	updateicon()
+
 // this function returns the robots jetpack, if one is installed
 /mob/living/silicon/robot/proc/installed_jetpack()
 	if(module)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a verb to borgs allowing them to lock/unlock their own covers

## Why It's Good For The Game

I was told this is a salt PR. I think there might be legitimate reasons to only allow roboticists/emags to do it, so I don't know if it's good for the game, actually. But I was told to salt PR it, so I did.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Cover lock/unlock verb for borgs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
