### PR TITLE
Z-Mimic Season Pass 1

### DIFF
--- a/citadel.dme
+++ b/citadel.dme
@@ -557,7 +557,7 @@
 #include "code\controllers\subsystem\vis_overlays.dm"
 #include "code\controllers\subsystem\vote.dm"
 #include "code\controllers\subsystem\xenoarch.dm"
-#include "code\controllers\subsystem\zmimic.dm"
+#include "code\controllers\subsystem\zcopy.dm"
 #include "code\controllers\subsystem\characters\_characters.dm"
 #include "code\controllers\subsystem\characters\backgrounds.dm"
 #include "code\controllers\subsystem\characters\character_species.dm"

--- a/code/__DEFINES/rendering/zmimic.dm
+++ b/code/__DEFINES/rendering/zmimic.dm
@@ -1,41 +1,61 @@
+#define ZM_DESTRUCTION_TIMER(TARGET) addtimer(CALLBACK(TARGET, TYPE_PROC_REF(/datum, qdel_self)), 10 SECONDS, TIMER_STOPPABLE)
 #define TURF_IS_MIMICKING(T) (isturf(T) && (T:mz_flags & MZ_MIMIC_BELOW))
-#define CHECK_OO_EXISTENCE(OO) if (OO && !MOVABLE_IS_ON_ZTURF(OO) && !OO.destruction_timer) { OO.destruction_timer = addtimer(CALLBACK(OO, TYPE_PROC_REF(/datum, qdel_self)), 10 SECONDS, TIMER_STOPPABLE); }
+#define CHECK_OO_EXISTENCE(OO) if (OO && !MOVABLE_IS_ON_ZTURF(OO) && !OO.destruction_timer) { OO.destruction_timer = ZM_DESTRUCTION_TIMER(OO); }
 #define UPDATE_OO_IF_PRESENT CHECK_OO_EXISTENCE(bound_overlay); if (bound_overlay) { update_above(); }
 
 // I do not apologize.
-#define MOVABLE_IS_BELOW_ZTURF(M) (isturf(loc) && ((M:zmm_flags & ZMM_LOOKAHEAD) ? ((get_step(M, M:dir)?:above?:mz_flags & MZ_MIMIC_BELOW) || (loc:above?:mz_flags & MZ_MIMIC_BELOW) || (get_step(M, global.reverse_dir[M:dir])?:above?:mz_flags & MZ_MIMIC_BELOW)) : TURF_IS_MIMICKING(loc:above)))
-#define MOVABLE_IS_ON_ZTURF(M) (isturf(loc) && ((M:zmm_flags & ZMM_LOOKAHEAD) ? ((get_step(M, M:dir)?:mz_flags & MZ_MIMIC_BELOW) || (loc:mz_flags & MZ_MIMIC_BELOW) || (get_step(M, global.reverse_dir[M:dir])?:mz_flags & MZ_MIMIC_BELOW)) : TURF_IS_MIMICKING(loc:above)))
 
-//# Turf Multi-Z flags.
-#define MZ_MIMIC_BELOW     (1<<0)  //! If this turf should mimic the turf on the Z below.
-#define MZ_MIMIC_OVERWRITE (1<<1)  //! If this turf is Z-mimicing, overwrite the turf's appearance instead of using a movable. This is faster, but means the turf cannot have its own appearance (say, edges or a translucent sprite).
-#define MZ_MIMIC_NO_AO     (1<<2)  //! If the turf shouldn't apply regular turf AO and only do Z-mimic AO.
-#define MZ_MIMIC_BASETURF  (1<<3)  //! Mimic baseturf instead of the below atom. Sometimes useful for elevators.
+// These aren't intended to be used anywhere else, they just can't be undef'd because DM is dum.
+#define ZM_INTERNAL_SCAN_LOOKAHEAD(M,VTR,F) ((get_step(M, M:dir)?:VTR & F) || (get_step(M, turn(M:dir, 180))?:VTR & F))
+#define ZM_INTERNAL_SCAN_LOOKBESIDE(M,VTR,F) ((get_step(M, turn(M:dir, 90))?:VTR & F) || (get_step(M, turn(M:dir, -90))?:VTR & F))
 
-#define MZ_ALLOW_LIGHTING  (1<<4)  //! If this turf should permit passage of lighting.
-#define MZ_NO_OCCLUDE      (1<<5)  //! Don't occlude below atoms if we're a non-mimic z-turf.
+/// Is this movable visible from a turf that is mimicking below? Note: this does not necessarily mean *directly* below.
+#define MOVABLE_IS_BELOW_ZTURF(M) (\
+	isturf(M:loc) && (TURF_IS_MIMICKING(M:loc:above) \
+	|| ((M:zmm_flags & ZMM_LOOKAHEAD) && ZM_INTERNAL_SCAN_LOOKAHEAD(M, above?:mz_flags, MZ_MIMIC_BELOW))  \
+	|| ((M:zmm_flags & ZMM_LOOKBESIDE) && ZM_INTERNAL_SCAN_LOOKBESIDE(M, above?:mz_flags, MZ_MIMIC_BELOW))) \
+)
+/// Is this movable located on a turf that is mimicking below? Note: this does not necessarily mean *directly* on.
+#define MOVABLE_IS_ON_ZTURF(M) (\
+	(TURF_IS_MIMICKING(M:loc) \
+	|| ((M:zmm_flags & ZMM_LOOKAHEAD) && ZM_INTERNAL_SCAN_LOOKAHEAD(M, mz_flags, MZ_MIMIC_BELOW)) \
+	|| ((M:zmm_flags & ZMM_LOOKBESIDE) && ZM_INTERNAL_SCAN_LOOKBESIDE(M, mz_flags, MZ_MIMIC_BELOW))) \
+)
+#define MOVABLE_SHALL_MIMIC(AM) (!(AM.zmm_flags & ZMM_IGNORE) && MOVABLE_IS_BELOW_ZTURF(AM))
 
-#define MZ_OPEN_UP         (1<<6)  //! Allow atom movement through top.
-#define MZ_OPEN_DOWN       (1<<7)  //! Allow atom movement through bottom.
+// Turf MZ flags.
+#define MZ_MIMIC_BELOW     (1 << 0)	//! If this turf should mimic the turf on the Z below.
+#define MZ_MIMIC_OVERWRITE (1 << 1)	//! If this turf is Z-mimicking, overwrite the turf's appearance instead of using a movable. This is faster, but means the turf cannot have its own appearance (say, edges or a translucent sprite).
+#define MZ_ALLOW_LIGHTING  (1 << 2)	//! If this turf should permit passage of lighting.
+#define MZ_MIMIC_NO_AO     (1 << 3)	//! If the turf shouldn't apply regular turf AO and only do Z-mimic AO.
+#define MZ_NO_OCCLUDE     (1 << 4)	//! Don't occlude below atoms if we're a non-mimic z-turf.
+#define MZ_OVERRIDE       (1 << 5)	//! Copy only z_appearance or baseturf and bail, do not attempt to copy movables. This is significantly cheaper and allows you to override the mimic, but results in movables not being visible.
+#define MZ_NO_SHADOW      (1 << 6)	//! If this turf is being copied, hide the shadower.
+#define MZ_TERMINATOR     (1 << 7)	//! Consider this turf the terminus of a Z-group, like the bottom of a Z-group or a MZ_OVERRIDE turf.
 
-#define MZ_ATMOS_UP        (1<<8)  //! Allow atmos passage through top.
-#define MZ_ATMOS_DOWN      (1<<9)  //! Allow atmos passage through bottom.
+#define MZ_OPEN_UP         (1 << 8)  //! Allow atom movement through top.
+#define MZ_OPEN_DOWN       (1 << 9)  //! Allow atom movement through bottom.
 
-//# Convenience flags.
-#define MZ_MIMIC_DEFAULTS (MZ_MIMIC_BELOW|MZ_ALLOW_LIGHTING)
+#define MZ_ATMOS_UP        (1 << 10)  //! Allow atmos passage through top.
+#define MZ_ATMOS_DOWN      (1 << 11)  //! Allow atmos passage through bottom.
+
+
+// Convenience flags.
+#define MZ_MIMIC_DEFAULTS (MZ_MIMIC_BELOW|MZ_ALLOW_LIGHTING)	//! Common defaults for zturfs.
 #define MZ_ATMOS_BOTH (MZ_ATMOS_UP|MZ_ATMOS_DOWN)
 #define MZ_OPEN_BOTH  (MZ_OPEN_UP|MZ_OPEN_DOWN)
+#define ZMM_WIDE_LOAD (ZMM_LOOKAHEAD | ZMM_LOOKBESIDE)	//! Atom is big and needs to scan one extra turf in both X and Y. This only extends the range by one turf. Cheap, but not free.
 
-/// For debug purposes, should contain the above defines in ascending order.
-// TODO: Make it just print mz_flags bitfield. @Zandario
-var/list/mimic_defines = list(
+// For debug purposes, should contain the above defines in ascending order.
+var/global/list/mimic_defines = list(
 	"MZ_MIMIC_BELOW",
 	"MZ_MIMIC_OVERWRITE",
-	"MZ_MIMIC_NO_AO",
-	"MZ_MIMIC_BASETURF",
-
 	"MZ_ALLOW_LIGHTING",
+	"MZ_MIMIC_NO_AO",
 	"MZ_NO_OCCLUDE",
+	"MZ_OVERRIDE",
+	"MZ_NO_SHADOW",
+	"MZ_TERMINATOR",
 
 	"MZ_OPEN_UP",
 	"MZ_OPEN_DOWN",
@@ -47,11 +67,12 @@ var/list/mimic_defines = list(
 DEFINE_BITFIELD(mz_flags, list(
 	BITFIELD(MZ_MIMIC_BELOW),
 	BITFIELD(MZ_MIMIC_OVERWRITE),
-	BITFIELD(MZ_MIMIC_NO_AO),
-	BITFIELD(MZ_MIMIC_BASETURF),
-
 	BITFIELD(MZ_ALLOW_LIGHTING),
+	BITFIELD(MZ_MIMIC_NO_AO),
 	BITFIELD(MZ_NO_OCCLUDE),
+	BITFIELD(MZ_OVERRIDE),
+	BITFIELD(MZ_NO_SHADOW),
+	BITFIELD(MZ_TERMINATOR),
 
 	BITFIELD(MZ_OPEN_UP),
 	BITFIELD(MZ_OPEN_DOWN),
@@ -61,12 +82,13 @@ DEFINE_BITFIELD(mz_flags, list(
 ))
 
 
-//# Movable mz_flags.
-#define ZMM_IGNORE          (1<<0) //! Do not copy this movable. Atoms with INVISIBILITY_ABSTRACT implicitly do not copy.
-#define ZMM_MANGLE_PLANES   (1<<1) //! Check this movable's overlays/underlays for explicit plane use and mangle for compatibility with Z-Mimic. If you're using emissive overlays, you probably should be using this flag. Expensive, only use if necessary.
-#define ZMM_LOOKAHEAD       (1<<2) //! Look one turf ahead and one turf back when considering z-turfs that might be seeing this atom. Cheap, but not free.
-#define ZMM_AUTOMANGLE_NRML (1<<3) //! Behaves the same as ZMM_MANGLE_PLANES, but is automatically applied by SSoverlays. Do not manually use.
-#define ZMM_AUTOMANGLE_PRI  (1<<4) //! Behaves the same as ZMM_MANGLE_PLANES, but is automatically applied by SSoverlays. Do not manually use.
+// Movable flags.
+#define ZMM_IGNORE          (1 << 0)	//! Do not copy this movable. Atoms may be excluded from copy automatically regardless of this flag.
+#define ZMM_MANGLE_PLANES   (1 << 1)	//! Check this movable's overlays/underlays for explicit plane use and mangle for compatibility with Z-Mimic. If you're using emissive overlays, you probably should be using this flag. Expensive, only use if necessary.
+#define ZMM_LOOKAHEAD       (1 << 2)	//! Look one turf ahead and one turf back when considering z-turfs that might be seeing this atom. Cheap, but not free.
+#define ZMM_LOOKBESIDE      (1 << 3)	//! Look one turf beside (left/right) when considering z-turfs that might be seeing this atom. Cheap, but not free.
+#define ZMM_AUTOMANGLE_NRML (1 << 4)	//! Behaves the same as ZMM_MANGLE_PLANES, but is automatically applied by SSoverlays. Do not manually use.
+#define ZMM_AUTOMANGLE_PRI  (1 << 5)	//! Behaves the same as ZMM_MANGLE_PLANES, but is automatically applied by SSoverlays. Do not manually use.
 
 #define ZMM_AUTOMANGLE (ZMM_AUTOMANGLE_NRML|ZMM_AUTOMANGLE_PRI)	// convenience
 
@@ -74,6 +96,7 @@ DEFINE_BITFIELD(zmm_flags, list(
 	BITFIELD(ZMM_IGNORE),
 	BITFIELD(ZMM_MANGLE_PLANES),
 	BITFIELD(ZMM_LOOKAHEAD),
+	BITFIELD(ZMM_LOOKBESIDE),
 	BITFIELD(ZMM_AUTOMANGLE_NRML),
 	BITFIELD(ZMM_AUTOMANGLE_PRI)
 ))

--- a/code/controllers/subsystem/zcopy.dm
+++ b/code/controllers/subsystem/zcopy.dm
@@ -1,6 +1,8 @@
-/**
- *! Here be dragons.
- */
+/*
+
+	Here be dragons.
+
+*/
 
 #define OPENTURF_MAX_PLANE -70
 /// The maxiumum number of planes deep we'll go before we just dump everything on the same plane.
@@ -11,8 +13,21 @@
 #define SHADOWER_DARKENING_COLOR "#999999"
 #define READ_BASETURF(T) (islist(T.baseturfs) ? T.baseturfs[length(T.baseturfs)] : T.baseturfs)
 
-SUBSYSTEM_DEF(zmimic)
-	name = "Z-Mimic"
+
+#define ZM_RECORD_STATS
+
+#ifdef ZM_RECORD_STATS
+#define ZM_RECORD_START STAT_START_STOPWATCH
+#define ZM_RECORD_STOP STAT_STOP_STOPWATCH
+#define ZM_RECORD_WRITE(X...) STAT_LOG_ENTRY(##X)
+#else
+#define ZM_RECORD_START
+#define ZM_RECORD_STOP
+#define ZM_RECORD_WRITE(X...)
+#endif
+
+SUBSYSTEM_DEF(zcopy)
+	name = "Z-Copy"
 	wait = 1
 	init_order = INIT_ORDER_ZMIMIC
 	priority = FIRE_PRIORITY_ZMIMIC
@@ -27,7 +42,18 @@ SUBSYSTEM_DEF(zmimic)
 	var/openspace_turfs = 0
 
 	var/multiqueue_skips_turf = 0
+	var/multiqueue_skips_discovery = 0
 	var/multiqueue_skips_object = 0
+
+	var/total_updates_turf = 0
+	var/total_updates_discovery = 0
+	var/total_updates_object = 0
+
+#ifdef ZM_RECORD_STATS
+	var/list/turf_stats = list()
+	var/list/discovery_stats = list()
+	var/list/mimic_stats = list()
+#endif
 
 	// Highest Z level in a given Z-group for absolute layering.
 	// zstm[zlev] = group_max
@@ -43,10 +69,10 @@ SUBSYSTEM_DEF(zmimic)
 	var/fixup_hit = 0
 
 // for admin proc-call
-/datum/controller/subsystem/zmimic/proc/update_all()
+/datum/controller/subsystem/zcopy/proc/update_all()
 	// disable()
 	can_fire = FALSE
-	log_debug("SSzmimic: update_all() invoked.")
+	log_debug("SSzcopy: update_all() invoked.")
 
 	var/turf/T 	// putting the declaration up here totally speeds it up, right?
 	var/num_upd = 0
@@ -71,7 +97,7 @@ SUBSYSTEM_DEF(zmimic)
 
 		CHECK_TICK
 
-	log_debug("SSzmimic: [num_upd + num_amupd] turf updates queued ([num_upd] direct, [num_amupd] indirect), [num_del] orphans destroyed.")
+	log_debug("SSzcopy: [num_upd + num_amupd] turf updates queued ([num_upd] direct, [num_amupd] indirect), [num_del] orphans destroyed.")
 
 	// enable()
 	if (!can_fire)
@@ -79,10 +105,10 @@ SUBSYSTEM_DEF(zmimic)
 		can_fire = TRUE
 
 // for admin proc-call
-/datum/controller/subsystem/zmimic/proc/hard_reset()
+/datum/controller/subsystem/zcopy/proc/hard_reset()
 	// disable()
 	can_fire = FALSE
-	log_debug("SSzmimic: hard_reset() invoked.")
+	log_debug("SSzcopy: hard_reset() invoked.")
 	var/num_deleted = 0
 	var/num_turfs = 0
 
@@ -109,28 +135,30 @@ SUBSYSTEM_DEF(zmimic)
 
 		CHECK_TICK
 
-	log_debug("SSzmimic: deleted [num_deleted] overlays, and queued [num_turfs] turfs for update.")
+	log_debug("SSzcopy: deleted [num_deleted] overlays, and queued [num_turfs] turfs for update.")
 
 	// enable()
 	if (!can_fire)
 		next_fire = world.time + wait
 		can_fire = TRUE
 
-/datum/controller/subsystem/zmimic/stat_entry()
+/datum/controller/subsystem/zcopy/stat_entry()
 	var/list/entries = list(
 		"",	// newline
 		"ZSt: [build_zstack_display()]",	// This is a human-readable list of the z-stacks known to ZM.
 		"ZMx: [zlev_maximums.Join(", ")]",	// And this is the raw internal state.
 		// This one gets broken out from the below because it's more important.
 		"Q: { T: [queued_turfs.len - (qt_idex - 1)] O: [queued_overlays.len - (qo_idex - 1)] }",
-		// In order: Total, Skipped
-		"T: { T: [openspace_turfs] O: [openspace_overlays] } Sk: { T: [multiqueue_skips_turf] O: [multiqueue_skips_object] }",
-		"F: { H: [fixup_hit] M: [fixup_miss] N: [fixup_noop] FC: [fixup_cache.len] FKG: [fixup_known_good.len] }",	// Fixup stats.
+		// In order: Total, Queued, Skipped
+		"T(O): { T: [openspace_turfs] O: [openspace_overlays] }",
+		"T(U): { T: [total_updates_turf] D: [total_updates_discovery] O: [total_updates_object] }",
+		"Sk: { T: [multiqueue_skips_turf] D: [multiqueue_skips_discovery] O: [multiqueue_skips_object] }",
+		"F: { H: [fixup_hit] M: [fixup_miss] N: [fixup_noop] FC: [fixup_cache.len] FKG: [fixup_known_good.len] }"
 	)
 	return ..() + entries.Join("<br>&emsp;")
 
 // 1, 2, 3..=7, 8
-/datum/controller/subsystem/zmimic/proc/build_zstack_display()
+/datum/controller/subsystem/zcopy/proc/build_zstack_display()
 	if (!zlev_maximums.len)
 		return "<none>"
 	var/list/zmx = list()
@@ -148,14 +176,14 @@ SUBSYSTEM_DEF(zmimic)
 	while (idx <= zlev_maximums.len)
 	return jointext(zmx, ", ")
 
-/datum/controller/subsystem/zmimic/Initialize(timeofday)
+/datum/controller/subsystem/zcopy/Initialize(timeofday)
 	calculate_zstack_limits()
 	// Flush the queue.
 	fire(FALSE, TRUE)
 	return ..()
 
 // If you add a new Zlevel or change Z-connections, call this.
-/datum/controller/subsystem/zmimic/proc/calculate_zstack_limits()
+/datum/controller/subsystem/zcopy/proc/calculate_zstack_limits()
 	zlev_maximums = new(world.maxz)
 	var/start_zlev = 1
 	for (var/z in 1 to world.maxz)
@@ -163,12 +191,12 @@ SUBSYSTEM_DEF(zmimic)
 			for (var/member_zlev in start_zlev to z)
 				zlev_maximums[member_zlev] = z
 			if (z - start_zlev > OPENTURF_MAX_DEPTH)
-				log_subsystem("zmimic", "WARNING: Z-levels [start_zlev] through [z] exceed maximum depth of [OPENTURF_MAX_DEPTH]; layering may behave strangely in this Z-stack.")
+				log_subsystem("zcopy", "WARNING: Z-levels [start_zlev] through [z] exceed maximum depth of [OPENTURF_MAX_DEPTH]; layering may behave strangely in this Z-stack.")
 			else if (z - start_zlev > 1)
-				log_subsystem("zmimic", "Found Z-Stack: [start_zlev] -> [z] = [z - start_zlev + 1] zl")
+				log_subsystem("zcopy", "Found Z-Stack: [start_zlev] -> [z] = [z - start_zlev + 1] zl")
 			start_zlev = z + 1
 
-	log_subsystem("zmimic", "Z-Level maximums: [json_encode(zlev_maximums)]")
+	log_subsystem("zcopy", "Z-Level maximums: [json_encode(zlev_maximums)]")
 
 // /datum/controller/subsystem/zmimic/StartLoadingMap()
 // 	suspend()
@@ -177,7 +205,8 @@ SUBSYSTEM_DEF(zmimic)
 // 	wake()
 
 /// Fully reset Z-Mimic, rebuilding state from scratch. Use this if you change Z-stack mappings after Z-Mimic has initialized. Expensive.
-/datum/controller/subsystem/zmimic/proc/RebuildZState()
+/// WARNING: This is *completely unsupported*. It will probably irreversibly corrupt Z-lighting everywhere in the world. Use at own risk.
+/datum/controller/subsystem/zcopy/proc/RebuildZState()
 	// suspend()
 	UNTIL(state == SS_IDLE)
 
@@ -193,7 +222,7 @@ SUBSYSTEM_DEF(zmimic)
 			CHECK_TICK
 	// wake()
 
-/datum/controller/subsystem/zmimic/fire(resumed = FALSE, no_mc_tick = FALSE)
+/datum/controller/subsystem/zcopy/fire(resumed = FALSE, no_mc_tick = FALSE)
 	if (!resumed)
 		qt_idex = 1
 		qo_idex = 1
@@ -202,8 +231,16 @@ SUBSYSTEM_DEF(zmimic)
 	if (!no_mc_tick)
 		MC_SPLIT_TICK
 
+	tick_turfs(no_mc_tick)
+
+	if (!no_mc_tick)
+		MC_SPLIT_TICK
+
+	tick_mimic(no_mc_tick)
+
+// - Turf mimic -
+/datum/controller/subsystem/zcopy/proc/tick_turfs(no_mc_tick)
 	var/list/curr_turfs = queued_turfs
-	var/list/curr_ov = queued_overlays
 
 	while (qt_idex <= curr_turfs.len)
 		var/turf/T = curr_turfs[qt_idex]
@@ -231,17 +268,22 @@ SUBSYSTEM_DEF(zmimic)
 		// Z-Turf on the bottom-most level, just fake-copy space (or baseturf).
 		// It's impossible for anything to be on the synthetic turf, so ignore the rest of the ZM machinery.
 		if (!T.below)
+			ZM_RECORD_START
 			flush_z_state(T)
-			if (T.mz_flags & MZ_MIMIC_BASETURF)
+			if (T.mz_flags & MZ_OVERRIDE)
 				simple_appearance_copy(T, READ_BASETURF(T), OPENTURF_MAX_PLANE)
 			else
 				simple_appearance_copy(T, /turf/space)
 
 			T.z_generation += 1
 			T.z_queued -= 1
+			total_updates_turf += 1
 
 			if (T.above)
 				T.above.update_mimic()
+
+			ZM_RECORD_STOP
+			ZM_RECORD_WRITE(turf_stats, "Fake: [T.type] on [T.z]")
 
 			if (no_mc_tick)
 				CHECK_TICK
@@ -255,9 +297,12 @@ SUBSYSTEM_DEF(zmimic)
 
 		T.z_generation += 1
 
+		ZM_RECORD_START
+
 		// Get the bottom-most turf, the one we want to mimic.
+		// Baseturf mimics act as false bottoms of the stack.
 		var/turf/Td = T
-		while (Td.below)
+		while (Td.below && !(Td.mz_flags & (MZ_OVERRIDE|MZ_TERMINATOR)))
 			Td = Td.below
 
 		// Depth must be the depth of the *visible* turf, not self.
@@ -267,14 +312,18 @@ SUBSYSTEM_DEF(zmimic)
 		var/t_target = OPENTURF_MAX_PLANE - turf_depth	// This is where the turf (but not the copied atoms) gets put.
 
 		// Turf is set to mimic baseturf, handle that and bail.
-		if (T.mz_flags & MZ_MIMIC_BASETURF)
+		if (T.mz_flags & MZ_OVERRIDE)
 			flush_z_state(T)
-			simple_appearance_copy(T, READ_BASETURF(T), t_target)
+			simple_appearance_copy(T, Td.z_appearance || READ_BASETURF(T), t_target)
 
 			if (T.above)
 				T.above.update_mimic()
 
+			total_updates_turf += 1
 			T.z_queued -= 1
+
+			ZM_RECORD_STOP
+			ZM_RECORD_WRITE(turf_stats, "Simple: [T.type] on [T.z]")
 
 			if (no_mc_tick)
 				CHECK_TICK
@@ -282,22 +331,20 @@ SUBSYSTEM_DEF(zmimic)
 				break
 			continue
 
-		// If we previously were MZ_MIMIC_BASETURF, there might be an orphaned proxy.
+		// If we previously were MZ_OVERRIDE, there might be an orphaned proxy.
 		else if (T.mimic_underlay)
 			QDEL_NULL(T.mimic_underlay)
-
 
 		// Handle space parallax & starlight.
 		if (T.below.z_eventually_space)
 			T.z_eventually_space = TRUE
-			if ((T.below.mz_flags & MZ_MIMIC_OVERWRITE) || T.below.type == /turf/space)
-				t_target = SPACE_PLANE
+			t_target = SPACE_PLANE
 
 		if (T.mz_flags & MZ_MIMIC_OVERWRITE)
 			// This openturf doesn't care about its icon, so we can just overwrite it.
 			if (T.below.mimic_proxy)
 				QDEL_NULL(T.below.mimic_proxy)
-			T.appearance = T.below
+			T.appearance = Td.z_appearance || Td
 			T.name = initial(T.name)
 			T.desc = initial(T.desc)
 			T.gender = initial(T.gender)
@@ -308,7 +355,7 @@ SUBSYSTEM_DEF(zmimic)
 			if (!T.below.mimic_proxy)
 				T.below.mimic_proxy = new(T)
 			var/atom/movable/openspace/turf_proxy/TO = T.below.mimic_proxy
-			TO.appearance = Td
+			TO.appearance = Td.z_appearance || Td
 			TO.name = T.name
 			TO.gender = T.gender	// Need to grab this too so PLURAL works properly in examine.
 			TO.opacity = FALSE
@@ -333,74 +380,44 @@ SUBSYSTEM_DEF(zmimic)
 
 		// Handle below atoms.
 
-		// Add everything below us to the update queue.
+		var/shadower_set = FALSE
+
+		// Add everything below us to the discovery queue.
 		for (var/thing in T.below)
 			var/atom/movable/object = thing
 			if (QDELETED(object) || (object.zmm_flags & ZMM_IGNORE) || object.loc != T.below || object.invisibility == INVISIBILITY_ABSTRACT)
-				// Don't queue deleted stuff, stuff that's not visible, blacklisted stuff, or stuff that's centered on another tile but intersects ours.
+				/* Don't queue:
+					- (q)deleted objects
+					- Explicitly ignored objects
+					- Objects not rooted on this turf (multitiles)
+					- Always-invisible atoms
+				*/
 				continue
 
 			// Special case: these are merged into the shadower to reduce memory usage.
 			if (object.type == /atom/movable/lighting_overlay)
-				T.shadower.copy_lighting(object)
+				T.shadower.copy_lighting(object, !(T.below.mz_flags & MZ_NO_SHADOW))
 				continue
 
-			if (!object.bound_overlay)	// Generate a new overlay if the atom doesn't already have one.
-				object.bound_overlay = new(T)
-				object.bound_overlay.associated_atom = object
+			// If an atom already has an overlay, we probably don't need to discover it again.
+			// ...but we need to force it if the object was salvaged from another zturf.
+			if (!object.bound_overlay || object.bound_overlay.destruction_timer)
+				discover_movable(object, T)
 
-			var/override_depth
-			var/original_type = object.type
-			var/original_z = object.z
-			var/have_performed_fixup = FALSE
-
-			switch (object.type)
-				// Layering for recursive mimic needs to be inherited.
-				if (/atom/movable/openspace/mimic)
-					var/atom/movable/openspace/mimic/OOO = object
-					original_type = OOO.mimiced_type
-					override_depth = OOO.override_depth
-					original_z = OOO.original_z
-					have_performed_fixup = OOO.have_performed_fixup
-
-				// If this is a turf proxy (the mimic for a non-OVERWRITE turf), it needs to respect space parallax if relevant.
-				if (/atom/movable/openspace/turf_proxy)
-					if (T.z_eventually_space)
-						// Yes, this is an awful hack; I don't want to add yet another override_* var.
-						override_depth = OPENTURF_MAX_PLANE - SPACE_PLANE
-
-				if (/atom/movable/openspace/turf_mimic)
-					original_z += 1
-
-			var/atom/movable/openspace/mimic/OO = object.bound_overlay
-
-			// If the OO was queued for destruction but was claimed by another OT, stop the destruction timer.
-			if (OO.destruction_timer)
-				deltimer(OO.destruction_timer)
-				OO.destruction_timer = null
-
-			OO.depth = override_depth || min(zlev_maximums[T.z] - original_z, OPENTURF_MAX_DEPTH)
-
-			// These types need to be pushed a layer down for bigturfs to function correctly.
-			switch (original_type)
-				if (/atom/movable/openspace/multiplier, /atom/movable/openspace/turf_proxy)
-					if (OO.depth < OPENTURF_MAX_DEPTH)
-						OO.depth += 1
-
-			OO.mimiced_type = original_type
-			OO.override_depth = override_depth
-			OO.original_z = original_z
-			OO.have_performed_fixup ||= have_performed_fixup
-
-			// Multi-queue to maintain ordering of updates to these
-			//   queueing it multiple times will result in only the most recent
-			//   actually processing.
-			OO.queued += 1
-			queued_overlays += OO
+		if (!shadower_set)
+			if (T.below.mz_flags & MZ_NO_SHADOW)
+				T.shadower.color = null
+			else
+				T.shadower.color = SHADOWER_DARKENING_COLOR
 
 		T.z_queued -= 1
 		if (T.above)
 			T.above.update_mimic()
+
+		total_updates_turf += 1
+
+		ZM_RECORD_STOP
+		ZM_RECORD_WRITE(turf_stats, "Complex: [T.type] on [T.z]")
 
 		if (no_mc_tick)
 			CHECK_TICK
@@ -411,9 +428,9 @@ SUBSYSTEM_DEF(zmimic)
 		curr_turfs.Cut(1, qt_idex)
 		qt_idex = 1
 
-	if (!no_mc_tick)
-		MC_SPLIT_TICK
-
+// - Phase: Mimic update -- actually update the mimics' appearance, order sensitive -
+/datum/controller/subsystem/zcopy/proc/tick_mimic(no_mc_tick)
+	var/list/curr_ov = queued_overlays
 	while (qo_idex <= curr_ov.len)
 		var/atom/movable/openspace/mimic/OO = curr_ov[qo_idex]
 		curr_ov[qo_idex] = null
@@ -426,8 +443,9 @@ SUBSYSTEM_DEF(zmimic)
 				break
 			continue
 
-		if (QDELETED(OO.associated_atom))	// This shouldn't happen, but just in-case.
+		if (QDELETED(OO.associated_atom))	// This shouldn't happen.
 			qdel(OO)
+			log_debug("Z-Mimic: Received mimic with QDELETED parent ([OO.associated_atom || "<NULL>"])")
 
 			if (no_mc_tick)
 				CHECK_TICK
@@ -446,22 +464,24 @@ SUBSYSTEM_DEF(zmimic)
 				break
 			continue
 
+		ZM_RECORD_START
+
 		// Actually update the overlay.
 		if (OO.dir != OO.associated_atom.dir)
-			OO.setDir(OO.associated_atom.dir)
+			OO.dir = OO.associated_atom.dir	// updates are propagated up another way, don't use set_dir
+		OO.appearance = OO.associated_atom
+		OO.zmm_flags = OO.associated_atom.zmm_flags
 
 		if (OO.particles != OO.associated_atom.particles)
 			OO.particles = OO.associated_atom.particles
 
-		OO.appearance = OO.associated_atom
-		OO.zmm_flags = OO.associated_atom.zmm_flags
 		OO.plane = OPENTURF_MAX_PLANE - OO.depth
 
 		OO.opacity = FALSE
 		OO.queued = 0
 
 		// If an atom has explicit plane sets on its overlays/underlays, we need to replace the appearance so they can be mangled to work with our planing.
-		if (OO.zmm_flags & (ZMM_MANGLE_PLANES | ZMM_AUTOMANGLE))
+		if (OO.zmm_flags & ZMM_MANGLE_PLANES)
 			var/new_appearance = fixup_appearance_planes(OO.appearance)
 			if (new_appearance)
 				OO.appearance = new_appearance
@@ -469,6 +489,11 @@ SUBSYSTEM_DEF(zmimic)
 
 		if (OO.bound_overlay)	// If we have a bound overlay, queue it too.
 			OO.update_above()
+
+		total_updates_object += 1
+
+		ZM_RECORD_STOP
+		ZM_RECORD_WRITE(mimic_stats, OO.mimiced_type)
 
 		if (no_mc_tick)
 			CHECK_TICK
@@ -479,17 +504,88 @@ SUBSYSTEM_DEF(zmimic)
 		curr_ov.Cut(1, qo_idex)
 		qo_idex = 1
 
-/datum/controller/subsystem/zmimic/proc/flush_z_state(turf/T)
+// return: is-invalid
+/datum/controller/subsystem/zcopy/proc/discover_movable(atom/movable/object)
+	ASSERT(!QDELETED(object))
+
+	var/turf/Tloc = object.loc
+	if (!isturf(Tloc) || !Tloc.above)
+		return TRUE
+
+	var/turf/T = Tloc.above
+
+	ZM_RECORD_START
+
+	if (!object.bound_overlay)
+		var/atom/movable/openspace/mimic/M = new(T)
+		object.bound_overlay = M
+		M.associated_atom = object
+		if (TURF_IS_MIMICKING(M.loc))
+			.(M)
+
+	var/override_depth
+	var/original_type = object.type
+	var/original_z = object.z
+
+	switch (object.type)
+		// Layering for recursive mimic needs to be inherited.
+		if (/atom/movable/openspace/mimic)
+			var/atom/movable/openspace/mimic/OOO = object
+			original_type = OOO.mimiced_type
+			override_depth = OOO.override_depth
+			original_z = OOO.original_z
+
+		// If this is a turf proxy (the mimic for a non-OVERWRITE turf), it needs to respect space parallax if relevant.
+		if (/atom/movable/openspace/turf_proxy)
+			if (T.z_eventually_space)
+				// Yes, this is an awful hack; I don't want to add yet another override_* var.
+				override_depth = OPENTURF_MAX_PLANE - SPACE_PLANE
+
+	var/atom/movable/openspace/mimic/OO = object.bound_overlay
+
+	// If the OO was queued for destruction but was claimed by another OT, stop the destruction timer.
+	if (OO.destruction_timer)
+		deltimer(OO.destruction_timer)
+		OO.destruction_timer = null
+
+	OO.depth = override_depth || min(zlev_maximums[T.z] - original_z, OPENTURF_MAX_DEPTH)
+
+	switch (original_type)
+		// These types need to be pushed a layer down for bigturfs to function correctly.
+		if (/atom/movable/openspace/turf_proxy, /atom/movable/openspace/turf_mimic)
+			OO.depth += 1
+		if (/atom/movable/openspace/multiplier)
+			OO.depth += 1
+
+	OO.mimiced_type = original_type
+	OO.override_depth = override_depth
+	OO.original_z = original_z
+
+	// Multi-queue to maintain ordering of updates to these
+	//   queueing it multiple times will result in only the most recent
+	//   actually processing.
+	OO.queued += 1
+	queued_overlays += OO
+
+	total_updates_discovery += 1
+
+	ZM_RECORD_STOP
+	ZM_RECORD_WRITE(discovery_stats, "Depth [OO.depth] on [OO.z]")
+
+	return FALSE
+
+/datum/controller/subsystem/zcopy/proc/flush_z_state(turf/T)
 	if (T.below) // Z-Mimic turfs aren't necessarily above another turf.
 		if (T.below.mimic_above_copy)
 			QDEL_NULL(T.below.mimic_above_copy)
 		if (T.below.mimic_proxy)
 			QDEL_NULL(T.below.mimic_proxy)
+
 	QDEL_NULL(T.mimic_underlay)
 	for (var/atom/movable/openspace/mimic/OO in T)
 		qdel(OO)
 
-/datum/controller/subsystem/zmimic/proc/simple_appearance_copy(turf/T, new_appearance, target_plane)
+/datum/controller/subsystem/zcopy/proc/simple_appearance_copy(turf/T, new_appearance, target_plane)
 	if (T.mz_flags & MZ_MIMIC_OVERWRITE)
 		T.appearance = new_appearance
 		T.name = initial(T.name)
@@ -504,7 +600,7 @@ SUBSYSTEM_DEF(zmimic)
 		var/atom/movable/openspace/turf_proxy/TO = T.mimic_underlay
 		TO.appearance = new_appearance
 		TO.name = T.name
-		TO.gender = T.gender // Need to grab this too so PLURAL works properly in examine.
+		TO.gender = T.gender	// Need to grab this too so PLURAL works properly in examine.
 		TO.mouse_opacity = initial(TO.mouse_opacity)
 		if (TO.plane == 0 && target_plane)
 			TO.plane = target_plane
@@ -513,7 +609,7 @@ SUBSYSTEM_DEF(zmimic)
 // For each of overlay,underlay, call fixup_appearance_planes; if it returns a new appearance, replace self
 
 /// Generate a new appearance from `appearance` with planes mangled to work with Z-Mimic. Do not pass a depth.
-/datum/controller/subsystem/zmimic/proc/fixup_appearance_planes(appearance, depth = 0)
+/datum/controller/subsystem/zcopy/proc/fixup_appearance_planes(appearance, depth = 0)
 
 	// Adding this to guard against a reported runtime - supposed to be impossible, so cause is unclear.
 	if(!appearance)
@@ -601,7 +697,7 @@ SUBSYSTEM_DEF(zmimic)
 				fixed_underlays[i] = fixed_appearance
 
 		if (mutated)
-			for (var/i in 1 to fixed_overlays.len)
+			for (var/i in 1 to fixed_underlays.len)
 				if (fixed_underlays[i] == null)
 					fixed_underlays[i] = appearance:underlays[i]
 
@@ -633,6 +729,7 @@ SUBSYSTEM_DEF(zmimic)
 	return MA
 
 #define FMT_DEPTH(X) (X == null ? "(null)" : X)
+#define FMT_OK(X) (X) ? "<font color='green'>OK</font>" : "<font color='red'>MISMATCH</font>"
 
 // This is a dummy object used so overlays can be shown in the analyzer.
 /atom/movable/openspace/debug
@@ -641,6 +738,7 @@ SUBSYSTEM_DEF(zmimic)
 	var/turf/parent
 	var/computed_depth
 
+// this is for debug display only -- fixed as in unchanging, not mangling
 var/list/zmimic_fixed_planes = list(
 	"0" = "World plane (Non-Z)",
 	"-15" = "Cloaked plane (Non-Z)",
@@ -659,7 +757,7 @@ var/list/zmimic_fixed_planes = list(
 
 	var/real_update_count = 0
 	var/claimed_update_count = T.z_queued
-	var/list/tq = SSzmimic.queued_turfs.Copy()
+	var/list/tq = SSzcopy.queued_turfs.Copy()
 	for (var/turf/Tu in tq)
 		if (Tu == T)
 			real_update_count += 1
@@ -673,7 +771,7 @@ var/list/zmimic_fixed_planes = list(
 		"<head><meta charset='utf-8'/></head><body>",
 		"<h1>Analysis of [T] at [T.x],[T.y],[T.z]</h1>",
 		"<b>Queue occurrences:</b> [T.z_queued]",
-		"<b>Above space:</b> Apparent [T.z_eventually_space ? "Yes" : "No"], Actual [is_above_space ? "Yes" : "No"] - [T.z_eventually_space == is_above_space ? "<font color='green'>OK</font>" : "<font color='red'>MISMATCH</font>"]",
+		"<b>Above space:</b> Apparent [T.z_eventually_space ? "Yes" : "No"], Actual [is_above_space ? "Yes" : "No"] - [FMT_OK(T.z_eventually_space == is_above_space)]",
 		"<b>Z Flags</b>: [english_list(bitfield2list(T.mz_flags, global.mimic_defines), "(none)")]",
 		"<b>Has Shadower:</b> [T.shadower ? "Yes" : "No"]",
 		"<b>Has turf proxy:</b> [T.mimic_proxy ? "Yes" : "No"]",
@@ -682,20 +780,20 @@ var/list/zmimic_fixed_planes = list(
 		"<b>Below:</b> [!T.below ? "(nothing)" : "[T.below] at [T.below.x],[T.below.y],[T.below.z]"]",
 		"<b>Depth:</b> [FMT_DEPTH(T.z_depth)] [T.z_depth == OPENTURF_MAX_DEPTH ? "(max)" : ""]",
 		"<b>Generation:</b> [T.z_generation]",
-		"<b>Update count:</b> Claimed [claimed_update_count], Actual [real_update_count] - [claimed_update_count == real_update_count ? "<font color='green'>OK</font>" : "<font color='red'>MISMATCH</font>"]",
+		"<b>Update count:</b> Claimed [claimed_update_count], Actual [real_update_count] - [FMT_OK(claimed_update_count == real_update_count)]",
 		"<ul>"
 	)
 
 	if (!T.below)
 		out += "<h3>Using synthetic rendering (Not Z).<h3>"
-	else if (T.mz_flags & MZ_MIMIC_BASETURF)
-		out += "<h3>Using synthetic rendering (BASETURF).</h3>"
+	else if (T.mz_flags & MZ_OVERRIDE)
+		out += "<h3>Using synthetic rendering (OVERRIDE) — override is [T.z_appearance ? "MANUAL" : "BASETURF (resolved to [READ_BASETURF(T)])"].</h3>"
 
 	var/list/found_oo = list(T)
 	var/turf/Tbelow = T
 	while ((Tbelow = Tbelow.below))
 		var/atom/movable/openspace/debug/turf/VTO = new
-		VTO.computed_depth = SSzmimic.zlev_maximums[Tbelow.z] - Tbelow.z
+		VTO.computed_depth = SSzcopy.zlev_maximums[Tbelow.z] - Tbelow.z
 		VTO.appearance = Tbelow
 		VTO.parent = Tbelow
 		VTO.plane = OPENTURF_MAX_PLANE - VTO.computed_depth
@@ -726,7 +824,7 @@ var/list/zmimic_fixed_planes = list(
 	for (var/plane_str in zmimic_fixed_planes)
 		if (atoms_list_list[plane_str])
 			out += "<strong>[zmimic_fixed_planes[plane_str]]</strong>"
-			SSzmimic.debug_fmt_planelist(atoms_list_list[plane_str], out, T)
+			SSzcopy.debug_fmt_planelist(atoms_list_list[plane_str], out, T)
 
 			atoms_list_list -= plane_str
 
@@ -737,20 +835,20 @@ var/list/zmimic_fixed_planes = list(
 			continue
 
 		out += "<strong>Depth [d], plane [pl]</strong>"
-		SSzmimic.debug_fmt_planelist(atoms_list_list["[pl]"], out, T)
+		SSzcopy.debug_fmt_planelist(atoms_list_list["[pl]"], out, T)
 
 		// Flush the list so we can find orphans.
 		atoms_list_list -= "[pl]"
 
 	if (atoms_list_list["[SPACE_PLANE]"])	// Space parallax plane
 		out += "<strong>Space parallax plane</strong> ([SPACE_PLANE])"
-		SSzmimic.debug_fmt_planelist(atoms_list_list["[SPACE_PLANE]"], out, T)
+		SSzcopy.debug_fmt_planelist(atoms_list_list["[SPACE_PLANE]"], out, T)
 		atoms_list_list -= "[SPACE_PLANE]"
 
 	log_debug("atoms_list_list => [json_encode(atoms_list_list)]")
 	for (var/key in atoms_list_list)
 		out += "<strong style='color: red;'>Unknown plane: [key]</strong>"
-		SSzmimic.debug_fmt_planelist(atoms_list_list[key], out, T)
+		SSzcopy.debug_fmt_planelist(atoms_list_list[key], out, T)
 
 		out += "<hr/>"
 
@@ -762,10 +860,10 @@ var/list/zmimic_fixed_planes = list(
 		qdel(item)
 
 // Yes, I know this proc is a bit of a mess. Feel free to clean it up.
-/datum/controller/subsystem/zmimic/proc/debug_fmt_thing(atom/A, list/out, turf/original)
+/datum/controller/subsystem/zcopy/proc/debug_fmt_thing(atom/A, list/out, turf/original)
 	if (istype(A, /atom/movable/openspace/mimic))
 		var/atom/movable/openspace/mimic/OO = A
-		var/base = "<li>[fmt_label("Mimic", A)] plane [A.plane], layer [A.layer], depth [FMT_DEPTH(OO.depth)], fixup [OO.have_performed_fixup ? "Y" : "N"]"
+		var/base = "<li>[fmt_label("Mimic", A)] plane [A.plane], layer [A.layer], depth [FMT_DEPTH(OO.depth)]"
 		if (QDELETED(OO.associated_atom))	// This shouldn't happen, but can if the deletion hook is not working.
 			return "[base] - [OO.type] copying <unknown> ([OO.mimiced_type]) - <font color='red'>ORPHANED</font></em></li>"
 
@@ -793,7 +891,7 @@ var/list/zmimic_fixed_planes = list(
 
 	else if (A.type == /atom/movable/openspace/debug/turf)
 		var/atom/movable/openspace/debug/turf/VTO = A
-		return "<li>[fmt_label("VTO", VTO.parent)] plane [VTO.plane], layer [VTO.layer], computed depth [FMT_DEPTH(VTO.computed_depth)] - [VTO.parent] ([VTO.parent.type]) - <font color='red'>FOREIGN</font>"
+		return "<li>[fmt_label("VTO", VTO.parent)] <em><font color='#646464'>plane [VTO.plane], layer [VTO.layer], computed depth [FMT_DEPTH(VTO.computed_depth)] - [VTO.parent] ([VTO.parent.type])</font></em> - <font color='red'>FOREIGN</font>"
 
 	else if (A.type == /atom/movable/openspace/turf_proxy)
 		return "<li>[fmt_label("Turf Proxy", A)] plane [A.plane], layer [A.layer], Z-level [A.z] - [A] ([A.type])</li>"
@@ -801,12 +899,12 @@ var/list/zmimic_fixed_planes = list(
 	else
 		return "<li>[fmt_label("?", A)] plane [A.plane], layer [A.layer], Z-level [A.z] - [A] ([A.type])</li>"
 
-/datum/controller/subsystem/zmimic/proc/fmt_label(label, atom/target, vv = TRUE)
+/datum/controller/subsystem/zcopy/proc/fmt_label(label, atom/target, vv = TRUE)
 	. = "\icon[target] <b>\[[label]\]</b> "
 	if (vv)
 		. += "(<a href='?_src_=vars;Vars=\ref[target]'>VV</a>) "
 
-/datum/controller/subsystem/zmimic/proc/debug_fmt_planelist(list/things, list/out, turf/original)
+/datum/controller/subsystem/zcopy/proc/debug_fmt_planelist(list/things, list/out, turf/original)
 	if (things)
 		out += "<ul>"
 		for (var/thing in things)
@@ -816,4 +914,49 @@ var/list/zmimic_fixed_planes = list(
 		out += "<em>No atoms.</em>"
 
 #undef FMT_DEPTH
-#undef READ_BASETURF
+#undef FMT_OK
+#undef ZM_RECORD_START
+#undef ZM_RECORD_STOP
+#undef ZM_RECORD_WRITE
+
+#ifdef ZM_RECORD_STATS
+/client/proc/zms_display_turf()
+	set name = "ZM Stats - 1Turf"
+	set category = "Debug"
+
+	if(!check_rights(R_DEBUG))
+		return
+
+	if (!length(SSzcopy.turf_stats))
+		alert("No stats.")
+		return
+
+	render_stats(SSzcopy.turf_stats, src)
+
+/client/proc/zms_display_discovery()
+	set name = "ZM Stats - 2Discovery"
+	set category = "Debug"
+
+	if(!check_rights(R_DEBUG))
+		return
+
+	if (!length(SSzcopy.discovery_stats))
+		alert("No stats.")
+		return
+
+	render_stats(SSzcopy.discovery_stats, src)
+
+/client/proc/zms_display_mimic()
+	set name = "ZM Stats - 3Mimic"
+	set category = "Debug"
+
+	if(!check_rights(R_DEBUG))
+		return
+
+	if (!length(SSzcopy.mimic_stats))
+		alert("No stats.")
+		return
+
+	render_stats(SSzcopy.mimic_stats, src)
+
+#endif

--- a/code/game/atoms/movable/movement.dm
+++ b/code/game/atoms/movable/movement.dm
@@ -311,6 +311,31 @@
 	move_speed = world.time - l_move_time
 	l_move_time = world.time
 
+// Hooks for foreign code.
+/atom/movable/Move(...)
+	var/old_loc = loc
+	. = ..()
+	if (!.)
+		return
+
+	if (light_source_solo)
+		light_source_solo.source_atom.update_light()
+	else if (light_source_multi)
+		var/datum/light_source/L
+		var/thing
+		for (thing in light_source_multi)
+			L = thing
+			L.source_atom.update_light()
+
+	// Z-Mimic.
+	if (bound_overlay)
+		// The overlay will handle cleaning itself up on non-openspace turfs.
+		bound_overlay.forceMove(get_step(src, UP))
+		if (bound_overlay && bound_overlay.dir != dir)
+			bound_overlay.setDir(dir)
+	else if (isturf(loc) && (!old_loc || !TURF_IS_MIMICKING(old_loc)) && MOVABLE_SHALL_MIMIC(src))
+		SSzcopy.discover_movable(src)
+
 //! WARNING WARNING THIS IS SHITCODE
 /atom/movable/proc/handle_buckled_mob_movement(newloc, direct, glide_size_override, forcemoving)
 	for(var/mob/M as anything in buckled_mobs)

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -138,6 +138,9 @@ GLOBAL_LIST_EMPTY(dirty_vars)
 
 var/list/debug_verbs = list (
 	/client/proc/analyze_openturf,
+	/client/proc/zms_display_turf,
+	/client/proc/zms_display_discovery,
+	/client/proc/zms_display_mimic,
 	/client/proc/atmos_toggle_debug,
 	/client/proc/atmosscan,
 	/client/proc/camera_view,

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -93,6 +93,16 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	M.Scale(desired_scale_x, desired_scale_y)
 	M.Translate(0, 16 * (desired_scale_y - 1))
 
+	// Mark atom as wide/long for ZM.
+	if (desired_scale_x > 1)
+		zmm_flags |= ZMM_LOOKAHEAD
+	else
+		zmm_flags &= ~ZMM_LOOKAHEAD
+	if (desired_scale_y > 1)
+		zmm_flags |= ZMM_LOOKBESIDE
+	else
+		zmm_flags &= ~ZMM_LOOKBESIDE
+
 	// handle turning
 	M.Turn(lying)
 	// extremely lazy heuristic to see if we should shift down to appear to be, well, down.

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -916,6 +916,7 @@
 	cut_overlays()
 
 	if (dogborg)
+		zmm_flags |= ZMM_LOOKAHEAD
 		// Resting dogborgs don't get overlays.
 		if (stat == CONSCIOUS && resting)
 			if(sitting)
@@ -925,6 +926,8 @@
 			else
 				icon_state = "[module_sprites[icontype]]-rest"
 			return
+	else
+		zmm_flags &= ~ZMM_LOOKAHEAD
 
 	if(stat == CONSCIOUS)
 		if(!shell || deployed) // Shell borgs that are not deployed will have no eyes.

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -116,13 +116,6 @@
 /turf/check_impact(atom/movable/falling_atom)
 	return TRUE
 
-/turf/smooth_icon()
-	. = ..()
-	if(SSzmimic.initialized)
-		var/turf/simulated/open/above = above()
-		if(istype(above))
-			above.queue()
-
 //* lookups
 
 /turf/proc/above()

--- a/code/modules/multiz/turfs/open.dm
+++ b/code/modules/multiz/turfs/open.dm
@@ -16,7 +16,6 @@
 	. = ..()
 	icon_state = ""
 	ASSERT(!isnull(below()))
-	queue()
 
 /turf/simulated/open/Entered(atom/movable/mover)
 	..()
@@ -28,11 +27,6 @@
 	. = ..()
 	if(AM.movement_type & MOVEMENT_GROUND)
 		AM.fall()
-
-/turf/simulated/open/proc/queue()
-	if(smoothing_flags & SMOOTH_QUEUED)
-		return
-	smoothing_flags |= SMOOTH_QUEUED
 
 //! We hijack smoothing flags.
 /turf/simulated/open/smooth_icon()

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -27,7 +27,7 @@
 
 	var/turf/T = loc
 
-	if (MOVABLE_IS_BELOW_ZTURF(T.above))
+	if (MOVABLE_IS_BELOW_ZTURF(src))
 		SSzcopy.queued_overlays += bound_overlay
 		bound_overlay.queued += 1
 	else

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -4,38 +4,17 @@
 	/// Movable-level Z-Mimic flags. This uses ZMM_* flags, not ZM_* flags.
 	var/zmm_flags = NONE
 
-/atom/movable/doMove(atom/destination)
-	. = ..(destination)
+/atom/movable/doMove(atom/dest)
+	. = ..(dest)
 	if (. && bound_overlay)
 		// The overlay will handle cleaning itself up on non-openspace turfs.
-		if (isturf(destination))
-			var/turf/current = get_turf(src)
-			bound_overlay.doMove(current.above)
+		if (isturf(dest))
+			// If you feel a need to change this from get_step(), don't. Any change that would require that is illegal with Z-Mimic's layering model.
+			bound_overlay.doMove(get_step(src, UP))
 			if (bound_overlay && dir != bound_overlay.dir)
 				bound_overlay.setDir(dir)
 		else	// Not a turf, so we need to destroy immediately instead of waiting for the destruction timer to proc.
 			qdel(bound_overlay)
-
-/atom/movable/Move(...)
-	. = ..()
-	if (!.)
-		return
-
-	if (bound_overlay)
-		var/turf/current = get_turf(src)
-		bound_overlay.doMove(current.above)
-		// forceMove could've deleted our overlay
-		if (bound_overlay && bound_overlay.dir != dir)
-			bound_overlay.setDir(dir)
-
-	if (light_source_solo)
-		light_source_solo.source_atom.update_light()
-	else if (light_source_multi)
-		var/datum/light_source/L
-		var/thing
-		for (thing in light_source_multi)
-			L = thing
-			L.source_atom.update_light()
 
 /atom/movable/setDir(ndir)
 	. = ..()
@@ -46,11 +25,13 @@
 	if (!bound_overlay || !isturf(loc))
 		return
 
-	if (MOVABLE_IS_BELOW_ZTURF(src))
-		SSzmimic.queued_overlays += bound_overlay
+	var/turf/T = loc
+
+	if (MOVABLE_IS_BELOW_ZTURF(T.above))
+		SSzcopy.queued_overlays += bound_overlay
 		bound_overlay.queued += 1
-	else if (bound_overlay && !bound_overlay.destruction_timer)
-		bound_overlay.destruction_timer = addtimer(CALLBACK(bound_overlay, TYPE_PROC_REF(/datum, qdel_self)), 10 SECONDS, TIMER_STOPPABLE)
+	else
+		qdel(bound_overlay)
 
 // Grabs a list of every openspace object that's directly or indirectly mimicking this object. Returns an empty list if none found.
 /atom/movable/proc/get_above_oo()
@@ -67,7 +48,7 @@
 	atom_flags = ATOM_ABSTRACT
 	anchored = TRUE
 	mouse_opacity = FALSE
-	abstract_type = /atom/movable/openspace // unsure if this is valid, check with Lohi
+	abstract_type = /atom/movable/openspace
 
 /atom/movable/openspace/can_fall()
 	return FALSE
@@ -119,34 +100,36 @@
 	var/turf/myturf = loc
 	if (istype(myturf))
 		myturf.shadower = null
+
 	return ..()
 
-/atom/movable/openspace/multiplier/proc/copy_lighting(atom/movable/lighting_overlay/LO)
+/atom/movable/openspace/multiplier/proc/copy_lighting(atom/movable/lighting_overlay/LO, use_shadower_mult = TRUE)
 	appearance = LO
 	layer = MIMICED_LIGHTING_LAYER_MAIN
 	plane = OPENTURF_MAX_PLANE
 	blend_mode = BLEND_MULTIPLY
 	invisibility = 0
 
-	if (icon_state == LIGHTING_BASE_ICON_STATE)
-		// We're using a color matrix, so just darken the colors across the board.
-		var/list/c_list = color
-		c_list[CL_MATRIX_RR] *= SHADOWER_DARKENING_FACTOR
-		c_list[CL_MATRIX_RG] *= SHADOWER_DARKENING_FACTOR
-		c_list[CL_MATRIX_RB] *= SHADOWER_DARKENING_FACTOR
-		c_list[CL_MATRIX_GR] *= SHADOWER_DARKENING_FACTOR
-		c_list[CL_MATRIX_GG] *= SHADOWER_DARKENING_FACTOR
-		c_list[CL_MATRIX_GB] *= SHADOWER_DARKENING_FACTOR
-		c_list[CL_MATRIX_BR] *= SHADOWER_DARKENING_FACTOR
-		c_list[CL_MATRIX_BG] *= SHADOWER_DARKENING_FACTOR
-		c_list[CL_MATRIX_BB] *= SHADOWER_DARKENING_FACTOR
-		c_list[CL_MATRIX_AR] *= SHADOWER_DARKENING_FACTOR
-		c_list[CL_MATRIX_AG] *= SHADOWER_DARKENING_FACTOR
-		c_list[CL_MATRIX_AB] *= SHADOWER_DARKENING_FACTOR
-		color = c_list
-	else
-		// Not a color matrix, so we can just use the color var ourselves.
-		color = SHADOWER_DARKENING_COLOR
+	if (use_shadower_mult)
+		if (icon_state == LIGHTING_BASE_ICON_STATE)
+			// We're using a color matrix, so just darken the colors across the board.
+			var/list/c_list = color
+			c_list[CL_MATRIX_RR] *= SHADOWER_DARKENING_FACTOR
+			c_list[CL_MATRIX_RG] *= SHADOWER_DARKENING_FACTOR
+			c_list[CL_MATRIX_RB] *= SHADOWER_DARKENING_FACTOR
+			c_list[CL_MATRIX_GR] *= SHADOWER_DARKENING_FACTOR
+			c_list[CL_MATRIX_GG] *= SHADOWER_DARKENING_FACTOR
+			c_list[CL_MATRIX_GB] *= SHADOWER_DARKENING_FACTOR
+			c_list[CL_MATRIX_BR] *= SHADOWER_DARKENING_FACTOR
+			c_list[CL_MATRIX_BG] *= SHADOWER_DARKENING_FACTOR
+			c_list[CL_MATRIX_BB] *= SHADOWER_DARKENING_FACTOR
+			c_list[CL_MATRIX_AR] *= SHADOWER_DARKENING_FACTOR
+			c_list[CL_MATRIX_AG] *= SHADOWER_DARKENING_FACTOR
+			c_list[CL_MATRIX_AB] *= SHADOWER_DARKENING_FACTOR
+			color = c_list
+		else
+			// Not a color matrix, so we can just use the color var ourselves.
+			color = SHADOWER_DARKENING_COLOR
 
 	if (our_overlays || priority_overlays)
 		compile_overlays()
@@ -154,9 +137,9 @@
 		// compile_overlays() calls update_above().
 		update_above()
 
-//! -- OPENSPACE MIMIC --
+// -- OPENSPACE MIMIC --
 
-/// Object used to hold a mimiced atom's appearance.
+// Object used to hold a mimiced atom's appearance.
 /atom/movable/openspace/mimic
 	plane = OPENTURF_MAX_PLANE
 	var/atom/movable/associated_atom
@@ -170,10 +153,10 @@
 
 /atom/movable/openspace/mimic/New()
 	atom_flags |= ATOM_INITIALIZED
-	SSzmimic.openspace_overlays += 1
+	SSzcopy.openspace_overlays += 1
 
 /atom/movable/openspace/mimic/Destroy()
-	SSzmimic.openspace_overlays -= 1
+	SSzcopy.openspace_overlays -= 1
 	queued = 0
 
 	if (associated_atom)
@@ -188,26 +171,40 @@
 /atom/movable/openspace/mimic/attackby(obj/item/W, mob/user)
 	to_chat(user, SPAN_NOTICE("\The [src] is too far away."))
 
-/atom/movable/openspace/mimic/attack_hand(mob/user, list/params)
+/atom/movable/openspace/mimic/attack_hand(mob/user)
 	to_chat(user, SPAN_NOTICE("You cannot reach \the [src] from here."))
 
 /atom/movable/openspace/mimic/examine(...)
 	SHOULD_CALL_PARENT(FALSE)
 	. = associated_atom.examine(arglist(args))	// just pass all the args to the copied atom
 
-/atom/movable/openspace/mimic/doMove(atom/destination)
+/atom/movable/openspace/mimic/doMove(turf/dest)
+	var/atom/old_loc = loc
 	. = ..()
-	if (MOVABLE_IS_BELOW_ZTURF(associated_atom))
+	if (TURF_IS_MIMICKING(dest))
 		if (destruction_timer)
 			deltimer(destruction_timer)
 			destruction_timer = null
+		if (old_loc.z != loc.z)
+			reset_internal_layering()
 	else if (!destruction_timer)
-		destruction_timer = addtimer(CALLBACK(src, TYPE_PROC_REF(/datum, qdel_self)), 10 SECONDS, TIMER_STOPPABLE)
+		destruction_timer = ZM_DESTRUCTION_TIMER(src)
 
 // Called when the turf we're on is deleted/changed.
 /atom/movable/openspace/mimic/proc/owning_turf_changed()
 	if (!destruction_timer)
-		destruction_timer = addtimer(CALLBACK(src, TYPE_PROC_REF(/datum, qdel_self)), 10 SECONDS, TIMER_STOPPABLE)
+		destruction_timer = ZM_DESTRUCTION_TIMER(src)
+
+/atom/movable/openspace/mimic/proc/reset_internal_layering()
+	if (bound_overlay?.override_depth)
+		depth = bound_overlay.override_depth
+	else if (isturf(associated_atom.loc))
+		depth = min(SSzcopy.zlev_maximums[associated_atom.z] - associated_atom.z, OPENTURF_MAX_DEPTH)
+		override_depth = depth
+
+	plane = OPENTURF_MAX_PLANE - depth
+
+	bound_overlay?.reset_internal_layering()
 
 // -- TURF PROXY --
 

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -25,8 +25,6 @@
 	if (!bound_overlay || !isturf(loc))
 		return
 
-	var/turf/T = loc
-
 	if (MOVABLE_IS_BELOW_ZTURF(src))
 		SSzcopy.queued_overlays += bound_overlay
 		bound_overlay.queued += 1

--- a/code/modules/multiz/zmimic/mimic_turf.dm
+++ b/code/modules/multiz/zmimic/mimic_turf.dm
@@ -1,4 +1,3 @@
-
 /turf
 	/// The z-turf above us, if present.
 	var/tmp/turf/above
@@ -16,8 +15,10 @@
 	var/tmp/z_queued = 0
 	/// If this Z-turf leads to space, uninterrupted.
 	var/tmp/z_eventually_space = FALSE
+	/// Use this appearance for our appearance instead of `appearance`. If MZ_OVERRIDE is set, *only* this will be visible, no movables will be copied.
+	var/z_appearance
 
-	//debug
+	// debug
 	var/tmp/z_depth
 	var/tmp/z_generation = 0
 
@@ -29,7 +30,7 @@
 	if(mz_flags & MZ_MIMIC_BELOW)
 		z_queued += 1
 		// This adds duplicates for a reason. Do not change this unless you understand how ZM queues work.
-		SSzmimic.queued_turfs += src
+		SSzcopy.queued_turfs += src
 
 /// Enables Z-mimic for a turf that didn't already have it enabled.
 /turf/proc/enable_zmimic(additional_flags = 0)
@@ -54,7 +55,7 @@
 	if (shadower)
 		CRASH("Attempt to enable Z-mimic on already-enabled turf!")
 	shadower = new(src)
-	SSzmimic.openspace_turfs += 1
+	SSzcopy.openspace_turfs += 1
 	var/turf/under = below()
 	if (under)
 		below = under
@@ -67,7 +68,7 @@
 
 /// Cleans up Z-mimic objects for this turf. You shouldn't call this directly 99% of the time.
 /turf/proc/cleanup_zmimic()
-	SSzmimic.openspace_turfs -= 1
+	SSzcopy.openspace_turfs -= 1
 	// Don't remove ourselves from the queue, the subsystem will explode. We'll naturally fall out of the queue.
 	z_queued = 0
 
@@ -87,9 +88,3 @@
 	if (below)
 		below.above = null
 		below = null
-
-/turf/Entered(atom/movable/thing, atom/oldLoc)
-	..()
-	if (thing.bound_overlay || (thing.zmm_flags & ZMM_IGNORE) || thing.invisibility == INVISIBILITY_ABSTRACT || !TURF_IS_MIMICKING(above))
-		return
-	above.update_mimic()


### PR DESCRIPTION
This is largely just synchronizing ZM with the latest upstream version, though I also renamed SSzmimic to make updates like this easier.

Changes:
- It is no longer possible to outrun Z-Mimic, except now without the cost of doubling ZM init time.
- `ZMM_LOOKBESIDE` is now supported to handle wide mobs as well as long mobs. Use `ZMM_WIDE_LOAD` for both wide and long, such as scaled up atoms.
- It is now possible for a turf to override its Z-Mimic appearance.
- `MZ_TERMINATOR` can now be specified to cause a turf to act as the bottom of a ZM stack. 
- `MZ_NO_SHADOW` can be specified to opt out of Z-M's darkening effect, though lighting copy and AO are still active.
- Some bugs in layering caused by atoms moving up or down z-levels have been fixed.
- Z-Mimic now has a basic performance profiler.
- ZM appearance fixup no longer breaks underlays.