### PR TITLE
Makes blood no longer toxic to consume for all except skrell

### DIFF
--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Core.dm
@@ -54,7 +54,7 @@
 				return
 		if(IS_TESHARI) //birb.
 			nutritionvalue = 30
-		if(IS_UNATHI) //canivorous lizord...
+		if(IS_UNATHI) //carnivorous lizord...
 			nutritionvalue = 45
 		if(IS_ALRAUNE) //lorewise, alraune are meant to be able to enjoy blood anyways.
 			nutritionvalue = 60

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Core.dm
@@ -43,29 +43,40 @@
 	var/effective_dose = dose
 	if(issmall(M)) effective_dose *= 2
 
-	// Treat it like nutriment for the jello, but not equivalent.
-	if(alien == IS_SLIME)
-		/// Unless it's Promethean goo, then refill this one's goo.
-		if(data["species"] == M.species.name)
-			M.inject_blood(src, volume * volume_mod)
-			remove_self(volume)
-			return
-
-		M.heal_organ_damage(0.2 * removed * volume_mod, 0)	// More 'effective' blood means more usable material.
-		M.nutrition += 20 * removed * volume_mod
-		M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed)
-		M.adjustToxLoss(removed / 2) // Still has some water in the form of plasma.
-		return
-
+	var/nutritionvalue = 10 //for reference, normal nutrition has a value of about 30.
 	var/is_vampire = M.species.is_vampire
+	switch(alien)
+		if(IS_SLIME)
+			nutritionvalue = 20
+			if(data["species"] == M.species.name) //just 'inject' the blood if it happens to be promethean "blood".
+				M.inject_blood(src, volume * volume_mod)
+				remove_self(volume)
+				return
+		if(IS_TESHARI) //birb.
+			nutritionvalue = 30
+		if(IS_UNATHI) //canivorous lizord...
+			nutritionvalue = 45
+		if(IS_CHIMERA) //obligate carnivores.
+			nutritionvalue = 80
+		if(IS_SKRELL) //arguing that blood is "meat" and is still toxic for the vegan skrell at least
+			if(effective_dose > 5)
+				if(!is_vampire) //a vetalan skrell sounds funny as hell
+					M.adjustToxLoss(removed)
+			if(effective_dose > 15)
+				if(!is_vampire)
+					M.adjustToxLoss(removed)
+
 	if(is_vampire)
 		handle_vampire(M, alien, removed, is_vampire)
-	if(effective_dose > 5)
-		if(!is_vampire)
-			M.adjustToxLoss(removed)
-	if(effective_dose > 15)
-		if(!is_vampire)
-			M.adjustToxLoss(removed)
+		M.heal_organ_damage(0.5 * removed * volume_mod, 0) //heals vampires more.
+		M.adjust_hydration(7 * removed) //hydrates vetalan better.
+	else
+		M.heal_organ_damage(0.2 * removed * volume_mod, 0)	// Heal brute slightly like normal nutrition. More 'effective' blood means more usable material.
+		M.adjust_nutrition(nutritionvalue * removed * volume_mod)
+		M.adjust_hydration(2 * removed) //contains some water.
+
+	M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed) //same rating as eating nutriment
+
 	if(data && data["virus2"])
 		var/list/vlist = data["virus2"]
 		if(vlist.len)

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Core.dm
@@ -41,11 +41,19 @@
 /datum/reagent/blood/affect_ingest(mob/living/carbon/M, alien, removed)
 
 	var/effective_dose = dose
-	if(issmall(M)) effective_dose *= 2
+	if(issmall(M)) 
+		effective_dose *= 2
 
 	var/nutritionvalue = 10 //for reference, normal nutrition has a value of about 30.
 	var/is_vampire = M.species.is_vampire
-	switch(alien)
+	switch(alien) //unique interactions sorted from the species who benefit the least to the species who benefit the most.
+		if(IS_SKRELL) //arguing that blood is "meat" and is still toxic for the vegan skrell at least
+			if(effective_dose > 5)
+				if(!is_vampire) //a vetalan skrell sounds funny as hell
+					M.adjustToxLoss(removed)
+			if(effective_dose > 15)
+				if(!is_vampire)
+					M.adjustToxLoss(removed)
 		if(IS_SLIME)
 			nutritionvalue = 20
 			if(data["species"] == M.species.name) //just 'inject' the blood if it happens to be promethean "blood".
@@ -56,28 +64,21 @@
 			nutritionvalue = 30
 		if(IS_UNATHI) //carnivorous lizord...
 			nutritionvalue = 45
-		if(IS_ALRAUNE) //lorewise, alraune are meant to be able to enjoy blood anyways.
+		if(IS_ALRAUNE) //lorewise, alraune are meant to enjoy blood.
 			nutritionvalue = 60
 		if(IS_CHIMERA) //obligate carnivores.
 			nutritionvalue = 80
-		if(IS_SKRELL) //arguing that blood is "meat" and is still toxic for the vegan skrell at least
-			if(effective_dose > 5)
-				if(!is_vampire) //a vetalan skrell sounds funny as hell
-					M.adjustToxLoss(removed)
-			if(effective_dose > 15)
-				if(!is_vampire)
-					M.adjustToxLoss(removed)
 
 	if(is_vampire)
 		handle_vampire(M, alien, removed, is_vampire)
-		M.heal_organ_damage(0.5 * removed * volume_mod, 0) //heals vampires more.
-		M.adjust_hydration(7 * removed) //hydrates vetalan better.
+		M.heal_organ_damage(0.7 * removed * volume_mod, 0) // Heals vampires more.
+		M.adjust_hydration(7 * removed) // Hydrates vetalan better.
+		M.add_chemical_effect(CE_BLOODRESTORE, 8 * removed) // Same rating as taking iron
 	else
-		M.heal_organ_damage(0.2 * removed * volume_mod, 0)	// Heal brute slightly like normal nutrition. More 'effective' blood means more usable material.
 		M.adjust_nutrition(nutritionvalue * removed * volume_mod)
-		M.adjust_hydration(2 * removed) //contains some water.
-
-	M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed) //same rating as eating nutriment
+		M.heal_organ_damage(0.2 * removed * volume_mod, 0)	// Heal brute slightly like normal nutrition. More 'effective' blood means more usable material.
+		M.adjust_hydration(2 * removed) // Still has some water in the form of plasma. Hydrates less than a normal drink.
+		M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed) //same rating as eating nutriment
 
 	if(data && data["virus2"])
 		var/list/vlist = data["virus2"]

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Core.dm
@@ -56,6 +56,8 @@
 			nutritionvalue = 30
 		if(IS_UNATHI) //canivorous lizord...
 			nutritionvalue = 45
+		if(IS_ALRAUNE) //lorewise, alraune are meant to be sucking blood anyways.
+			nutritionvalue = 60
 		if(IS_CHIMERA) //obligate carnivores.
 			nutritionvalue = 80
 		if(IS_SKRELL) //arguing that blood is "meat" and is still toxic for the vegan skrell at least

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Core.dm
@@ -56,7 +56,7 @@
 			nutritionvalue = 30
 		if(IS_UNATHI) //canivorous lizord...
 			nutritionvalue = 45
-		if(IS_ALRAUNE) //lorewise, alraune are meant to be sucking blood anyways.
+		if(IS_ALRAUNE) //lorewise, alraune are meant to be able to enjoy blood anyways.
 			nutritionvalue = 60
 		if(IS_CHIMERA) //obligate carnivores.
 			nutritionvalue = 80

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -45,7 +45,6 @@
 	affect_ingest(M, alien, removed)
 
 /datum/reagent/nutriment/affect_ingest(mob/living/carbon/M, alien, removed)
-	var/hyd_removed
 	switch(alien)
 		if(IS_DIONA)
 			return
@@ -58,7 +57,7 @@
 	M.heal_organ_damage(0.5 * removed, 0)
 	if(!M.species.is_vampire) // If this is set to 0, they don't get nutrition from food.
 		M.nutrition += nutriment_factor * removed // For hunger and fatness
-	M.adjust_hydration(hydration_factor * hyd_removed)
+	M.adjust_hydration(hydration_factor * removed)
 	M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed)
 
 /datum/reagent/nutriment/glucose
@@ -1245,7 +1244,7 @@
 	taste_description = "tropical, somewhat buttery water"
 	color = "#fafafa70"
 	nutrition=1
-	
+
 	glass_name = "Coconut Water"
 	glass_desc = "A fresh clear liquid found within coconuts."
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes blood no longer toxic to consume for all except skrell.
In addition, it also:
- Allows all to benefit nutritionally from it, some specific species more than others. Unathi, alraune, and xenochimera benefit the most from it.
- Drinking blood provides some hydration, but not really as much as just drinking a drink.
- It also heals some brute damage.
- Vetalan are healed and hydrated more from blood.
- The skrell follow the original behavior of blood being toxic to them.

## Why It's Good For The Game

Humans in real life do in fact, consume blood, especially in specific foods like gelatin. I can't really see why they shouldn't be able to drink blood in a game.

You can make a case that drinking raw blood is actually in fact bad for a human to do, but so is eating raw meat. There currently isn't any mechanical downsides to eating raw meat as a human however currently, so there shouldn't be any mechanical downsides to drinking blood. Let character roleplay decide what someone can or can't drink, instead of mechanics in this case.

Besides, the risk of eating raw meat and blood in real life comes from the risk of diseases, which there are mechanics for in blood already. If the blood's infected with a virus, it'll transfer over to whoever drinks it.

Some things like Blood Sausage and Moghesian Sea Surprise are things you can prepare in-game and they contain blood - likely prepared blood. Let's not poison crew unknowingly.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Blood is no longer toxic to consume for all species except Skrell, and in fact, can be slightly beneficial in some ways. Just roleplay it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
