### PR TITLE
walking around doesnt draw additional hunger

### DIFF
--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -5,12 +5,9 @@
 		if(src.nutrition && src.stat != 2)
 			if(ishuman(src))
 				var/mob/living/carbon/human/M = src
-				if(M.stat != 2 && M.nutrition > 0)
-					M.nutrition -= M.species.hunger_factor/10
-					if(M.m_intent == "run")
-						M.nutrition -= M.species.hunger_factor/10
-					if(M.nutrition < 0)
-						M.nutrition = 0
+				if(M.stat != 2 && M.nutrition > 0 && M.m_intent == MOVE_INTENT_RUN)
+					// Only running takes nutrition now, still as much as before
+					M.nutrition = max(0, M.nutrition - M.species.hunger_factor/5)
 			else
 				src.nutrition -= DEFAULT_HUNGER_FACTOR/10
 				if(src.m_intent == "run")

--- a/code/modules/mob/living/carbon/human/movement.dm
+++ b/code/modules/mob/living/carbon/human/movement.dm
@@ -33,7 +33,7 @@
 				tally += (halloss / 45) //halloss shouldn't slow you down if you can't even feel it
 
 	var/hungry = (500 - nutrition)/5 // So overeat would be 100 and default level would be 80
-	if (hungry >= 70)
+	if (m_intent == MOVE_INTENT_RUN && hungry >= 70)//You can walk while hungry, but you cant run so fast while hungry
 		tally += hungry/50
 
 	if(reagents.has_reagent("numbenzyme"))


### PR DESCRIPTION
running still does (same amount as before)
Walking does not get slowed down from hunger

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
walking around doesnt draw additional hunger
running still does (same amount as before)
Walking does not get slowed down from hunger
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: tweaked walking to not draw extra nutrition (running still draws the same amount as before)
tweak: tweaked walking to not get slowed down from hunger
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
