### PR TITLE
makes Planetary solars use the local time and weather for calculations, instead of some random subsystem in the background

### DIFF
--- a/code/datums/sun.dm
+++ b/code/datums/sun.dm
@@ -33,9 +33,3 @@
 		dx = s/abs(s)
 		dy = c / abs(s)
 
-	//now tell the solar control computers to update their status and linked devices
-	for(var/obj/machinery/power/solar_control/SC in GLOB.solars_list)
-		if(!SC.powernet)
-			GLOB.solars_list.Remove(SC)
-			continue
-		SC.update()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -107,8 +107,8 @@ GLOBAL_LIST_EMPTY(solars_list)
 		our_planet = SSplanets.z_to_planet[z]
 
 	if(our_planet && istype(our_planet))
-		solar_brightness = our_planet.sun_apparent_brightness
-		var/time_num = text2num(our_planet.current_time.show_time("hh"))
+		solar_brightness = our_planet.sun_apparent_brightness * 1.3
+		var/time_num = text2num(our_planet.current_time.show_time("hh")) + text2num(our_planet.current_time.show_time("mm")) / 60
 		var/hours_in_day = our_planet.current_time.seconds_in_day / (1 HOURS)
 		var/sunangle_by_time = (time_num / hours_in_day) * 360 // day as progress from 0 to 1 * 360
 		p_angle = abs(adir - sunangle_by_time)
@@ -118,11 +118,7 @@ GLOBAL_LIST_EMPTY(solars_list)
 		//find the smaller angle between the direction the panel is facing and the direction of the SSsun.sun (the sign is not important here)
 		p_angle = min(abs(adir - SSsun.sun.angle), 360 - abs(adir - SSsun.sun.angle))
 
-	if(p_angle > 90)// if facing more than 90deg from SSsun.sun, zero output
-		sunfrac = 0
-		return
-
-	sunfrac = cos(p_angle) * solar_brightness
+	sunfrac = max(cos(p_angle), 0) * solar_brightness
 
 /obj/machinery/power/solar/process(delta_time)//TODO: remove/add this from machines to save on processing as needed ~Carn PRIORITY
 	if(machine_stat & BROKEN)
@@ -435,6 +431,8 @@ GLOBAL_LIST_EMPTY(solars_list)
 			targetdir = (targetdir + trackrate/abs(trackrate) + 360) % 360 	//... do it
 			nexttime += 36000/abs(trackrate) //reset the counter for the next 1�
 
+	update()
+
 	updateDialog()
 
 /obj/machinery/power/solar_control/Topic(href, href_list)
@@ -483,11 +481,13 @@ GLOBAL_LIST_EMPTY(solars_list)
 	var/angle = 0
 	var/datum/planet/our_planet = null
 	var/turf/T = get_turf(src)
-	if(T.outdoors && (T.z <= SSplanets.z_to_planet.len))
+	if(T.z <= SSplanets.z_to_planet.len)
 		our_planet = SSplanets.z_to_planet[z]
 
 	if(our_planet && istype(our_planet))
-		angle = (text2num(our_planet.current_time.show_time("hh")) / (our_planet.current_time.seconds_in_day / 1 HOURS)) * 360 // day as progress from 0 to 1 * 360
+		var/time_num = text2num(our_planet.current_time.show_time("hh")) + (text2num(our_planet.current_time.show_time("mm"))/60)
+		var/day_hours = our_planet.current_time.seconds_in_day / (1 HOURS)
+		angle = round((time_num / day_hours) * 360) // day as progress from 0 to 1 * 360
 	else
 		angle = SSsun.sun.angle
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
only tested with the rift with Noon and clear weather where it produced about 280kW
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
no more pseudo science
probably need to buff solars output a bit
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: tweaked solars to work off /datum/planet instead of SSSun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
