### PR TITLE
fixes prisoner IDs not having genpop entry permissions

### DIFF
--- a/code/game/objects/items/id_cards/station_ids.dm
+++ b/code/game/objects/items/id_cards/station_ids.dm
@@ -372,6 +372,7 @@
 	var/sentence = 0 //Sentance in minutes
 	var/crime = "\[redacted\]"
 
+	job_access_type = null
 	access = list(ACCESS_SECURITY_GENPOP_ENTER)
 
 /obj/item/card/id/prisoner/New()

--- a/code/game/objects/structures/crates_lockers/closets/secure/genpop.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/genpop.dm
@@ -46,13 +46,13 @@
 	return TRUE
 
 /obj/structure/closet/secure_closet/genpop/proc/handle_edit_sentence(mob/user)
-	var/prisoner_name = input(user, "Please input the name of the prisoner.", "Prisoner Name", registered_id.registered_name) as text|null
+	var/prisoner_name = tgui_input_text(user, "Please input the name of the prisoner.", "Prisoner Name", registered_id.registered_name)
 	if(prisoner_name == null | !user.Adjacent(src))
 		return FALSE
-	var/sentence_length = input(user, "Please input the length of their sentence in minutes (0 for perma).", "Sentence Length", registered_id.sentence) as num|null
+	var/sentence_length = tgui_input_number(user, "Please input the length of their sentence in minutes (0 for perma).", "Sentence Length", registered_id.sentence)
 	if(sentence_length == null | !user.Adjacent(src))
 		return FALSE
-	var/crimes = input(user, "Please input their crimes.", "Crimes", registered_id.crime) as text|null
+	var/crimes = tgui_input_text(user, "Please input their crimes.", "Crimes", registered_id.crime)
 	if(crimes == null | !user.Adjacent(src))
 		return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: made the genpop lockers use tgui inputs when setting up prisoner IDs
fix: fixed prisoner IDs missing the GENPOP_ENTRY access
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
