### PR TITLE
Fixes blueshields being red

### DIFF
--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -345,7 +345,7 @@
 
 /obj/item/clothing/accessory/armor/tag/ntbs
 	name = "\improper BLUESHIELD tag"
-	desc = "An armor tag with the words BLUESHIELD printed in red lettering."
+	desc = "An armor tag with the words BLUESHIELD printed in blue lettering."
 	icon_state = "ntbstag"
 
 /obj/item/clothing/accessory/armor/tag/ntc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Totally fixes a game breaking issue.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
They're blue not red, clearly that's why redshields are a thing
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Changes the blueshield tag from 'red' to 'blue'
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
