### PR TITLE
Blowing your head no longer runtimes the server

### DIFF
--- a/code/modules/organs/external/subtypes/standard.dm
+++ b/code/modules/organs/external/subtypes/standard.dm
@@ -276,7 +276,7 @@
 	if(owner)
 		if(iscarbon(owner))
 			name = "[owner.real_name]'s head"
-			//spawn(1) //This appears to do nothing and causes the checks above it to become stale. If this needs to be added back in consider moving it above if(owner). ~Shadowcat
+			
 				owner.update_hair()
 	get_icon()
 	..()

--- a/code/modules/organs/external/subtypes/standard.dm
+++ b/code/modules/organs/external/subtypes/standard.dm
@@ -277,7 +277,7 @@
 		if(iscarbon(owner))
 			name = "[owner.real_name]'s head"
 			
-				owner.update_hair()
+		owner.update_hair()
 	get_icon()
 	..()
 

--- a/code/modules/organs/external/subtypes/standard.dm
+++ b/code/modules/organs/external/subtypes/standard.dm
@@ -276,8 +276,7 @@
 	if(owner)
 		if(iscarbon(owner))
 			name = "[owner.real_name]'s head"
-			
-		owner.update_hair()
+			owner.update_hair()
 	get_icon()
 	..()
 

--- a/code/modules/organs/external/subtypes/standard.dm
+++ b/code/modules/organs/external/subtypes/standard.dm
@@ -276,7 +276,7 @@
 	if(owner)
 		if(iscarbon(owner))
 			name = "[owner.real_name]'s head"
-			spawn(1)
+			//spawn(1) //This appears to do nothing and causes the checks above it to become stale. If this needs to be added back in consider moving it above if(owner). ~Shadowcat
 				owner.update_hair()
 	get_icon()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Exploding a person will delete their head before their hair causing a null access runtime.
Removes a spawn(1) that makes a check stale.
Maybe Testmerge this first. I don't think this should cause any problems but I know some icon ops need a delay to work?
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Blowing heads without error is a critical citadel feature.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
-Deletes apparently pointless and buggy spawn(1) delay
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Shadowcat
fix: fixes a runtime in the cleanup code for exploding carbon mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
