### PR TITLE
Fixes gimlet recipe

### DIFF
--- a/code/modules/reagents/Drink-Recipes.dm
+++ b/code/modules/reagents/Drink-Recipes.dm
@@ -1336,7 +1336,7 @@
 	name = "Gimlet"
 	id = "gimlet"
 	result = "gimlet"
-	required_reagents = list("gin" = 1, "limejuice" = 1, "sodawater" = 1)
+	required_reagents = list("gin" = 1, "limejuice" = 1, "sugar" = 1)
 	result_amount = 3
 
 /datum/chemical_reaction/drinks/newsheriff


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gin Fizz and Gimlet had the exact same recipe (`"gin" = 1, "sodawater" = 1, "limejuice" = 1`). Gimlet's recipe now is `"gin" = 1, "limejuice" = 1, "sugar" = 1` because it made sense. And because I saw on the internet that sugar goes with it. I don't drink. I don't even know what gimlet is, I just looked it up
![image](https://github.com/Citadel-Station-13/Citadel-Station-13-RP/assets/64568243/767bfede-b089-4f25-852b-0186960f3793)

## Why It's Good For The Game

Fixes #6264 

## Changelog

:cl:
fix: Gimlet can actually be made now, since it doesn't share the same recipe as Gin Fizz anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
