### PR TITLE
Update skateboard injuries

### DIFF
--- a/code/modules/vehicles_legacy/skateboard.dm
+++ b/code/modules/vehicles_legacy/skateboard.dm
@@ -87,11 +87,22 @@
 			var/turf/T2 = get_step(A, pick(throw_dirs))
 			unload(H)
 			H.throw_at_old(T2, 1, 1, src)
+
+			//Surface injuries
+			H.adjustBruteLoss(rand(3, 5))
 			var/head_slot = SLOT_HEAD
 			if(!head_slot || !(istype(head_slot,/obj/item/clothing/head/helmet) || istype(head_slot,/obj/item/clothing/head/hardhat)))
-				H.setBrainLoss(2,5)
+				//5% chance to suffer severe head trauma because you weren't wearing a helmet
+				if(prob(5))
+					var/obj/item/organ/external/egg = H.get_organ(BP_HEAD)
+					egg?.fracture()
+					H.adjustBrainLoss(rand(5, 10))
+					visible_message("<span class='danger'>[src] crashes into [A], sending [H] flying! They land on their head, that doesn't look good...</span>")
+				else 
+					//Minor brain injury from hitting your head
+					H.adjustBrainLoss(rand(1, 2))
+					visible_message("<span class='danger'>[src] crashes into [A], sending [H] flying!</span>")
 				H.update_health()
-			visible_message("<span class='danger'>[src] crashes into [A], sending [H] flying!</span>")
 			H.afflict_paralyze(20 * 12)
 		else if (rough_terrain)
 			var/list/throw_dirs = list(1, 2, 4, 8, 5, 6, 9, 10)
@@ -100,9 +111,15 @@
 			H.throw_at_old(T2, 1, 1, src)
 			var/head_slot = SLOT_HEAD
 			if(!head_slot || !(istype(head_slot,/obj/item/clothing/head/helmet) || istype(head_slot,/obj/item/clothing/head/hardhat)))
-				H.setBrainLoss(2,5)
+				if(prob(5))
+					var/obj/item/organ/external/egg = H.get_organ(BP_HEAD)
+					egg?.fracture()
+					H.adjustBrainLoss(rand(5, 10))
+					visible_message("<span class='danger'>[src] crashes into [A], sending [H] flying! They land on their head, that doesn't look good...</span>")
+				else 
+					H.adjustBrainLoss(rand(1, 2))
+					visible_message("<span class='danger'>[src] crashes into [A], sending [H] flying!</span>")
 				H.update_health()
-			visible_message("<span class='danger'>[src] crashes into [A], sending [H] flying!</span>")
 			H.afflict_paralyze(20 * 12)
 		else
 			var/backdir = turn(dir, 180)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates skateboard injuries after discussion. If you crash, you now receive some surface injuries regardless. If you are not wearing a helmet, you will receive minor brain damage from knocking your head around, and there is a 5% chance to suffer a severe head injury (your skull automatically fractures and you receive significant brain trauma).

## Why It's Good For The Game

hehe funny skaetberd

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Crashing on a skateboard without proper protection is now much more dangerous.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
