### PR TITLE
Adds "Hush (ft. Mizz Fish") by kroh to the hacked jukebox songs

### DIFF
--- a/config_static/jukebox.json
+++ b/config_static/jukebox.json
@@ -10259,5 +10259,15 @@
 "jukebox": true,
 "ost": "Armored Core",
 "genre": "Arcade"
+},
+{
+"url": "https://files.catbox.moe/rzcos7.mp3",
+"title": "[ERRRD0NK!@%@!]Hush (ft. Mizz Fish)",
+"duration": 1821,
+"artist": "kroh",
+"genre": "Electronic",
+"secret": true,
+"lobby": false,
+"jukebox": true
 }
 ]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds ["Hush (ft. Mizz Fish)" by kroh](https://www.youtube.com/watch?v=Qflixb8ss3Q) to the hacked jukebox songs, under the Electronic tab. It's a secret song since the lyrics directly reference the Syndicate (although it's not actually technically our Syndicate), so probably not NT-approved.

## Why It's Good For The Game

It's a cool song. Also the syndicate reference is kind of on the nose.
