### PR TITLE
Phoron/frostlock actual fix

### DIFF
--- a/code/game/machinery/doors/airlock/phoronlocks.dm
+++ b/code/game/machinery/doors/airlock/phoronlocks.dm
@@ -75,7 +75,7 @@
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock		//Special scrubber with bonus inbuilt heater
 	active_power_usage = 2000
 	efficiency_multiplier = 4
-	var/target_temp = T20C + 2
+	var/target_temp = T20C
 	var/heating_power = 150000
 
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock/heater //Variant for use on rift

--- a/code/game/machinery/doors/airlock/phoronlocks.dm
+++ b/code/game/machinery/doors/airlock/phoronlocks.dm
@@ -236,7 +236,7 @@
 				signalScrubber(tag_scrubber, 1) // Start cleaning
 				signalPump(tag_airpump, 1, 1, memory["target_pressure"]) // And pressurizng to offset losses
 				memory["processing"] = TRUE
-			else if(memory["chamber_sensor_temperature"] < memory["target_temperature"])
+			else if(memory["chamber_sensor_temperature"] < memory["target_temperature"] - 0.1)
 				signalScrubber(tag_scrubber, 1)//the scrubbers also work as heats because fuck making sense
 				memory["processing"] = TRUE
 			else if(memory["chamber_sensor_pressure"] < memory["internal_sensor_pressure"] - 0.1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Actually fixes what #6828 band-aids. Frostlocks are trying to be too perfect, give it an epsilon.

## Why It's Good For The Game

Frostlocks opening is good

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Frostlocks can now cycle in properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
