### PR TITLE
Fixes biogenerator not properly updating storage cache for bags

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -268,7 +268,7 @@
 		else
 			if(!user.attempt_insert_item_for_installation(O, src))
 				return
-			beaker = FALSE
+			beaker = O //why the fuck was it "false" before?
 			SStgui.update_uis(src)
 	else if(processing)
 		to_chat(user, SPAN_NOTICE("\The [src] is currently processing."))
@@ -280,7 +280,8 @@
 			to_chat(user, SPAN_NOTICE("\The [src] is already full! Activate it."))
 		else
 			for(var/obj/item/reagent_containers/food/snacks/grown/G in O.contents)
-				G.loc = src
+				O.obj_storage.remove(G)
+				G.forceMove(src)
 				i++
 				if(i >= 10)
 					to_chat(user, SPAN_NOTICE("You fill \the [src] to its capacity."))

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -126,6 +126,7 @@
 
 	beaker = inserted_beaker
 	update_appearance()
+	SStgui.update_uis(src)
 
 /*
  * Eject the current stored beaker either into the user's hands or onto the ground.
@@ -263,13 +264,7 @@
 	if(default_unfasten_wrench(user, O, 40))
 		return
 	if(istype(O, /obj/item/reagent_containers/glass))
-		if(beaker)
-			to_chat(user, SPAN_NOTICE("\The [src] is already loaded."))
-		else
-			if(!user.attempt_insert_item_for_installation(O, src))
-				return
-			beaker = O //why the fuck was it "false" before?
-			SStgui.update_uis(src)
+		insert_beaker(user, O)
 	else if(processing)
 		to_chat(user, SPAN_NOTICE("\The [src] is currently processing."))
 	else if(istype(O, /obj/item/storage/bag))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. Basically, if plant bags interacted with the biogenerator, it'd eventually lose storage size gradually because the biogen wasn't using the right procs for transferring storage over. Also probably fixes beakers not being inserted properly.

## Why It's Good For The Game

Fixes good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes biogenerator shrinking the storage size of plant bags.
fix: Beakers can be inserted and ejected from the biogenerator properly now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
