### PR TITLE
adds a mask that warms breath as you take it

### DIFF
--- a/citadel.dme
+++ b/citadel.dme
@@ -2489,6 +2489,7 @@
 #include "code\modules\clothing\masks\_mask.dm"
 #include "code\modules\clothing\masks\boxing.dm"
 #include "code\modules\clothing\masks\breath.dm"
+#include "code\modules\clothing\masks\breath_warmer.dm"
 #include "code\modules\clothing\masks\gasmask.dm"
 #include "code\modules\clothing\masks\miscellaneous.dm"
 #include "code\modules\clothing\masks\voice.dm"

--- a/code/game/machinery/vending/loadout.dm
+++ b/code/game/machinery/vending/loadout.dm
@@ -226,6 +226,7 @@
 		/obj/item/clothing/mask/bandana/green = 5,
 		/obj/item/clothing/mask/bandana/red = 5,
 		/obj/item/clothing/mask/surgical = 5,
+		/obj/item/clothing/mask/warmer = 5,
 	)
 	premium = list(/obj/item/bedsheet/rainbow = 1)
 	contraband = list(/obj/item/clothing/mask/gas/clown_hat = 1)

--- a/code/modules/clothing/masks/_mask.dm
+++ b/code/modules/clothing/masks/_mask.dm
@@ -12,5 +12,5 @@
 	var/list/say_messages
 	var/list/say_verbs
 
-/obj/item/clothing/mask/proc/filter_air(datum/gas_mixture/air)
+/obj/item/clothing/mask/proc/process_air(datum/gas_mixture/air)
 	return

--- a/code/modules/clothing/masks/_mask.dm
+++ b/code/modules/clothing/masks/_mask.dm
@@ -12,5 +12,14 @@
 	var/list/say_messages
 	var/list/say_verbs
 
+// gets one gas_mixture
+// that mixture is modified (and then used for breathing)
+// additionally removed gases can be returned to be passed to atmos
 /obj/item/clothing/mask/proc/process_air(datum/gas_mixture/air)
 	return
+
+//gets one gas_mixture (the exhale)
+//returns what should be passed to the environment
+/obj/item/clothing/mask/proc/process_exhale(datum/gas_mixture/air)
+	return
+

--- a/code/modules/clothing/masks/breath_warmer.dm
+++ b/code/modules/clothing/masks/breath_warmer.dm
@@ -1,15 +1,12 @@
 /obj/item/clothing/mask/warmer
 	name = "warming mask"
-	desc = "A sterile mask designed to help prevent the spread of diseases."
+	desc = "A mask that warms your breath, making the cold more bearable."
 	icon = 'icons/obj/clothing/ties.dmi'
 	icon_state = "gaiter_snow_up"
 	item_state_slots = list(SLOT_ID_RIGHT_HAND = "sterile", SLOT_ID_LEFT_HAND = "sterile")
 	w_class = WEIGHT_CLASS_SMALL
 	body_cover_flags = FACE
 	clothing_flags = FLEXIBLEMATERIAL
-	gas_transfer_coefficient = 0.90
-	permeability_coefficient = 0.01
-	armor_type = /datum/armor/mask/surgical
 
 //Warms with 1000 watts
 /obj/item/clothing/mask/warmer/process_air(datum/gas_mixture/air)

--- a/code/modules/clothing/masks/breath_warmer.dm
+++ b/code/modules/clothing/masks/breath_warmer.dm
@@ -1,0 +1,21 @@
+/obj/item/clothing/mask/warmer
+	name = "warming mask"
+	desc = "A sterile mask designed to help prevent the spread of diseases."
+	icon = 'icons/obj/clothing/ties.dmi'
+	icon_state = "gaiter_snow_up"
+	item_state_slots = list(SLOT_ID_RIGHT_HAND = "sterile", SLOT_ID_LEFT_HAND = "sterile")
+	w_class = WEIGHT_CLASS_SMALL
+	body_cover_flags = FACE
+	clothing_flags = FLEXIBLEMATERIAL
+	gas_transfer_coefficient = 0.90
+	permeability_coefficient = 0.01
+	armor_type = /datum/armor/mask/surgical
+
+//Warms with 1000 watts
+/obj/item/clothing/mask/warmer/process_air(datum/gas_mixture/air)
+	var/mob/living/carbon/wearer = src.loc
+	if(istype(wearer))
+		var/energy_to_warm = air.get_thermal_energy_change(wearer.bodytemperature)
+		air.adjust_thermal_energy(clamp(energy_to_warm, 0, 1000))
+
+

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -14,7 +14,7 @@
 	var/gas_filter_strength = 1			//For gas mask filters
 	var/list/filtered_gases = list(GAS_ID_PHORON, GAS_ID_NITROUS_OXIDE)
 
-/obj/item/clothing/mask/gas/filter_air(datum/gas_mixture/air)
+/obj/item/clothing/mask/gas/process_air(datum/gas_mixture/air)
 	var/datum/gas_mixture/gas_filtered = new
 
 	for(var/g in filtered_gases)

--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -74,7 +74,7 @@
 		//handle mask filtering
 		if(istype(wear_mask, /obj/item/clothing/mask))
 			var/obj/item/clothing/mask/M = wear_mask
-			var/datum/gas_mixture/gas_filtered = M.filter_air(breath)
+			var/datum/gas_mixture/gas_filtered = M.process_air(breath)
 			loc.assume_air(gas_filtered)
 		return breath
 	return null

--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -96,4 +96,8 @@
 
 /mob/living/carbon/proc/handle_post_breath(datum/gas_mixture/breath)
 	if(breath)
-		loc?.assume_air(breath) //by default, exhale
+		if(istype(wear_mask, /obj/item/clothing/mask))
+			var/obj/item/clothing/mask/M = wear_mask
+			loc.assume_air(M.process_exhale(breath))
+		else
+			loc?.assume_air(breath) //by default, exhale

--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -72,7 +72,7 @@
 
 	if(breath)
 		//handle mask filtering
-		if(istype(wear_mask, /obj/item/clothing/mask) && breath)
+		if(istype(wear_mask, /obj/item/clothing/mask))
 			var/obj/item/clothing/mask/M = wear_mask
 			var/datum/gas_mixture/gas_filtered = M.filter_air(breath)
 			loc.assume_air(gas_filtered)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -246,7 +246,7 @@
 	var/timeofdeath = 0 //?Living
 
 	// todo: go to carbon, simple mobs don't need environmental stabilization
-	var/bodytemperature = 310.055 //98.7 F
+	var/bodytemperature = 310.055 //98.7 F or 36,905 C
 	var/drowsyness = 0 //?Carbon
 
 	var/nutrition = 400 //?Carbon

--- a/maps/rift/levels/rift-04-surface1.dmm
+++ b/maps/rift/levels/rift-04-surface1.dmm
@@ -1616,9 +1616,6 @@
 "biN" = (
 /obj/machinery/door/window/eastright,
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/tank/oxygen,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1629,7 +1626,8 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/clothing/mask/gas/clear,
+/obj/item/clothing/mask/warmer,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
 /turf/simulated/floor/tiled/steel,
 /area/storage/surface_eva)
 "biY" = (
@@ -3181,9 +3179,6 @@
 "cfw" = (
 /obj/machinery/door/window/eastleft,
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/tank/oxygen,
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
@@ -3197,6 +3192,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/item/clothing/suit/storage/hooded/wintercoat,
 /obj/item/clothing/mask/gas/clear,
 /turf/simulated/floor/tiled/steel,
 /area/storage/surface_eva)
@@ -3590,9 +3586,6 @@
 	dir = 8
 	},
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/tank/oxygen,
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
 	},
@@ -3604,7 +3597,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/clothing/mask/gas/clear,
+/obj/item/clothing/mask/warmer,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
 /turf/simulated/floor/tiled/steel,
 /area/storage/surface_eva)
 "cvM" = (
@@ -12699,9 +12693,6 @@
 "igZ" = (
 /obj/machinery/door/window/eastright,
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/tank/oxygen,
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
 	},
@@ -12713,6 +12704,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/item/clothing/suit/storage/hooded/wintercoat,
 /obj/item/clothing/mask/gas/clear,
 /turf/simulated/floor/tiled/steel,
 /area/storage/surface_eva)
@@ -18767,9 +18759,6 @@
 "maf" = (
 /obj/machinery/door/window/westright,
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/tank/oxygen,
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
@@ -18783,7 +18772,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/clothing/mask/gas/clear,
+/obj/item/clothing/mask/warmer,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
 /turf/simulated/floor/tiled/steel,
 /area/storage/surface_eva)
 "mau" = (
@@ -21068,9 +21058,6 @@
 	dir = 8
 	},
 /obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/tank/oxygen,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -21081,6 +21068,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/item/clothing/suit/storage/hooded/wintercoat,
 /obj/item/clothing/mask/gas/clear,
 /turf/simulated/floor/tiled/steel,
 /area/storage/surface_eva)

--- a/maps/sectors/frozen_192/levels/frozen_192.dmm
+++ b/maps/sectors/frozen_192/levels/frozen_192.dmm
@@ -948,6 +948,11 @@
 	icon_state = "tile_full"
 	},
 /area/class_p/unexplored)
+"Wc" = (
+/obj/structure/table/standard,
+/obj/item/clothing/mask/warmer,
+/turf/simulated/floor/classp,
+/area/class_p/unexplored)
 "Wr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -31161,7 +31166,7 @@ yW
 at
 at
 Pr
-cp
+Wc
 yW
 iL
 iL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As it says in the title, the heating power of 1kW is picked arbitrary to allow the mask to actually help on atlas atmos, it might be adjusted later to use a more realistic system
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We have gas masks that filter hostile gases, why not have one that warms your breath. Now that we spend most of our time on a snowball planet?
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new mask for warming breath
code: removes a redundant check in breath code
refactor: renamed the filter_gas() proc on masks to process_air()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
