### PR TITLE
Add vulpkanin background info

### DIFF
--- a/code/modules/lore_hardcoded/citizenship.dm
+++ b/code/modules/lore_hardcoded/citizenship.dm
@@ -69,6 +69,13 @@
 	desc = "Exiles from Unathi Clans. They are unwelcome in Unathi society by and large, and often resort to crime. Those who are not killed \
 	often flee to the Frontier, where they may find opportunities for a new life."
 
+/datum/lore/character_background/citizenship/vulpunitedstar
+	name = "Vulpkanin United Star"
+	id = "vulpunitedstar"
+	desc = "The Vulpkanin United Star is the galactic voice of all Vulpkanin from the Vazzend and other claimed systems. It is a relative newcomer \
+	on the galactic stage, having been conceived only a couple of centuries ago. Though it doesn't enjoy as much power or influence as the neighboring \
+	Vikara Combine, the VUS advocates for peace and open borders with most other galactic nations, and invests plenty of resources into the sciences."
+
 /datum/lore/character_background/citizenship/custom
 	name = "Other"
 	id = "custom"

--- a/code/modules/lore_hardcoded/origin.dm
+++ b/code/modules/lore_hardcoded/origin.dm
@@ -8,6 +8,12 @@
 			return
 	return ..()
 
+/datum/lore/character_background/origin/altam
+	name = "Altam"
+	id = "altam"
+	desc = "Altam, located within the Vazzend system, is a somewhat-chilly planet and the seat of the Vulpkanin United Star. Its population is predominantly Vulpkanin, though migrant races are welcome in most areas, from the chilling polar tundras to the temperate equatorial forests."
+	innate_languages = list(LANGUAGE_ID_VULPKANIN)
+
 /datum/lore/character_background/origin/qerrbalak
 	name = "Qerr'Balak"
 	id = "qerrbalak"

--- a/code/modules/lore_hardcoded/religion.dm
+++ b/code/modules/lore_hardcoded/religion.dm
@@ -8,6 +8,12 @@
 			return
 	return ..()
 
+/datum/lore/character_background/religion/alverrtcheff
+	name = "Alverrtcheff"
+	id = "alverrtcheff"
+	desc = "Alverrtcheff, or The Grand Founder, is the name of both the deity and the religion associated with it. A type of deism, it was founded by the Vulpkanin under the belief that Alverrtcheff created the universe but does not meddle in it."
+	category = "Misc"
+
 /datum/lore/character_background/religion/custom
 	name = "Other"
 	id = "custom"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds Altam (the homeworld of the vulpkanin) as an origin under the misc tab, the Vulpkanin United Star as a citizenship option, and Alverrtcheff as a religion option under the misc tab.

Currently this is not species-locked and anyone can pick it.

## Why It's Good For The Game

Races having their lore represented in-game is a good thing

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new background options for the Vulpkanin.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
