### PR TITLE
Shrinking the hammerhead (slightly)

### DIFF
--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -225,29 +225,6 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/pool)
-"amc" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/obj/machinery/button/remote/blast_door{
-	id = "hammerfighter1";
-	name = "Fighter Bay 1";
-	pixel_x = -6;
-	pixel_y = 26
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "hammerfighter2";
-	name = "Fighter Bay 2";
-	pixel_x = 5;
-	pixel_y = 26
-	},
-/obj/structure/handrail,
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "amf" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/structure/cable/green{
@@ -2457,15 +2434,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
-"buA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/security/hammerhead_bay)
 "buD" = (
 /obj/structure/grille,
 /obj/structure/sign/warning/falling,
@@ -2552,6 +2520,29 @@
 	},
 /turf/simulated/open/lythios43c,
 /area/rift/surfacebase/outside/outside2)
+"byu" = (
+/obj/structure/handrail{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "hammerfighterport";
+	name = "Port Fighter Bay";
+	pixel_x = -3;
+	pixel_y = -30
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "hammerfighterstarboard";
+	name = "Starboard Fighter Bay";
+	pixel_x = 5;
+	pixel_y = -30
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/cockpit)
 "byv" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -2911,13 +2902,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/asmaint2)
-"bLw" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "bLy" = (
 /obj/effect/floor_decal/borderfloorblack{
 	alpha = 255;
@@ -4109,15 +4093,6 @@
 	},
 /turf/simulated/floor/tiled/red,
 /area/security/security_processing)
-"cDO" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/hammerhead/general)
 "cDU" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -4275,10 +4250,6 @@
 	},
 /turf/simulated/floor/water/deep/pool,
 /area/crew_quarters/pool)
-"cJj" = (
-/obj/effect/floor_decal/corner_techfloor_gray,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/cockpit)
 "cJR" = (
 /obj/machinery/door/blast/regular{
 	id = "xenobiodiv7";
@@ -6182,6 +6153,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
+"dRQ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 10
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/turf/simulated/floor/plating,
+/area/shuttle/hammerhead/general)
 "dSq" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloor{
@@ -6845,6 +6826,15 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/security/interrogation)
+"etT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/security/hammerhead_bay)
 "eut" = (
 /turf/simulated/wall/prepainted/medical,
 /area/medical/surgery)
@@ -7023,16 +7013,6 @@
 	},
 /turf/simulated/open,
 /area/hallway/primary/surfacetwo)
-"eAU" = (
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/obj/structure/fuel_port{
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "eAV" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/bag/circuits/basic,
@@ -7911,13 +7891,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
-"fcW" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "fcX" = (
 /obj/structure/table/steel,
 /obj/item/book/manual/security_space_law,
@@ -7940,6 +7913,28 @@
 /area/medical/sleeper)
 "fdm" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
+/turf/simulated/floor/plating,
+/area/shuttle/hammerhead/general)
+"fdo" = (
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "hammerfighterport";
+	name = "Port Fighter Bay";
+	pixel_x = 6;
+	pixel_y = -26
+	},
+/obj/machinery/light/no_nightshift,
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "hammerheadpport";
+	name = "Port Personnel Door";
+	pixel_x = -5;
+	pixel_y = -26
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "fdT" = (
@@ -7968,14 +7963,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research/rnd)
-"feI" = (
-/obj/structure/handrail{
-	dir = 1
-	},
-/obj/structure/lattice,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "feR" = (
 /obj/structure/frame{
 	anchored = 1
@@ -8291,6 +8278,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/briefing_room)
+"fpW" = (
+/obj/machinery/door/airlock/voidcraft/vertical{
+	name = "Control Room";
+	req_one_access = list(1,38)
+	},
+/obj/effect/floor_decal/corner_techfloor_gray{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "fqf" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/sleep/Dorm_3)
@@ -9364,15 +9361,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/breakroom)
-"gbm" = (
-/obj/machinery/atmospheric_field_generator/perma,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "hammerfighter5";
-	name = "Fighter Bay Exit 5"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/hammerhead/general)
 "gbO" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 8
@@ -10994,13 +10982,6 @@
 "heZ" = (
 /turf/simulated/wall/prepainted/medical,
 /area/medical/morgue)
-"hfg" = (
-/obj/machinery/portable_atmospherics/canister/phoron,
-/obj/machinery/atmospherics/portables_connector/fuel{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "hfz" = (
 /obj/structure/table/woodentable,
 /obj/machinery/microwave,
@@ -11241,28 +11222,17 @@
 /area/assembly/robotics)
 "hnx" = (
 /obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/catwalk,
+/obj/machinery/light/no_nightshift,
 /obj/machinery/button/remote/blast_door{
 	dir = 1;
-	id = "hammerfighter5";
-	name = "Fighter Bay 5";
+	id = "hammerfighterport";
+	name = "Port Fighter Bay";
 	pixel_x = -5;
 	pixel_y = -26
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "hammerfighter6";
-	name = "Fighter Bay 6";
-	pixel_x = 6;
-	pixel_y = -26
-	},
-/obj/structure/handrail{
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
@@ -11790,6 +11760,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
+"hFZ" = (
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/machinery/air_alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = -4
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "hGo" = (
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/showers)
@@ -11945,16 +11932,6 @@
 "hKi" = (
 /turf/simulated/wall/r_wall/prepainted/medical,
 /area/medical/chemistry)
-"hKy" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "hKz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -14993,6 +14970,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/interrogation)
+"jJS" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 4
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/structure/fuel_port{
+	pixel_x = 1;
+	pixel_y = 30
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/hammerhead/general)
 "jJU" = (
 /obj/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/airlock_sensor{
@@ -15699,19 +15690,6 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"kdK" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/guncabinet{
-	anchored = 1
-	},
-/obj/machinery/air_alarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/general)
 "ker" = (
 /obj/structure/table/rack/shelf/steel,
 /turf/simulated/floor/tiled/red,
@@ -16629,13 +16607,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
-"kEU" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/hammerhead/general)
 "kFB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16833,6 +16804,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
+"kNL" = (
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "hammerfighterstarboard";
+	name = "Starboard Fighter Bay";
+	pixel_x = 5;
+	pixel_y = 26
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "hammerheadpsb";
+	name = "Starboard Personnel Door";
+	pixel_x = -6;
+	pixel_y = 26
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/hammerhead/general)
 "kNQ" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -17139,15 +17132,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rnd/lockers)
-"kWx" = (
-/obj/machinery/atmospheric_field_generator/perma,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "hammerfighter3";
-	name = "Fighter Bay Exit 3"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/hammerhead/general)
 "kWP" = (
 /obj/machinery/atmospherics/component/unary/cryo_cell,
 /obj/effect/floor_decal/corner/paleblue{
@@ -18275,22 +18259,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
+"lCs" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/cockpit)
 "lCv" = (
 /obj/structure/toilet{
 	pixel_y = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/Dorm_4)
-"lCY" = (
-/obj/machinery/door/airlock/voidcraft/vertical{
-	name = "Control Room";
-	req_one_access = list(1,38)
-	},
-/obj/effect/floor_decal/corner_techfloor_gray{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/cockpit)
 "lDe" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -18690,15 +18676,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/wall/r_wall/prepainted,
 /area/medical/chemistry)
-"lPt" = (
-/obj/structure/cable/orange{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/orange{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/cockpit)
 "lQj" = (
 /obj/structure/closet/crate{
 	name = "Grenade Crate"
@@ -21053,8 +21030,8 @@
 /obj/machinery/atmospheric_field_generator/perma,
 /obj/machinery/door/blast/regular{
 	dir = 4;
-	id = "hammerfighter4";
-	name = "Fighter Bay Exit 4"
+	id = "hammerfighterport";
+	name = "Port Fighter Bay"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/hammerhead/general)
@@ -21447,22 +21424,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/brig)
-"nxS" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/structure/catwalk,
-/obj/machinery/light/no_nightshift,
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "hammerfighter6";
-	name = "Fighter Bay 6";
-	pixel_x = -5;
-	pixel_y = -26
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "nxY" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/coffee_shop)
@@ -22536,19 +22497,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
-"ogw" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/machinery/computer/ship/engines{
-	dir = 4
-	},
-/obj/item/radio/intercom/department/security{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "ogH" = (
 /obj/machinery/meter{
 	pixel_x = 6;
@@ -23392,8 +23340,8 @@
 /obj/machinery/atmospheric_field_generator/perma,
 /obj/machinery/door/blast/regular{
 	dir = 4;
-	id = "hammerfighter1";
-	name = "Fighter Bay Exit 1"
+	id = "hammerfighterstarboard";
+	name = "Starboard Fighter Bay Exit"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/hammerhead/general)
@@ -25148,28 +25096,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/sleep)
-"pUb" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "hammerfighter1";
-	name = "Fighter Bay 1";
-	pixel_x = 5;
-	pixel_y = 26
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "hammerheadpsb";
-	name = "Starboard Personnel Door";
-	pixel_x = -6;
-	pixel_y = 26
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "pUL" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -25533,6 +25459,12 @@
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
+"qij" = (
+/obj/structure/cable/orange{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/cockpit)
 "qiJ" = (
 /obj/structure/grille,
 /obj/structure/foamedmetal,
@@ -25786,12 +25718,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rnd/research/researchdivision)
-"qpx" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/cockpit)
 "qpE" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -26795,19 +26721,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
-"qUM" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/voidcraft/vertical{
-	name = "Control Room";
-	req_one_access = list(1,38)
-	},
-/obj/effect/floor_decal/corner_techfloor_gray{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/cockpit)
 "qVn" = (
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 8
@@ -27004,25 +26917,21 @@
 /area/crew_quarters/sleep)
 "rcg" = (
 /obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
 /obj/structure/catwalk,
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
 /obj/machinery/button/remote/blast_door{
-	id = "hammerfighter2";
-	name = "Fighter Bay 2";
+	id = "hammerfighterstarboard";
+	name = "Starboard Fighter Bay";
 	pixel_x = -6;
 	pixel_y = 26
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "hammerfighter3";
-	name = "Fighter Bay 3";
-	pixel_x = 5;
-	pixel_y = 26
-	},
-/obj/structure/handrail,
 /turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "rcB" = (
@@ -28986,12 +28895,6 @@
 "sse" = (
 /turf/simulated/wall/prepainted/security,
 /area/security/security_processing)
-"sss" = (
-/obj/structure/handrail,
-/obj/structure/lattice,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "ssT" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small{
@@ -29304,16 +29207,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/hor)
-"sCV" = (
-/obj/machinery/power/smes/buildable{
-	charge = 1.5e+007;
-	cur_coils = 3
-	},
-/obj/structure/cable/orange{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "sDd" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/structure/bed/chair{
@@ -29629,9 +29522,6 @@
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/water/pool,
 /area/crew_quarters/pool)
-"sNY" = (
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "sPc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -29647,33 +29537,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rnd/research/researchdivision)
-"sPt" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "hammerfighter4";
-	name = "Fighter Bay 4";
-	pixel_x = -5;
-	pixel_y = -26
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "hammerfighter5";
-	name = "Fighter Bay 5";
-	pixel_x = 6;
-	pixel_y = -26
-	},
-/obj/structure/handrail{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "sPP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -30702,20 +30565,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel,
 /area/medical/reception)
-"tBx" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 10
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/obj/item/radio/intercom/department/security{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "tBE" = (
 /obj/structure/railing{
 	dir = 4
@@ -30962,28 +30811,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
-"tGD" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "hammerfighter4";
-	name = "Fighter Bay 4";
-	pixel_x = 6;
-	pixel_y = -26
-	},
-/obj/machinery/light/no_nightshift,
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "hammerheadpport";
-	name = "Port Personnel Door";
-	pixel_x = -5;
-	pixel_y = -26
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "tGY" = (
 /obj/landmark/spawnpoint/job/warden,
 /obj/machinery/light_switch{
@@ -31175,15 +31002,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/pool/emergency_closet)
-"tSM" = (
-/obj/machinery/atmospheric_field_generator/perma,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "hammerfighter6";
-	name = "Fighter Bay Exit 6"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/hammerhead/general)
 "tSV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -31237,6 +31055,27 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/holodeck_control)
+"tUK" = (
+/obj/structure/handrail{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "hammerfighterport";
+	name = "Port Fighter Bay";
+	pixel_x = -4;
+	pixel_y = 33
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "hammerfighterstarboard";
+	name = "Starboard Fighter Bay";
+	pixel_x = 4;
+	pixel_y = 33
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/cockpit)
 "tUW" = (
 /obj/machinery/light{
 	dir = 8
@@ -34015,6 +33854,19 @@
 /obj/machinery/vending/fitness,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/pool)
+"vKi" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/voidcraft/vertical{
+	name = "Control Room";
+	req_one_access = list(1,38)
+	},
+/obj/effect/floor_decal/corner_techfloor_gray{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "vKj" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/shutters{
@@ -34075,19 +33927,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rnd/research/researchdivision)
-"vMM" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = -4
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "vNQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -34134,6 +33973,15 @@
 /obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"vQJ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 5
+	},
+/obj/machinery/computer/ship/engines{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/hammerhead/general)
 "vQP" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -34250,15 +34098,6 @@
 /obj/effect/overlay/snow/floor,
 /turf/simulated/floor/lythios43c/indoors,
 /area/rift/surfacebase/outside/outside2)
-"vVo" = (
-/obj/machinery/atmospheric_field_generator/perma,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "hammerfighter2";
-	name = "Fighter Bay Exit 2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/hammerhead/general)
 "vVr" = (
 /obj/effect/floor_decal/rust,
 /obj/item/tool/screwdriver,
@@ -35246,6 +35085,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
+"wDF" = (
+/obj/item/radio/intercom/department/security{
+	pixel_y = -24
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/hammerhead/general)
 "wDR" = (
 /obj/machinery/door/airlock/maintenance/medical{
 	name = "Medbay Auxillary Storage"
@@ -35920,13 +35765,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
-"xfg" = (
-/obj/structure/handrail,
-/obj/structure/lattice,
-/obj/structure/lattice,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "xfy" = (
 /obj/structure/closet/wardrobe/red,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -36513,25 +36351,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/assembly/robotics)
-"xCl" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "hammerfighter3";
-	name = "Fighter Bay 3";
-	pixel_x = -6;
-	pixel_y = 26
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "xCG" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
@@ -37342,6 +37161,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/rnd/breakroom)
+"xVE" = (
+/obj/machinery/power/smes/buildable{
+	charge = 1.5e+007;
+	cur_coils = 3
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/hammerhead/general)
 "xVY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 4
@@ -37747,57 +37579,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/medical/surgeryprep)
-"yjG" = (
-/obj/structure/handrail{
-	dir = 8
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 8;
-	id = "hammerfighter1";
-	name = "Fighter Bay 1";
-	pixel_x = 23;
-	pixel_y = 8
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 8;
-	id = "hammerfighter2";
-	name = "Fighter Bay 2";
-	pixel_x = 32;
-	pixel_y = 8
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 8;
-	id = "hammerfighter3";
-	name = "Fighter Bay 3";
-	pixel_x = 42;
-	pixel_y = 8
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 8;
-	id = "hammerfighter4";
-	name = "Fighter Bay 4";
-	pixel_x = 23;
-	pixel_y = -7
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 8;
-	id = "hammerfighter5";
-	name = "Fighter Bay 5";
-	pixel_x = 32;
-	pixel_y = -7
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 8;
-	id = "hammerfighter6";
-	name = "Fighter Bay 6";
-	pixel_x = 42;
-	pixel_y = -7
-	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/cockpit)
 "yjX" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -52490,12 +52271,12 @@ qly
 qly
 qly
 qly
-oOw
-oOw
-oOw
-oOw
-oOw
-oOw
+qly
+qly
+qly
+qly
+qly
+qly
 qly
 qly
 qly
@@ -52682,16 +52463,16 @@ qly
 qly
 qly
 qly
+qly
+qly
 oOw
 oOw
 oOw
 oOw
-gzZ
-nNP
 oOw
 oOw
-oOw
-oOw
+qly
+qly
 qly
 qly
 qly
@@ -52873,22 +52654,22 @@ uAn
 qly
 qly
 qly
-iCM
-iCM
+qly
+qly
+qly
 oOw
 oOw
-sUa
-seE
-oOw
-uuN
-wqC
-oOw
-bpb
-eqt
 oOw
 oOw
-iCM
-iCM
+gzZ
+nNP
+oOw
+oOw
+oOw
+oOw
+qly
+qly
+qly
 qly
 qly
 qly
@@ -53066,24 +52847,24 @@ pBj
 uAn
 qly
 qly
+qly
+qly
 iCM
 iCM
-xjH
-aKa
-qpx
-sQt
-sYU
 oOw
-ufs
-sUJ
+sUa
+seE
 oOw
-xaM
-sQt
-qpx
-aKa
-iqw
+uuN
+wqC
+oOw
+bpb
+eqt
+oOw
 iCM
 iCM
+qly
+qly
 qly
 qly
 uAn
@@ -53260,24 +53041,24 @@ pBj
 uAn
 fqV
 qly
+qly
 iCM
-uuY
-ehg
-sQt
-sQt
-ffG
-dhC
-mhJ
-fyj
-jyv
-wdn
-dhC
-pBz
-sQt
-sQt
-ehg
-hhM
 iCM
+xjH
+aKa
+sQt
+sYU
+oOw
+ufs
+sUJ
+oOw
+xaM
+sQt
+aKa
+iqw
+iCM
+iCM
+qly
 qly
 sZb
 uAn
@@ -53454,24 +53235,24 @@ dVV
 uAn
 qly
 qly
-oOw
-eXr
-yjG
-ujL
+qly
+iCM
+uuY
+ehg
 sQt
+ffG
+dhC
+mhJ
+fyj
+jyv
+wdn
+dhC
+pBz
 sQt
-lPt
-xEQ
-xEQ
-vEO
-liE
-qJl
-sQt
-cJj
-ujL
-yjG
-hOS
-oOw
+ehg
+hhM
+iCM
+qly
 qly
 qly
 uAn
@@ -53648,24 +53429,24 @@ enB
 uAn
 qly
 qly
+qly
 oOw
-oOw
-oOw
-oOw
-oUW
-dbt
-djJ
+eXr
+tUK
 ujL
-jyv
-vAW
+sQt
+qij
+lCs
+xEQ
+vEO
+liE
+qJl
+sQt
 ujL
-djU
-dbt
-gyO
+byu
+hOS
 oOw
-oOw
-oOw
-oOw
+qly
 qly
 qly
 uAn
@@ -53843,22 +53624,22 @@ kvr
 swv
 qly
 qly
-qly
+ilr
+oOw
+oOw
+oOw
+oUW
+dbt
+djJ
+jyv
+vAW
+djU
+dbt
+gyO
 oOw
 oOw
 oOw
 oOw
-oOw
-oOw
-iag
-mvg
-oOw
-oOw
-oOw
-oOw
-oOw
-oOw
-qly
 qly
 qly
 qly
@@ -54039,18 +53820,18 @@ qly
 qly
 qly
 qly
-qly
-qly
-eBF
 oOw
 oOw
-lCY
-qUM
 oOw
 oOw
-qly
-qly
-qly
+oOw
+iag
+mvg
+oOw
+oOw
+oOw
+oOw
+oOw
 qly
 qly
 qly
@@ -54235,14 +54016,14 @@ qly
 qly
 qly
 qly
+eBF
 ilr
 ilr
-ilr
-aSz
-bFP
-ilr
+fpW
+vKi
 ilr
 ilr
+qly
 qly
 qly
 qly
@@ -54428,16 +54209,16 @@ eqc
 qly
 qly
 qly
+qly
 ilr
 ilr
-qnJ
-nVS
-nVS
-qkS
-xbD
-kdK
+ilr
+aSz
+bFP
 ilr
 ilr
+ilr
+qly
 qly
 qly
 qly
@@ -54622,16 +54403,16 @@ eqc
 qly
 qly
 qly
-pQK
-pxC
-pxC
+ilr
+ilr
+qnJ
+nVS
+nVS
+qkS
 xbD
-xbD
-rLY
-xbD
-pxC
-pxC
-kJk
+hFZ
+ilr
+ilr
 qly
 qly
 qly
@@ -54815,18 +54596,18 @@ cnl
 aTs
 qly
 qly
-iZI
-ilr
-pUb
-nLz
-mxh
+qly
+pQK
+pxC
+pxC
+xbD
 xbD
 rLY
-mFf
-nLz
-tGD
-ilr
-lrj
+xbD
+pxC
+pxC
+kJk
+qly
 qly
 qly
 qly
@@ -55009,18 +54790,18 @@ rrr
 cWw
 qly
 qly
-vDu
-oPv
-fSv
-gHJ
-hsv
-lKw
-wJB
-lXc
-grT
-fSv
-njk
-vDu
+iZI
+ilr
+kNL
+nLz
+mxh
+xbD
+rLY
+mFf
+nLz
+fdo
+ilr
+lrj
 qly
 qly
 qly
@@ -55206,12 +54987,12 @@ qly
 vDu
 oPv
 fSv
-fSv
-jug
-pxC
-dzD
-wcF
-fSv
+gHJ
+hsv
+lKw
+wJB
+lXc
+grT
 fSv
 njk
 vDu
@@ -55397,18 +55178,18 @@ rrr
 cWw
 qly
 qly
-feI
-ilr
-amc
-hKy
-cDO
+vDu
+oPv
+fSv
+fSv
+jug
 pxC
 dzD
-kEU
-hKy
-sPt
-ilr
-xfg
+wcF
+fSv
+fSv
+njk
+vDu
 qly
 qly
 qly
@@ -55592,16 +55373,16 @@ cWw
 qly
 qly
 vDu
-vVo
+oPv
 fSv
-gHJ
+kwh
 hsv
 lKw
 uSS
 lXc
 grT
-fSv
-gbm
+uRN
+njk
 vDu
 qly
 qly
@@ -55786,7 +55567,7 @@ cWw
 qly
 qly
 vDu
-vVo
+oPv
 fSv
 fSv
 jug
@@ -55795,7 +55576,7 @@ dzD
 wcF
 fSv
 fSv
-gbm
+njk
 vDu
 qly
 qly
@@ -55979,18 +55760,18 @@ cnl
 nSi
 qly
 qly
-feI
+cYC
 ilr
 rcg
-hKy
-cDO
-pxC
-dzD
-kEU
-hKy
+mkP
+tnu
+pPV
+kDT
+ybB
+mkP
 hnx
 ilr
-sss
+aJI
 qly
 qly
 qly
@@ -56173,18 +55954,18 @@ cnl
 eqc
 qly
 qly
-vDu
-kWx
-fSv
-kwh
-hsv
-lKw
-uSS
-lXc
-grT
-uRN
-tSM
-vDu
+bru
+lhE
+rda
+pxC
+trq
+pPV
+cVx
+ojI
+ieh
+vIN
+azT
+vnt
 qly
 qly
 qly
@@ -56363,26 +56144,26 @@ pBj
 pBj
 uAn
 qly
-qly
-eqc
-qly
-qly
-vDu
-kWx
-fSv
-fSv
-jug
-pxC
-dzD
-wcF
-fSv
-fSv
-tSM
-vDu
+iFy
+dFm
 qly
 qly
 qly
-nxh
+lhE
+qxx
+xIV
+jTU
+jJU
+fZv
+jhd
+vfd
+jwp
+azT
+qly
+qly
+qly
+uht
+rrx
 hMX
 uAn
 uAn
@@ -56557,26 +56338,26 @@ pBj
 pBj
 uAn
 fqV
+qdY
+fJu
 qly
-eqc
 qly
-qly
-cYC
 ilr
-xCl
-mkP
-tnu
-pPV
-kDT
-ybB
-mkP
-nxS
 ilr
-aJI
+ijJ
+bap
+ilr
+ayE
+ceM
+ilr
+kMU
+jNS
+ilr
+ilr
 qly
 qly
-qly
-nxh
+spg
+mAS
 sZb
 uAn
 jux
@@ -56751,26 +56532,26 @@ pBj
 pBj
 uAn
 swv
-iFy
-dFm
+pqq
+kAt
+qly
+ilr
+ilr
+jJS
+slB
+wDF
+ilr
+uhb
+iXD
+ilr
+cya
+lag
+kCx
+ilr
+ilr
 qly
 qly
-bru
-lhE
-rda
-pxC
-trq
-pPV
-cVx
-ojI
-ieh
-vIN
-azT
-vnt
-qly
-qly
-uht
-rrx
+nxh
 qly
 uAn
 pCP
@@ -56945,26 +56726,26 @@ pBj
 pBj
 uAn
 qly
-qdY
-fJu
+ecx
 qly
 qly
+ilr
+mPW
+fdm
+ogH
+vQJ
+ilr
+pUZ
+oxe
+ilr
+xVE
+frQ
+dRQ
+rsA
+ilr
 qly
-lhE
-qxx
-xIV
-jTU
-jJU
-fZv
-jhd
-vfd
-jwp
-azT
 qly
-qly
-qly
-spg
-mAS
+nxh
 cbV
 uAn
 pCP
@@ -57139,24 +56920,24 @@ pBj
 pBj
 uAn
 qly
-buA
-eqc
+ecx
 qly
 ilr
 ilr
+iRD
+qNg
+iRD
+qNg
 ilr
-ijJ
-bap
+tKD
+qDr
 ilr
-ayE
-ceM
-ilr
-kMU
-jNS
-ilr
+iRD
+qNg
+iRD
+qNg
 ilr
 ilr
-qly
 qly
 nxh
 qly
@@ -57333,22 +57114,22 @@ pBj
 pBj
 uAn
 qly
-pqq
-kAt
+ecx
+qly
 ilr
 ilr
-hfg
-ogw
-slB
-sNY
+xlX
+dym
+xlX
+dym
 ilr
-uhb
-iXD
+dKZ
+cEL
 ilr
-cya
-lag
-kCx
-bLw
+xlX
+dym
+xlX
+dym
 ilr
 ilr
 qly
@@ -57530,20 +57311,20 @@ qly
 ecx
 qly
 ilr
-mPW
-fdm
-eAU
-ogH
-vMM
 ilr
-pUZ
-oxe
+qly
+qly
+qly
+qly
+qly
+qly
+eyy
+qly
+qly
+qly
+qly
+qly
 ilr
-sCV
-frQ
-tBx
-fcW
-rsA
 ilr
 qly
 nxh
@@ -57722,24 +57503,24 @@ pBj
 uAn
 fqV
 ecx
-ilr
-ilr
-iRD
-qNg
-ilr
-iRD
-qNg
-ilr
-tKD
-qDr
-ilr
-iRD
-qNg
-ilr
-iRD
-qNg
-ilr
-ilr
+qly
+qly
+qly
+qly
+qly
+qly
+qly
+qly
+qly
+etT
+qly
+qly
+qly
+qly
+qly
+qly
+qly
+qly
 nxh
 sZb
 uAn
@@ -57916,24 +57697,24 @@ pBj
 uAn
 swv
 ecx
-ilr
-ilr
-xlX
-dym
-ilr
-xlX
-dym
-ilr
-dKZ
-cEL
-ilr
-xlX
-dym
-ilr
-xlX
-dym
-ilr
-ilr
+qly
+qly
+qly
+qly
+qly
+qly
+qly
+qly
+qly
+etT
+qly
+qly
+qly
+qly
+qly
+qly
+qly
+qly
 nxh
 hMX
 uAn
@@ -58110,8 +57891,6 @@ pBj
 uAn
 qly
 ecx
-ilr
-ilr
 qly
 qly
 qly
@@ -58119,15 +57898,17 @@ qly
 qly
 qly
 qly
-eyy
+qly
+qly
+etT
 qly
 qly
 qly
 qly
 qly
 qly
-ilr
-ilr
+qly
+qly
 nxh
 qly
 uAn


### PR DESCRIPTION
Space saved: 2 tiles vertical, 4 tiles horizontal. 
Removes two of the six spaces for fighters. 
Removes the refillable air canister.