### PR TITLE
Makes intolerance values way more "logical", easier to follow

### DIFF
--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Dispenser.dm
@@ -100,12 +100,13 @@
 	if(is_vampire)
 		handle_vampire(M, alien, removed, is_vampire)
 
-	var/effective_dose = strength_mod * dose // this was being recalculated a bunch before--why?
 	if(HAS_TRAIT(M, TRAIT_ALCOHOL_INTOLERANT))
-		if(prob((50*removed/strength)))
+		var/intolerant_dose = 50*strength_mod*removed/strength
+		if(prob((intolerant_dose)))
 			M.add_chemical_effect(CE_ALCOHOL_TOXIC, 1)
-		M.adjustToxLoss(50*removed/strength) // 10 strength = 5 tox per u, so 10u deathbell = 50, 10u vodka = 3.3333..., 10u beer = 10
+		M.adjustToxLoss(intolerant_dose) // 10 strength = 5 tox per u, so 10u deathbell = 50, 10u vodka = 3.3333..., 10u beer = 10
 		return 0
+	var/effective_dose = strength_mod * dose // this was being recalculated a bunch before--why?
 	M.add_chemical_effect(CE_ALCOHOL, 1)
 	if(effective_dose >= strength) // Early warning
 		M.make_dizzy(6) // It is decreased at the speed of 3 per tick

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Dispenser.dm
@@ -102,9 +102,9 @@
 
 	var/effective_dose = strength_mod * dose // this was being recalculated a bunch before--why?
 	if(HAS_TRAIT(M, TRAIT_ALCOHOL_INTOLERANT))
-		if(prob(effective_dose/10))
+		if(prob((*effective_dose/strength)))
 			M.add_chemical_effect(CE_ALCOHOL_TOXIC, 1)
-		M.adjustToxLoss(effective_dose/10)
+		M.adjustToxLoss(5*effective_dose/strength)
 		return 0
 	M.add_chemical_effect(CE_ALCOHOL, 1)
 	if(effective_dose >= strength) // Early warning

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Dispenser.dm
@@ -102,7 +102,7 @@
 
 	var/effective_dose = strength_mod * dose // this was being recalculated a bunch before--why?
 	if(HAS_TRAIT(M, TRAIT_ALCOHOL_INTOLERANT))
-		if(prob((*effective_dose/strength)))
+		if(prob((5*effective_dose/strength)))
 			M.add_chemical_effect(CE_ALCOHOL_TOXIC, 1)
 		M.adjustToxLoss(5*effective_dose/strength)
 		return 0

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Dispenser.dm
@@ -102,9 +102,9 @@
 
 	var/effective_dose = strength_mod * dose // this was being recalculated a bunch before--why?
 	if(HAS_TRAIT(M, TRAIT_ALCOHOL_INTOLERANT))
-		if(prob((5*effective_dose/strength)))
+		if(prob((50*removed/strength)))
 			M.add_chemical_effect(CE_ALCOHOL_TOXIC, 1)
-		M.adjustToxLoss(5*effective_dose/strength)
+		M.adjustToxLoss(50*removed/strength) // 10 strength = 5 tox per u, so 10u deathbell = 50, 10u vodka = 3.3333..., 10u beer = 10
 		return 0
 	M.add_chemical_effect(CE_ALCOHOL, 1)
 	if(effective_dose >= strength) // Early warning


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Before: strength of the booze didn't matter, just how much you took, and damage went up quadratically with dose. This was mostly because I didn't understand how the actual dose system worked, ha.

After: damage is 50*species mod*amount metabolized/strength. This is balanced around 1 tox damage per unit of beer; you get 5x as much from deathbell, 3.333... times as much from vodka, and so on.

## Why It's Good For The Game

It rarely, if ever, comes into effect, but it's best that it acts in a way that's predictable.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Alcohol intolerance damage now makes more sense
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
