### PR TITLE
Adds water, iced tea, and sugar to the cafe synthesizer

### DIFF
--- a/code/modules/reagents/machinery/dispenser/synthesizer.dm
+++ b/code/modules/reagents/machinery/dispenser/synthesizer.dm
@@ -84,6 +84,7 @@
 /obj/item/reagent_synth/cafe
 	name = "reagent synthesis module (Cafe)"
 	reagents_provided = list(
+		/datum/reagent/water,
 		/datum/reagent/drink/coffee,
 		/datum/reagent/drink/coffee/cafe_latte,
 		/datum/reagent/drink/coffee/soy_latte,
@@ -92,7 +93,9 @@
 		/datum/reagent/drink/milk/cream,
 		/datum/reagent/drink/tea,
 		/datum/reagent/drink/ice,
+		/datum/reagent/drink/tea/icetea,
 		/datum/reagent/nutriment/mint,
+		/datum/reagent/sugar,
 		/datum/reagent/drink/juice/orange,
 		/datum/reagent/drink/juice/lemon,
 		/datum/reagent/drink/juice/lime,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

## Why It's Good For The Game

- Water is fucking water.
- You could already make iced tea using a soda dispenser. You can make iced tea using tea and ice with the cafe dispenser. Might as well allow you to skip a step.
- Sugar is used often in coffee and tea based recipes. Pretty sure a majority of cafes in the current world uses sugar too.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Water, iced tea, and sugar are added to the cafe synthesizers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
