### PR TITLE
Melee trait fix and balance

### DIFF
--- a/code/modules/mob/living/carbon/human/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/traits/positive.dm
@@ -34,15 +34,23 @@
 
 /datum/trait/positive/melee_attack
 	name = "Sharp Melee"
-	desc = "Provides sharp melee attacks that do slightly more damage."
+	desc = "Provides sharp melee attacks that do more damage."
 	cost = 1
-	var_changes = list("unarmed_types" = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp))
+	var_changes = list("unarmed_types" = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws/good, /datum/unarmed_attack/bite/sharp/good))
+
+/datum/trait/positive/melee_attack/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	S.update_attack_types()
 
 /datum/trait/positive/melee_attack_fangs
-	name = "Sharp Melee & Numbing Fangs"
-	desc = "Provides sharp melee attacks that do slightly more damage, along with fangs that makes the person bit unable to feel their body or pain."
+	name = "Sharp Melee & Venomous Fangs"
+	desc = "Provides sharp melee attacks that do more damage, along with venomous fangs."
 	cost = 2
-	var_changes = list("unarmed_types" = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp, /datum/unarmed_attack/bite/sharp/numbing))
+	var_changes = list("unarmed_types" = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws/good/venom, /datum/unarmed_attack/bite/sharp/good/venom))
+
+/datum/trait/positive/melee_attack_fangs/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	S.update_attack_types()
 
 /datum/trait/positive/minor_brute_resist
 	name = "Minor Brute Resist"

--- a/code/modules/species/species_attack.dm
+++ b/code/modules/species/species_attack.dm
@@ -157,3 +157,26 @@
 /datum/unarmed_attack/bite/sharp/shadekin/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
 	..()
 	user.shadekin_adjust_energy(energy_gain)
+
+//Traits attack
+/datum/unarmed_attack/bite/sharp/good
+	damage = 10
+	damage_tier = MELEE_TIER_LIGHT
+
+/datum/unarmed_attack/claws/good
+	damage = 10
+	damage_tier = MELEE_TIER_LIGHT
+
+/datum/unarmed_attack/bite/sharp/good/venom
+
+/datum/unarmed_attack/bite/sharp/good/venom/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
+	..()
+	if(target.can_inject(null,FALSE,zone,FALSE))
+		target.bloodstr.add_reagent("toxin",2) //8 extra damage per hit over time
+
+/datum/unarmed_attack/claws/good/venom
+
+/datum/unarmed_attack/claws/good/venom/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
+	..()
+	if(target.can_inject(null,FALSE,zone,FALSE))
+		target.bloodstr.add_reagent("toxin",2)


### PR DESCRIPTION
## About The Pull Request

This PR resolves the issue of the traits attacks not applying as well rebalancing them to be a meaningful change.

As for the reason as to why: A basic human attack does 5 to 10 damage. A claw attack does 5 damage. A sharp bite does 3 damage. The numbing bite injects ~2.5 numbying enzyme per hit with 20 being the OD

So not only would it mean that spending 1 point on sharp attacks would actually nerf you. But also if you went the extra mile to take the numbing bite, it would take roughly 8 hits just to reach the OD threshold. A mere toolbox does 10 damage already, a welder even 15. So you would be able to put someone into crit with just 7 hits using a welder. Making the whole trait obsolete by the most basic items.

Instead I have given claws and bites a fixed damage number of 10 with a slightly better armor rating pierce. Not as powerful as Vox claws but better. As for the venomous bite, I am a bit undecided with what toxin to use and the quantity per inject. From a little testing I did, injecting 2 units of basic toxin is not a whole ton and barely feels like it has an impact. Yet this also has the potential to be stupid powerful if tuned up again.
