### PR TITLE
Fixes life crystals not detecting gibbed owners

### DIFF
--- a/code/modules/vore/fluffstuff/life_crystals.dm
+++ b/code/modules/vore/fluffstuff/life_crystals.dm
@@ -41,8 +41,8 @@
 		to_chat(user, "<span class='notice'>The [name] doesn't do anything.</span>")
 		return 0
 
-	owner = user	//We're paired to this guy
-	owner_c = user.client	//This is his client
+	owner = user	//We're paired to this person
+	owner_c = user.client	//This is their client
 	update_state(1)
 	to_chat(user, "<span class='notice'>The [name] glows pleasantly blue.</span>")
 	START_PROCESSING(SSobj, src)
@@ -51,9 +51,10 @@
 	//He's dead, jim
 	if(state < 1)
 		return
-	if(!owner)//How did we get here?
+	if(!owner && !owner_c) //How did we get here?
+		//It's likely because the owner got gibbed. But if it truly bugged out, there'd be no client.
 		return
-	if((owner.stat == DEAD) || (get_turf(owner) != get_turf(src)))
+	if((!owner && owner_c) || (owner.stat == DEAD) || (get_turf(owner) != get_turf(src)))
 		if(state == 1)
 			become_alert()
 		if((state == 2) && (last_vitals < world.time - 1 MINUTE))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. The life crystal never got set off if the owner ever gets gibbed. This is most common with prometheans, but it can easily apply to anyone else.

## Why It's Good For The Game

Fix man good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Life crystals will now detect owners who vanished out of existence via gibbing or some other means like dusting... provided the crystal survived.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
