### PR TITLE
fixes wrong fake stairs on miaphus beach

### DIFF
--- a/code/game/objects/effects/debris/cleanable/blood.dm
+++ b/code/game/objects/effects/debris/cleanable/blood.dm
@@ -184,6 +184,9 @@ var/global/list/image/splatter_cache=list()
 	if(random_icon_states.len)
 		for(var/obj/effect/debris/cleanable/blood/writing/W in loc)
 			random_icon_states.Remove(W.icon_state)
+		if(!LAZYLEN(random_icon_states))//If all iconstates are already in used by someone else on our tile, delete yourself
+			qdel(src)
+			return
 		icon_state = pick(random_icon_states)
 	else
 		icon_state = "writing1"

--- a/code/modules/mapping/submaps_legacy.dm
+++ b/code/modules/mapping/submaps_legacy.dm
@@ -83,7 +83,10 @@
 					// to_chat(world, "Invalid due to overlapping with area [new_area.type] at ([check.x], [check.y], [check.z]), when attempting to place at ([T.x], [T.y], [T.z]).")
 					break
 				CHECK_TICK
-
+				if(LAZYLEN(check.contents))//The default space tile has no contents, so if there is something there, we shouldnt overwrite it
+					valid = FALSE
+					break
+				CHECK_TICK
 			CHECK_TICK
 
 			if(!valid)

--- a/code/modules/maps/overmap/space/debrisfield.dm
+++ b/code/modules/maps/overmap/space/debrisfield.dm
@@ -186,7 +186,11 @@
 \[i\]Class\[/i\]: Light Escort Carrier
 \[i\]Transponder\[/i\]: Transmitting (MIL), Weak Signal
 \[b\]Notice\[/b\]: Registration Expired"}
-	rename_areas(newname)
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/overmap/entity/visitable/ship/landable/tinycarrier/LateInitialize()
+	. = ..()
+	rename_areas(scanner_name)
 
 /obj/overmap/entity/visitable/ship/landable/tinycarrier/proc/rename_areas(newname)
 	var/datum/shuttle/S = SSshuttle.shuttles[shuttle]

--- a/maps/sectors/miaphus_192/levels/miaphus_192_beach.dmm
+++ b/maps/sectors/miaphus_192/levels/miaphus_192_beach.dmm
@@ -807,8 +807,8 @@
 /turf/simulated/floor/wood,
 /area/tether_away/beach/mineshaft)
 "eZ" = (
-/obj/structure/stairs/middle{
-	dir = 2
+/obj/effect/floor_decal/industrial/halfstair{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/tether_away/beach/desalinator)
@@ -963,8 +963,8 @@
 /turf/simulated/floor/wood,
 /area/tether_away/beach/resort/canteen)
 "gC" = (
-/obj/structure/stairs/middle{
-	dir = 4
+/obj/effect/floor_decal/industrial/halfstair{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/tether_away/beach/desalinator)
@@ -1414,8 +1414,8 @@
 	},
 /area/tether_away/beach/mineshaft)
 "jJ" = (
-/obj/structure/stairs/middle{
-	dir = 4
+/obj/effect/floor_decal/industrial/halfstair{
+	dir = 8
 	},
 /turf/simulated/floor/outdoors/beach/sand/desert,
 /area/tether_away/beach/desalinator)
@@ -1601,9 +1601,7 @@
 /turf/simulated/floor/wood/broken,
 /area/tether_away/beach/resort/dorm2)
 "la" = (
-/obj/structure/stairs/middle{
-	dir = 1
-	},
+/obj/effect/floor_decal/industrial/halfstair,
 /turf/simulated/mineral/floor/cave{
 	name = "dirt"
 	},
@@ -2325,8 +2323,8 @@
 /turf/simulated/floor/wood,
 /area/tether_away/beach/resort/dorm1)
 "rM" = (
-/obj/structure/stairs/middle{
-	dir = 2
+/obj/effect/floor_decal/industrial/halfstair{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/asteroid_steel{
 	outdoors = 1
@@ -5942,7 +5940,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	desc = "Its bone dry.";
-	dir = 2;
 	name = "water pipe"
 	},
 /turf/simulated/floor/tiled/steel_dirty,

--- a/maps/submaps/level_specific/debrisfield_vr/debris14.dmm
+++ b/maps/submaps/level_specific/debrisfield_vr/debris14.dmm
@@ -31,7 +31,6 @@
 /area/tether_away/debrisfield_vr/shuttle_buffer)
 "h" = (
 /obj/structure/lattice,
-/obj/structure/lattice,
 /turf/space,
 /area/tether_away/debrisfield_vr/shuttle_buffer)
 "i" = (


### PR DESCRIPTION
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a couple runtimes that frequently occure during IntTests
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes wrong fake stairs on miaphus beach
fix: fixes duplicate lattice on debris14.dmm
fix: adds extra check to submap seeding, checking if the tiles are empty
fix: adds check when adding blood writing, to make sure we arent using to many instances per tile
fix: fix rename_areas for the tiny carrier should happen during lateload to avoid not finding the shuttle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
