### PR TITLE
Stops dual esword users from accidentally tripping on accident infront of the enemy

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -357,8 +357,6 @@
 /obj/item/melee/energy/sword/dualsaber/proc/jedi_spin(mob/living/user)
 	for(var/i in list(NORTH,SOUTH,EAST,WEST))
 		user.setDir(i)
-		if(i == WEST)
-			user.emote("flip")
 		sleep(1)
 
 /*
@@ -475,8 +473,6 @@
 /obj/item/melee/energy/sword/charge/dualsaber/proc/jedi_spin(mob/living/user)
 	for(var/i in list(NORTH,SOUTH,EAST,WEST))
 		user.setDir(i)
-		if(i == WEST)
-			user.emote("flip")
 		sleep(1)
 
 //Energy Blade (ninja uses this)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -349,16 +349,6 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	projectile_parry_chance = 85
 
-/obj/item/melee/energy/sword/dualsaber/pre_attack(atom/target, mob/user, clickchain_flags, list/params)
-	if(prob(50))
-		INVOKE_ASYNC(src, PROC_REF(jedi_spin), user)
-	return ..()
-
-/obj/item/melee/energy/sword/dualsaber/proc/jedi_spin(mob/living/user)
-	for(var/i in list(NORTH,SOUTH,EAST,WEST))
-		user.setDir(i)
-		sleep(1)
-
 /*
  *Ionic Rapier
  */
@@ -464,16 +454,6 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	projectile_parry_chance = 65
 	hitcost = 150
-
-/obj/item/melee/energy/sword/charge/dualsaber/pre_attack(atom/target, mob/user, clickchain_flags, list/params)
-	if(prob(50))
-		INVOKE_ASYNC(src, PROC_REF(jedi_spin), user)
-	return ..()
-
-/obj/item/melee/energy/sword/charge/dualsaber/proc/jedi_spin(mob/living/user)
-	for(var/i in list(NORTH,SOUTH,EAST,WEST))
-		user.setDir(i)
-		sleep(1)
 
 //Energy Blade (ninja uses this)
 


### PR DESCRIPTION
Darth Maul didnt trip when he did his spinning. We shouldnt either. Its dumb.

Also TG fixed this ages ago when the flip had a chance to fail. Dual eswords here are not nearly as strong as they are on TG.

Should (TM) remove the pointless flip. 

## About The Pull Request

Fixes dual esword users (as rare as they are cause there are better alternatives) being massive bottoms and accidentally tripping on accident infront of the enemy leaving them in a compromising position.

## Why It's Good For The Game

Randomly getting stunned is not fun. Randomly getting stunned because you faced west randomly due to a proc that is running isnt fun at all since you have zero way to counter it other than picking more viable alternatives. This should diversify weapon choice for both event characters and in the off chance somebody uses a dual chargeblade for whatever reason. ACTUALLY AXES JEDI SPIN ENTIRELY, ITS REALLY BAD INGAME RIGHT NOW, EVERY HIT MAKES YOU SPIN LIKE A 2008 MEME KID!

## Changelog


:cl:
balance: Dual Esword users and its variants users are no longer Theta-tripping on accident infront of the enemy because of a bad roll. Actually axes the jedi spin entirely.
:cl:

## Alternatives???

Nah fam. I am good.
