### PR TITLE
promethean number tweaks

### DIFF
--- a/code/modules/organs/external/species/slime.dm
+++ b/code/modules/organs/external/species/slime.dm
@@ -13,49 +13,49 @@
 
 /obj/item/organ/external/arm/unbreakable/slime
 	nonsolid = 1
-	max_damage = 35
+	max_damage = 20
 	spread_dam = 1
 	transparent = 1
 
 /obj/item/organ/external/arm/right/unbreakable/slime
 	nonsolid = 1
-	max_damage = 35
+	max_damage = 20
 	spread_dam = 1
 	transparent = 1
 
 /obj/item/organ/external/leg/unbreakable/slime
 	nonsolid = 1
-	max_damage = 35
+	max_damage = 20
 	spread_dam = 1
 	transparent = 1
 
 /obj/item/organ/external/leg/right/unbreakable/slime
 	nonsolid = 1
-	max_damage = 35
+	max_damage = 20
 	spread_dam = 1
 	transparent = 1
 
 /obj/item/organ/external/foot/unbreakable/slime
 	nonsolid = 1
-	max_damage = 35
+	max_damage = 20
 	spread_dam = 1
 	transparent = 1
 
 /obj/item/organ/external/foot/right/unbreakable/slime
 	nonsolid = 1
-	max_damage = 35
+	max_damage = 20
 	spread_dam = 1
 	transparent = 1
 
 /obj/item/organ/external/hand/unbreakable/slime
 	nonsolid = 1
-	max_damage = 35
+	max_damage = 20
 	spread_dam = 1
 	transparent = 1
 
 /obj/item/organ/external/hand/right/unbreakable/slime
 	nonsolid = 1
-	max_damage = 35
+	max_damage = 20
 	spread_dam = 1
 	transparent = 1
 
@@ -63,7 +63,7 @@
 	nonsolid = 1
 	cannot_gib = 0
 	vital = 0
-	max_damage = 35
+	max_damage = 20
 	encased = 0
 	spread_dam = 1
 	transparent = 1

--- a/code/modules/organs/external/species/slime.dm
+++ b/code/modules/organs/external/species/slime.dm
@@ -13,49 +13,49 @@
 
 /obj/item/organ/external/arm/unbreakable/slime
 	nonsolid = 1
-	max_damage = 20
+	max_damage = 25
 	spread_dam = 1
 	transparent = 1
 
 /obj/item/organ/external/arm/right/unbreakable/slime
 	nonsolid = 1
-	max_damage = 20
+	max_damage = 25
 	spread_dam = 1
 	transparent = 1
 
 /obj/item/organ/external/leg/unbreakable/slime
 	nonsolid = 1
-	max_damage = 20
+	max_damage = 25
 	spread_dam = 1
 	transparent = 1
 
 /obj/item/organ/external/leg/right/unbreakable/slime
 	nonsolid = 1
-	max_damage = 20
+	max_damage = 25
 	spread_dam = 1
 	transparent = 1
 
 /obj/item/organ/external/foot/unbreakable/slime
 	nonsolid = 1
-	max_damage = 20
+	max_damage = 25
 	spread_dam = 1
 	transparent = 1
 
 /obj/item/organ/external/foot/right/unbreakable/slime
 	nonsolid = 1
-	max_damage = 20
+	max_damage = 25
 	spread_dam = 1
 	transparent = 1
 
 /obj/item/organ/external/hand/unbreakable/slime
 	nonsolid = 1
-	max_damage = 20
+	max_damage = 25
 	spread_dam = 1
 	transparent = 1
 
 /obj/item/organ/external/hand/right/unbreakable/slime
 	nonsolid = 1
-	max_damage = 20
+	max_damage = 25
 	spread_dam = 1
 	transparent = 1
 
@@ -63,7 +63,7 @@
 	nonsolid = 1
 	cannot_gib = 0
 	vital = 0
-	max_damage = 20
+	max_damage = 25
 	encased = 0
 	spread_dam = 1
 	transparent = 1

--- a/code/modules/species/promethean/promethean.dm
+++ b/code/modules/species/promethean/promethean.dm
@@ -60,12 +60,10 @@ var/datum/species/shapeshifter/promethean/prometheans
 
 	gluttonous = 0
 	virus_immune = TRUE
-	slowdown = -0.2
 	brute_mod = 0.9
 	burn_mod  = 1.1
 	oxy_mod   = 0
 	flash_mod = 0.5 //No centralized, lensed eyes.
-	item_slowdown_mod = 0.66
 
 	cloning_modifier = /datum/modifier/cloning_sickness/promethean
 


### PR DESCRIPTION
## About The Pull Request

1. removes the inexplicable speed increase and item...not-slowdown, from prommies
2. nerfs their limb hp **(~~literally arbitrary placeholder values picked for rn til people come up with a comfy number, i think somewhere from 25 to 30 feels good and hits a good threshhold but who knows.~~) 25 is probably good**

## Why It's Good For The Game

we already spent a long time talking on discord about this but the tl;dr is that promethean is a really, really strong species at base, and has the added benefit of not suffering from baymed. 

event managers have expressed a bit of frustration at how strong the species is and i also agree w/ it. this is what was eventually settled on, while people work on adding other stuff to them in the background. (i think them having pain would also be cool since they're literally a fully biological species but that is neither here nor there, and it may be unironically rather crippling)

not really a 'fix' so much as a bandaid, as expressed by...someone  i forgor who

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: promethean number tweaks - removes random free speed buffs (almost half as fast as a taj bonus??) and decreases limb splodey threshhold
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
