### PR TITLE
Adds apprentice titles for shaft miners and roboticists

### DIFF
--- a/code/modules/jobs/job_types/station/science/roboticist.dm
+++ b/code/modules/jobs/job_types/station/science/roboticist.dm
@@ -27,7 +27,8 @@
 	alt_titles = list(
 		"Biomechanical Engineer" = /datum/prototype/struct/alt_title/biomech,
 		"Mechatronic Engineer" = /datum/prototype/struct/alt_title/mech_tech,
-		"Artificer-Biotechnicist" = /datum/prototype/struct/alt_title/artificer_biotechnicist
+		"Artificer-Biotechnicist" = /datum/prototype/struct/alt_title/artificer_biotechnicist,
+		"Junior Roboticist" = /datum/prototype/struct/alt_title/junior_roboticist,
 		)
 
 /datum/prototype/struct/alt_title/artificer_biotechnicist
@@ -36,6 +37,11 @@
 		/datum/lore/character_background/faction/naramadiguilds
 	)
 	background_enforce = TRUE
+
+/datum/prototype/struct/alt_title/junior_roboticist
+	title = "Junior Roboticist"
+	title_blurb = "A Junior Roboticist is someone still learning the field of robotics and  \
+					should seek guidance from other roboticists and the research seniors and lead."
 
 /datum/prototype/struct/alt_title/biomech
 	title = "Biomechanical Engineer"

--- a/code/modules/jobs/job_types/station/supply/shaft_miner.dm
+++ b/code/modules/jobs/job_types/station/supply/shaft_miner.dm
@@ -27,7 +27,9 @@
 	alt_titles = list(
 		"Drill Technician" = /datum/prototype/struct/alt_title/miner/drill_tech,
 		"Belt Miner" = /datum/prototype/struct/alt_title/miner/belt,
-		"Salvage Technician" = /datum/prototype/struct/alt_title/salvage
+		"Salvage Technician" = /datum/prototype/struct/alt_title/salvage,
+		"Apprentice Miner" = /datum/prototype/struct/alt_title/miner/apprenticemine,
+		"Apprentice Salvager" = /datum/prototype/struct/alt_title/miner/apprenticesalv
 		)
 
 /datum/prototype/struct/alt_title/miner
@@ -39,6 +41,14 @@
 
 /datum/prototype/struct/alt_title/miner/belt
 	title = "Belt Miner"
+
+/datum/prototype/struct/alt_title/miner/apprenticemine
+	title = "Apprentice Miner"
+	title_blurb = "An Apprentice Miner is still learning about the typical grind of a miner, and should seek the guidance of other miners and salvagers for direction."
+
+/datum/prototype/struct/alt_title/miner/apprenticesalv
+	title = "Apprentice Salvager"
+	title_blurb = "An Apprentice Salvager is still learning about the typical grind of a salvager, and should seek the guidance of other miners and salvagers for direction."
 
 /datum/prototype/struct/alt_title/salvage
 	title = "Salvage Technician"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

## Why It's Good For The Game

I'm considering robotics and shaft mining complex enough to need these titles so players new to these jobs will have people hopefully go easy on them and will teach them the ropes.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Apprentice titles are added to the Shaft Miner and Roboticist jobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
