### PR TITLE
Makes alcohol intolerance work properly with blood

### DIFF
--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Dispenser.dm
@@ -49,9 +49,10 @@
 	var/effective_dose = dose * strength_mod * (1 + volume/60) //drinking a LOT will make you go down faster
 	M.add_chemical_effect(CE_ALCOHOL, 1)
 	if(HAS_TRAIT(M, TRAIT_ALCOHOL_INTOLERANT))
-		if(prob(effective_dose/10))
+		var/intolerant_dose = 100*strength_mod*removed/strength
+		if(prob((intolerant_dose)))
 			M.add_chemical_effect(CE_ALCOHOL_TOXIC, 1)
-		M.adjustToxLoss(effective_dose/10)
+		M.adjustToxLoss(intolerant_dose) // 10 strength = 10 tox per u, so 10u deathbell = 100, 10u vodka = 6.6666..., 10u beer = 20
 		return 0
 	if(effective_dose >= strength) // Early warning
 		M.make_dizzy(18) // It is decreased at the speed of 3 per tick


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Twice as strong injected than ingested, since that feels it ought to be worse.

## Why It's Good For The Game

Weird quadratic damage uncorrelated with actual amount of alcohol is weird

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Alcohol intolerance is now consistent between injection/ingestion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
