### PR TITLE
Changes around some engi points vendor options

### DIFF
--- a/code/modules/mining/ore_redemption_machine/engineering_points_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/engineering_points_vendor.dm
@@ -12,10 +12,6 @@
 	//circuit = /obj/item/circuitboard/engineering_equip
 	prize_list = list(
 		//Mining vendor steals
-		new /datum/data/mining_equipment("Whiskey",						    /obj/item/reagent_containers/food/drinks/bottle/whiskey,		3),
-		new /datum/data/mining_equipment("Absinthe",					    /obj/item/reagent_containers/food/drinks/bottle/absinthe,	    3),
-		new /datum/data/mining_equipment("Special Blend Whiskey",		    /obj/item/reagent_containers/food/drinks/bottle/specialwhiskey,	5),
-		new /datum/data/mining_equipment("Random Booze",			        /obj/random/alcohol,		                                    3),
 		new /datum/data/mining_equipment("Cigar",						    /obj/item/clothing/mask/smokable/cigarette/cigar/havana,        5),
 		new /datum/data/mining_equipment("Soap",						    /obj/item/soap/nanotrasen,									    2),
 		new /datum/data/mining_equipment("Laser Pointer",				    /obj/item/laser_pointer,										9),
@@ -29,10 +25,6 @@
 		new /datum/data/mining_equipment("Hardsuit - Plasma Cutter",	    /obj/item/hardsuit_module/device/plasmacutter,						10),
 		new /datum/data/mining_equipment("Hardsuit - Maneuvering Jets",	    /obj/item/hardsuit_module/maneuvering_jets,							12),
 		new /datum/data/mining_equipment("Hardsuit - Intelligence Storage",	/obj/item/hardsuit_module/ai_container,								25),
-		new /datum/data/mining_equipment("Injector (L) - Glucose",          /obj/item/reagent_containers/hypospray/autoinjector/biginjector/glucose,	50),
-		new /datum/data/mining_equipment("Injector (L) - Panacea",          /obj/item/reagent_containers/hypospray/autoinjector/biginjector/purity,	50),
-		new /datum/data/mining_equipment("Injector (L) - Trauma",           /obj/item/reagent_containers/hypospray/autoinjector/biginjector/brute,	50),
-		new /datum/data/mining_equipment("Nanopaste Tube",				    /obj/item/stack/nanopaste,										10),
 		//Mining vendor steals - Ends
         //Power tools like the CE gets, if kev comes crying: https://cdn.discordapp.com/attachments/296237931587305472/956517623519141908/unknown.png
 		new /datum/data/mining_equipment("Advanced Hardsuit",							/obj/item/hardsuit/ce,									150),

--- a/code/modules/mining/ore_redemption_machine/engineering_points_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/engineering_points_vendor.dm
@@ -12,6 +12,7 @@
 	//circuit = /obj/item/circuitboard/engineering_equip
 	prize_list = list(
 		//Mining vendor steals
+		new /datum/data/mining_equipment("Vodka",						    /obj/item/reagent_containers/food/drinks/bottle/vodka,			3),
 		new /datum/data/mining_equipment("Cigar",						    /obj/item/clothing/mask/smokable/cigarette/cigar/havana,        5),
 		new /datum/data/mining_equipment("Soap",						    /obj/item/soap/nanotrasen,									    2),
 		new /datum/data/mining_equipment("Laser Pointer",				    /obj/item/laser_pointer,										9),
@@ -25,6 +26,7 @@
 		new /datum/data/mining_equipment("Hardsuit - Plasma Cutter",	    /obj/item/hardsuit_module/device/plasmacutter,						10),
 		new /datum/data/mining_equipment("Hardsuit - Maneuvering Jets",	    /obj/item/hardsuit_module/maneuvering_jets,							12),
 		new /datum/data/mining_equipment("Hardsuit - Intelligence Storage",	/obj/item/hardsuit_module/ai_container,								25),
+		new /datum/data/mining_equipment("Injector (L) - Panacea",          /obj/item/reagent_containers/hypospray/autoinjector/biginjector/purity,	50)
 		//Mining vendor steals - Ends
         //Power tools like the CE gets, if kev comes crying: https://cdn.discordapp.com/attachments/296237931587305472/956517623519141908/unknown.png
 		new /datum/data/mining_equipment("Advanced Hardsuit",							/obj/item/hardsuit/ce,									150),

--- a/code/modules/mining/ore_redemption_machine/engineering_points_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/engineering_points_vendor.dm
@@ -26,7 +26,7 @@
 		new /datum/data/mining_equipment("Hardsuit - Plasma Cutter",	    /obj/item/hardsuit_module/device/plasmacutter,						10),
 		new /datum/data/mining_equipment("Hardsuit - Maneuvering Jets",	    /obj/item/hardsuit_module/maneuvering_jets,							12),
 		new /datum/data/mining_equipment("Hardsuit - Intelligence Storage",	/obj/item/hardsuit_module/ai_container,								25),
-		new /datum/data/mining_equipment("Injector (L) - Panacea",          /obj/item/reagent_containers/hypospray/autoinjector/biginjector/purity,	50)
+		new /datum/data/mining_equipment("Injector (L) - Panacea",          /obj/item/reagent_containers/hypospray/autoinjector/biginjector/purity,	50),
 		//Mining vendor steals - Ends
         //Power tools like the CE gets, if kev comes crying: https://cdn.discordapp.com/attachments/296237931587305472/956517623519141908/unknown.png
 		new /datum/data/mining_equipment("Advanced Hardsuit",							/obj/item/hardsuit/ce,									150),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the following to the engineering points vendor (crypto thing):

1. Vodka

Removes the following:

1. Whiskey
2. Absinthe
3. Special blend whiskey
4. Random booze
5. Injector (L) - Glucose
6. Injector (L) - Trauma
7. Nanopaste tube

1-4 are because it's kiiinda immersion-shattering that you're explicitly operating heavy equipment and dangerous gases to be able to buy strong alcohol, which the dang regulations say you're not allowed to use on-duty. 5-7 are because they're *really* obviously geared for miners: engineers don't really have any use for any of that.

**However**, vodka replaced the boozes, because it has the rad cure element. That's at least a *little* flavorful. 

## Why It's Good For The Game

Clutter removal, making it less obvious that the engineering points vendor is a copy+pasted mining points vendor (lol), not encouraging engineers to be drunk on the job (LRP!! LRP!!)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed some items from engineering points vendor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
