### PR TITLE
Bandaid fixes wheelchair-bound crew not being added to the crew manifest when they latejoin.

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -478,7 +478,6 @@
 	// Moving wheelchair if they have one
 	if(character.buckled && istype(character.buckled, /obj/structure/bed/chair/wheelchair))
 		character.buckled.forceMove(character.loc)
-		character.buckled.setDir(character.dir)
 
 	SSticker.mode.latespawn(character)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This just simply removes setDir when putting someone in a wheelchair because for some reason it runtimes with a null error, saying that the wheelchair is null. There's a screenshot of this runtime in Maintainer Triage. In theory, this would've just rotated the wheelchair to be facing the direction the crew is in, which isn't that big of a deal when it'll just rotate in the crew member's direction as soon as they move anyways.

## Why It's Good For The Game

Maybe we shouldn't discriminate against limp crew members for... well, using wheelchairs?

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Wheelchair-bound crewmembers latejoining will be added to the crew manifest again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
