### PR TITLE
Reduces chance of paroxetine hallucination

### DIFF
--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Medicine.dm
@@ -552,7 +552,7 @@
 				H.losebreath = 10
 				H.adjustOxyLoss(5)
 		if(prob(2))
-			to_chat(H,"<span class='warning'>You feel a dull pain behind your eyes and at thee back of your head...</span>")
+			to_chat(H,"<span class='warning'>You feel a dull pain behind your eyes and at the back of your head...</span>")
 			H.hallucination += 20 //It messes with your mind for some reason.
 			H.eye_blurry += 20 //Groggy vision for a small bit.
 		if(prob(3))
@@ -1421,11 +1421,11 @@
 	else
 		if(world.time > data + ANTIDEPRESSANT_MESSAGE_DELAY)
 			data = world.time
-			if(prob(90))
-				to_chat(M, "<span class='notice'>Your mind feels much more stable.</span>")
-			else
+			if(prob(1))
 				to_chat(M, "<span class='warning'>Your mind breaks apart...</span>")
 				M.hallucination += 200
+			else
+				to_chat(M, "<span class='notice'>Your mind feels much more stable.</span>")
 
 /datum/reagent/adranol//Moved from Chemistry-Reagents-Medicine_vr.dm
 	name = "Adranol"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Was 10% per 5 minutes (>50% every 35 minutes), now 1% per 5 minutes (>50% every 345 minutes).

## Why It's Good For The Game

Paroxetine is the strongest hallucinogen in the game. This is not an exaggeration: the supermatter caps at the amount paroxetine _adds_. An exploding supermatter is more powerful, but only _if you're on top of it_. Putting _supermatter into the R-UST_ causes less hallucinations.

I think this is appropriate given the flavor text, but the chance is way too high right now; there's a 96% chance per (max-length) round of it happening _at least once_, and this reduces it to a mere 24% chance, which is _still_ pretty high, actually.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Paroxetine now causes a complete mind-whammy every 6 hours instead of every 30 minutes on average
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
