### PR TITLE
Fixes atmos retention fields meant to stay on turning off after atmospheric alarms are settled

### DIFF
--- a/code/game/area/area.dm
+++ b/code/game/area/area.dm
@@ -363,8 +363,9 @@
 		if(!all_arfgs)
 			return
 		for(var/obj/machinery/atmospheric_field_generator/E in all_arfgs)
-			E.disable_field()
-			E.wasactive = FALSE
+			if(!E.alwaysactive)
+				E.disable_field()
+				E.wasactive = FALSE
 
 
 /area/proc/fire_alert()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

## Why It's Good For The Game

if they're meant to stay on, they're MEANT TO STAY ON. No more endless Atlas Cargo garage loops and Surt airlock loops.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes atmospheric retention fields that are meant to stay on turning off after atmospheric alarms are settled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
