### PR TITLE
Alraune internals fix and some buffs

### DIFF
--- a/code/__DEFINES/inventory/carry_weight.dm
+++ b/code/__DEFINES/inventory/carry_weight.dm
@@ -22,8 +22,8 @@
 #define CARRY_STRENGTH_ADD_TESHARI 0
 #define CARRY_STRENGTH_ADD_XENOCHIMERA 2.5
 #define CARRY_STRENGTH_ADD_XENOHYBRID 2.5
-#define CARRY_STRENGTH_ADD_ALRAUNE 3
-#define CARRY_STRENGTH_ADD_DIONA 3
+#define CARRY_STRENGTH_ADD_ALRAUNE 10 //alraune already deal with slowdown, let's give them some big bonus for being slow.
+#define CARRY_STRENGTH_ADD_DIONA 20 //hee hoo
 
 //? Carry factor - multiplier for penalizing over-limit weight; higher is worse.
 
@@ -38,8 +38,8 @@
 #define CARRY_FACTOR_MOD_PROTEAN 1.12
 #define CARRY_FACTOR_MOD_XENOCHIMERA 0.88
 #define CARRY_FACTOR_MOD_XENOHYBRID 0.88
-#define CARRY_FACTOR_MOD_ALRAUNE 0.25 //! finally, a real reason to be an alraune
-#define CARRY_FACTOR_MOD_DIONA 0.1 //! i am groot
+#define CARRY_FACTOR_MOD_ALRAUNE 0.1 //! finally, a real reason to be an alraune
+#define CARRY_FACTOR_MOD_DIONA 0.05 //! i am groot
 
 //? Carry equation constants
 

--- a/code/modules/species/station/alraune.dm
+++ b/code/modules/species/station/alraune.dm
@@ -32,10 +32,10 @@
 	metabolic_rate = 0.75 // slow metabolism
 
 	brute_mod     = 1    //nothing special
-	burn_mod      = 1.5  //plants don't like fire
+	burn_mod      = 1.1  //plants don't like fire
 	radiation_mod = 0.7  //cit change: plants seem to be pretty resilient. shouldn't come up much.
 
-	item_slowdown_mod = 0.25 //while they start slow, they don't get much slower
+	item_slowdown_mod = 0.1 //while they start slow, they don't get much slower
 	bloodloss_rate = 0.1 //While they do bleed, they bleed out VERY slowly
 	max_age = 500
 	health_hud_intensity = 1.5
@@ -141,21 +141,8 @@
 	//They don't have lungs so breathe() will just return. Instead, they breathe through their skin.
 	//This is mostly normal breath code with some tweaks that apply to their particular biology.
 
-	var/datum/gas_mixture/breath = null
-	/// If they're wearing a fully sealed suit, their internals take priority.
-	var/fullysealed = FALSE
-	/// If no sealed suit, internals take priority in low pressure environements.
-	var/environmentalair = FALSE
-
-	if(H.wear_suit && (H.wear_suit.min_pressure_protection = 0) && H.head && (H.head.min_pressure_protection = 0))
-		fullysealed = TRUE
-	else // find out if local gas mixture is enough to override use of internals
-		var/envpressure = H.loc.return_pressure()
-		if(envpressure >= hazard_low_pressure)
-			environmentalair = TRUE
-
-	if(fullysealed || !environmentalair)
-		breath = H.get_breath_from_internal()
+	//just fuck off with this snowflake bullshit about checking if they're sealed off and just test for internals. too complicated.
+	var/datum/gas_mixture/breath = H.get_breath_from_internal()
 
 	if(!breath) //No breath from internals so let's try to get air from our location
 		// cut-down version of get_breath_from_environment - notably, gas masks provide no benefit
@@ -244,7 +231,7 @@
 	if(inhaling)
 		co2buff = (clamp(inhale_pp, 0, minimum_breath_pressure))/minimum_breath_pressure //returns a value between 0 and 1.
 
-	var/light_amount = fullysealed ? H.getlightlevel() : H.getlightlevel()/5 // if they're covered, they're not going to get much light on them.
+	var/light_amount = H.getlightlevel()
 
 	if(co2buff && !H.toxloss && light_amount >= 0.1) //if there's enough light and CO2 and you're not poisoned, heal. Note if you're wearing a sealed suit your heal rate will suck.
 		H.adjustBruteLoss(-(light_amount * co2buff * 2)) //at a full partial pressure of CO2 and full light, you'll only heal half as fast as diona.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Alraune can use internals again. The reason why they couldn't was because their snowflake code was trying to check to see if the alraune was able to take from the environment first before making them depend on internals. I've decided to wipe that code - if the alraune want to use internals, let them just use internals. Who cares if it might be wasteful?
- Boosted alraune and diona physiology again. They're stronger now, to compensate for that slowdown.
- Alraune burn modifier changed from 1.5 to 1.1

I may also do something to increase their pain tolerance, or just negate their pain altogether, but I'll need to ponder on that.

## Why It's Good For The Game

Fix good.

Also, alraunes too slow. Let's not make alraunes slower.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Alraune physiology is boosted again to carry even more without being slowed down.
fix: Alraunes can use internals again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
