### PR TITLE
fixes emps, tweaks protean balancing number sagain

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -4,6 +4,12 @@
 		return null
 	..()
 
+/mob/living/carbon/emp_act(severity)
+	. = ..()
+	// tODO: REFACTOR THIS DUMB SHIT
+	for(var/obj/item/organ/organ in organs | internal_organs)
+		organ.emp_act(severity)
+
 /mob/living/carbon/standard_weapon_hit_effects(obj/item/I, mob/living/user, var/effective_force, var/blocked, var/soaked, var/hit_zone)
 	if(!effective_force || blocked >= 100)
 		return 0

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1291,6 +1291,7 @@
 		W.add_fingerprint(src)
 
 /mob/living/carbon/human/emp_act(severity)
+	. = ..()
 	if(isSynthetic())
 		switch(severity)
 			if(1)
@@ -1310,8 +1311,6 @@
 		to_chat(src, "<font align='center' face='fixedsys' size='10' color='red'><B>*BZZZT*</B></font>")
 		to_chat(src, "<font face='fixedsys'><span class='danger'>Warning: Electromagnetic pulse detected.</span></font>")
 		to_chat(src, "<font face='fixedsys'><span class='danger'>Warning: Navigation systems offline. Restarting...</span></font>")
-		..()
-
 
 /mob/living/carbon/human/can_inject(var/mob/user, var/error_msg, var/target_zone, var/ignore_thickness = FALSE)
 	. = 1

--- a/code/modules/organs/external/external.dm
+++ b/code/modules/organs/external/external.dm
@@ -186,13 +186,13 @@
 	var/burn_damage = 0
 	switch(severity)
 		if (1)
-			burn_damage += rand(10, 16)
+			burn_damage += rand(10, 14)
 		if (2)
-			burn_damage += rand(8, 12)
+			burn_damage += rand(7, 8.5)
 		if(3)
 			burn_damage += rand(4, 8)
 		if(4)
-			burn_damage += rand(2, 6)
+			burn_damage += rand(2, 5)
 
 	if(burn_damage)
 		inflict_bodypart_damage(
@@ -357,6 +357,9 @@
 	// todo: this is awful
 	var/sharp = damage_mode & DAMAGE_MODE_SHARP
 	var/edge = damage_mode & DAMAGE_MODE_EDGE
+	// cache owner incase we get detached
+	// todo: this is awful
+	var/mob/living/carbon/owner = src.owner
 
 	// todo: lol this is shit
 	// legacy: organ damage on high damage

--- a/code/modules/organs/subtypes/nano.dm
+++ b/code/modules/organs/subtypes/nano.dm
@@ -2,7 +2,7 @@
 /obj/item/organ/external/chest/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 100
+	max_damage = 200
 	min_broken_damage = 1000
 	vital = TRUE
 	emp_mod = 7

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -228,7 +228,7 @@
 		var/mob/living/silicon/robot/R = loc
 		severity *= R.cell_emp_mult
 
-	charge -= charge / severity
+	charge -= charge / (severity + 1)
 	if (charge < 0)
 		charge = 0
 

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -18,8 +18,8 @@
 	var/sev4_range = 1
 
 /obj/projectile/ion/on_hit(var/atom/target, var/blocked = 0)
-		empulse(target, sev1_range, sev2_range, sev3_range, sev4_range)
-		return 1
+	empulse(target, sev1_range, sev2_range, sev3_range, sev4_range)
+	return 1
 
 /obj/projectile/ion/small
 	sev1_range = -1

--- a/code/modules/species/protean/protean.dm
+++ b/code/modules/species/protean/protean.dm
@@ -307,8 +307,7 @@
 	holder.adjustBruteLoss(-brute_heal_left, include_robo = TRUE)
 	holder.adjustFireLoss(-burn_heal_left, include_robo = TRUE)
 	holder.adjustToxLoss(-3.6) // With them now having tox immunity, this is redundant, along with the rad regen, but I'm keeping it in, in case they do somehow get some system instability
-	holder.radiation = max(RAD_MOB_CURE_PROTEAN_REGEN)
-
+	holder.cure_radiation(RAD_MOB_CURE_PROTEAN_REGEN)
 
 /proc/protean_requires_healing(mob/living/carbon/human/H)
 	if(!istype(H))

--- a/code/modules/species/protean/protean_blob.dm
+++ b/code/modules/species/protean/protean_blob.dm
@@ -109,8 +109,7 @@
 		var/obj/item/organ/external/E = humanform.get_organ(BP_TORSO)
 		//Set us to their health, but, human health ignores robolimbs so we do it 'the hard way'
 		health = maxHealth - E.brute_dam - E.burn_dam
-		movement_cooldown = 0.5 + max(0, (maxHealth - health) - 100) / 35
-		base_attack_cooldown = 10 + max(0, (maxHealth - health) - 100) / 15
+		movement_cooldown = 0.5 + max(0, (maxHealth - health) - 100) / 50
 
 		//Alive, becoming dead
 		if((stat < DEAD) && (health <= 0))
@@ -663,7 +662,7 @@
 		if("headsets")
 			chosen_list = GLOB.clothing_headsets
 			icon_file = 'icons/mob/clothing/ears.dmi'
-			
+
 	var/picked = input(src,"What clothing would you like to mimic?","Mimic Clothes") as null|anything in chosen_list
 
 	if(!ispath(chosen_list[picked]))
@@ -673,7 +672,7 @@
 	if(isnull(H.icon_override))
 		H.icon_override = icon_file
 	H.update_worn_icon()	//so our overlays update.
-	
+
 	if (ismob(H.loc))
 		var/mob/M = H.loc
 		M.update_inv_belt() //so our overlays
@@ -717,7 +716,7 @@
 			chosenpart = H.boots
 			chosen_list = GLOB.clothing_shoes
 
-	
+
 	var/picked = input(src,"What clothing would you like to mimic?","Mimic Clothes") as null|anything in chosen_list
 
 	if(!ispath(chosen_list[picked]))
@@ -738,7 +737,7 @@
 
 	var/obj/item/holder/H = loc
 	var/color_in = input("Pick a color. Cancelling sets it to default.","Color", H.color) as null|color
-	
+
 	if(color_in)
 		H.color = color_in
 	else


### PR DESCRIPTION
here i go again

- emps once again hit everything in someone (lessening in severity for things inside backpacks)
- emps no longer entirely annihilate cells like before
- non-synths can now be emp'd properly
- protean blob speed scaling and attack speed scaling changed yet again 
- protean values are tweaked to be more consistent (3 shot blob, 1-2 shot cripple + limb explosion with ion, 1-2 sev 1 emps to fully cripple)

the proper emp rework will come soon (tm)