### PR TITLE
Hammerhead Upgrade + Rigsuits + Baron Integrity Increase

### DIFF
--- a/code/game/mecha/combat/fighter.dm
+++ b/code/game/mecha/combat/fighter.dm
@@ -337,6 +337,9 @@
 	icon_state = "baron"
 	initial_icon = "baron"
 
+	integrity = 600
+	integrity_max = 600
+
 	catalogue_data = list(/datum/category_item/catalogue/technology/baron)
 	wreckage = /obj/effect/decal/mecha_wreckage/baron
 
@@ -387,8 +390,8 @@
 
 	step_in = 3 //slightly slower than a baron (this shit doesnt actually work atm, likely due to the whole equipment weight nonsense)
 
-	integrity = 800
-	integrity_max = 800 //double baron HP, only room for one defensive upgrade. No specials(cloaking, speed, ect) or universals.
+	integrity = 1200
+	integrity_max = 1200 //double baron HP, only room for one defensive upgrade. No specials(cloaking, speed, ect) or universals.
 
 	max_hull_equip = 1
 	max_weapon_equip = 4

--- a/code/game/turfs/simulated/wall_types/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types/wall_types.dm
@@ -418,6 +418,11 @@
 /turf/simulated/shuttle/wall/voidcraft/red
 	stripe_color = "#FF0000"
 
+/turf/simulated/shuttle/wall/voidcraft/red/hard_corner
+	name = "hardcorner wall"
+	icon_state = "void-hc"
+	hard_corner = 1
+
 /turf/simulated/shuttle/wall/voidcraft/blue
 	stripe_color = "#0000FF"
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -176,6 +176,10 @@ CREATE_WALL_MOUNTING_TYPES_SHIFTED(/obj/machinery/power/apc, 22)
 	/// tracks how behind we arre in charging TODO: literally rewrite apcs entirely to use a proper accumulator-cell system with an internal buffer, ffs
 	var/lazy_draw_accumulator = 0
 
+	//Used for shuttles, workaround for broken mounting
+	//TODO: Remove when legacy walls are nuked
+	var/old_wall = FALSE
+
 /obj/machinery/power/apc/updateDialog()
 	if (machine_stat & (BROKEN|MAINT))
 		return
@@ -258,6 +262,9 @@ CREATE_WALL_MOUNTING_TYPES_SHIFTED(/obj/machinery/power/apc, 22)
 // APCs are pixel-shifted, so they need to be updated.
 /obj/machinery/power/apc/setDir(new_dir)
 	. = ..()
+
+	if(old_wall)
+		return
 
 	base_pixel_x = 0
 	base_pixel_y = 0

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -296,6 +296,9 @@ var/global/list/light_type_cache = list()
 	var/brightness_power_ns
 	var/brightness_color_ns
 
+	//Used for shuttles, workaround for broken mounting
+	var/old_wall = FALSE
+
 	#ifdef IN_MAP_EDITOR // So its actually visible in the mapping editor
 	icon_state = "tube_map"
 	#endif
@@ -502,6 +505,10 @@ var/global/list/light_type_cache = list()
 
 /obj/machinery/light/setDir(ndir)
 	. = ..()
+
+	if(old_wall)
+		return
+
 	base_pixel_y = 0
 	base_pixel_x = 0
 	var/turf/T = get_step(get_turf(src), src.dir)

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -297,6 +297,7 @@ var/global/list/light_type_cache = list()
 	var/brightness_color_ns
 
 	//Used for shuttles, workaround for broken mounting
+	//TODO: Remove when legacy walls are nuked
 	var/old_wall = FALSE
 
 	#ifdef IN_MAP_EDITOR // So its actually visible in the mapping editor

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -821,7 +821,7 @@
 	icon_state = "32-1"
 	},
 /turf/simulated/open,
-/area/rift/surfacebase/outside/outside2)
+/area/maintenance/lower/medsec_maintenance)
 "aBA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -942,7 +942,7 @@
 /obj/item/clothing/glasses/sunglasses/medhud,
 /obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
-/area/rift/surfacebase/outside/outside2)
+/area/maintenance/medbay)
 "aHd" = (
 /obj/structure/frame{
 	anchored = 1
@@ -4077,7 +4077,7 @@
 "cBh" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/rift/surfacebase/outside/outside2)
+/area/maintenance/medbay)
 "cBE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18956,15 +18956,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/security/hallway)
-"lZB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/rift/surfacebase/outside/outside2)
 "lZO" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -24391,7 +24382,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/rift/surfacebase/outside/outside2)
+/area/medical/surgery_hallway)
 "pru" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 6
@@ -25141,9 +25132,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
-"pVy" = (
-/turf/simulated/floor/tiled/steel,
-/area/rift/surfacebase/outside/outside2)
 "pVW" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -27193,9 +27181,6 @@
 	},
 /turf/simulated/floor/tiled/monowhite,
 /area/medical/resleeving)
-"rjt" = (
-/turf/simulated/wall/prepainted/medical,
-/area/rift/surfacebase/outside/outside2)
 "rjB" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -27474,12 +27459,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
-"roS" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/rift/surfacebase/outside/outside2)
 "rpT" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -29432,9 +29411,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/locker)
-"sJf" = (
-/turf/simulated/wall/prepainted/security,
-/area/rift/surfacebase/outside/outside2)
 "sJg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -29827,7 +29803,7 @@
 /obj/structure/table/steel,
 /obj/item/material/ashtray/glass,
 /turf/simulated/floor/plating,
-/area/rift/surfacebase/outside/outside2)
+/area/maintenance/medbay)
 "tbz" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -36724,7 +36700,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/rift/surfacebase/outside/outside2)
+/area/maintenance/medbay)
 "xLB" = (
 /obj/structure/closet/secure_closet/medical3{
 	name = "surgeon's locker"
@@ -49434,7 +49410,7 @@ oWM
 jzu
 aqF
 vyn
-aKq
+vyn
 kIL
 kIL
 kIL
@@ -49822,7 +49798,7 @@ fJJ
 moy
 aqF
 hga
-pVy
+hga
 kIL
 rzB
 mqP
@@ -50210,7 +50186,7 @@ ghA
 cQN
 aqF
 qnm
-pVy
+hga
 kIL
 bgd
 tFx
@@ -50404,7 +50380,7 @@ aqF
 aqF
 aqF
 qnm
-pVy
+hga
 kIL
 obW
 qot
@@ -50598,7 +50574,7 @@ hga
 fiN
 oVk
 qnm
-rjt
+cRS
 kIL
 bmS
 bmS
@@ -50792,7 +50768,7 @@ vyB
 jZl
 vTi
 qnm
-rjt
+cRS
 czB
 lXv
 wEc
@@ -51180,7 +51156,7 @@ vyn
 mmN
 dtc
 oVk
-rjt
+cRS
 gHs
 lQo
 ohN
@@ -51374,7 +51350,7 @@ vyn
 mmN
 dtc
 oVk
-rjt
+cRS
 cRS
 iWe
 iWe
@@ -51762,7 +51738,7 @@ wNZ
 uJC
 dtc
 oVk
-aKq
+vyn
 cRS
 cRS
 cRS
@@ -51956,7 +51932,7 @@ wNZ
 uJC
 dtc
 oVk
-aKq
+vyn
 oyx
 vzc
 gPk
@@ -52150,7 +52126,7 @@ vyn
 fgh
 dtc
 oVk
-aKq
+vyn
 dAe
 bIT
 oVk
@@ -52538,7 +52514,7 @@ vyn
 uJC
 bgE
 hga
-aKq
+vyn
 hUU
 dAe
 nqW
@@ -52732,7 +52708,7 @@ vyn
 mmN
 bgE
 oVk
-aKq
+vyn
 qtM
 dAe
 nqW
@@ -52926,7 +52902,7 @@ bWq
 gcX
 iMV
 bWq
-aKq
+bWq
 bWq
 wDR
 bWq
@@ -53120,7 +53096,7 @@ tmh
 kiP
 cYj
 ucP
-lZB
+aMU
 fSu
 jOk
 jOk
@@ -53314,7 +53290,7 @@ szQ
 gcX
 jGy
 lFw
-roS
+mDK
 yaL
 mDK
 eVV
@@ -53508,7 +53484,7 @@ szQ
 gcX
 szQ
 xyC
-uJq
+szQ
 ora
 szQ
 lTc
@@ -53896,7 +53872,7 @@ dep
 dep
 vLE
 dep
-sJf
+dep
 ora
 xco
 lTc
@@ -54090,7 +54066,7 @@ usA
 jQY
 mEM
 uNo
-sJf
+dep
 qSP
 ssT
 lTc

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -4804,6 +4804,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/bed/chair/bay/shuttle,
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "dhE" = (
@@ -17492,9 +17495,9 @@
 	dir = 5
 	},
 /obj/machinery/door/window/brigdoor/southright{
-	name = "Holding Room";
-	icon_state = "rightsecure";
 	dir = 1;
+	icon_state = "rightsecure";
+	name = "Cockpit Access";
 	req_access = list(2);
 	req_one_access = list(2)
 	},
@@ -18074,7 +18077,9 @@
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 10
 	},
-/obj/machinery/door/window/brigdoor/southright,
+/obj/machinery/door/window/brigdoor/southright{
+	name = "Cockpit Access"
+	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/techfloor,
@@ -31450,8 +31455,12 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/research/xenobio)
 "uoE" = (
-/obj/machinery/light/no_nightshift{
-	dir = 4
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 8;
+	icon_state = "rightsecure";
+	name = "Crew Section Access";
+	req_access = list(2);
+	req_one_access = list(2)
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -1314,7 +1314,8 @@
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
-	name = "launch rail"
+	name = "launch rail";
+	desc = "Magnetic propulsion fighter launch rails. Caution! Electrified!"
 	},
 /area/shuttle/hammerhead/general)
 "aTl" = (
@@ -2110,7 +2111,8 @@
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
-	name = "launch rail"
+	name = "launch rail";
+	desc = "Magnetic propulsion fighter launch rails. Caution! Electrified!"
 	},
 /area/shuttle/hammerhead/cockpit)
 "bli" = (
@@ -2800,7 +2802,8 @@
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
-	name = "launch rail"
+	name = "launch rail";
+	desc = "Magnetic propulsion fighter launch rails. Caution! Electrified!"
 	},
 /area/shuttle/hammerhead/general)
 "bFQ" = (
@@ -8245,7 +8248,8 @@
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
-	name = "launch rail"
+	name = "launch rail";
+	desc = "Magnetic propulsion fighter launch rails. Caution! Electrified!"
 	},
 /area/shuttle/hammerhead/cockpit)
 "fof" = (
@@ -8294,7 +8298,8 @@
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
-	name = "launch rail"
+	name = "launch rail";
+	desc = "Magnetic propulsion fighter launch rails. Caution! Electrified!"
 	},
 /area/shuttle/hammerhead/general)
 "fqf" = (
@@ -12482,7 +12487,8 @@
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
-	name = "launch rail"
+	name = "launch rail";
+	desc = "Magnetic propulsion fighter launch rails. Caution! Electrified!"
 	},
 /area/shuttle/hammerhead/cockpit)
 "hYR" = (
@@ -12555,7 +12561,8 @@
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
-	name = "launch rail"
+	name = "launch rail";
+	desc = "Magnetic propulsion fighter launch rails. Caution! Electrified!"
 	},
 /area/shuttle/hammerhead/cockpit)
 "iaY" = (
@@ -17791,7 +17798,8 @@
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
-	name = "launch rail"
+	name = "launch rail";
+	desc = "Magnetic propulsion fighter launch rails. Caution! Electrified!"
 	},
 /area/shuttle/hammerhead/cockpit)
 "lqA" = (
@@ -19708,7 +19716,8 @@
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
-	name = "launch rail"
+	name = "launch rail";
+	desc = "Magnetic propulsion fighter launch rails. Caution! Electrified!"
 	},
 /area/shuttle/hammerhead/cockpit)
 "mvo" = (
@@ -22099,6 +22108,9 @@
 	dir = 4;
 	id = "hammerheadtba";
 	name = "Fighter Launch Tube Access"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/hammerhead/general)
@@ -25573,6 +25585,7 @@
 	id = "hammerheadtba";
 	name = "Fighter Launch Tube Access"
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/reinforced,
 /area/shuttle/hammerhead/general)
 "qly" = (
@@ -33691,7 +33704,8 @@
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
-	name = "launch rail"
+	name = "launch rail";
+	desc = "Magnetic propulsion fighter launch rails. Caution! Electrified!"
 	},
 /area/shuttle/hammerhead/cockpit)
 "vBG" = (
@@ -33765,7 +33779,8 @@
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
-	name = "launch rail"
+	name = "launch rail";
+	desc = "Magnetic propulsion fighter launch rails. Caution! Electrified!"
 	},
 /area/shuttle/hammerhead/cockpit)
 "vFi" = (
@@ -33905,7 +33920,8 @@
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
-	name = "launch rail"
+	name = "launch rail";
+	desc = "Magnetic propulsion fighter launch rails. Caution! Electrified!"
 	},
 /area/shuttle/hammerhead/general)
 "vKj" = (
@@ -34768,7 +34784,8 @@
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
-	name = "launch rail"
+	name = "launch rail";
+	desc = "Magnetic propulsion fighter launch rails. Caution! Electrified!"
 	},
 /area/shuttle/hammerhead/cockpit)
 "wrb" = (
@@ -36446,7 +36463,8 @@
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
-	name = "launch rail"
+	name = "launch rail";
+	desc = "Magnetic propulsion fighter launch rails. Caution! Electrified!"
 	},
 /area/shuttle/hammerhead/cockpit)
 "xFu" = (

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -1134,6 +1134,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
+"aNv" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "aNH" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -4104,9 +4107,6 @@
 "cEL" = (
 /obj/machinery/door/airlock/voidcraft/vertical,
 /obj/map_helper/airlock/door/ext_door,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/machinery/access_button/airlock_interior{
 	dir = 4;
 	frequency = 1380;
@@ -4115,6 +4115,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
@@ -4710,15 +4713,6 @@
 /turf/simulated/floor/wood,
 /area/rnd/breakroom)
 "dbt" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 8
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/obj/machinery/computer/ship/navigation/telescreen{
-	pixel_x = 32
-	},
 /obj/effect/floor_decal/corner_techfloor_grid/full{
 	dir = 4
 	},
@@ -8167,6 +8161,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
+"fnq" = (
+/obj/structure/bed/chair/bay/shuttle,
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "fnK" = (
 /obj/structure/barricade,
 /turf/simulated/floor/outdoors/snow/lythios43c,
@@ -9654,6 +9655,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
+"goD" = (
+/obj/machinery/door/airlock/voidcraft/vertical{
+	name = "Passenger Bay and Holding Cell";
+	req_one_access = list(1,38)
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "goH" = (
 /obj/structure/barricade,
 /obj/effect/floor_decal/rust,
@@ -11670,13 +11679,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
 "hFZ" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
 /obj/machinery/door/airlock/voidcraft/vertical{
-	name = "Shuttle Cockpit";
+	name = "Flight Operations";
 	req_one_access = list(1,38)
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "hGo" = (
@@ -13657,6 +13664,11 @@
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 10
 	},
+/obj/structure/closet/walllocker/emergsuit_wall{
+	dir = 8;
+	pixel_x = -32;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "iPh" = (
@@ -13892,6 +13904,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/structure/handrail{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
@@ -16687,19 +16702,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
-"kNL" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor/southleft{
-	dir = 4;
-	name = "Holding Room";
-	req_access = list(2);
-	req_one_access = list(2)
-	},
-/obj/structure/handrail,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/general)
 "kNQ" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -18783,6 +18785,9 @@
 	pixel_x = -24
 	},
 /obj/structure/bed/chair/bay/shuttle,
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "lWx" = (
@@ -19110,13 +19115,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/recreation_area)
-"mhJ" = (
-/obj/structure/closet/walllocker/emergsuit_wall{
-	dir = 8;
-	pixel_x = -32
-	},
-/turf/simulated/shuttle/wall/voidcraft/red,
-/area/shuttle/hammerhead/cockpit)
 "mhS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
@@ -19276,14 +19274,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
-"mkP" = (
-/obj/machinery/door/airlock/voidcraft/vertical{
-	name = "Shuttle Brig";
-	req_one_access = list(1,38)
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/space/basic,
-/area/shuttle/hammerhead/general)
 "mlx" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -23042,11 +23032,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/assembly/robotics)
 "oHu" = (
-/obj/item/radio/intercom/department/security{
-	dir = 1;
-	pixel_y = 35
-	},
 /obj/structure/bed/chair/bay/shuttle,
+/obj/machinery/door/window/brigdoor/northright{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "oIx" = (
@@ -23073,6 +23062,14 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/assembly/robotics)
+"oJx" = (
+/obj/machinery/door/airlock/voidcraft/vertical{
+	name = "Hammerhead Cockpit";
+	req_one_access = list(1,38)
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/cockpit)
 "oJG" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/sleep/Dorm_2)
@@ -25595,11 +25592,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/maintenance/medbay)
 "qnJ" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/structure/bed/chair/bay/shuttle{
+/obj/structure/handrail{
 	dir = 1
+	},
+/obj/item/radio/intercom/department/security{
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
@@ -26089,11 +26086,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
 "qDr" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /obj/effect/shuttle_landmark/rift/deck2/hammerhead,
 /obj/overmap/entity/visitable/ship/landable/hammerhead,
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
+/obj/structure/handrail{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
@@ -26797,10 +26802,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/pool)
 "raP" = (
-/obj/structure/closet/hydrant{
-	pixel_x = 32
-	},
 /obj/structure/bed/chair/bay/shuttle,
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "rba" = (
@@ -26846,9 +26851,6 @@
 "rcg" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 1
 	},
 /turf/simulated/shuttle/wall/voidcraft/red,
 /area/shuttle/hammerhead/general)
@@ -28526,18 +28528,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
-"seJ" = (
-/obj/machinery/door/window/brigdoor/southright{
-	dir = 4;
-	name = "Holding Room";
-	req_access = list(2);
-	req_one_access = list(2)
-	},
-/obj/structure/handrail{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/general)
 "sfs" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -28803,6 +28793,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
+"srt" = (
+/obj/structure/bed/chair/bay/shuttle,
+/obj/structure/closet/hydrant{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "srw" = (
 /obj/structure/railing,
 /turf/simulated/open/lythios43c,
@@ -29484,6 +29481,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_1)
+"sQe" = (
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 8
+	},
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "sQt" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
@@ -30781,6 +30787,7 @@
 	},
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume,
 /obj/map_helper/airlock/atmos/chamber_pump,
+/obj/structure/handrail,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
 "tLc" = (
@@ -30809,6 +30816,16 @@
 "tNc" = (
 /turf/simulated/wall/prepainted/security,
 /area/security/briefing_room)
+"tNt" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 1
+	},
+/obj/machinery/air_alarm{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "tOd" = (
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
@@ -31303,6 +31320,7 @@
 /obj/structure/closet/walllocker/emergsuit_wall{
 	pixel_y = 32
 	},
+/obj/structure/handrail,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
 "uht" = (
@@ -31541,7 +31559,7 @@
 /obj/machinery/door/window/brigdoor/southright{
 	dir = 8;
 	icon_state = "rightsecure";
-	name = "Crew Section Access";
+	name = "Flight Operations Access";
 	req_access = list(2);
 	req_one_access = list(2)
 	},
@@ -33988,12 +34006,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/maintenance/medbay)
-"vTR" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/general)
 "vUk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -53120,7 +53132,7 @@ ddq
 sQt
 ffG
 iOM
-mhJ
+oOw
 wqC
 wqC
 wdn
@@ -53502,7 +53514,7 @@ kvr
 swv
 qly
 qly
-ilr
+oOw
 oOw
 oOw
 oOw
@@ -53701,7 +53713,7 @@ qly
 oOw
 oOw
 oOw
-oOw
+sQt
 oOw
 iag
 mvg
@@ -53895,7 +53907,7 @@ qly
 qly
 jgM
 oOw
-oOw
+oJx
 oOw
 fpW
 vKi
@@ -54089,7 +54101,7 @@ qly
 qly
 ilr
 ilr
-ilr
+aNv
 ilr
 aSz
 bFP
@@ -54476,9 +54488,9 @@ qly
 qly
 qly
 ilr
-uRH
-vTR
-ilr
+fnq
+gHJ
+hsv
 oIx
 rLY
 xbD
@@ -54670,9 +54682,9 @@ qly
 qly
 qly
 ilr
-kNL
-seJ
-ilr
+uRH
+aNv
+goD
 oIx
 rLY
 mFf
@@ -54864,7 +54876,7 @@ qly
 qly
 qly
 ilr
-uRH
+srt
 gHJ
 hsv
 oIx
@@ -55253,8 +55265,8 @@ qly
 qly
 ilr
 oHu
-gHJ
-hsv
+sQe
+ilr
 oIx
 uSS
 usH
@@ -55447,8 +55459,8 @@ qly
 qly
 ilr
 raP
-gHJ
-hsv
+tNt
+ilr
 uAi
 gOT
 pcN
@@ -55638,10 +55650,10 @@ cnl
 nSi
 qly
 qly
-sZb
+qly
 ilr
 rcg
-mkP
+ilr
 ilr
 pPV
 kDT

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -1035,7 +1035,8 @@
 /area/security/armory/blue)
 "aJI" = (
 /obj/machinery/light/no_nightshift{
-	dir = 1
+	dir = 1;
+	old_wall = 1
 	},
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -1069,7 +1070,8 @@
 "aKa" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/light/no_nightshift{
-	dir = 8
+	dir = 8;
+	old_wall = 1
 	},
 /obj/structure/closet/medical_wall{
 	pixel_x = -32
@@ -2300,7 +2302,8 @@
 /area/rift/surfacebase/outside/outside2)
 "bpb" = (
 /obj/machinery/light/no_nightshift{
-	dir = 8
+	dir = 8;
+	old_wall = 1
 	},
 /obj/structure/table/steel_reinforced,
 /obj/machinery/recharger{
@@ -7671,7 +7674,8 @@
 "eXr" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/light/no_nightshift{
-	dir = 1
+	dir = 1;
+	old_wall = 1
 	},
 /obj/structure/closet/walllocker/emergsuit_wall{
 	dir = 4;
@@ -8284,7 +8288,8 @@
 "fpW" = (
 /obj/machinery/mech_recharger,
 /obj/machinery/light/no_nightshift{
-	dir = 1
+	dir = 1;
+	old_wall = 1
 	},
 /turf/simulated/floor/maglev{
 	dir = 8;
@@ -14980,7 +14985,8 @@
 	dir = 4
 	},
 /obj/machinery/light/no_nightshift{
-	dir = 8
+	dir = 8;
+	old_wall = 1
 	},
 /obj/structure/fuel_port{
 	pixel_x = 1;
@@ -16548,7 +16554,9 @@
 /area/maintenance/security/upper)
 "kCx" = (
 /obj/structure/cable/orange,
-/obj/machinery/power/apc/west_mount,
+/obj/machinery/power/apc/west_mount{
+	old_wall = 1
+	},
 /obj/machinery/meter{
 	pixel_x = 16
 	},
@@ -17794,7 +17802,8 @@
 /area/security/warden)
 "lrj" = (
 /obj/machinery/light/no_nightshift{
-	dir = 1
+	dir = 1;
+	old_wall = 1
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "hammerheadpport";
@@ -18842,7 +18851,8 @@
 	},
 /obj/structure/bed/chair/bay/shuttle,
 /obj/machinery/light/no_nightshift{
-	dir = 1
+	dir = 1;
+	old_wall = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
@@ -26894,7 +26904,8 @@
 "raP" = (
 /obj/structure/bed/chair/bay/shuttle,
 /obj/machinery/light/no_nightshift{
-	dir = 1
+	dir = 1;
+	old_wall = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
@@ -30365,7 +30376,9 @@
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 6
 	},
-/obj/machinery/power/apc/east_mount,
+/obj/machinery/power/apc/east_mount{
+	old_wall = 1
+	},
 /obj/structure/cable/orange{
 	icon_state = "0-2"
 	},
@@ -37187,7 +37200,8 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/light/no_nightshift{
-	dir = 1
+	dir = 1;
+	old_wall = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -19793,6 +19793,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security/upper)
+"mAj" = (
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "mAG" = (
 /obj/machinery/door/firedoor/glass{
 	dir = 1
@@ -23054,13 +23063,6 @@
 /obj/machinery/transhuman/synthprinter,
 /turf/simulated/floor/tiled/steel,
 /area/assembly/robotics)
-"oHu" = (
-/obj/structure/bed/chair/bay/shuttle,
-/obj/machinery/door/window/brigdoor/northright{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/general)
 "oIx" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -27487,6 +27489,13 @@
 /obj/item/bedsheet/bluedouble,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_2)
+"rtv" = (
+/obj/machinery/door/window/brigdoor/northright{
+	dir = 8
+	},
+/obj/structure/handrail,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "rtU" = (
 /obj/structure/table/steel,
 /obj/item/gps/security,
@@ -29505,9 +29514,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_1)
 "sQe" = (
-/obj/machinery/door/window/brigdoor/northleft{
-	dir = 8
-	},
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 1
 	},
@@ -55093,9 +55099,9 @@ qly
 qly
 qly
 ilr
-uRH
-gHJ
-hsv
+rtv
+mAj
+ilr
 oIx
 dzD
 wcF
@@ -55287,7 +55293,7 @@ qly
 qly
 qly
 ilr
-oHu
+uRH
 sQe
 ilr
 oIx

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -1311,6 +1311,10 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/machinery/light/no_nightshift{
+	dir = 1;
+	old_wall = 1
+	},
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
@@ -4870,7 +4874,8 @@
 	},
 /obj/structure/bed/chair/bay/shuttle,
 /obj/machinery/light/no_nightshift{
-	dir = 1
+	dir = 1;
+	old_wall = 1
 	},
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 5
@@ -12552,7 +12557,6 @@
 /turf/simulated/floor/tiled/red,
 /area/security/evastorage)
 "iag" = (
-/obj/structure/catwalk,
 /obj/machinery/door/blast/regular{
 	dir = 4;
 	id = "hammerheadfsb";
@@ -19698,7 +19702,6 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
 /obj/machinery/door/blast/regular{
 	dir = 4;
 	id = "hammerheadfsb";

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -11891,6 +11891,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rift/station/public_garden/stairwell)
+"hKF" = (
+/obj/structure/sign/warning/docking_area,
+/turf/simulated/wall/r_wall/prepainted/security,
+/area/security/hammerhead_bay)
 "hKO" = (
 /obj/machinery/light_switch{
 	dir = 1;
@@ -55492,7 +55496,7 @@ qly
 qly
 cVK
 tVi
-uAn
+hKF
 lEq
 nxk
 nAo
@@ -55880,7 +55884,7 @@ qly
 qly
 nxh
 qly
-uAn
+hKF
 meA
 rPy
 vrz

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -2068,6 +2068,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
+"bkW" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/turf/simulated/floor/maglev{
+	dir = 8;
+	icon_state = "maglevup";
+	name = "launch rail"
+	},
+/area/shuttle/hammerhead/cockpit)
 "bli" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -8228,6 +8238,9 @@
 /area/security/briefing_room)
 "fpW" = (
 /obj/machinery/mech_recharger,
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
@@ -17707,6 +17720,14 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/red)
+"lqt" = (
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/maglev{
+	dir = 8;
+	icon_state = "maglevup";
+	name = "launch rail"
+	},
+/area/shuttle/hammerhead/cockpit)
 "lqA" = (
 /obj/machinery/status_display{
 	pixel_x = 32
@@ -21801,16 +21822,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/briefing_room)
-"nNP" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/turf/simulated/floor/maglev{
-	dir = 8;
-	icon_state = "maglevup";
-	name = "launch rail"
-	},
-/area/shuttle/hammerhead/cockpit)
 "nOt" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -52529,7 +52540,7 @@ pFk
 pFk
 oOw
 wqC
-nNP
+wqC
 oOw
 oOw
 oOw
@@ -52722,8 +52733,8 @@ oOw
 sUa
 seE
 oOw
-wqC
-wqC
+bkW
+lqt
 oOw
 bpb
 eqt

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -4793,7 +4793,8 @@
 /area/crew_quarters/heads/hor)
 "ddq" = (
 /obj/structure/bed/chair/bay/shuttle{
-	dir = 8
+	dir = 8;
+	name = "Pilot's Seat"
 	},
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 1
@@ -7931,13 +7932,6 @@
 	pixel_y = -26
 	},
 /obj/machinery/light/no_nightshift,
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "hammerheadpport";
-	name = "Port Personnel Door";
-	pixel_x = -5;
-	pixel_y = -26
-	},
 /turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "fdT" = (
@@ -12156,6 +12150,13 @@
 	},
 /obj/effect/floor_decal/corner_techfloor_grid/full{
 	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "hammerfighterport";
+	name = "Port Fighter Bay";
+	pixel_x = 6;
+	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
@@ -17817,15 +17818,16 @@
 	dir = 1;
 	old_wall = 1
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "hammerheadpport";
-	name = "Port Personnel Door";
-	pixel_x = -6;
-	pixel_y = 26
-	},
 /obj/structure/lattice,
 /obj/structure/catwalk,
 /obj/structure/marker_beacon/red,
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "hammerfighterport";
+	name = "Port Fighter Bay";
+	pixel_x = 6;
+	pixel_y = 26
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "lrw" = (
@@ -19856,7 +19858,8 @@
 	dir = 1
 	},
 /obj/machinery/door/window/brigdoor/northleft{
-	dir = 8
+	dir = 8;
+	name = "Holding Cell"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
@@ -27567,7 +27570,8 @@
 /area/crew_quarters/sleep/Dorm_2)
 "rtv" = (
 /obj/machinery/door/window/brigdoor/northright{
-	dir = 8
+	dir = 8;
+	name = "Holding Cell"
 	},
 /obj/structure/handrail,
 /turf/simulated/floor/tiled/techfloor,
@@ -30907,6 +30911,16 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/locker)
+"tLv" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 8;
+	name = "Copilot's Seat"
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/cockpit)
 "tLz" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -53253,7 +53267,7 @@ qly
 qly
 iCM
 uuY
-ddq
+tLv
 sQt
 ffG
 iOM

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -11621,7 +11621,7 @@
 	req_one_access = list(1,38)
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/general)
+/area/shuttle/hammerhead/cockpit)
 "hGo" = (
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/showers)
@@ -12424,10 +12424,6 @@
 /obj/item/tank/jetpack/oxygen,
 /turf/simulated/floor/tiled/red,
 /area/security/evastorage)
-"iaf" = (
-/obj/spawner/window/low_wall/reinforced/full/firelocks,
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "iag" = (
 /obj/structure/catwalk,
 /obj/machinery/door/blast/regular{
@@ -14194,7 +14190,7 @@
 	},
 /obj/machinery/light/no_nightshift,
 /turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
+/area/shuttle/hammerhead/cockpit)
 "jhd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/light/no_nightshift{
@@ -22591,9 +22587,6 @@
 /obj/fiftyspawner/steel,
 /turf/simulated/floor/tiled/steel,
 /area/rnd/workshop)
-"ote" = (
-/turf/simulated/shuttle/wall/voidcraft/red,
-/area/security/hammerhead_bay)
 "otg" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
@@ -25652,7 +25645,7 @@
 	},
 /obj/structure/table/rack/shelf/steel,
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/general)
+/area/shuttle/hammerhead/cockpit)
 "qtI" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -31487,10 +31480,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/maintenance/medbay)
-"upV" = (
-/obj/structure/table/rack/shelf/steel,
-/turf/simulated/floor/tiled/techfloor,
-/area/security/hammerhead_bay)
 "uqC" = (
 /obj/structure/table/glass,
 /turf/simulated/floor/carpet/blue,
@@ -53799,15 +53788,15 @@ qly
 qly
 qly
 jgM
-ilr
-ilr
-ilr
+oOw
+oOw
+oOw
 fpW
 vKi
-iaf
-pxC
-upV
-ote
+iCM
+sQt
+pXD
+oOw
 qly
 qly
 qly
@@ -53998,10 +53987,10 @@ ilr
 ilr
 aSz
 bFP
-iaf
-pxC
+iCM
+sQt
 qtd
-ote
+oOw
 qly
 qly
 qly
@@ -54192,10 +54181,10 @@ qnJ
 ilr
 nVS
 qkS
-ilr
+oOw
 hFZ
-ilr
-ilr
+oOw
+oOw
 qly
 qly
 qly

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -7558,6 +7558,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/hammerhead_bay)
 "eWs" = (
@@ -9210,6 +9211,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
@@ -12111,7 +12115,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
+/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/hammerhead_bay)
 "hPi" = (

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -1013,6 +1013,7 @@
 	},
 /obj/structure/lattice,
 /obj/structure/catwalk,
+/obj/structure/marker_beacon/red,
 /turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "aJX" = (
@@ -1275,12 +1276,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/heads/hor)
 "aSz" = (
-/obj/effect/floor_decal/corner_techfloor_gray,
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/maglev{
+	dir = 8;
+	icon_state = "maglevup";
+	name = "launch rail"
+	},
 /area/shuttle/hammerhead/general)
 "aTl" = (
 /obj/effect/floor_decal/spline/plain,
@@ -2743,14 +2747,15 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner_techfloor_gray{
-	dir = 4
-	},
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/maglev{
+	dir = 8;
+	icon_state = "maglevup";
+	name = "launch rail"
+	},
 /area/shuttle/hammerhead/general)
 "bFQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2856,6 +2861,12 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/asmaint2)
+"bKY" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/cockpit)
 "bLy" = (
 /obj/effect/floor_decal/borderfloorblack{
 	alpha = 255;
@@ -4533,13 +4544,10 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/corner_techfloor_gray/full{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "cVK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -4701,8 +4709,8 @@
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_x = 32
 	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 6
+/obj/effect/floor_decal/corner_techfloor_grid/full{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
@@ -4731,6 +4739,15 @@
 /obj/item/hardsuit/hazmat/equipped,
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/heads/hor)
+"ddq" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/cockpit)
 "ddZ" = (
 /turf/simulated/floor/outdoors/gravsnow/lythios43c/indoors,
 /area/rift/surfacebase/outside/outside2)
@@ -4806,6 +4823,9 @@
 /obj/structure/bed/chair/bay/shuttle,
 /obj/machinery/light/no_nightshift{
 	dir = 1
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
@@ -5417,8 +5437,7 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/reinforced,
 /area/shuttle/hammerhead/general)
 "dzM" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central4,
@@ -6467,6 +6486,9 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "eho" = (
@@ -6516,6 +6538,9 @@
 /area/crew_quarters/sleep)
 "ejz" = (
 /obj/machinery/mech_recharger,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -8203,7 +8228,11 @@
 /area/security/briefing_room)
 "fpW" = (
 /obj/machinery/mech_recharger,
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/maglev{
+	dir = 8;
+	icon_state = "maglevup";
+	name = "launch rail"
+	},
 /area/shuttle/hammerhead/general)
 "fqf" = (
 /turf/simulated/wall/prepainted,
@@ -9165,13 +9194,10 @@
 /obj/effect/floor_decal/corner_techfloor_gray/full{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "fZA" = (
 /obj/effect/floor_decal/borderfloor{
@@ -9722,6 +9748,9 @@
 /obj/machinery/mech_recharger,
 /obj/mecha/combat/fighter/baron/sec/loaded{
 	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -10541,6 +10570,18 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rift/turbolift/maint)
+"gOT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/hammerhead/general)
 "gPk" = (
 /obj/structure/closet/crate/medical/blood,
 /obj/item/reagent_containers/blood/empty,
@@ -13600,6 +13641,9 @@
 /obj/structure/handrail{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "iPh" = (
@@ -14199,12 +14243,11 @@
 /obj/machinery/light/no_nightshift{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner_techfloor_gray/full,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "jho" = (
 /obj/machinery/bioscan_antenna/permanent{
@@ -17417,7 +17460,7 @@
 "lhE" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
-	id = "hammerheadfsb";
+	id = "hammerheadsbc";
 	name = "Starboard Cargo Door"
 	},
 /obj/machinery/atmospheric_field_generator/perma,
@@ -17490,9 +17533,6 @@
 "liE" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 5
 	},
 /obj/machinery/door/window/brigdoor/southright{
 	dir = 1;
@@ -17685,6 +17725,7 @@
 	},
 /obj/structure/lattice,
 /obj/structure/catwalk,
+/obj/structure/marker_beacon/red,
 /turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "lrw" = (
@@ -18073,9 +18114,6 @@
 "lCs" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 10
 	},
 /obj/machinery/door/window/brigdoor/southright{
 	name = "Cockpit Access"
@@ -18752,6 +18790,9 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 9
@@ -19006,6 +19047,18 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/chargebay)
+"mgb" = (
+/obj/machinery/atmospheric_field_generator/perma,
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "hammerfighterport";
+	name = "Port Fighter Bay"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/hammerhead/general)
 "mgD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -21229,6 +21282,18 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/security/hammerhead_bay)
+"nxi" = (
+/obj/machinery/atmospheric_field_generator/perma,
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "hammerfighterport";
+	name = "Port Fighter Bay"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/hammerhead/general)
 "nxk" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -21942,16 +22007,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "nVS" = (
-/obj/effect/floor_decal/corner_techfloor_grid/diagonal{
-	dir = 4
-	},
-/obj/structure/catwalk,
 /obj/machinery/door/blast/regular{
 	dir = 4;
 	id = "hammerheadtba";
 	name = "Fighter Launch Tube Access"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/reinforced,
 /area/shuttle/hammerhead/general)
 "nWU" = (
 /obj/structure/table/rack/shelf/steel,
@@ -22404,18 +22465,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
-"ojI" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner_techfloor_gray/full{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/hammerhead/general)
 "ojJ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -22990,9 +23039,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "oIx" = (
-/obj/effect/floor_decal/corner_techfloor_grid/diagonal,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
 /area/shuttle/hammerhead/general)
 "oJr" = (
 /obj/machinery/computer/rdconsole/robotics{
@@ -23349,10 +23399,14 @@
 /turf/simulated/floor/tiled/steel,
 /area/rnd/research/testingrange)
 "oSs" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 6
 	},
+/obj/effect/floor_decal/sign/dock/two,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/hammerhead/general)
 "oSM" = (
@@ -23742,6 +23796,9 @@
 /area/security/interrogation)
 "pcN" = (
 /obj/machinery/mech_recharger,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 5
@@ -24086,9 +24143,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security/upper)
 "pmF" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
+/obj/effect/floor_decal/sign/dock/one,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/hammerhead/general)
 "pnl" = (
@@ -24386,6 +24447,10 @@
 /turf/simulated/floor/wood,
 /area/maintenance/security/upper)
 "pxC" = (
+/obj/effect/floor_decal/corner_techfloor_gray/full{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_techfloor_grid/diagonal,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "pyc" = (
@@ -25300,6 +25365,9 @@
 	pixel_x = -27;
 	pixel_y = -26
 	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "qiJ" = (
@@ -25392,14 +25460,12 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner_techfloor_grid/diagonal,
-/obj/structure/catwalk,
 /obj/machinery/door/blast/regular{
 	dir = 4;
 	id = "hammerheadtba";
 	name = "Fighter Launch Tube Access"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/reinforced,
 /area/shuttle/hammerhead/general)
 "qly" = (
 /turf/simulated/floor/reinforced,
@@ -26149,6 +26215,9 @@
 /obj/structure/cable/orange{
 	icon_state = "1-8"
 	},
+/obj/effect/floor_decal/corner_techfloor_grid/full{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "qJo" = (
@@ -26796,7 +26865,7 @@
 	dir = 1
 	},
 /obj/machinery/button/remote/blast_door{
-	id = "hammerfighterstarboard";
+	id = "hammerheadsbc";
 	name = "Starboard Cargo Door";
 	pixel_x = -24;
 	pixel_y = 26
@@ -27278,6 +27347,9 @@
 "rpT" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
@@ -27870,11 +27942,8 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner_techfloor_grid/diagonal{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/borderfloorblack,
+/turf/simulated/floor/reinforced,
 /area/shuttle/hammerhead/general)
 "rMp" = (
 /obj/machinery/holoposter{
@@ -31285,6 +31354,9 @@
 /obj/structure/panic_button{
 	pixel_x = 32
 	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "ukp" = (
@@ -31676,6 +31748,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
+"uAi" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/hammerhead/general)
 "uAn" = (
 /turf/simulated/wall/r_wall/prepainted/security,
 /area/security/hammerhead_bay)
@@ -32343,8 +32421,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 1
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/reinforced,
 /area/shuttle/hammerhead/general)
 "uSV" = (
 /obj/effect/floor_decal/borderfloor{
@@ -33672,7 +33749,11 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/mech_recharger,
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/maglev{
+	dir = 8;
+	icon_state = "maglevup";
+	name = "launch rail"
+	},
 /area/shuttle/hammerhead/general)
 "vKj" = (
 /obj/machinery/door/firedoor/glass,
@@ -35045,8 +35126,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
 /area/shuttle/hammerhead/general)
 "wKw" = (
 /obj/machinery/light/small{
@@ -36419,6 +36502,9 @@
 /area/rnd/breakroom)
 "xIV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/effect/floor_decal/corner_techfloor_grid/diagonal{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "xKy" = (
@@ -52827,7 +52913,7 @@ iCM
 iCM
 xjH
 aKa
-ehg
+ddq
 sYU
 oOw
 wqC
@@ -53019,7 +53105,7 @@ qly
 qly
 iCM
 uuY
-ehg
+ddq
 sQt
 ffG
 iOM
@@ -53222,7 +53308,7 @@ xEQ
 vEO
 liE
 qJl
-sQt
+bKY
 ujL
 byu
 hOS
@@ -54770,12 +54856,12 @@ ilr
 uRH
 gHJ
 hsv
-nLz
+oIx
 wJB
 lXc
 grT
 pmF
-njk
+mgb
 vDu
 cED
 qly
@@ -54964,7 +55050,7 @@ ilr
 uRH
 gHJ
 hsv
-nLz
+oIx
 dzD
 wcF
 fSv
@@ -55158,7 +55244,7 @@ ilr
 oHu
 gHJ
 hsv
-nLz
+oIx
 uSS
 usH
 jmy
@@ -55352,12 +55438,12 @@ ilr
 raP
 gHJ
 hsv
-nLz
-dzD
+uAi
+gOT
 pcN
 ejz
 oSs
-njk
+nxi
 vDu
 cED
 qly
@@ -55742,7 +55828,7 @@ pxC
 trq
 buW
 cVx
-ojI
+ieh
 ieh
 vIN
 ilr

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -735,15 +735,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research/rnd)
-"azT" = (
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "hammerheadfport";
-	name = "Port Fighter Entrance"
-	},
-/obj/machinery/atmospheric_field_generator/perma,
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/hammerhead/general)
 "aAG" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/surgery,
@@ -1285,7 +1276,11 @@
 /area/crew_quarters/heads/hor)
 "aSz" = (
 /obj/effect/floor_decal/corner_techfloor_gray,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "aTl" = (
 /obj/effect/floor_decal/spline/plain,
@@ -1582,6 +1577,7 @@
 /obj/effect/floor_decal/corner_techfloor_gray{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
 "baJ" = (
@@ -2307,16 +2303,6 @@
 /obj/random/contraband,
 /turf/simulated/floor/plating/lythios43c,
 /area/rift/surfacebase/outside/outside2)
-"bru" = (
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "hammerheadfsb";
-	name = "Starboard Fighter Door";
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/turf/simulated/floor/reinforced,
-/area/security/hammerhead_bay)
 "brw" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/cell/device/weapon{
@@ -2441,6 +2427,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
+"buW" = (
+/obj/effect/floor_decal/corner_techfloor_gray/full,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/hammerhead/general)
 "bvh" = (
 /obj/random/contraband,
 /turf/simulated/floor/outdoors/safeice/lythios43c/indoors,
@@ -2507,20 +2500,6 @@
 	},
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 6
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "hammerfighterport";
-	name = "Port Fighter Bay";
-	pixel_x = -3;
-	pixel_y = -30
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "hammerfighterstarboard";
-	name = "Starboard Fighter Bay";
-	pixel_x = 5;
-	pixel_y = -30
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
@@ -2767,7 +2746,11 @@
 /obj/effect/floor_decal/corner_techfloor_gray{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "bFQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3373,6 +3356,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
+"ceT" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/hammerhead/general)
 "cfk" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/sleep/Dorm_4)
@@ -3719,6 +3706,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"cpn" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "cqn" = (
 /obj/fiftyspawner/steel,
 /turf/simulated/floor/tiled/techfloor,
@@ -4082,6 +4075,11 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/showers)
+"cED" = (
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/turf/simulated/floor/reinforced,
+/area/shuttle/hammerhead/general)
 "cEL" = (
 /obj/machinery/door/airlock/voidcraft/vertical,
 /obj/map_helper/airlock/door/ext_door,
@@ -4538,6 +4536,9 @@
 /obj/effect/floor_decal/corner_techfloor_gray/full{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
 "cVK" = (
@@ -4661,12 +4662,6 @@
 /obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
-"cYC" = (
-/obj/machinery/light/no_nightshift,
-/obj/structure/lattice,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "daF" = (
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/borderfloorblack/cee,
@@ -4808,6 +4803,7 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
+/obj/structure/bed/chair/bay/shuttle,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "dhE" = (
@@ -4870,29 +4866,8 @@
 /obj/machinery/fitness/punching_bag/clown,
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
-"djJ" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 8
-	},
-/obj/machinery/power/apc/east_mount,
-/obj/structure/cable/orange{
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/cockpit)
 "djU" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 6
-	},
-/obj/structure/panic_button{
-	pixel_x = 32
-	},
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "dke" = (
@@ -5439,7 +5414,8 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "dzM" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central4,
@@ -6535,6 +6511,13 @@
 /obj/spawner/window/low_wall/full/nogrille/firelocks,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep)
+"ejz" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/hammerhead/general)
 "ejY" = (
 /obj/structure/inflatable/door,
 /turf/simulated/floor/plating,
@@ -6744,6 +6727,10 @@
 	anchored = 1
 	},
 /obj/effect/floor_decal/corner_techfloor_grid/full,
+/obj/structure/closet/hydrant{
+	dir = 4;
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "eqI" = (
@@ -6998,17 +6985,6 @@
 /obj/effect/paint/purplegray,
 /turf/simulated/floor/reinforced,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
-"eBF" = (
-/obj/machinery/shipsensors,
-/obj/machinery/light/no_nightshift,
-/obj/effect/floor_decal/industrial/warning/full,
-/obj/item/gps/internal/base{
-	desc = "A tracking beacon embedded in the shuttle systems, to help explorers find where they landed.";
-	gps_tag = "BARGE";
-	name = "shuttle beacon"
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "eBG" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -7859,9 +7835,6 @@
 /area/shuttle/hammerhead/general)
 "fdo" = (
 /obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/machinery/button/remote/blast_door{
 	dir = 1;
 	id = "hammerfighterport";
@@ -8175,6 +8148,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research/xenobio)
+"foa" = (
+/obj/machinery/atmospheric_field_generator/perma,
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "hammerheadfsb";
+	name = "Fighter Launch Tube"
+	},
+/turf/simulated/floor/maglev{
+	dir = 8;
+	icon_state = "maglevup";
+	name = "launch rail"
+	},
+/area/shuttle/hammerhead/cockpit)
 "fof" = (
 /obj/machinery/light{
 	dir = 1
@@ -8213,13 +8199,7 @@
 /turf/simulated/floor/tiled,
 /area/security/briefing_room)
 "fpW" = (
-/obj/machinery/door/airlock/voidcraft/vertical{
-	name = "Control Room";
-	req_one_access = list(1,38)
-	},
-/obj/effect/floor_decal/corner_techfloor_gray{
-	dir = 5
-	},
+/obj/machinery/mech_recharger,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "fqf" = (
@@ -8439,12 +8419,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/security/hammerhead_bay)
-"fyj" = (
-/obj/effect/floor_decal/corner_techfloor_grid/diagonal{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/cockpit)
 "fyx" = (
 /turf/simulated/floor/tiled/steel,
 /area/security/range)
@@ -9743,8 +9717,11 @@
 /area/medical/medbay_primary_storage)
 "grT" = (
 /obj/machinery/mech_recharger,
-/obj/machinery/atmospherics/portables_connector{
+/obj/mecha/combat/fighter/baron/sec/loaded{
 	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/hammerhead/general)
@@ -9878,24 +9855,6 @@
 /obj/item/pen,
 /turf/simulated/floor/tiled,
 /area/security/briefing_room)
-"guy" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/glass,
-/obj/structure/lattice,
-/obj/structure/cable/green{
-	icon_state = "32-1"
-	},
-/turf/simulated/open,
-/area/maintenance/lower/medsec_maintenance)
 "guD" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -10074,15 +10033,10 @@
 /turf/simulated/floor/tiled/monowhite,
 /area/medical/medbay_primary_storage)
 "gyO" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner_techfloor_grid/full{
 	dir = 4
 	},
-/obj/structure/closet/hydrant{
-	pixel_x = 32
-	},
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "gza" = (
@@ -10113,16 +10067,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rift/trade_shop/loading)
-"gzZ" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/structure/bed/chair/bay/shuttle,
-/obj/effect/floor_decal/corner_techfloor_grid/full{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/cockpit)
 "gBj" = (
 /turf/simulated/wall/r_wall/prepainted/security,
 /area/security/interrogation)
@@ -10420,9 +10364,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "gHJ" = (
-/obj/machinery/mech_recharger,
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "gIF" = (
 /obj/structure/girder,
@@ -11007,10 +10952,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/rift/stairwell/primary/surfacetwo)
 "hhM" = (
-/obj/machinery/computer/shuttle_control/explore/hammerhead{
+/obj/effect/floor_decal/corner_techfloor_grid/full,
+/obj/machinery/computer/secure_data{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner_techfloor_grid/full,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "hhN" = (
@@ -11145,19 +11090,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/assembly/robotics)
 "hnx" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/warning/corner,
-/obj/structure/catwalk,
 /obj/machinery/light/no_nightshift,
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "hammerfighterport";
-	name = "Port Fighter Bay";
-	pixel_x = -5;
-	pixel_y = -26
-	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "hnY" = (
@@ -11314,11 +11249,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "hsv" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "hsO" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
@@ -11684,16 +11616,9 @@
 /obj/machinery/light/no_nightshift{
 	dir = 8
 	},
-/obj/machinery/air_alarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/table/rack/shelf/steel,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = -4
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 10
+/obj/machinery/door/airlock/voidcraft/vertical{
+	name = "Shuttle Cockpit";
+	req_one_access = list(1,38)
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
@@ -11949,10 +11874,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "hMP" = (
-/obj/structure/closet/secure_closet/security,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/gps/security,
+/obj/item/hardsuit/hazard/equipped,
 /turf/simulated/floor/tiled/red,
 /area/security/evastorage)
 "hMQ" = (
@@ -12424,6 +12351,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/triumph/surfacebase/sauna)
+"hYB" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "hammerheadfsb";
+	name = "Fighter Launch Tube"
+	},
+/obj/machinery/atmospheric_field_generator/perma,
+/turf/simulated/floor/maglev{
+	dir = 8;
+	icon_state = "maglevup";
+	name = "launch rail"
+	},
+/area/shuttle/hammerhead/cockpit)
 "hYR" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -12484,11 +12424,22 @@
 /obj/item/tank/jetpack/oxygen,
 /turf/simulated/floor/tiled/red,
 /area/security/evastorage)
+"iaf" = (
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/turf/simulated/floor/plating,
+/area/shuttle/hammerhead/general)
 "iag" = (
-/obj/effect/floor_decal/corner_techfloor_grid/full{
-	dir = 1
+/obj/structure/catwalk,
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "hammerheadfsb";
+	name = "Fighter Launch Tube"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/maglev{
+	dir = 8;
+	icon_state = "maglevup";
+	name = "launch rail"
+	},
 /area/shuttle/hammerhead/cockpit)
 "iaY" = (
 /obj/machinery/holopad,
@@ -12557,6 +12508,9 @@
 "ieh" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
@@ -12899,6 +12853,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
 "ijR" = (
@@ -13003,10 +12958,11 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_5)
 "iqw" = (
-/obj/machinery/computer/ship/helm{
+/obj/effect/floor_decal/corner_techfloor_grid/full,
+/obj/machinery/computer/security{
+	icon_state = "computer";
 	dir = 4
 	},
-/obj/effect/floor_decal/corner_techfloor_grid/full,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "iqx" = (
@@ -13638,6 +13594,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
+"iOM" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/structure/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/cockpit)
 "iPh" = (
 /obj/structure/stairs/spawner/east,
 /turf/simulated/floor/plating/lythios43c,
@@ -14003,19 +13968,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rnd/research/researchdivision)
-"iZI" = (
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "hammerheadpsb";
-	name = "Starboard personnel Door";
-	pixel_x = -5;
-	pixel_y = -25
-	},
-/obj/machinery/light/no_nightshift,
-/obj/structure/lattice,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/hammerhead/general)
 "iZJ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -14232,6 +14184,17 @@
 /obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"jgM" = (
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/machinery/shipsensors,
+/obj/item/gps/internal/base{
+	desc = "A tracking beacon embedded in the shuttle systems, to help explorers find where they landed.";
+	gps_tag = "BARGE";
+	name = "shuttle beacon"
+	},
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/plating,
+/area/shuttle/hammerhead/general)
 "jhd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/light/no_nightshift{
@@ -14342,6 +14305,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
+"jmy" = (
+/obj/machinery/mech_recharger,
+/obj/mecha/combat/fighter/baron/sec/loaded{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/hammerhead/general)
 "jmA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14572,12 +14542,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rift/station/public_garden/stairwell)
-"jug" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/hammerhead/general)
 "jul" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -14729,10 +14693,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rift/station/public_garden/stairwell)
-"jyv" = (
-/obj/effect/floor_decal/corner_techfloor_grid/diagonal,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/cockpit)
 "jyL" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -15052,6 +15012,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
 "jOg" = (
@@ -16273,14 +16234,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
-"kwh" = (
-/obj/machinery/mech_recharger,
-/obj/machinery/atmospherics/portables_connector,
-/obj/mecha/combat/fighter/baron/sec/loaded{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/hammerhead/general)
 "kws" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -16501,7 +16454,8 @@
 /obj/effect/floor_decal/corner_techfloor_gray/full{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "kFB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16589,15 +16543,6 @@
 /obj/effect/floor_decal/corner/red/bordercorner,
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/blue)
-"kJk" = (
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "hammerheadpport";
-	name = "Port Personnel Entrance"
-	},
-/obj/machinery/atmospheric_field_generator/perma,
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/hammerhead/general)
 "kJS" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/medbay)
@@ -16661,20 +16606,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/telescience_lab/storage)
-"kMS" = (
-/obj/machinery/door/airlock/maintenance/medical{
-	name = "Medical Maintenance Access";
-	req_access = list(5)
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/medical/surgery_hallway)
 "kMU" = (
 /obj/machinery/door/airlock/voidcraft/vertical{
 	name = "Air Management";
@@ -16686,6 +16617,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
 "kNo" = (
@@ -16701,26 +16633,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
 "kNL" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "hammerfighterstarboard";
-	name = "Starboard Fighter Bay";
-	pixel_x = 5;
-	pixel_y = 26
+/obj/machinery/door/window/brigdoor/southleft{
+	dir = 4;
+	name = "Holding Room";
+	req_access = list(2);
+	req_one_access = list(2)
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "hammerheadpsb";
-	name = "Starboard Personnel Door";
-	pixel_x = -6;
-	pixel_y = 26
-	},
-/turf/simulated/floor/plating,
+/obj/structure/handrail,
+/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "kNQ" = (
 /obj/effect/floor_decal/borderfloorwhite{
@@ -17059,6 +16982,7 @@
 /obj/item/tank/oxygen{
 	pixel_y = -4
 	},
+/obj/item/hardsuit/hazard/equipped,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
 "kWZ" = (
@@ -17262,13 +17186,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
-"kYZ" = (
-/obj/machinery/door/airlock/maintenance/medical{
-	name = "Medbay Auxillary Storage"
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
 "kZx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -17502,7 +17419,7 @@
 /obj/machinery/door/blast/regular{
 	dir = 4;
 	id = "hammerheadfsb";
-	name = "Starboard Fighter Entrance"
+	name = "Starboard Cargo Door"
 	},
 /obj/machinery/atmospheric_field_generator/perma,
 /turf/simulated/floor/tiled/techmaint,
@@ -17578,6 +17495,17 @@
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 5
 	},
+/obj/machinery/door/window/brigdoor/southright{
+	name = "Holding Room";
+	icon_state = "rightsecure";
+	dir = 1;
+	req_access = list(2);
+	req_one_access = list(2)
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "liF" = (
@@ -18150,9 +18078,9 @@
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 10
 	},
-/obj/structure/cable/orange{
-	icon_state = "2-4"
-	},
+/obj/machinery/door/window/brigdoor/southright,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "lCv" = (
@@ -18363,10 +18291,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/sleep)
-"lKw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/general)
 "lKB" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -18793,6 +18717,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
+"lVu" = (
+/obj/machinery/air_alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/bed/chair/bay/shuttle,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "lWx" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -18815,9 +18747,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/sleep)
 "lXc" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/machinery/mech_recharger,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/shuttle/hammerhead/general)
 "lXv" = (
 /obj/effect/floor_decal/borderfloorwhite{
@@ -19102,10 +19040,7 @@
 	dir = 8;
 	pixel_x = -32
 	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/shuttle/wall/voidcraft/red,
 /area/shuttle/hammerhead/cockpit)
 "mhS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
@@ -19267,11 +19202,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "mkP" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/door/airlock/voidcraft/vertical{
+	name = "Shuttle Brig";
+	req_one_access = list(1,38)
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor/glass,
+/turf/space/basic,
 /area/shuttle/hammerhead/general)
 "mlx" = (
 /obj/effect/floor_decal/borderfloor{
@@ -19623,10 +19559,17 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner_techfloor_grid/full{
-	dir = 4
+/obj/structure/catwalk,
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "hammerheadfsb";
+	name = "Fighter Launch Tube"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/maglev{
+	dir = 8;
+	icon_state = "maglevup";
+	name = "launch rail"
+	},
 /area/shuttle/hammerhead/cockpit)
 "mvo" = (
 /obj/effect/floor_decal/borderfloor{
@@ -19670,15 +19613,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
-"mxh" = (
-/obj/effect/floor_decal/corner_techfloor_grid/full{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/general)
 "myF" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass/security{
@@ -20042,7 +19976,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "mFI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -21711,9 +21646,6 @@
 /area/crew_quarters/sleep/Dorm_4)
 "nLz" = (
 /obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "nLU" = (
@@ -21807,11 +21739,11 @@
 /obj/machinery/light/no_nightshift{
 	dir = 8
 	},
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 1
+/turf/simulated/floor/maglev{
+	dir = 8;
+	icon_state = "maglevup";
+	name = "launch rail"
 	},
-/obj/effect/floor_decal/corner_techfloor_grid/full,
-/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "nOt" = (
 /obj/structure/cable/green{
@@ -22012,7 +21944,13 @@
 /obj/effect/floor_decal/corner_techfloor_grid/diagonal{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/catwalk,
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "hammerheadtba";
+	name = "Fighter Launch Tube Access"
+	},
+/turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "nWU" = (
 /obj/structure/table/rack/shelf/steel,
@@ -22472,6 +22410,9 @@
 /obj/effect/floor_decal/corner_techfloor_gray/full{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
 "ojJ" = (
@@ -22650,6 +22591,9 @@
 /obj/fiftyspawner/steel,
 /turf/simulated/floor/tiled/steel,
 /area/rnd/workshop)
+"ote" = (
+/turf/simulated/shuttle/wall/voidcraft/red,
+/area/security/hammerhead_bay)
 "otg" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
@@ -23039,6 +22983,19 @@
 /obj/machinery/transhuman/synthprinter,
 /turf/simulated/floor/tiled/steel,
 /area/assembly/robotics)
+"oHu" = (
+/obj/item/radio/intercom/department/security{
+	dir = 1;
+	pixel_y = 35
+	},
+/obj/structure/bed/chair/bay/shuttle,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
+"oIx" = (
+/obj/effect/floor_decal/corner_techfloor_grid/diagonal,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/hammerhead/general)
 "oJr" = (
 /obj/machinery/computer/rdconsole/robotics{
 	dir = 4
@@ -23207,15 +23164,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/telescience_lab/foyer)
-"oPv" = (
-/obj/machinery/atmospheric_field_generator/perma,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "hammerfighterstarboard";
-	name = "Starboard Fighter Bay Exit"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/hammerhead/general)
 "oPH" = (
 /obj/machinery/computer/security{
 	dir = 1
@@ -23402,6 +23350,13 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled/steel,
 /area/rnd/research/testingrange)
+"oSs" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/hammerhead/general)
 "oSM" = (
 /obj/machinery/button/remote/airlock{
 	id = "maint_cell_1";
@@ -23787,6 +23742,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/interrogation)
+"pcN" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/hammerhead/general)
 "pcO" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
@@ -24124,6 +24087,12 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/security/upper)
+"pmF" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/hammerhead/general)
 "pnl" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/evidence,
@@ -24600,6 +24569,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
+"pFk" = (
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/turf/space/basic,
+/area/shuttle/hammerhead/cockpit)
 "pFw" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -24827,7 +24800,8 @@
 /area/maintenance/substation/research)
 "pPV" = (
 /obj/effect/floor_decal/corner_techfloor_gray/full,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "pPZ" = (
 /obj/machinery/door/firedoor/glass,
@@ -24850,15 +24824,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
-"pQK" = (
-/obj/machinery/atmospheric_field_generator/perma,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "hammerheadpsb";
-	name = "Starboard Personnel Entrance"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/hammerhead/general)
 "pRj" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
@@ -25027,6 +24992,10 @@
 /obj/structure/closet/largecardboard,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/security/upper)
+"pXD" = (
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/cockpit)
 "pXN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -25324,6 +25293,15 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "hammerheadfsb";
+	name = "Fighter Tube Door";
+	pixel_x = -27;
+	pixel_y = -26
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "qiJ" = (
@@ -25417,7 +25395,13 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner_techfloor_grid/diagonal,
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/catwalk,
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "hammerheadtba";
+	name = "Fighter Launch Tube Access"
+	},
+/turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "qly" = (
 /turf/simulated/floor/reinforced,
@@ -25539,12 +25523,8 @@
 /obj/machinery/light/no_nightshift{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/guncabinet{
-	anchored = 1
-	},
-/obj/item/radio/intercom/department/security{
-	dir = 8;
-	pixel_x = -24
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
@@ -25666,6 +25646,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/pool/emergency_closet)
+"qtd" = (
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_x = 32
+	},
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "qtI" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -26058,11 +26045,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
-"qFo" = (
-/obj/structure/table/steel,
-/obj/item/material/ashtray/glass,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
 "qFG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
@@ -26274,6 +26256,19 @@
 /obj/effect/paint/purplegray,
 /turf/simulated/floor/plating,
 /area/rnd/lockers)
+"qLw" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 10
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = -4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "qMG" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -26723,6 +26718,13 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/pool)
+"raP" = (
+/obj/structure/closet/hydrant{
+	pixel_x = 32
+	},
+/obj/structure/bed/chair/bay/shuttle,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "rba" = (
 /obj/structure/railing{
 	dir = 4
@@ -26764,23 +26766,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/sleep)
 "rcg" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/obj/structure/catwalk,
 /obj/machinery/light/no_nightshift{
 	dir = 1
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "hammerfighterstarboard";
-	name = "Starboard Fighter Bay";
-	pixel_x = -6;
-	pixel_y = 26
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/shuttle/wall/voidcraft/red,
 /area/shuttle/hammerhead/general)
 "rcB" = (
 /obj/machinery/door_timer/cell_3{
@@ -26802,14 +26794,14 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/medical/chemistry)
 "rda" = (
-/obj/machinery/button/remote/blast_door{
-	id = "hammerheadfsb";
-	name = "Starboard Fighter Door";
-	pixel_x = -27;
-	pixel_y = 26
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "hammerfighterstarboard";
+	name = "Starboard Cargo Door";
+	pixel_x = -24;
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
@@ -26963,6 +26955,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
+"rin" = (
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/machinery/computer/secure_data,
+/turf/simulated/floor/plating,
+/area/shuttle/hammerhead/cockpit)
 "riA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -27280,6 +27277,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
+"rpT" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/cockpit)
 "rqo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27872,7 +27875,8 @@
 /obj/effect/floor_decal/corner_techfloor_grid/diagonal{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "rMp" = (
 /obj/machinery/holoposter{
@@ -28117,12 +28121,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
-"rSm" = (
-/obj/structure/closet/emcloset,
-/obj/item/clothing/glasses/sunglasses/medhud,
-/obj/random/maintenance/medical,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
 "rSM" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -28439,25 +28437,29 @@
 /obj/machinery/light/no_nightshift{
 	dir = 8
 	},
-/obj/structure/table/steel_reinforced,
-/obj/machinery/recharger{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/machinery/recharger{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/structure/cable/orange{
-	icon_state = "0-4"
-	},
 /obj/effect/floor_decal/corner_techfloor_grid/full,
 /obj/item/radio/intercom/department/security{
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/machinery/computer/shuttle_control/explore/hammerhead{
+	icon_state = "computer";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
+"seJ" = (
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 4;
+	name = "Holding Room";
+	req_access = list(2);
+	req_one_access = list(2)
+	},
+/obj/structure/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "sfs" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -28627,7 +28629,9 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "smO" = (
-/obj/structure/closet/secure_closet/security,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/gps/security,
+/obj/item/hardsuit/hazard/equipped,
 /turf/simulated/floor/tiled/red,
 /area/security/evastorage)
 "snv" = (
@@ -29119,6 +29123,21 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/maintenance/medbay)
+"sFh" = (
+/obj/machinery/button/remote/blast_door{
+	id = "hammerheadtba";
+	name = "Fighter Tube Access";
+	pixel_x = 8;
+	pixel_y = 26
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "hammerheadfsb";
+	name = "Fighter Tube Door";
+	pixel_x = -8;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/cockpit)
 "sGv" = (
 /obj/structure/curtain/medical,
 /obj/structure/cable/green{
@@ -29432,32 +29451,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "sUa" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	anchored = 1
-	},
 /obj/effect/floor_decal/corner_techfloor_grid/full{
 	dir = 8
+	},
+/obj/machinery/computer/ship/helm{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "sUg" = (
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
-"sUJ" = (
-/obj/machinery/door/window/brigdoor/southright{
-	dir = 4;
-	name = "Holding Room";
-	req_access = list(2);
-	req_one_access = list(2)
-	},
-/obj/structure/handrail{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/cockpit)
 "sUU" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
@@ -29529,11 +29533,20 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_4)
 "sYU" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 10
+	},
+/obj/structure/table/steel_reinforced,
+/obj/structure/cable/orange{
+	icon_state = "0-4"
+	},
+/obj/machinery/recharger{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/machinery/recharger{
+	pixel_x = -5;
+	pixel_y = 3
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
@@ -29609,10 +29622,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/workshop)
-"tbE" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
 "tca" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
@@ -29935,15 +29944,6 @@
 "tnj" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/coffee_shop)
-"tnu" = (
-/obj/effect/floor_decal/corner_techfloor_grid/full{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/general)
 "tny" = (
 /obj/structure/catwalk,
 /obj/structure/stairs/spawner/north,
@@ -30166,6 +30166,16 @@
 "tui" = (
 /turf/simulated/floor/reinforced,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
+"tuq" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
+/obj/machinery/power/apc/east_mount,
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/cockpit)
 "tut" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -31166,19 +31176,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
-"ufs" = (
-/obj/machinery/door/window/brigdoor/southleft{
-	dir = 4;
-	name = "Holding Room";
-	req_access = list(2);
-	req_one_access = list(2)
-	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 5
-	},
-/obj/structure/handrail,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/cockpit)
 "ufF" = (
 /obj/effect/overlay/snow/floor,
 /turf/simulated/floor/plating/lythios43c,
@@ -31287,8 +31284,8 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "ujL" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 6
+/obj/structure/panic_button{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
@@ -31459,6 +31456,12 @@
 "uom" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/research/xenobio)
+"uoE" = (
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/cockpit)
 "upg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -31484,6 +31487,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/maintenance/medbay)
+"upV" = (
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/tiled/techfloor,
+/area/security/hammerhead_bay)
 "uqC" = (
 /obj/structure/table/glass,
 /turf/simulated/floor/carpet/blue,
@@ -31522,6 +31529,16 @@
 /obj/item/storage/bag/trash,
 /turf/simulated/floor/tiled/dark,
 /area/security/range)
+"usH" = (
+/obj/machinery/mech_recharger,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/hammerhead/general)
 "usM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -31563,13 +31580,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/rift/station/public_garden/gantry)
-"uuN" = (
-/obj/structure/bed/chair/bay/shuttle,
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/hammerhead/cockpit)
 "uuX" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8
@@ -32228,6 +32238,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"uRH" = (
+/obj/structure/bed/chair/bay/shuttle,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "uRJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -32240,11 +32254,6 @@
 	},
 /turf/simulated/floor/tiled/monowhite,
 /area/medical/chemistry)
-"uRN" = (
-/obj/machinery/mech_recharger,
-/obj/mecha/combat/fighter/baron/sec/loaded,
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/hammerhead/general)
 "uRP" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -32330,11 +32339,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/surfacetwo)
 "uSS" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/cyan,
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "uSV" = (
 /obj/effect/floor_decal/borderfloor{
@@ -33062,15 +33074,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
-"vnt" = (
-/obj/machinery/button/remote/blast_door{
-	id = "hammerheadfport";
-	name = "Port Fighter door";
-	pixel_x = -27;
-	pixel_y = 26
-	},
-/turf/simulated/floor/reinforced,
-/area/security/hammerhead_bay)
 "vnE" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -33457,10 +33460,11 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner_techfloor_grid/diagonal{
-	dir = 4
+/turf/simulated/floor/maglev{
+	dir = 8;
+	icon_state = "maglevup";
+	name = "launch rail"
 	},
-/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "vBG" = (
 /turf/simulated/floor/plating,
@@ -33530,10 +33534,11 @@
 /obj/structure/cable/orange{
 	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 5
+/turf/simulated/floor/maglev{
+	dir = 8;
+	icon_state = "maglevup";
+	name = "launch rail"
 	},
-/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "vFi" = (
 /obj/machinery/door/blast/regular{
@@ -33641,17 +33646,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research/xenobio)
 "vIN" = (
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "hammerheadfport";
-	name = "Port Fighter door";
-	pixel_x = -26;
-	pixel_y = -26
-	},
 /obj/structure/cable/orange{
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "vJe" = (
@@ -33672,13 +33673,7 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/voidcraft/vertical{
-	name = "Control Room";
-	req_one_access = list(1,38)
-	},
-/obj/effect/floor_decal/corner_techfloor_gray{
-	dir = 10
-	},
+/obj/machinery/mech_recharger,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "vKj" = (
@@ -33903,6 +33898,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/maintenance/medbay)
+"vTR" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/hammerhead/general)
 "vUk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -34103,8 +34104,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
 "wcF" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/shuttle/hammerhead/general)
 "wcJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -34123,13 +34127,8 @@
 	dir = 8;
 	pixel_x = -32
 	},
-/obj/effect/floor_decal/corner_techfloor_gray{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/sign/warning/high_voltage,
+/turf/simulated/shuttle/wall/voidcraft/red,
 /area/shuttle/hammerhead/cockpit)
 "wdP" = (
 /obj/item/clothing/head/sombrero,
@@ -34469,7 +34468,15 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/structure/closet/secure_closet/security,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/suit_cooling_unit,
+/obj/item/gps/security,
+/obj/item/tank/oxygen{
+	pixel_y = -4
+	},
+/obj/item/clothing/suit/space/void/security,
+/obj/item/clothing/head/helmet/space/void/security,
 /turf/simulated/floor/tiled/red,
 /area/security/evastorage)
 "wpj" = (
@@ -34532,13 +34539,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "wqC" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 1
+/turf/simulated/floor/maglev{
+	dir = 8;
+	icon_state = "maglevup";
+	name = "launch rail"
 	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "wrb" = (
 /obj/structure/table,
@@ -35036,13 +35041,14 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "wJB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 8
-	},
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "wKw" = (
 /obj/machinery/light/small{
@@ -35444,6 +35450,7 @@
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 5
 	},
+/obj/structure/bed/chair/bay/shuttle,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "xba" = (
@@ -35460,6 +35467,18 @@
 /area/security/evastorage)
 "xbD" = (
 /obj/effect/floor_decal/corner_techfloor_grid/diagonal,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "hammerheadtba";
+	name = "Fighter Tube Access";
+	pixel_x = -26;
+	pixel_y = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "xbW" = (
@@ -36196,10 +36215,11 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 10
+/turf/simulated/floor/maglev{
+	dir = 8;
+	icon_state = "maglevup";
+	name = "launch rail"
 	},
-/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/cockpit)
 "xFu" = (
 /obj/structure/catwalk,
@@ -37119,7 +37139,8 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/shuttle/hammerhead/general)
 "ybH" = (
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
@@ -48380,7 +48401,7 @@ bBF
 keH
 oLJ
 oLJ
-oLJ
+pBj
 oLJ
 oLJ
 pBj
@@ -48768,7 +48789,7 @@ sZs
 sZs
 aqp
 jFC
-jFC
+pBj
 jFC
 jFC
 jFC
@@ -48962,7 +48983,7 @@ gYG
 wsr
 aqF
 hJs
-hJs
+pBj
 hJs
 hJs
 hJs
@@ -49156,7 +49177,7 @@ oWM
 jzu
 aqF
 vyn
-vyn
+pBj
 kIL
 kIL
 kIL
@@ -49350,7 +49371,7 @@ kPS
 aqF
 aqF
 kez
-qFo
+pBj
 kIL
 pvE
 gFN
@@ -49544,7 +49565,7 @@ fJJ
 moy
 aqF
 hga
-hga
+pBj
 kIL
 rzB
 mqP
@@ -49738,7 +49759,7 @@ xTV
 mEd
 hBC
 sEV
-tbE
+pBj
 kIL
 pdw
 sop
@@ -49932,7 +49953,7 @@ ghA
 cQN
 aqF
 qnm
-hga
+pBj
 kIL
 bgd
 tFx
@@ -50126,7 +50147,7 @@ aqF
 aqF
 aqF
 qnm
-hga
+pBj
 kIL
 obW
 qot
@@ -50320,7 +50341,7 @@ hga
 fiN
 oVk
 qnm
-cRS
+pBj
 kIL
 bmS
 bmS
@@ -50514,7 +50535,7 @@ vyB
 jZl
 vTi
 qnm
-cRS
+pBj
 czB
 lXv
 wEc
@@ -50708,7 +50729,7 @@ gVs
 hOw
 qzf
 jHS
-kMS
+pBj
 veK
 cMx
 sqp
@@ -50902,7 +50923,7 @@ vyn
 mmN
 dtc
 oVk
-cRS
+pBj
 gHs
 lQo
 ohN
@@ -51096,7 +51117,7 @@ vyn
 mmN
 dtc
 oVk
-cRS
+pBj
 cRS
 iWe
 iWe
@@ -51290,7 +51311,7 @@ wNZ
 uJC
 dtc
 hga
-rSm
+pBj
 cRS
 iWe
 iWe
@@ -51484,7 +51505,7 @@ wNZ
 uJC
 dtc
 oVk
-vyn
+pBj
 cRS
 cRS
 cRS
@@ -51678,7 +51699,7 @@ wNZ
 uJC
 dtc
 oVk
-vyn
+pBj
 oyx
 vzc
 gPk
@@ -51872,7 +51893,7 @@ vyn
 fgh
 dtc
 oVk
-vyn
+pBj
 dAe
 bIT
 oVk
@@ -52066,7 +52087,7 @@ rls
 ouY
 rRc
 oVk
-kYZ
+pBj
 dAe
 dAe
 nqW
@@ -52227,10 +52248,10 @@ qly
 qly
 qly
 qly
+pFk
 oOw
-oOw
-oOw
-oOw
+hYB
+foa
 oOw
 oOw
 qly
@@ -52260,7 +52281,7 @@ vyn
 uJC
 bgE
 hga
-vyn
+pBj
 hUU
 dAe
 nqW
@@ -52420,10 +52441,10 @@ qly
 qly
 qly
 oOw
+pFk
+pFk
 oOw
-oOw
-oOw
-gzZ
+wqC
 nNP
 oOw
 oOw
@@ -52454,7 +52475,7 @@ vyn
 mmN
 bgE
 oVk
-vyn
+pBj
 qtM
 dAe
 nqW
@@ -52617,13 +52638,13 @@ oOw
 sUa
 seE
 oOw
-uuN
+wqC
 wqC
 oOw
 bpb
 eqt
 oOw
-iCM
+rin
 iCM
 qly
 qly
@@ -52648,7 +52669,7 @@ bWq
 gcX
 iMV
 bWq
-bWq
+pBj
 bWq
 wDR
 bWq
@@ -52808,11 +52829,11 @@ iCM
 iCM
 xjH
 aKa
-sQt
+ehg
 sYU
 oOw
-ufs
-sUJ
+wqC
+wqC
 oOw
 xaM
 sQt
@@ -52842,7 +52863,7 @@ tmh
 kiP
 cYj
 ucP
-aMU
+pBj
 fSu
 jOk
 jOk
@@ -53003,10 +53024,10 @@ uuY
 ehg
 sQt
 ffG
-dhC
+iOM
 mhJ
-fyj
-jyv
+wqC
+wqC
 wdn
 dhC
 pBz
@@ -53036,7 +53057,7 @@ szQ
 gcX
 jGy
 lFw
-mDK
+pBj
 yaL
 mDK
 eVV
@@ -53195,8 +53216,8 @@ qly
 oOw
 eXr
 tUK
-ujL
-sQt
+tuq
+rpT
 qij
 lCs
 xEQ
@@ -53230,7 +53251,7 @@ szQ
 gcX
 szQ
 xyC
-szQ
+pBj
 ora
 szQ
 lTc
@@ -53392,11 +53413,11 @@ oOw
 oOw
 oUW
 dbt
-djJ
-jyv
+djU
+wqC
 vAW
 djU
-dbt
+uoE
 gyO
 oOw
 oOw
@@ -53424,7 +53445,7 @@ szQ
 diz
 kXq
 jBV
-guy
+pBj
 ora
 xco
 lTc
@@ -53590,8 +53611,8 @@ oOw
 iag
 mvg
 oOw
-oOw
-oOw
+sFh
+pXD
 oOw
 oOw
 qly
@@ -53618,7 +53639,7 @@ dep
 dep
 vLE
 dep
-dep
+pBj
 ora
 xco
 lTc
@@ -53777,16 +53798,16 @@ pkX
 qly
 qly
 qly
-qly
-eBF
+jgM
+ilr
 ilr
 ilr
 fpW
 vKi
-ilr
-ilr
-qly
-qly
+iaf
+pxC
+upV
+ote
 qly
 qly
 qly
@@ -53812,7 +53833,7 @@ usA
 jQY
 mEM
 uNo
-dep
+pBj
 qSP
 ssT
 lTc
@@ -53971,16 +53992,16 @@ eqc
 qly
 qly
 qly
-qly
+ilr
 ilr
 ilr
 ilr
 aSz
 bFP
-ilr
-ilr
-ilr
-qly
+iaf
+pxC
+qtd
+ote
 qly
 qly
 qly
@@ -54166,12 +54187,12 @@ qly
 qly
 qly
 ilr
-ilr
+lVu
 qnJ
-nVS
+ilr
 nVS
 qkS
-xbD
+ilr
 hFZ
 ilr
 ilr
@@ -54359,16 +54380,16 @@ aTs
 qly
 qly
 qly
-pQK
-pxC
-pxC
-xbD
-xbD
+ilr
+uRH
+vTR
+ilr
+oIx
 rLY
 xbD
-pxC
-pxC
-kJk
+cpn
+qLw
+ilr
 qly
 qly
 qly
@@ -54552,12 +54573,12 @@ rrr
 cWw
 qly
 qly
-iZI
+qly
 ilr
 kNL
-nLz
-mxh
-xbD
+seJ
+ilr
+oIx
 rLY
 mFf
 nLz
@@ -54746,19 +54767,19 @@ rrr
 cWw
 qly
 qly
-vDu
-oPv
-fSv
+qly
+ilr
+uRH
 gHJ
 hsv
-lKw
+nLz
 wJB
 lXc
 grT
-fSv
+pmF
 njk
 vDu
-qly
+cED
 qly
 qly
 cVK
@@ -54940,19 +54961,19 @@ rrr
 cWw
 qly
 qly
-vDu
-oPv
-fSv
-fSv
-jug
-pxC
+qly
+ilr
+uRH
+gHJ
+hsv
+nLz
 dzD
 wcF
 fSv
-fSv
+ceT
 njk
 vDu
-qly
+cED
 qly
 qly
 cVK
@@ -55134,19 +55155,19 @@ rrr
 cWw
 qly
 qly
-vDu
-oPv
-fSv
-kwh
+qly
+ilr
+oHu
+gHJ
 hsv
-lKw
+nLz
 uSS
-lXc
-grT
-uRN
+usH
+jmy
+ceT
 njk
 vDu
-qly
+cED
 qly
 qly
 cVK
@@ -55328,19 +55349,19 @@ rrr
 cWw
 qly
 qly
-vDu
-oPv
-fSv
-fSv
-jug
-pxC
+qly
+ilr
+raP
+gHJ
+hsv
+nLz
 dzD
-wcF
-fSv
-fSv
+pcN
+ejz
+oSs
 njk
 vDu
-qly
+cED
 qly
 qly
 cVK
@@ -55522,15 +55543,15 @@ cnl
 nSi
 qly
 qly
-cYC
+sZb
 ilr
 rcg
 mkP
-tnu
+ilr
 pPV
 kDT
 ybB
-mkP
+nLz
 hnx
 ilr
 aJI
@@ -55716,18 +55737,18 @@ cnl
 eqc
 qly
 qly
-bru
+qly
 lhE
 rda
 pxC
 trq
-pPV
+buW
 cVx
 ojI
 ieh
 vIN
-azT
-vnt
+ilr
+qly
 qly
 qly
 qly
@@ -55920,7 +55941,7 @@ fZv
 jhd
 vfd
 jwp
-azT
+ilr
 qly
 qly
 qly

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -24740,10 +24740,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
-"pFk" = (
-/obj/spawner/window/low_wall/reinforced/full/firelocks,
-/turf/space/basic,
-/area/shuttle/hammerhead/cockpit)
 "pFw" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -52481,7 +52477,7 @@ qly
 qly
 qly
 qly
-pFk
+iCM
 oOw
 hYB
 foa
@@ -52674,8 +52670,8 @@ qly
 qly
 qly
 oOw
-pFk
-pFk
+iCM
+iCM
 oOw
 wqC
 wqC

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -804,6 +804,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
+"aBu" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/lattice,
+/obj/structure/cable/green{
+	icon_state = "32-1"
+	},
+/turf/simulated/open,
+/area/rift/surfacebase/outside/outside2)
 "aBA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -919,6 +937,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
+"aGE" = (
+/obj/structure/closet/emcloset,
+/obj/item/clothing/glasses/sunglasses/medhud,
+/obj/random/maintenance/medical,
+/turf/simulated/floor/plating,
+/area/rift/surfacebase/outside/outside2)
 "aHd" = (
 /obj/structure/frame{
 	anchored = 1
@@ -2078,7 +2102,8 @@
 /area/maintenance/lower/medsec_maintenance)
 "bkW" = (
 /obj/machinery/light/no_nightshift{
-	dir = 1
+	dir = 1;
+	old_wall = 1
 	},
 /turf/simulated/floor/maglev{
 	dir = 8;
@@ -4043,6 +4068,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/briefing_room)
+"cBh" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/rift/surfacebase/outside/outside2)
 "cBE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5856,6 +5885,9 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
+"dIO" = (
+/turf/simulated/shuttle/wall/voidcraft/red/hard_corner,
+/area/shuttle/hammerhead/general)
 "dIR" = (
 /obj/machinery/vending,
 /turf/simulated/floor/tiled/dark,
@@ -14289,7 +14321,8 @@
 "jhd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/light/no_nightshift{
-	dir = 4
+	dir = 4;
+	old_wall = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/structure/cable/green{
@@ -15332,7 +15365,8 @@
 /area/rnd/research/researchdivision)
 "jTU" = (
 /obj/machinery/light/no_nightshift{
-	dir = 4
+	dir = 4;
+	old_wall = 1
 	},
 /obj/effect/floor_decal/corner_techfloor_gray/full{
 	dir = 8
@@ -17743,7 +17777,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/red)
 "lqt" = (
-/obj/machinery/light/no_nightshift,
+/obj/machinery/light/no_nightshift{
+	old_wall = 1
+	},
 /turf/simulated/floor/maglev{
 	dir = 8;
 	icon_state = "maglevup";
@@ -18902,6 +18938,15 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/security/hallway)
+"lZB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/rift/surfacebase/outside/outside2)
 "lZO" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -24003,6 +24048,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research/xenobio)
+"pgr" = (
+/turf/simulated/shuttle/wall/voidcraft/red/hard_corner,
+/area/shuttle/hammerhead/cockpit)
 "pgI" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -24308,6 +24356,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/breakroom)
+"prf" = (
+/obj/machinery/door/airlock/maintenance/medical{
+	name = "Medical Maintenance Access";
+	req_access = list(5)
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/rift/surfacebase/outside/outside2)
 "pru" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 6
@@ -25057,6 +25119,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
+"pVy" = (
+/turf/simulated/floor/tiled/steel,
+/area/rift/surfacebase/outside/outside2)
 "pVW" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -27104,6 +27169,9 @@
 	},
 /turf/simulated/floor/tiled/monowhite,
 /area/medical/resleeving)
+"rjt" = (
+/turf/simulated/wall/prepainted/medical,
+/area/rift/surfacebase/outside/outside2)
 "rjB" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -27382,6 +27450,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
+"roS" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/rift/surfacebase/outside/outside2)
 "rpT" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -29334,6 +29408,9 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/locker)
+"sJf" = (
+/turf/simulated/wall/prepainted/security,
+/area/rift/surfacebase/outside/outside2)
 "sJg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -29722,6 +29799,11 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
+"taO" = (
+/obj/structure/table/steel,
+/obj/item/material/ashtray/glass,
+/turf/simulated/floor/plating,
+/area/rift/surfacebase/outside/outside2)
 "tbz" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -36605,6 +36687,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hor)
+"xLy" = (
+/obj/machinery/door/airlock/maintenance/medical{
+	name = "Medbay Auxillary Storage"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/rift/surfacebase/outside/outside2)
 "xLB" = (
 /obj/structure/closet/secure_closet/medical3{
 	name = "surgeon's locker"
@@ -48537,7 +48626,7 @@ bBF
 keH
 oLJ
 oLJ
-pBj
+oLJ
 oLJ
 oLJ
 pBj
@@ -48925,7 +49014,7 @@ sZs
 sZs
 aqp
 jFC
-pBj
+jFC
 jFC
 jFC
 jFC
@@ -49119,7 +49208,7 @@ gYG
 wsr
 aqF
 hJs
-pBj
+hJs
 hJs
 hJs
 hJs
@@ -49313,7 +49402,7 @@ oWM
 jzu
 aqF
 vyn
-pBj
+aKq
 kIL
 kIL
 kIL
@@ -49507,7 +49596,7 @@ kPS
 aqF
 aqF
 kez
-pBj
+taO
 kIL
 pvE
 gFN
@@ -49701,7 +49790,7 @@ fJJ
 moy
 aqF
 hga
-pBj
+pVy
 kIL
 rzB
 mqP
@@ -49895,7 +49984,7 @@ xTV
 mEd
 hBC
 sEV
-pBj
+cBh
 kIL
 pdw
 sop
@@ -50089,7 +50178,7 @@ ghA
 cQN
 aqF
 qnm
-pBj
+pVy
 kIL
 bgd
 tFx
@@ -50283,7 +50372,7 @@ aqF
 aqF
 aqF
 qnm
-pBj
+pVy
 kIL
 obW
 qot
@@ -50477,7 +50566,7 @@ hga
 fiN
 oVk
 qnm
-pBj
+rjt
 kIL
 bmS
 bmS
@@ -50671,7 +50760,7 @@ vyB
 jZl
 vTi
 qnm
-pBj
+rjt
 czB
 lXv
 wEc
@@ -50865,7 +50954,7 @@ gVs
 hOw
 qzf
 jHS
-pBj
+prf
 veK
 cMx
 sqp
@@ -51059,7 +51148,7 @@ vyn
 mmN
 dtc
 oVk
-pBj
+rjt
 gHs
 lQo
 ohN
@@ -51253,7 +51342,7 @@ vyn
 mmN
 dtc
 oVk
-pBj
+rjt
 cRS
 iWe
 iWe
@@ -51447,7 +51536,7 @@ wNZ
 uJC
 dtc
 hga
-pBj
+aGE
 cRS
 iWe
 iWe
@@ -51641,7 +51730,7 @@ wNZ
 uJC
 dtc
 oVk
-pBj
+aKq
 cRS
 cRS
 cRS
@@ -51835,7 +51924,7 @@ wNZ
 uJC
 dtc
 oVk
-pBj
+aKq
 oyx
 vzc
 gPk
@@ -52029,7 +52118,7 @@ vyn
 fgh
 dtc
 oVk
-pBj
+aKq
 dAe
 bIT
 oVk
@@ -52223,7 +52312,7 @@ rls
 ouY
 rRc
 oVk
-pBj
+xLy
 dAe
 dAe
 nqW
@@ -52388,7 +52477,7 @@ pFk
 oOw
 hYB
 foa
-oOw
+pgr
 oOw
 qly
 qly
@@ -52417,7 +52506,7 @@ vyn
 uJC
 bgE
 hga
-pBj
+aKq
 hUU
 dAe
 nqW
@@ -52611,7 +52700,7 @@ vyn
 mmN
 bgE
 oVk
-pBj
+aKq
 qtM
 dAe
 nqW
@@ -52805,7 +52894,7 @@ bWq
 gcX
 iMV
 bWq
-pBj
+aKq
 bWq
 wDR
 bWq
@@ -52999,7 +53088,7 @@ tmh
 kiP
 cYj
 ucP
-pBj
+lZB
 fSu
 jOk
 jOk
@@ -53193,7 +53282,7 @@ szQ
 gcX
 jGy
 lFw
-pBj
+roS
 yaL
 mDK
 eVV
@@ -53387,7 +53476,7 @@ szQ
 gcX
 szQ
 xyC
-pBj
+uJq
 ora
 szQ
 lTc
@@ -53546,7 +53635,7 @@ qly
 oOw
 oOw
 oOw
-oOw
+pgr
 oUW
 dbt
 djU
@@ -53581,7 +53670,7 @@ szQ
 diz
 kXq
 jBV
-pBj
+aBu
 ora
 xco
 lTc
@@ -53741,7 +53830,7 @@ qly
 qly
 oOw
 oOw
-oOw
+pgr
 sQt
 oOw
 iag
@@ -53775,7 +53864,7 @@ dep
 dep
 vLE
 dep
-pBj
+sJf
 ora
 xco
 lTc
@@ -53969,7 +54058,7 @@ usA
 jQY
 mEM
 uNo
-pBj
+sJf
 qSP
 ssT
 lTc
@@ -54129,7 +54218,7 @@ qly
 qly
 qly
 ilr
-ilr
+dIO
 aNv
 ilr
 aSz
@@ -55680,7 +55769,7 @@ nSi
 qly
 qly
 qly
-ilr
+dIO
 rcg
 ilr
 ilr
@@ -56265,10 +56354,10 @@ ilr
 ilr
 ijJ
 bap
-ilr
+dIO
 ayE
 ceM
-ilr
+dIO
 kMU
 jNS
 ilr

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -1304,6 +1304,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
 /turf/simulated/floor/reinforced,
 /area/security/hammerhead_bay)
 "aTy" = (
@@ -9665,6 +9668,7 @@
 	req_one_access = list(1,38)
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/hammerhead/general)
 "goH" = (
@@ -21883,6 +21887,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/security/hammerhead_bay)

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -705,10 +705,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "ayE" = (
-/obj/machinery/door/airlock/voidcraft/vertical,
 /obj/map_helper/airlock/door/int_door,
 /obj/effect/floor_decal/corner_techfloor_gray{
 	dir = 8
+	},
+/obj/machinery/door/airlock/glass_external{
+	name = "NPB Hammerhead"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
@@ -3361,7 +3363,6 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/pool)
 "ceM" = (
-/obj/machinery/door/airlock/voidcraft/vertical,
 /obj/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -3380,6 +3381,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass_external{
+	name = "NPB Hammerhead"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
@@ -4108,7 +4112,6 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/hammerhead/general)
 "cEL" = (
-/obj/machinery/door/airlock/voidcraft/vertical,
 /obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button/airlock_interior{
 	dir = 4;
@@ -4121,6 +4124,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
+	},
+/obj/machinery/door/airlock/glass_external{
+	name = "NPB Hammerhead"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
@@ -5932,7 +5938,6 @@
 /turf/simulated/floor/tiled/monowhite,
 /area/medical/surgery_hallway)
 "dKZ" = (
-/obj/machinery/door/airlock/voidcraft/vertical,
 /obj/map_helper/airlock/door/ext_door,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 4;
@@ -5942,6 +5947,9 @@
 	pixel_y = 23
 	},
 /obj/map_helper/airlock/sensor/ext_sensor,
+/obj/machinery/door/airlock/glass_external{
+	name = "NPB Hammerhead"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/hammerhead/general)
 "dLr" = (


### PR DESCRIPTION
## About The Pull Request

Redesigns the hammerhead somewhat to be more like a patrol and response carrier, with a more streamlined design for carrying personnel and detainees. 

Brings the Rift to parity with other maps for security EVA by replacing the spare security officer lockers in EVA storage with an additional security voidsuit and two hazard rigs, plus a hazard rig in the HoS' office.

Increases the Baron's integrity by 200 (from 400 to 600) to offset the damage impacting a wall causes (which is the only way to stop in space currently), and increases the Duke's integrity by 400 to match the intended double armour value.

:cl:
tweak: Redesigned the Hammerhead Patrol Barge
tweak: Increased armour values for the Baron and Duke space fighters
balance: Added an additional voidsuit and three hazard rigs to security to bring the rift to parity with other map values
add: Adds an old_wall flag to lights, allowing them to be placed on old-style walls without ending up inside of them
/:cl: