### PR TITLE
Fixes Nebula Docking issues.

### DIFF
--- a/code/modules/maps/overmap/space/trade_station/trade_station.dm
+++ b/code/modules/maps/overmap/space/trade_station/trade_station.dm
@@ -9,22 +9,29 @@
 	color = "#8F6E4C"
 
 	initial_generic_waypoints = list(
-		"nebula_pad_1",
-		"nebula_pad_2",
-		"nebula_space_SW",
-		"nebula_pad_3",
+		"nebula_pad_1a",
+		"nebula_pad_1b",
+		"nebula_pad_2a",
+		"nebula_pad_2b",
+		"nebula_pad_3a",
+		"nebula_pad_3b",
+		"nebula_pad_3c",
+		"nebula_pad_3d",
 		"nebula_pad_4a",
 		"nebula_pad_4b",
 		"nebula_pad_4c",
-		"nebula_pad_5",
-		"nebula_pad_6",
+		"nebula_pad_4d",
+		"nebula_pad_5a",
+		"nebula_pad_5b",
+		"nebula_pad_6a",
+		"nebula_pad_6b",
 		"nebula_space_SE",
 		"nebula_space_S",
 		"nebula_space_SW"
 		)
 
 	initial_restricted_waypoints = list(
-		"Beruang Trade Ship" = list("tradeport_hangar"), "Beluga Passenger Liner" = list("nebula_pad_3")
+		"Beruang Trade Ship" = list("tradeport_hangar")
 		)
 /* // Old Restricted list. Leaving commented out for reference - Bloop
 	initial_restricted_waypoints = list(

--- a/maps/sectors/tradeport/shuttles.dm
+++ b/maps/sectors/tradeport/shuttles.dm
@@ -30,37 +30,3 @@
 
 /area/shuttle/trade_ship/cockpit
 	name = "\improper Beruang Trade Shuttle Cockpit"
-
-// Tradeport Off-Map Visitor shuttle
-/datum/shuttle/autodock/overmap/visitor_ship
-	name = "Beluga Passenger Liner"
-	warmup_time = 10
-	shuttle_area = list(/area/shuttle/visitor_ship/general, /area/shuttle/visitor_ship/cockpit)
-	current_location = "nebula_pad_3"
-	docking_controller_tag = "visitor_space_lock"
-	fuel_consumption = 10
-	move_time = 10
-
-/obj/overmap/entity/visitable/ship/landable/visitor_ship
-	name = "Beluga Passenger Liner"
-	desc = "You know our motto: 'Right place right time!'"
-	color = "#754116" //Brown
-	fore_dir = WEST
-	vessel_mass = 10000
-	vessel_size = SHIP_SIZE_SMALL
-	shuttle = "Beluga Passenger Liner"
-
-/obj/machinery/computer/shuttle_control/explore/visitor_ship
-	name = "short jump console"
-	shuttle_tag = "Beluga Passenger Liner"
-
-/area/shuttle/visitor_ship
-	requires_power = 1
-	icon_state = "shuttle2"
-	area_flags = AREA_RAD_SHIELDED
-
-/area/shuttle/visitor_ship/general
-	name = "\improper Beluga Passenger Liner"
-
-/area/shuttle/visitor_ship/cockpit
-	name = "\improper Beluga Passenger Liner Cockpit"

--- a/maps/sectors/tradeport_192/levels/tradeport_192.dmm
+++ b/maps/sectors/tradeport_192/levels/tradeport_192.dmm
@@ -1801,7 +1801,7 @@
 "gs" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
 	frequency = 1380;
-	id_tag = "nebula_pump3";
+	id_tag = "nebula_pump3a";
 	name = "Nebula Pump Controller";
 	pixel_x = 25
 	},
@@ -1860,8 +1860,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Nebula Gas - Employees Only";
-	req_access = list(160);
-	req_one_access = null
+	req_access = list(160)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/yellow{
@@ -1945,7 +1944,7 @@
 "gW" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
 	frequency = 1380;
-	id_tag = "nebula_pump2";
+	id_tag = "nebula_pump2a";
 	name = "Nebula Pump Controller";
 	pixel_x = -25
 	},
@@ -2043,6 +2042,12 @@
 	dir = 8
 	},
 /obj/structure/catwalk,
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "nebula_pump4d";
+	name = "Nebula Pump Controller";
+	pixel_x = 25
+	},
 /turf/simulated/floor,
 /area/tradeport/pads)
 "hn" = (
@@ -3435,8 +3440,7 @@
 "md" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4;
-	name = "Nebula Commercial District";
-	req_access = null
+	name = "Nebula Commercial District"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/old_tile/blue,
@@ -3796,8 +3800,7 @@
 "ns" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4;
-	name = "Nebula Commercial District";
-	req_access = null
+	name = "Nebula Commercial District"
 	},
 /turf/simulated/floor/tiled/old_tile/red,
 /area/tradeport)
@@ -3963,6 +3966,15 @@
 "ob" = (
 /turf/simulated/floor/plating,
 /area/tradeport/commhall)
+"oc" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "nebula_pump6b";
+	name = "Nebula Pump Controller";
+	pixel_x = -25
+	},
+/turf/simulated/floor/reinforced,
+/area/tradeport/pads)
 "od" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/old_tile/gray,
@@ -3985,9 +3997,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor{
-	dir = 2
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/old_tile/red,
 /area/tradeport)
 "oj" = (
@@ -4651,6 +4661,22 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/old_tile/red,
 /area/tradeport)
+"qO" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/catwalk,
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "nebula_pump3d";
+	name = "Nebula Pump Controller";
+	pixel_x = -25
+	},
+/turf/simulated/floor,
+/area/tradeport/pads)
 "qQ" = (
 /obj/structure/table/bench/steel,
 /turf/simulated/floor/tiled/old_tile/red,
@@ -5383,7 +5409,6 @@
 /area/tradeport/dock)
 "tP" = (
 /obj/machinery/door/airlock/glass_external{
-	frequency = null;
 	name = "Ship Hatch"
 	},
 /obj/map_helper/airlock/door/ext_door,
@@ -5922,8 +5947,7 @@
 "vE" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4;
-	name = "Nebula Commercial District";
-	req_access = null
+	name = "Nebula Commercial District"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
@@ -6138,6 +6162,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tradeport/dock)
+"wu" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "nebula_pump5b";
+	name = "Nebula Pump Controller";
+	pixel_x = 25
+	},
+/turf/simulated/floor/reinforced,
+/area/tradeport/pads)
 "wx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/old_tile/red,
@@ -7103,7 +7136,6 @@
 	pixel_y = 5
 	},
 /obj/machinery/door/airlock/glass_external{
-	frequency = null;
 	name = "Ship Hatch"
 	},
 /obj/map_helper/airlock/door/ext_door,
@@ -7114,7 +7146,6 @@
 	dir = 4;
 	frequency = 1445;
 	id = "burn_in";
-	req_access = null;
 	volume_rate = 700
 	},
 /turf/simulated/mineral/floor/vacuum,
@@ -7562,7 +7593,6 @@
 	pixel_y = -5
 	},
 /obj/machinery/door/airlock/glass_external{
-	frequency = null;
 	name = "Ship Hatch"
 	},
 /obj/map_helper/airlock/door/int_door,
@@ -7701,7 +7731,6 @@
 "BU" = (
 /obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
-	frequency = null;
 	name = "Ship Hatch"
 	},
 /obj/machinery/access_button/airlock_interior{
@@ -7977,6 +8006,15 @@
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /turf/simulated/floor/plating,
 /area/tradeport/commons)
+"CN" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "nebula_pump3b";
+	name = "Nebula Pump Controller";
+	pixel_x = 25
+	},
+/turf/simulated/floor/reinforced,
+/area/tradeport/pads)
 "CO" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -8499,9 +8537,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/cockpit)
 "EQ" = (
-/obj/machinery/door/firedoor{
-	dir = 2
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/old_tile/blue,
 /area/tradeport)
 "ER" = (
@@ -9065,7 +9101,6 @@
 	},
 /obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
-	frequency = null;
 	name = "Ship Hatch"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -9640,8 +9675,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/freezer{
 	name = "Nebula Gas - Freezer";
-	req_access = list(160);
-	req_one_access = null
+	req_access = list(160)
 	},
 /obj/machinery/door/firedoor{
 	req_one_access = list(160)
@@ -9784,7 +9818,7 @@
 "JJ" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
 	frequency = 1380;
-	id_tag = "nebula_pump5";
+	id_tag = "nebula_pump5a";
 	name = "Nebula Pump Controller";
 	pixel_x = 25
 	},
@@ -9800,9 +9834,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor{
-	dir = 2
-	},
+/obj/machinery/door/firedoor,
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/tradeport/pads)
@@ -9926,6 +9958,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/tradeport/expansion)
+"Kq" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "nebula_pump3c";
+	name = "Nebula Pump Controller";
+	pixel_x = 25
+	},
+/turf/simulated/floor/reinforced,
+/area/tradeport/pads)
 "Ks" = (
 /obj/machinery/lathe/autolathe{
 	desc = "Your typical Autolathe. It appears to have much more options than your regular one, however...";
@@ -10054,7 +10095,6 @@
 	},
 /obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
-	frequency = null;
 	name = "Ship Hatch"
 	},
 /obj/machinery/access_button/airlock_exterior{
@@ -10527,7 +10567,6 @@
 	frequency = 1382;
 	id_tag = "safari_access";
 	name = "John Safari's Adventure Emporium";
-	req_access = null;
 	tag = "safari_door"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10547,7 +10586,7 @@
 "Mz" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
 	frequency = 1380;
-	id_tag = "nebula_pump6";
+	id_tag = "nebula_pump6a";
 	name = "Nebula Pump Controller";
 	pixel_x = -25
 	},
@@ -11136,9 +11175,7 @@
 /turf/simulated/floor/plating,
 /area/tradeport/engineering)
 "OE" = (
-/obj/machinery/door/firedoor{
-	dir = 2
-	},
+/obj/machinery/door/firedoor,
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/tradeport/pads)
@@ -11541,7 +11578,6 @@
 /obj/machinery/airlock_sensor{
 	frequency = 8018;
 	id_tag = "trade_space_lock";
-	master_tag = null;
 	pixel_x = 25
 	},
 /obj/map_helper/airlock/sensor/chamber_sensor,
@@ -11971,6 +12007,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/tradeport/cyndi)
+"Ru" = (
+/obj/effect/shuttle_landmark{
+	base_area = /area/tradeport/pads;
+	base_turf = /turf/simulated/floor/reinforced;
+	docking_controller = "nebula_pump3d";
+	landmark_tag = "nebula_pad_3d";
+	name = "Nebula Pad 3d"
+	},
+/turf/simulated/floor/reinforced,
+/area/tradeport/pads)
 "Rv" = (
 /obj/machinery/light{
 	dir = 8
@@ -12063,7 +12109,6 @@
 "RJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/glass_external{
-	frequency = null;
 	name = "Ship Hatch"
 	},
 /obj/map_helper/airlock/door/int_door,
@@ -12251,6 +12296,15 @@
 /obj/structure/sign/graffiti/pisoff,
 /turf/simulated/floor/plating,
 /area/tradeport)
+"St" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "nebula_pump1b";
+	name = "Nebula Pump Controller";
+	pixel_x = 25
+	},
+/turf/simulated/floor/reinforced,
+/area/tradeport/pads)
 "Su" = (
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/shuttle/trade_ship/general)
@@ -12404,6 +12458,16 @@
 	},
 /turf/simulated/floor/tiled/old_tile/purple,
 /area/tradeport/spine)
+"SX" = (
+/obj/effect/shuttle_landmark{
+	base_area = /area/tradeport/pads;
+	base_turf = /turf/simulated/floor/reinforced;
+	docking_controller = "nebula_pump4d";
+	landmark_tag = "nebula_pad_4d";
+	name = "Nebula Pad 4d"
+	},
+/turf/simulated/floor/reinforced,
+/area/tradeport/pads)
 "SY" = (
 /obj/structure/railing{
 	dir = 1
@@ -12870,7 +12934,7 @@
 "Uz" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
 	frequency = 1380;
-	id_tag = "nebula_pump1";
+	id_tag = "nebula_pump1a";
 	name = "Nebula Pump Controller";
 	pixel_x = 25
 	},
@@ -13184,6 +13248,15 @@
 	},
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/shuttle/trade_ship/general)
+"VR" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "nebula_pump2b";
+	name = "Nebula Pump Controller";
+	pixel_x = -25
+	},
+/turf/simulated/floor/reinforced,
+/area/tradeport/pads)
 "VS" = (
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
@@ -14068,8 +14141,7 @@
 	internal_pressure_bound_default = 4000;
 	pressure_checks = 2;
 	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 1
+	pump_direction = 0
 	},
 /turf/simulated/floor/reinforced/airmix,
 /area/tradeport/atmospherics)
@@ -14243,13 +14315,7 @@
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	frequency = 8018;
 	id_tag = "trade_space_lock";
-	pixel_x = -25;
-	tag_airpump = null;
-	tag_chamber_sensor = null;
-	tag_exterior_door = null;
-	tag_exterior_sensor = null;
-	tag_interior_door = null;
-	tag_interior_sensor = null
+	pixel_x = -25
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
@@ -35806,7 +35872,7 @@ kf
 kf
 kf
 kf
-kf
+Ru
 kf
 kf
 kf
@@ -37933,6 +37999,7 @@ kf
 Yn
 kf
 kf
+Fj
 kf
 kf
 kf
@@ -37945,8 +38012,7 @@ kf
 kf
 kf
 kf
-kf
-kf
+pI
 kf
 kf
 IF
@@ -38903,7 +38969,6 @@ kf
 Yn
 kf
 kf
-Fj
 kf
 kf
 kf
@@ -38916,7 +38981,8 @@ kf
 kf
 kf
 kf
-pI
+kf
+kf
 kf
 kf
 gP
@@ -40057,7 +40123,7 @@ dX
 cB
 kZ
 Yn
-kf
+St
 Uz
 ur
 kf
@@ -40067,7 +40133,7 @@ kf
 ia
 kf
 kf
-kf
+CN
 kf
 Ef
 ur
@@ -40081,7 +40147,7 @@ kf
 ur
 Ef
 kf
-kf
+Kq
 kf
 gP
 ia
@@ -40089,7 +40155,7 @@ kf
 kf
 kf
 kf
-kf
+wu
 yD
 np
 ur
@@ -40283,7 +40349,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
+ia
 zr
 Fu
 bO
@@ -40462,7 +40528,7 @@ Rm
 dn
 dn
 Rm
-Rm
+qO
 le
 dn
 dn
@@ -40865,7 +40931,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
+ia
 eJ
 Jg
 bO
@@ -41027,7 +41093,7 @@ ia
 vP
 bY
 ia
-kf
+VR
 gW
 ur
 kf
@@ -41059,7 +41125,7 @@ kf
 kf
 kf
 kf
-kf
+oc
 Em
 qU
 ur
@@ -42201,7 +42267,6 @@ kf
 Yn
 kf
 kf
-Bv
 kf
 kf
 kf
@@ -42214,7 +42279,8 @@ kf
 kf
 kf
 kf
-wC
+kf
+kf
 kf
 kf
 kf
@@ -42977,6 +43043,7 @@ kf
 Yn
 kf
 kf
+Bv
 kf
 kf
 kf
@@ -42989,8 +43056,7 @@ kf
 kf
 kf
 kf
-kf
-kf
+wC
 kf
 kf
 kf
@@ -44730,7 +44796,7 @@ kf
 kf
 kf
 kf
-kf
+SX
 kf
 kf
 kf

--- a/maps/sectors/tradeport_192/levels/tradeport_192.dmm
+++ b/maps/sectors/tradeport_192/levels/tradeport_192.dmm
@@ -400,7 +400,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/turf/simulated/shuttle/wall/voidcraft,
+/obj/effect/paint/wallgunmetal,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/general)
 "bs" = (
 /obj/structure/railing{
@@ -714,7 +715,8 @@
 /area/tradeport/commons)
 "cF" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/turf/simulated/shuttle/wall/voidcraft,
+/obj/effect/paint/wallgunmetal,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/general)
 "cG" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
@@ -2122,7 +2124,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/turf/simulated/shuttle/wall/voidcraft,
+/obj/effect/paint/wallgunmetal,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/general)
 "hL" = (
 /obj/structure/table/rack/shelf/steel,
@@ -2348,7 +2351,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/turf/simulated/shuttle/wall/voidcraft,
+/obj/effect/paint/wallgunmetal,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/general)
 "iA" = (
 /obj/structure/cable/yellow{
@@ -3027,7 +3031,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
-/turf/simulated/shuttle/wall/voidcraft,
+/obj/effect/paint/wallgunmetal,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/general)
 "kJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3837,7 +3842,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/shuttle/wall/voidcraft,
+/obj/effect/paint/wallgunmetal,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/general)
 "nC" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -3896,7 +3902,8 @@
 /obj/machinery/holosign/bar{
 	id = "tradersign"
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/obj/effect/paint/wallgunmetal,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/general)
 "nO" = (
 /obj/machinery/atmospherics/component/binary/pump/high_power/on{
@@ -5141,7 +5148,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/shuttle/wall/voidcraft,
+/obj/effect/paint/wallgunmetal,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/general)
 "sP" = (
 /turf/simulated/wall/r_wall,
@@ -5590,7 +5598,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/shuttle/wall/voidcraft,
+/obj/effect/paint/wallgunmetal,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/general)
 "uF" = (
 /obj/structure/window/reinforced{
@@ -5993,7 +6002,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
-/turf/simulated/shuttle/wall/voidcraft,
+/obj/effect/paint/wallgunmetal,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/general)
 "vP" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
@@ -6126,7 +6136,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/turf/simulated/shuttle/wall/voidcraft,
+/obj/effect/paint/wallgunmetal,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/general)
 "wn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7329,6 +7340,7 @@
 /obj/structure/table/steel_reinforced,
 /obj/fiftyspawner/glass,
 /obj/fiftyspawner/steel,
+/obj/fiftyspawner/plastic,
 /turf/simulated/floor/tiled/dark,
 /area/tradeport/facility)
 "AD" = (
@@ -7359,6 +7371,8 @@
 /area/tradeport/pads)
 "AJ" = (
 /obj/structure/table/steel_reinforced,
+/obj/fiftyspawner/wmarble,
+/obj/fiftyspawner/bmarble,
 /turf/simulated/floor/tiled/dark,
 /area/tradeport/facility)
 "AK" = (
@@ -7400,6 +7414,17 @@
 	dir = 1;
 	pixel_y = 25
 	},
+/obj/structure/closet/crate,
+/obj/fiftyspawner/bcarpet,
+/obj/fiftyspawner/blucarpet,
+/obj/fiftyspawner/arcadecarpet,
+/obj/fiftyspawner/carpet,
+/obj/fiftyspawner/gaycarpet,
+/obj/fiftyspawner/oracarpet,
+/obj/fiftyspawner/purcarpet,
+/obj/fiftyspawner/sblucarpet,
+/obj/fiftyspawner/tealcarpet,
+/obj/fiftyspawner/turcarpet,
 /turf/simulated/floor/tiled/dark,
 /area/tradeport/facility)
 "AT" = (
@@ -7786,8 +7811,11 @@
 /turf/simulated/floor/snow,
 /area/tradeport/cyndishow)
 "BZ" = (
-/turf/simulated/shuttle/wall/voidcraft,
-/area/shuttle/trade_ship/cockpit)
+/obj/structure/table/steel_reinforced,
+/obj/fiftyspawner/wood,
+/obj/fiftyspawner/wood,
+/turf/simulated/floor/tiled/dark,
+/area/tradeport/facility)
 "Ca" = (
 /obj/machinery/vending/loadout/overwear,
 /turf/simulated/floor/wood,
@@ -8795,7 +8823,8 @@
 /area/shuttle/trade_ship/general)
 "FP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/shuttle/wall/voidcraft,
+/obj/effect/paint/wallgunmetal,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/general)
 "FQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9892,7 +9921,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/wall/voidcraft,
+/obj/effect/paint/wallgunmetal,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/general)
 "Kb" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -10727,7 +10757,8 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/tradeport/cafeteria)
 "MX" = (
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/obj/effect/paint/wallgunmetal,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/cockpit)
 "MY" = (
 /obj/machinery/door/firedoor{
@@ -11548,7 +11579,8 @@
 /turf/simulated/floor/airless,
 /area/tradeport/exterior)
 "PJ" = (
-/turf/simulated/shuttle/wall/voidcraft,
+/obj/effect/paint/wallgunmetal,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/general)
 "PL" = (
 /obj/machinery/light{
@@ -12306,7 +12338,8 @@
 /turf/simulated/floor/reinforced,
 /area/tradeport/pads)
 "Su" = (
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/obj/effect/paint/purple,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/general)
 "Sy" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -12765,7 +12798,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/shuttle/wall/voidcraft,
+/obj/effect/paint/wallgunmetal,
+/turf/simulated/wall/rshull,
 /area/shuttle/trade_ship/general)
 "Ud" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -35389,7 +35423,7 @@ Dh
 Dh
 Dh
 Dh
-Dh
+cd
 Dh
 wV
 wV
@@ -35986,10 +36020,10 @@ Jv
 Jv
 Jv
 PJ
-Su
+PJ
 EP
 aG
-Su
+PJ
 PJ
 Jv
 Jv
@@ -36567,12 +36601,12 @@ Jv
 Jv
 Jv
 Jv
-Su
-BZ
-BZ
+PJ
+MX
+MX
 vk
-BZ
-Su
+MX
+PJ
 Jv
 Jv
 Jv
@@ -36956,7 +36990,7 @@ nm
 PJ
 Jv
 PJ
-BZ
+MX
 MX
 nw
 vG
@@ -37143,15 +37177,15 @@ wV
 dA
 Jv
 Jv
-PJ
 Su
+PJ
 VQ
 KQ
 PJ
 Jv
 PJ
 gi
-BZ
+MX
 mb
 Ra
 PJ
@@ -37159,8 +37193,8 @@ Jv
 PJ
 uA
 UZ
-Su
 PJ
+Su
 Jv
 NQ
 dA
@@ -37337,7 +37371,7 @@ wV
 dA
 Jv
 Jv
-PJ
+Su
 hu
 CW
 vb
@@ -37354,7 +37388,7 @@ PJ
 LK
 ah
 bB
-PJ
+Su
 Jv
 NQ
 dA
@@ -37441,7 +37475,7 @@ kf
 kf
 kf
 kf
-qX
+kf
 kf
 kf
 kf
@@ -37531,7 +37565,7 @@ wV
 dA
 Jv
 Jv
-PJ
+Su
 Fd
 CW
 DG
@@ -37539,7 +37573,7 @@ PJ
 Vd
 PJ
 Ut
-BZ
+MX
 Sa
 Gd
 PJ
@@ -37548,7 +37582,7 @@ PJ
 qb
 UZ
 eS
-PJ
+Su
 Jv
 NQ
 dA
@@ -37725,7 +37759,7 @@ wV
 dA
 VO
 Jv
-PJ
+Su
 PJ
 DA
 PJ
@@ -37736,13 +37770,13 @@ MX
 Fq
 jC
 BK
-BZ
+MX
 Uc
 PJ
 PJ
 cP
 PJ
-PJ
+Su
 Jv
 gM
 dA
@@ -37798,7 +37832,7 @@ ia
 kf
 kf
 kf
-rh
+kf
 kf
 kf
 Zl
@@ -37919,7 +37953,7 @@ wV
 dA
 Jv
 Jv
-PJ
+Su
 cg
 CW
 hB
@@ -37930,13 +37964,13 @@ PJ
 PJ
 HX
 aZ
-Su
+PJ
 sO
 Fl
 UZ
 UZ
 jJ
-PJ
+Su
 Jv
 NQ
 dA
@@ -38022,7 +38056,7 @@ kf
 kf
 kf
 kf
-kf
+qX
 kf
 kf
 kf
@@ -38185,7 +38219,7 @@ Ph
 Yn
 kf
 kf
-kf
+rh
 kf
 kf
 kf
@@ -38894,14 +38928,14 @@ PJ
 PJ
 PJ
 PJ
-Su
+PJ
 HT
 Ct
 MK
 xd
 wZ
 NO
-Su
+PJ
 PJ
 PJ
 PJ
@@ -39085,7 +39119,7 @@ Jv
 Jv
 Jv
 PJ
-Su
+PJ
 ab
 wD
 hN
@@ -39098,7 +39132,7 @@ zY
 dy
 FR
 Bu
-Su
+PJ
 PJ
 Jv
 Jv
@@ -39359,7 +39393,7 @@ kf
 kf
 kf
 kf
-kf
+gh
 kf
 kf
 kf
@@ -39752,7 +39786,7 @@ kf
 kf
 kf
 kf
-gh
+kf
 kf
 kf
 kf
@@ -39861,7 +39895,7 @@ Jv
 Jv
 Jv
 PJ
-Su
+PJ
 Fr
 uS
 Yc
@@ -39874,7 +39908,7 @@ NO
 fh
 If
 HQ
-Su
+PJ
 PJ
 Jv
 Jv
@@ -40055,20 +40089,20 @@ Jv
 Jv
 PJ
 PJ
-Su
+PJ
 aA
 aA
 aA
-Su
+PJ
 Ax
 NC
 NC
 BG
-Su
+PJ
 aA
 aA
 aA
-Su
+PJ
 PJ
 PJ
 Jv
@@ -40248,7 +40282,7 @@ dA
 VO
 nM
 PJ
-Su
+PJ
 bI
 Dg
 xK
@@ -40263,7 +40297,7 @@ ge
 Ow
 uD
 nf
-Su
+PJ
 PJ
 nM
 FS
@@ -40828,14 +40862,14 @@ sP
 sP
 qj
 Jv
-Su
 PJ
-Su
+PJ
+PJ
 kq
 im
 rw
 ry
-Su
+PJ
 aH
 mp
 eW
@@ -40845,9 +40879,9 @@ Ch
 EM
 tH
 LG
-Su
 PJ
-Su
+PJ
+PJ
 NQ
 qj
 SO
@@ -41028,14 +41062,14 @@ PJ
 PJ
 gj
 PJ
-Su
-Su
+PJ
+PJ
 wh
 ZX
 NC
 lX
-Su
-Su
+PJ
+PJ
 PJ
 TZ
 Ka
@@ -41484,7 +41518,7 @@ ia
 kf
 kf
 kf
-vq
+kf
 kf
 kf
 kf
@@ -41516,7 +41550,7 @@ kf
 kf
 kf
 kf
-Jw
+kf
 kf
 kf
 kf
@@ -41605,24 +41639,24 @@ Rz
 dA
 Jv
 Jv
-PJ
 Su
+PJ
 Bl
 yv
 lH
-Su
-Su
+PJ
+PJ
 hs
 hl
 Yx
 BP
-Su
-Su
+PJ
+PJ
 jX
 js
 WT
-Su
 PJ
+Su
 Jv
 NQ
 dA
@@ -41709,7 +41743,7 @@ kf
 kf
 kf
 kf
-kf
+Jw
 kf
 kf
 kf
@@ -41798,7 +41832,7 @@ sP
 Rz
 dA
 Jv
-PJ
+Su
 PJ
 bJ
 NO
@@ -41817,7 +41851,7 @@ tt
 IC
 SR
 PJ
-PJ
+Su
 NQ
 nq
 tu
@@ -41992,7 +42026,7 @@ sP
 Rz
 dA
 Jv
-PJ
+Su
 PJ
 oR
 zG
@@ -42011,7 +42045,7 @@ VX
 Pz
 QY
 PJ
-PJ
+Su
 NQ
 nq
 dw
@@ -42186,7 +42220,7 @@ sP
 Rz
 dA
 Jv
-PJ
+Su
 iz
 wl
 wl
@@ -42205,7 +42239,7 @@ wl
 wl
 wl
 br
-PJ
+Su
 NQ
 nq
 tu
@@ -42259,7 +42293,7 @@ Nk
 Yn
 kf
 kf
-kf
+vq
 kf
 kf
 kf
@@ -42380,7 +42414,7 @@ sP
 sP
 dA
 VO
-PJ
+Su
 uE
 uE
 uE
@@ -42399,7 +42433,7 @@ uE
 uE
 uE
 uE
-PJ
+Su
 gM
 nq
 dw
@@ -42574,7 +42608,7 @@ dD
 sP
 dA
 Jv
-PJ
+Su
 Iz
 Iz
 Iz
@@ -42593,7 +42627,7 @@ Iz
 Iz
 Iz
 Iz
-PJ
+Su
 NQ
 nq
 tu
@@ -43043,7 +43077,7 @@ kf
 Yn
 kf
 kf
-Bv
+kf
 kf
 kf
 kf
@@ -44121,7 +44155,7 @@ Dh
 wV
 wV
 sP
-AJ
+BZ
 EH
 yp
 Yz
@@ -44207,7 +44241,7 @@ Nc
 ia
 kf
 kf
-kf
+Bv
 kf
 kf
 kf
@@ -44796,7 +44830,7 @@ kf
 kf
 kf
 kf
-SX
+kf
 kf
 kf
 kf
@@ -44985,7 +45019,7 @@ kf
 kf
 kf
 kf
-kf
+SX
 kf
 kf
 kf
@@ -45563,7 +45597,6 @@ Dh
 Dh
 Dh
 ia
-Ef
 kf
 kf
 kf
@@ -45581,7 +45614,8 @@ kf
 kf
 kf
 kf
-Nc
+kf
+kf
 ia
 Dh
 Dh
@@ -45757,25 +45791,25 @@ Dh
 Dh
 Dh
 ia
-ia
-jD
-jD
-jD
-jD
-jD
-jD
-jD
-jD
-jD
-jD
-jD
-jD
-jD
-jD
-jD
-jD
-jD
-ia
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
 ia
 Dh
 Dh
@@ -45950,27 +45984,27 @@ Dh
 Dh
 Dh
 Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-cd
-cd
-cd
-cd
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
+ia
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+ia
 Dh
 Dh
 Dh
@@ -46144,27 +46178,27 @@ Dh
 Dh
 Dh
 Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-cd
-cd
-cd
-cd
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
+ia
+Ef
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+kf
+Nc
+ia
 Dh
 Dh
 Dh
@@ -46338,27 +46372,27 @@ Dh
 Dh
 Dh
 Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-cd
-cd
-cd
-cd
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
+ia
+ia
+jD
+jD
+jD
+jD
+jD
+jD
+jD
+jD
+jD
+jD
+jD
+jD
+jD
+jD
+jD
+jD
+jD
+ia
+ia
 Dh
 Dh
 Dh


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
-Fixes explo shuttle being unable to dock with Nebula Gas (Oopsies)
-Adjusts the docks to allow all default spawn shuttles on Triumph and Atlas to dock with at least 1 hanger at Nebula Gas.
-Swaps out the Beruangs walls for shuttle rwalls since I'm here touching the map.
-Adds a crate of assorted carpets and a few 50 stacks of basic materials to the warehouse so Traders can drip out their ship.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The suffering of Pathfinders will now end. Exploration can purchase phoron and cheesy honkers from the gas station once again.
Also everyone else can go to the gas station now.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
-Fixes explo shuttle being unable to dock with Nebula Gas.
-Adjusts the docks to allow all default spawn shuttles on Triumph and Atlas to dock with at least 1 hanger at Nebula Gas.
-Swaps out the Beruangs walls for shuttle rwalls.
-Adds a crate of assorted carpets and a few 50 stacks of basic materials to the warehouse.
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: _Shadowcat_
add: Added stacks of carpets to Tradeport.
fix: Fixed docks at tradeport for all default shuttles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
