### PR TITLE
Makes the R-UST tell you that turning it off makes it explode

### DIFF
--- a/code/modules/power/fusion/core/core_control.dm
+++ b/code/modules/power/fusion/core/core_control.dm
@@ -50,7 +50,7 @@
 			Device ident '[cur_viewed_device.id_tag]' <span style='color: [cur_viewed_device.owned_field ? "green" : "red"]'>[cur_viewed_device.owned_field ? "active" : "inactive"].</span><br>
 			<b>Power status:</b> [cur_viewed_device.avail()]/[cur_viewed_device.active_power_usage * 0.001] kW<br>
 			<hr>
-			<a href='?src=\ref[src];toggle_active=1'>Bring field [cur_viewed_device.owned_field ? "offline" : "online"].</a><br>
+			<a href='?src=\ref[src];toggle_active=1'>Bring field [cur_viewed_device.owned_field ? "offline, which will cause it to explode" : "online"].</a><br>
 			<hr>
 			<b>Field power density (W.m<sup>-3</sup>):</b><br>
 			<a href='?src=\ref[src];str=-1000'>----</a>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Right now there's a button that says "Bring field offline." Any reasonable person would assume this is the button you press to shut it down if something's going wrong, since shutting things down is usually one of the first steps in the process of things going wrong. This button causes it to explode. That is its entire purpose. It does nothing but make the R-UST explode. Exploding the R-UST is the purpose of the button. The game indicates this none.

## Why It's Good For The Game

The "explode the R-UST" button being properly labeled is a good thing

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: the "explode the R-UST" button in the R-UST UI is now labeled properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
