### PR TITLE
Makes exsanguination not make blood uninjectable

### DIFF
--- a/code/modules/mob/living/carbon/human/blood.dm
+++ b/code/modules/mob/living/carbon/human/blood.dm
@@ -269,9 +269,10 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 	if(vessel.get_reagent_amount("blood") < amount)
 		return null
 
+	if(amount >= vessel.get_reagent_amount("blood"))
+		amount = vessel.get_reagent_amount("blood") - 1	// Bit of a safety net; it's impossible to add blood if there's not blood already in the vessel.
+
 	. = ..()
-	if(amt >= vessel.get_reagent_amount("blood"))
-		amt = vessel.get_reagent_amount("blood") - 1	// Bit of a safety net; it's impossible to add blood if there's not blood already in the vessel.
 	vessel.remove_reagent("blood",amount) // Removes blood if human
 
 //Transfers blood from container ot vessels

--- a/code/modules/mob/living/carbon/human/blood.dm
+++ b/code/modules/mob/living/carbon/human/blood.dm
@@ -45,6 +45,15 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 			B.color = B.data["blood_colour"]
 			B.name = B.data["blood_name"]
 
+/mob/living/carbon/human/proc/fixblood_if_broken()
+	if(species.species_flags & NO_BLOOD)
+		return
+	if(!should_have_organ(O_HEART))
+		return
+	if(!vessel.has_reagent("blood"))
+		vessel.add_reagent("blood", 0.1)
+		fixblood()
+
 // Takes care blood loss and regeneration
 /mob/living/carbon/human/handle_blood()
 	if(inStasisNow())
@@ -211,7 +220,7 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 	if(!amt)
 		return 0
 
-	if(amt > vessel.get_reagent_amount("blood"))
+	if(amt >= vessel.get_reagent_amount("blood"))
 		amt = vessel.get_reagent_amount("blood") - 1	// Bit of a safety net; it's impossible to add blood if there's not blood already in the vessel.
 
 	return vessel.remove_reagent("blood",amt * (src.mob_size/MOB_MEDIUM))
@@ -261,6 +270,8 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 		return null
 
 	. = ..()
+	if(amt >= vessel.get_reagent_amount("blood"))
+		amt = vessel.get_reagent_amount("blood") - 1	// Bit of a safety net; it's impossible to add blood if there's not blood already in the vessel.
 	vessel.remove_reagent("blood",amount) // Removes blood if human
 
 //Transfers blood from container ot vessels
@@ -286,6 +297,8 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 		reagents.add_reagent("blood", amount, injected.data)
 		reagents.update_total()
 		return
+	
+	fixblood_if_broken()
 
 	var/datum/reagent/blood/our = get_blood(vessel)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If you remove all of someone's blood, they no longer have blood. At all. Ever. It's gone. You cannot add it back.

## Why It's Good For The Game

this bug has existed for 6 years

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Blood added with IV to bloodless people that should have blood no longer disappears into the aether never to be seen again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
