### PR TITLE
removes weird ooc 'Craft me!' scanner module in atlas geothermal, replaces with note

### DIFF
--- a/maps/rift/levels/rift-09-west_caves.dmm
+++ b/maps/rift/levels/rift-09-west_caves.dmm
@@ -410,6 +410,12 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/paper{
+	info = "Hi, Abby. Thank you for reaching out. The general, simplified outline for the geothermal generator is as such; using the items on hand (two scanner arrays, four cable coils), you are able to craft an Advanced Geothermal Scanning Array. After putting it into the machine, simply use the provided multitool to put it in motion! You'll then be able to activate the SMES and restore powerflow. If you're having trouble finding the aforementioned supplies, make sure to look around!";
+	name = "geothermal instructions";
+	pixel_x = 6;
+	pixel_y = -7
+	},
 /turf/simulated/floor/tiled/steel_dirty/lythios43c/indoors,
 /area/rift/geothermal)
 "eQ" = (
@@ -3721,9 +3727,7 @@
 /obj/item/tool/screwdriver,
 /obj/item/stack/cable_coil,
 /obj/item/stock_parts/scanning_module,
-/obj/item/stock_parts/scanning_module{
-	name = "Craft me!"
-	},
+/obj/item/stock_parts/scanning_module,
 /turf/simulated/floor/tiled/steel_dirty/lythios43c/indoors,
 /area/rift/geothermal)
 "Sc" = (
@@ -30560,7 +30564,7 @@ cU
 Cc
 pt
 pt
-pt
+Cc
 Cc
 EI
 EI
@@ -30754,7 +30758,7 @@ cU
 Cc
 pt
 pt
-pt
+Cc
 Cc
 Cc
 Cc


### PR DESCRIPTION
## About The Pull Request

as the above. is now 2 scanners normally named and an IC note w/ more instruction

![image](https://github.com/Citadel-Station-13/Citadel-Station-13-RP/assets/54826962/e04da1c6-1cea-45ff-ad18-c7b4d2ce523d)
one of these scanners was just named 'Craft me!' with 0 elaboration, at best seemed a little unintuitive and ooc.

## Why It's Good For The Game

yeah.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: scannernotethingatlas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
