### PR TITLE
Makes canes/crutches usable for amputees

### DIFF
--- a/code/modules/loadout/loadout_general.dm
+++ b/code/modules/loadout/loadout_general.dm
@@ -1,6 +1,7 @@
 /datum/loadout_entry/cane
 	name = "Cane"
 	path = /obj/item/cane
+	slot = SLOT_ID_HANDS
 
 /datum/loadout_entry/cane/white
 	name = "Cane - White"

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -105,11 +105,12 @@
 
 	// Canes and crutches help you stand (if the latter is ever added)
 	// One cane mitigates a broken leg+foot, or a missing foot.
-	// Two canes are needed for a lost leg. If you are missing both legs, canes aren't gonna help you.
+	var/cane_help=4
 	if (l_hand && istype(l_hand, /obj/item/cane))
-		stance_damage -= 2
+		stance_damage -= cane_help
+		cane_help-=1
 	if (r_hand && istype(r_hand, /obj/item/cane))
-		stance_damage -= 2
+		stance_damage -= cane_help
 
 	// standing is poor
 	if(stance_damage >= 4 || (stance_damage >= 2 && prob(5)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. This makes it so that a cane/crutch can be used to fully support a one-legged person, instead of requiring two.

If both legs are missing, two crutches still won't be enough. I don't know if that's what the old system was supposed to "fix", but it's trivial to fix if you give it some thought, so I kinda doubt it.

## Why It's Good For The Game

the previous mechanics make amputees literally completely unplayable for no reason

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Crutches/canes now provide more support
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
