### PR TITLE
Goodbye Questionable Buttons inside Walls and Bins, Hello Atlas Engineering Autolathe

### DIFF
--- a/maps/rift/levels/rift-02-underground2.dmm
+++ b/maps/rift/levels/rift-02-underground2.dmm
@@ -4710,7 +4710,7 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled/monotile,
-/area/rift)
+/area/engineering/engine_monitoring)
 "qc" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -7836,6 +7836,10 @@
 "CC" = (
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/miningdock)
+"CG" = (
+/obj/machinery/lathe/autolathe,
+/turf/simulated/floor/tiled,
+/area/engineering/workshop)
 "CH" = (
 /obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks,
 /obj/effect/paint/sun,
@@ -29765,7 +29769,7 @@ cX
 KY
 ES
 FZ
-FZ
+CG
 oD
 gs
 Mb

--- a/maps/rift/levels/rift-02-underground2.dmm
+++ b/maps/rift/levels/rift-02-underground2.dmm
@@ -4709,16 +4709,8 @@
 "qa" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for the engine control room blast doors.";
-	id = "engine_monitor_blast";
-	name = "Monitoring Room Blast Doors";
-	pixel_y = -5;
-	req_access = list(10);
-	pixel_x = -1
-	},
 /turf/simulated/floor/tiled/monotile,
-/area/engineering/engine_monitoring)
+/area/rift)
 "qc" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -7844,17 +7836,6 @@
 "CC" = (
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/miningdock)
-"CG" = (
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for the engine charging port.";
-	id = "engine_room_blast";
-	name = "Engine Room Window Blast Doors";
-	pixel_x = -7;
-	pixel_y = 6;
-	req_access = list(10)
-	},
-/turf/simulated/mineral/icerock/lythios43c,
-/area/rift/surfacebase/underground/under2)
 "CH" = (
 /obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks,
 /obj/effect/paint/sun,
@@ -32714,7 +32695,7 @@ aa
 aa
 aa
 aa
-CG
+aa
 aa
 aa
 aa

--- a/maps/rift/levels/rift-02-underground2.dmm
+++ b/maps/rift/levels/rift-02-underground2.dmm
@@ -10496,10 +10496,6 @@
 /obj/machinery/requests_console/preset/ce{
 	pixel_y = -30
 	},
-/obj/machinery/mass_driver{
-	dir = 8;
-	id = "enginecore"
-	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
 "Nm" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removed two buttons, one that was over a disposal bin in engine monitoring and another that was inside the rock walls deep behind maintenances. Also added an autolathe in tool storage that I requested several times, I used to just build my own until it got too repetitive, and the spot I chose I think it's the best I could choose. I also removed the mass driver. It's a machine that shoots items into space, it doesn't belong on a planetary ground base.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This makes the life of engineers who expand rooms or simply build machinery easier without being slaves to science's whim. It also removes two buttons and a mass driver that existed for no reason, and were mistakes, this is all pretty much another pet peeve of mine.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
* Removed shutter button over bin in engine monitoring
* Removed shutter button over closed wall tile next to the lava pool behind engineering maintenance underground 2
* Removed mass driver in CE's office
* Added autolathe in engineering tool storage
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: autolathe in engineering
fix: floating buttons
remove: mass driver
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
