### PR TITLE
genpop QOL updates

### DIFF
--- a/maps/rift/levels/rift-03-underground1.dmm
+++ b/maps/rift/levels/rift-03-underground1.dmm
@@ -2310,6 +2310,13 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"fJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "fK" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloor{
@@ -4497,6 +4504,12 @@
 	},
 /turf/simulated/floor/concrete/indoors,
 /area/security/prison/lower)
+"mT" = (
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "mU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -4823,8 +4836,8 @@
 /obj/machinery/camera/network/security{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/concrete/indoors,
 /area/security/prison/lower)
 "on" = (
@@ -4896,11 +4909,11 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/concrete/indoors,
 /area/security/prison/lower)
@@ -5190,8 +5203,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "pq" = (
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/concrete/indoors,
 /area/security/prison/lower)
 "pr" = (
@@ -5326,6 +5341,12 @@
 "pM" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/rift/station/fighter_bay/transport_tunnel_garage)
+"pN" = (
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/tile/indoors,
+/area/security/prison/lower)
 "pO" = (
 /obj/structure/railing{
 	dir = 8
@@ -5548,6 +5569,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/underone)
+"qD" = (
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/tile/indoors,
+/area/security/prison/lower)
 "qF" = (
 /obj/machinery/door/airlock/maintenance/sec{
 	req_one_access = null
@@ -6859,6 +6886,10 @@
 /obj/machinery/pipedispenser/disposal,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"vp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "vq" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /obj/machinery/meter,
@@ -6994,12 +7025,6 @@
 	},
 /turf/simulated/floor/concrete/rng/indoors,
 /area/rift/station/fighter_bay/transport_tunnel_garage)
-"vN" = (
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 8
-	},
-/turf/simulated/floor/concrete/indoors,
-/area/security/prison/lower)
 "vP" = (
 /obj/item/stack/tile/floor,
 /obj/machinery/light/small{
@@ -7414,6 +7439,10 @@
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/wood,
 /area/rift/station/fighter_bay)
+"xi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "xj" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -9331,6 +9360,12 @@
 	},
 /turf/simulated/floor/tiled/monowhite,
 /area/security/prison/lower)
+"Dz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "DC" = (
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(47)
@@ -10329,6 +10364,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/drone_fabrication)
+"GG" = (
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "GH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
@@ -10427,11 +10468,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "Hb" = (
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/concrete/indoors,
 /area/security/prison/lower)
@@ -11011,6 +11052,11 @@
 /obj/item/reagent_containers/spray/squirt,
 /turf/simulated/floor/plating,
 /area/maintenance/elevator)
+"IS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "IT" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 4;
@@ -12725,9 +12771,10 @@
 /turf/simulated/floor/tiled,
 /area/rnd/secure_storage/upper)
 "Og" = (
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/concrete/indoors,
 /area/security/prison/lower)
 "Oh" = (
@@ -13602,10 +13649,10 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "Rq" = (
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /turf/simulated/floor/concrete/indoors,
@@ -13645,11 +13692,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/rift/station/fighter_bay/maintenance)
 "Rx" = (
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/concrete/indoors,
 /area/security/prison/lower)
@@ -13724,10 +13771,10 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "RK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/floor/concrete/indoors,
@@ -13994,6 +14041,12 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/underone)
+"SD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "SE" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/light{
@@ -14366,11 +14419,9 @@
 /turf/simulated/floor,
 /area/hallway/primary/underone)
 "Uj" = (
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/concrete/indoors,
 /area/security/prison/lower)
@@ -33372,10 +33423,10 @@ ua
 FP
 Vg
 Vg
+GG
 Vg
 Vg
-Vg
-Vg
+mT
 YF
 ua
 Np
@@ -33564,12 +33615,12 @@ Sa
 GK
 yC
 om
-pq
-pq
+IS
+IS
 pq
 Hb
-Vg
-Vg
+vp
+SD
 wj
 ua
 Np
@@ -34342,7 +34393,7 @@ Vg
 Vg
 Vg
 RK
-pq
+IS
 Rq
 Vg
 Vg
@@ -35699,7 +35750,7 @@ dD
 dD
 Ip
 Vg
-vN
+Rx
 dD
 Tk
 Tk
@@ -36087,7 +36138,7 @@ dD
 dD
 Ip
 Vg
-Vg
+Rx
 LR
 Vk
 Vk
@@ -36281,7 +36332,7 @@ dD
 dD
 Xt
 Vg
-Vg
+Rx
 fN
 sP
 sP
@@ -36475,7 +36526,7 @@ dD
 Gf
 Ip
 Vg
-Vg
+Rx
 fN
 sP
 sP
@@ -36669,7 +36720,7 @@ Mk
 Mk
 dD
 Vg
-Vg
+Rx
 fN
 sP
 sP
@@ -36863,7 +36914,7 @@ Vg
 Vg
 Vg
 Vg
-Vg
+Rx
 iA
 sP
 yc
@@ -37051,13 +37102,13 @@ dD
 JV
 yY
 Vg
-Vg
-Vg
-Vg
-Vg
-Vg
-Vg
-Vg
+Dz
+xi
+xi
+xi
+fJ
+IS
+Rq
 lK
 sP
 sP
@@ -37245,11 +37296,11 @@ ua
 ua
 kM
 dD
-dD
+qD
 Vg
 Vg
 Vg
-dD
+pN
 dD
 dD
 lK

--- a/maps/rift/levels/rift-03-underground1.dmm
+++ b/maps/rift/levels/rift-03-underground1.dmm
@@ -3421,6 +3421,7 @@
 /obj/machinery/chemical_dispenser/catering/bar_soft{
 	dir = 4
 	},
+/obj/machinery/fire_alarm/west_mount,
 /turf/simulated/floor/tiled/white,
 /area/security/prison/lower)
 "jx" = (
@@ -4027,6 +4028,10 @@
 "lB" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/appliance/cooker/fryer,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = 30
+	},
 /turf/simulated/floor/tiled/white,
 /area/security/prison/lower)
 "lC" = (
@@ -4818,6 +4823,8 @@
 /obj/machinery/camera/network/security{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /turf/simulated/floor/concrete/indoors,
 /area/security/prison/lower)
 "on" = (
@@ -4888,6 +4895,12 @@
 	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 8
 	},
 /turf/simulated/floor/concrete/indoors,
 /area/security/prison/lower)
@@ -5020,6 +5033,12 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "16-0"
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/prison/lower)
@@ -5170,6 +5189,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"pq" = (
+/obj/machinery/atmospherics/pipe/simple/visible/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "pr" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -5471,6 +5495,15 @@
 "qu" = (
 /obj/structure/closet/crate/freezer,
 /turf/simulated/floor/tiled/freezer/cold,
+/area/security/prison/lower)
+"qw" = (
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor,
 /area/security/prison/lower)
 "qy" = (
 /obj/structure/cable/green{
@@ -6060,6 +6093,7 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/marble,
 /obj/machinery/appliance/mixer/candy,
+/obj/machinery/fire_alarm/east_mount,
 /turf/simulated/floor/tiled/white,
 /area/security/prison/lower)
 "sP" = (
@@ -6960,6 +6994,12 @@
 	},
 /turf/simulated/floor/concrete/rng/indoors,
 /area/rift/station/fighter_bay/transport_tunnel_garage)
+"vN" = (
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "vP" = (
 /obj/item/stack/tile/floor,
 /obj/machinery/light/small{
@@ -7916,6 +7956,8 @@
 /obj/machinery/door/airlock/maintenance/sec{
 	req_one_access = null
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /turf/simulated/floor,
 /area/security/prison/lower)
 "yD" = (
@@ -7966,6 +8008,10 @@
 	dir = 8
 	},
 /turf/simulated/floor/concrete/tile/indoors,
+/area/security/prison/lower)
+"yL" = (
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/turf/simulated/floor/concrete/indoors,
 /area/security/prison/lower)
 "yM" = (
 /obj/effect/floor_decal/rust,
@@ -8489,12 +8535,6 @@
 /obj/machinery/holoplant,
 /turf/simulated/floor/tiled/white,
 /area/rnd/secure_storage/upper)
-"Ay" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/concrete/indoors,
-/area/security/prison/lower)
 "Az" = (
 /obj/machinery/door/window/westleft,
 /obj/machinery/door/blast/shutters{
@@ -8662,6 +8702,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/engineering)
+"Bi" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = 30
+	},
+/turf/simulated/floor/concrete/tile/indoors,
+/area/security/prison/lower)
 "Bj" = (
 /turf/simulated/shuttle/wall/voidcraft,
 /area/turbolift/rmine/under1)
@@ -9865,6 +9913,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/underone)
+"Fx" = (
+/obj/machinery/atmospherics/component/unary/vent_pump/on,
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "Fz" = (
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
@@ -10291,6 +10343,12 @@
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"GK" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/visible/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
+/turf/simulated/floor,
+/area/security/prison/lower)
 "GM" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
@@ -10368,6 +10426,15 @@
 /obj/random/maintenance/engineering,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"Hb" = (
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 5
+	},
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "Hc" = (
 /obj/structure/railing{
 	dir = 4
@@ -11450,6 +11517,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"Kz" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/security/prison/lower)
 "KA" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
@@ -12647,6 +12724,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/rnd/secure_storage/upper)
+"Og" = (
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 9
+	},
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "Oh" = (
 /obj/item/circuitboard/skills{
 	pixel_x = -3;
@@ -12787,6 +12870,12 @@
 "Ox" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/security/prison/lower)
@@ -13372,6 +13461,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/station/protean_nanite_room)
+"QS" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 5
+	},
+/turf/simulated/floor,
+/area/security/prison/lower)
 "QU" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13502,6 +13601,15 @@
 /obj/effect/paint/pipecyan,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
+"Rq" = (
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 9
+	},
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "Rr" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/structure/cable{
@@ -13536,6 +13644,15 @@
 /obj/machinery/camera/network/civilian,
 /turf/simulated/floor/tiled/steel,
 /area/rift/station/fighter_bay/maintenance)
+"Rx" = (
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "Rz" = (
 /obj/machinery/door/blast/shutters{
 	dir = 2;
@@ -13606,6 +13723,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"RK" = (
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 6
+	},
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "RL" = (
 /obj/structure/grille,
 /obj/structure/foamedmetal,
@@ -13701,6 +13827,16 @@
 	},
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/crew_quarters/pool)
+"Sa" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/security/prison/lower)
 "Sb" = (
 /turf/simulated/floor/tiled/white,
 /area/security/prison/lower)
@@ -14229,6 +14365,15 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/underone)
+"Uj" = (
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/indoors,
+/area/security/prison/lower)
 "Ul" = (
 /obj/machinery/space_heater,
 /obj/structure/railing,
@@ -14393,6 +14538,9 @@
 	dir = 1
 	},
 /obj/machinery/scale,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
 /turf/simulated/floor/concrete/indoors,
 /area/security/prison/lower)
 "UL" = (
@@ -15939,6 +16087,12 @@
 "ZH" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/door/airlock/maintenance/sec,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/security/prison/lower)
 "ZJ" = (
@@ -32628,7 +32782,7 @@ aa
 aa
 BH
 gq
-vc
+Kz
 vc
 BH
 aa
@@ -33016,7 +33170,7 @@ ua
 ua
 ua
 JJ
-vc
+Kz
 Vd
 VJ
 ua
@@ -33210,9 +33364,9 @@ ua
 Zi
 vc
 JT
-JT
-vc
-vc
+qw
+GK
+QS
 JJ
 ua
 FP
@@ -33406,14 +33560,14 @@ JT
 JT
 JJ
 Oo
-vc
-vc
+Sa
+GK
 yC
 om
-Vg
-Vg
-Vg
-Vg
+pq
+pq
+pq
+Hb
 Vg
 Vg
 wj
@@ -33606,8 +33760,8 @@ ua
 ua
 UJ
 Jy
-Ay
-Vg
+Jy
+Rx
 Vg
 Jy
 UG
@@ -33995,7 +34149,7 @@ Vg
 Vg
 Vg
 Vg
-Vg
+Rx
 Vg
 Vg
 Vg
@@ -34187,9 +34341,9 @@ Vg
 Vg
 Vg
 Vg
-Vg
-Vg
-Vg
+RK
+pq
+Rq
 Vg
 Vg
 Vg
@@ -34381,7 +34535,7 @@ dD
 dD
 dD
 Vg
-Vg
+Rx
 dD
 Tk
 Tk
@@ -34575,7 +34729,7 @@ ei
 ei
 dD
 Vg
-Vg
+Rx
 dD
 OU
 OU
@@ -34769,7 +34923,7 @@ dD
 lE
 Ip
 Vg
-Vg
+Rx
 dD
 Tk
 Tk
@@ -34963,7 +35117,7 @@ dD
 dD
 lm
 Vg
-Vg
+Rx
 dD
 dD
 dD
@@ -35157,7 +35311,7 @@ dD
 dD
 Ip
 Vg
-Vg
+Rx
 dD
 Tk
 Tk
@@ -35350,8 +35504,8 @@ dD
 dD
 dD
 Ip
-Vg
-Vg
+yL
+Uj
 dD
 OU
 OU
@@ -35545,7 +35699,7 @@ dD
 dD
 Ip
 Vg
-Vg
+vN
 dD
 Tk
 Tk
@@ -35738,8 +35892,8 @@ dD
 dD
 dD
 Ip
-Vg
-Vg
+Fx
+Og
 dD
 dD
 dD
@@ -38839,7 +38993,7 @@ ua
 IA
 SE
 pg
-pg
+Bi
 pg
 SE
 eu

--- a/maps/rift/levels/rift-04-surface1.dmm
+++ b/maps/rift/levels/rift-04-surface1.dmm
@@ -858,6 +858,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "aEE" = (
@@ -2326,6 +2327,20 @@
 	},
 /turf/simulated/floor/lino,
 /area/tether/surfacebase/entertainment/backstage)
+"bDQ" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/machinery/atmospherics/component/unary/vent_pump/on,
+/turf/simulated/floor/tiled/steel,
+/area/security/prison/upper)
 "bEb" = (
 /obj/structure/table/rack/shelf,
 /obj/random/maintenance/security,
@@ -2376,6 +2391,14 @@
 /obj/vehicle_old/train/trolley,
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/hallway)
+"bHw" = (
+/obj/structure/table/reinforced,
+/obj/item/deck/cards{
+	pixel_x = -10;
+	pixel_y = -9
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/security/prison/upper)
 "bHO" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 10
@@ -4800,6 +4823,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "dky" = (
@@ -6378,13 +6402,6 @@
 	},
 /turf/simulated/floor/tiled/monowhite,
 /area/medical/patient_wing)
-"eeH" = (
-/obj/machinery/door/firedoor/glass{
-	dir = 8
-	},
-/obj/machinery/door/airlock/maintenance/sec,
-/turf/simulated/floor/plating,
-/area/security/prison/upper)
 "eeN" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
@@ -9709,6 +9726,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "gzd" = (
@@ -10757,6 +10775,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "hdw" = (
@@ -11461,10 +11480,10 @@
 /obj/machinery/turnstile/exit{
 	dir = 8
 	},
-/obj/structure/curtain/open/shower/security,
 /obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
+/obj/structure/curtain/open/black,
 /turf/simulated/floor/tiled/monodark,
 /area/security/prison/upper)
 "hzW" = (
@@ -13425,13 +13444,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security/lower)
 "iFM" = (
-/obj/machinery/door/airlock/glass/security{
-	id_tag = "cell_lock_3";
-	name = "Cell 3";
-	req_one_access = null
-	},
 /obj/machinery/door/firedoor/glass{
 	dir = 8
+	},
+/obj/machinery/door/airlock/security{
+	id_tag = "cell_lock_3";
+	name = "Cell 1";
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/monodark,
 /area/security/prison/upper)
@@ -13535,6 +13554,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "iJb" = (
@@ -15912,6 +15932,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "kkQ" = (
@@ -16246,13 +16269,13 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/crew_quarters/medbreak)
 "kwn" = (
-/obj/machinery/door/airlock/glass/security{
+/obj/machinery/door/firedoor/glass{
+	dir = 8
+	},
+/obj/machinery/door/airlock/security{
 	id_tag = "cell_lock_2";
 	name = "Cell 2";
 	req_one_access = null
-	},
-/obj/machinery/door/firedoor/glass{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/monodark,
 /area/security/prison/upper)
@@ -18601,6 +18624,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry_lab)
+"lXo" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/security/prison/upper)
 "lYg" = (
 /obj/structure/symbol/sa,
 /turf/simulated/wall/prepainted,
@@ -19813,6 +19851,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 6
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "mIB" = (
@@ -20629,6 +20671,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research/southwest_wing)
+"nja" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/pill_bottle/dice{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/security/prison/upper)
 "njD" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 10
@@ -25704,6 +25754,12 @@
 /obj/structure/cable/green{
 	icon_state = "32-2"
 	},
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/supply{
+	dir = 8
+	},
 /turf/simulated/open,
 /area/maintenance/lowmedbaymaint)
 "qhZ" = (
@@ -26072,6 +26128,9 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 10
 	},
 /turf/simulated/floor/plating,
@@ -28290,6 +28349,10 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = -30
 	},
 /turf/simulated/floor/tiled/steel,
 /area/security/prison/upper)
@@ -33383,6 +33446,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
@@ -35421,6 +35485,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "vQy" = (
@@ -35706,13 +35771,13 @@
 /turf/simulated/floor/outdoors/snow/lythios43c,
 /area/rift/surfacebase/outside/outside1)
 "vXz" = (
-/obj/machinery/door/airlock/glass/security{
+/obj/machinery/door/firedoor/glass{
+	dir = 8
+	},
+/obj/machinery/door/airlock/security{
 	id_tag = "cell_lock_1";
 	name = "Cell 1";
 	req_one_access = null
-	},
-/obj/machinery/door/firedoor/glass{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/monodark,
 /area/security/prison/upper)
@@ -36054,6 +36119,20 @@
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/dark,
+/area/security/prison/upper)
+"wju" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/steel,
 /area/security/prison/upper)
 "wjG" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -37761,6 +37840,21 @@
 	},
 /turf/simulated/floor/lythios43c,
 /area/rift/surfacebase/outside/outside1)
+"xie" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/security/prison/upper)
 "xit" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 10
@@ -58084,8 +58178,8 @@ gcW
 gcW
 gcW
 gcW
-iXO
-cQN
+bDQ
+lXo
 nqs
 eNh
 nqk
@@ -58472,8 +58566,8 @@ gcW
 gcW
 gcW
 gcW
-iXO
-cQN
+wju
+xie
 nqs
 wEf
 lSE
@@ -59428,7 +59522,7 @@ buH
 pnT
 peQ
 yeR
-yeR
+nja
 ejz
 cVb
 gcW
@@ -59621,7 +59715,7 @@ qYv
 buH
 pnT
 ygq
-yeR
+bHw
 yeR
 ejz
 cVb
@@ -60020,7 +60114,7 @@ pnT
 pnT
 pnT
 pnT
-eeH
+pnT
 pnT
 pnT
 pnT

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -2925,6 +2925,9 @@
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monodark,
 /area/security/security_processing)
 "bHs" = (
@@ -8676,6 +8679,10 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_processing)
 "fEL" = (
@@ -13399,6 +13406,18 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/sleep)
+"iED" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/security/hallway)
 "iEO" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/medical,
@@ -15154,6 +15173,9 @@
 "jMp" = (
 /obj/machinery/turnstile/exit{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_processing)
@@ -23017,6 +23039,9 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_processing)
 "oxe" = (
@@ -23606,6 +23631,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
+"oQZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/security/security_processing)
 "oRp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -24009,6 +24040,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -30776,6 +30810,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_processing)
 "tAT" = (
@@ -31120,6 +31155,9 @@
 /area/crew_quarters/sleep)
 "tJz" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -31927,6 +31965,9 @@
 	dir = 1
 	},
 /obj/structure/curtain/open/black,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_processing)
 "uom" = (
@@ -56435,7 +56476,7 @@ hpE
 kzS
 bnf
 tkZ
-vCw
+iED
 grI
 nDY
 nQn
@@ -57017,7 +57058,7 @@ kxd
 ceg
 llM
 llM
-llM
+oQZ
 llM
 yeT
 cPE

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -36556,12 +36556,6 @@
 /obj/effect/floor_decal/corner/red/bordercorner2{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 5
-	},
 /turf/simulated/floor/tiled/steel,
 /area/security/hallway)
 "xsA" = (


### PR DESCRIPTION
Fixes a disposal chute in processing.

Localized entirely within genpop:

Removes airlock next to genpop watchtower.
Adds more fire extinguishers/alarms.
Fixes some spline.
Adds cards/dice to table.
Adds 2 sets of vent/scrubbers to top floor and bottom floor, one per.
Replaced glass cell doors with solid steel.