### PR TITLE
Replaces airlocks access vars with access helpers on Triumph (2/3)

### DIFF
--- a/code/modules/mapping/map_helpers/access_helper/airlock.dm
+++ b/code/modules/mapping/map_helpers/access_helper/airlock.dm
@@ -316,7 +316,7 @@
 	)
 
 /obj/map_helper/access_helper/airlock/station/supply/infirmary
-	req_one_access = list (
+	req_one_access = list(
 		ACCESS_SUPPLY_MAIN,
 		ACCESS_MEDICAL_MAIN,
 	)
@@ -368,15 +368,22 @@
 	)
 
 /obj/map_helper/access_helper/airlock/station/science/secure_storage
-	req_one_access = list (
+	req_one_access = list(
 		ACCESS_COMMAND_CAPTAIN,
 		ACCESS_SCIENCE_RD,
 	)
 
 /obj/map_helper/access_helper/airlock/station/science/infirmary
-	req_one_access = list (
+	req_one_access = list(
 		ACCESS_SCIENCE_MAIN,
 		ACCESS_MEDICAL_MAIN,
+	)
+
+// ppl really want pathfinders to have access to this
+/obj/map_helper/access_helper/airlock/station/science/research_lab
+	req_one_access = list(
+		ACCESS_GENERAL_PATHFINDER,
+		ACCESS_SCIENCE_MAIN,
 	)
 
 /**
@@ -471,7 +478,7 @@
 	)
 
 /obj/map_helper/access_helper/airlock/station/exploration/infirmary
-	req_one_access = list (
+	req_one_access = list(
 		ACCESS_GENERAL_EXPLORER,
 		ACCESS_GENERAL_PILOT,
 		ACCESS_COMMAND_BRIDGE,

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -2312,7 +2312,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/map_helper/access_helper/airlock/station/science/fabrication,
+/obj/map_helper/access_helper/airlock/station/science/research_lab,
 /turf/simulated/floor/tiled/steel,
 /area/rnd/research)
 "bns" = (

--- a/maps/triumph/engines/burn.dmm
+++ b/maps/triumph/engines/burn.dmm
@@ -993,14 +993,15 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "Ol" = (
-/obj/machinery/door/airlock/vault{
-	name = "REACTOR ROOM";
-	req_one_access = list(10)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/door/airlock/vault{
+	name = "REACTOR ROOM";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "On" = (
@@ -1114,8 +1115,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/vault{
 	name = "REACTOR ROOM";
-	req_one_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "Qx" = (
@@ -1202,8 +1204,9 @@
 	},
 /obj/machinery/door/airlock/vault{
 	name = "REACTOR ROOM";
-	req_one_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "TK" = (
@@ -1253,8 +1256,9 @@
 	},
 /obj/machinery/door/airlock/vault{
 	name = "REACTOR ROOM";
-	req_one_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "UK" = (
@@ -1271,8 +1275,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/vault{
 	name = "REACTOR ROOM";
-	req_one_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "UW" = (
@@ -1353,8 +1358,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/vault{
 	name = "REACTOR ROOM";
-	req_one_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "Ww" = (

--- a/maps/triumph/engines/fission.dmm
+++ b/maps/triumph/engines/fission.dmm
@@ -136,8 +136,9 @@
 	},
 /obj/machinery/door/airlock/vault{
 	name = "REACTOR ROOM";
-	req_one_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "gN" = (
@@ -566,14 +567,15 @@
 /turf/simulated/floor/reinforced,
 /area/engineering/engine_room)
 "Cu" = (
-/obj/machinery/door/airlock/vault{
-	name = "REACTOR ROOM";
-	req_one_access = list(10)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/door/airlock/vault{
+	name = "REACTOR ROOM";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "CF" = (
@@ -639,8 +641,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/vault{
 	name = "REACTOR ROOM";
-	req_one_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "Fp" = (
@@ -750,8 +753,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/vault{
 	name = "REACTOR ROOM";
-	req_one_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "JB" = (
@@ -762,7 +766,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/hatch,
+/obj/map_helper/access_helper/airlock/station/maintenance,
+/obj/machinery/door/airlock/hatch{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "JR" = (
@@ -1020,8 +1027,9 @@
 	},
 /obj/machinery/door/airlock/vault{
 	name = "REACTOR ROOM";
-	req_one_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "RH" = (
@@ -1064,8 +1072,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/vault{
 	name = "REACTOR ROOM";
-	req_one_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "Td" = (
@@ -1190,7 +1199,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/hatch,
+/obj/map_helper/access_helper/airlock/station/maintenance,
+/obj/machinery/door/airlock/hatch{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "Vv" = (

--- a/maps/triumph/engines/rust.dmm
+++ b/maps/triumph/engines/rust.dmm
@@ -326,8 +326,9 @@
 	},
 /obj/machinery/door/airlock/vault{
 	name = "REACTOR ROOM";
-	req_one_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "dB" = (
@@ -403,8 +404,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/vault{
 	name = "REACTOR ROOM";
-	req_one_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "gu" = (
@@ -932,14 +934,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "Hw" = (
-/obj/machinery/door/airlock/vault{
-	name = "REACTOR ROOM";
-	req_one_access = list(10)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/door/airlock/vault{
+	name = "REACTOR ROOM";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "HR" = (
@@ -1003,8 +1006,9 @@
 	},
 /obj/machinery/door/airlock/vault{
 	name = "REACTOR ROOM";
-	req_one_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "Ll" = (
@@ -1057,8 +1061,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/vault{
 	name = "REACTOR ROOM";
-	req_one_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "Nf" = (
@@ -1080,8 +1085,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/vault{
 	name = "REACTOR ROOM";
-	req_one_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "NY" = (

--- a/maps/triumph/engines/sme.dmm
+++ b/maps/triumph/engines/sme.dmm
@@ -300,6 +300,7 @@
 	name = "REACTOR ROOM";
 	req_one_access = list(10)
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "lS" = (
@@ -882,8 +883,9 @@
 	icon_state = "door_locked";
 	id_tag = "engine_access_hatch";
 	locked = 1;
-	req_access = list(11)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/reinforced,
 /area/engineering/engine_room)
 "FV" = (
@@ -1007,6 +1009,7 @@
 	name = "REACTOR ROOM";
 	req_one_access = list(10)
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "MW" = (
@@ -1096,6 +1099,7 @@
 	name = "REACTOR ROOM";
 	req_one_access = list(10)
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "Ry" = (
@@ -1244,6 +1248,7 @@
 	name = "REACTOR ROOM";
 	req_one_access = list(10)
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "VH" = (
@@ -1269,14 +1274,15 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "VK" = (
-/obj/machinery/door/airlock/vault{
-	name = "REACTOR ROOM";
-	req_one_access = list(10)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/door/airlock/vault{
+	name = "REACTOR ROOM";
+	req_one_access = list(10)
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "VS" = (
@@ -1394,6 +1400,7 @@
 	name = "REACTOR ROOM";
 	req_one_access = list(10)
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "Yr" = (

--- a/maps/triumph/levels/deck1.dmm
+++ b/maps/triumph/levels/deck1.dmm
@@ -98,12 +98,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/door/airlock/glass/engineeringatmos{
-	name = "Atmospherics"
-	},
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/glass/engineeringatmos{
+	name = "Atmospherics";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/atmospherics,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/storage)
 "an" = (
@@ -194,10 +196,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
 	},
+/obj/machinery/door/airlock/hatch{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_airlock)
 "aw" = (
@@ -329,8 +334,11 @@
 /turf/simulated/floor/airless/ceiling,
 /area/maintenance/engi_engine)
 "aX" = (
-/obj/machinery/door/airlock/glass/engineering,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass/engineering{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "aY" = (
@@ -729,6 +737,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "ck" = (
@@ -1008,7 +1017,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/machinery/door/airlock/glass_external,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos/storage)
 "dn" = (
@@ -1121,8 +1133,10 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/glass/engineering{
-	name = "Engineering Equipment"
+	name = "Engineering Equipment";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/equipment,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
 "dH" = (
@@ -1171,12 +1185,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/engineering{
-	name = "Telecomms Control Room"
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/glass/engineering{
+	name = "Telecomms Control Room";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
@@ -1284,8 +1300,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/engineering{
-	name = "Shield Room"
+	name = "Shield Room";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "ep" = (
@@ -1532,10 +1550,13 @@
 /turf/simulated/floor/reinforced/oxygen,
 /area/engineering/atmos/gas_storage)
 "fa" = (
-/obj/machinery/door/airlock/maintenance/engi,
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/engineering)
 "fb" = (
@@ -1706,7 +1727,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/hatch,
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
@@ -1716,6 +1736,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
 	},
+/obj/machinery/door/airlock/hatch{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_smes)
 "fI" = (
@@ -2049,9 +2073,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
-"gF" = (
-/turf/simulated/floor/wood,
-/area/maintenance/dormitory)
 "gG" = (
 /obj/structure/lattice,
 /obj/machinery/camera/network/outside{
@@ -2285,17 +2306,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/engineering{
-	name = "Tech Storage";
-	req_access = list(23);
-	req_one_access = list()
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage";
+	req_one_access = list()
+	},
+/obj/map_helper/access_helper/airlock/station/technical_storage,
 /turf/simulated/floor/tiled/dark,
 /area/storage/tech)
 "hB" = (
@@ -3542,12 +3563,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "Port Nacelle"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 1
 	},
+/obj/machinery/door/airlock/hatch{
+	name = "Port Nacelle";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/engi_engine)
 "lT" = (
@@ -3745,10 +3768,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/drone_fabrication)
 "mB" = (
-/obj/machinery/door/airlock/maintenance/engi,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/tcommsat/powercontrol)
 "mC" = (
@@ -3789,14 +3815,16 @@
 "mL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/hatch{
-	name = "Starboard Nacelle"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/hatch{
+	name = "Starboard Nacelle";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/engi_engine)
 "mM" = (
@@ -4087,18 +4115,23 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass/engineering{
-	name = "Engineering Equipment"
+	name = "Engineering Equipment";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/equipment,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
 "nT" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/maintenance/engi,
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/equipment,
 /turf/simulated/floor/plating,
 /area/maintenance/engi_engine)
 "nW" = (
@@ -4574,14 +4607,16 @@
 "pG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/hatch{
-	name = "Starboard Nacelle"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/hatch{
+	name = "Starboard Nacelle";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/starboardnacelle)
 "pJ" = (
@@ -4751,8 +4786,11 @@
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
 "qq" = (
-/obj/machinery/door/airlock/maintenance/engi,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
 "qr" = (
@@ -4872,8 +4910,10 @@
 "qF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/engineering{
-	name = "Shield Room"
+	name = "Shield Room";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
 "qG" = (
@@ -5755,15 +5795,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/machinery/door/airlock/glass/engineering{
-	name = "Engineering Equipment"
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/glass/engineering{
+	name = "Engineering Equipment";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/equipment,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
 "tw" = (
@@ -5816,8 +5858,9 @@
 	},
 /obj/machinery/door/airlock/vault{
 	name = "Shunt Drive";
-	req_one_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/shunt)
 "tF" = (
@@ -6186,7 +6229,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/workshop)
 "uL" = (
-/obj/machinery/door/airlock/maintenance/engi,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6194,6 +6236,10 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
 "uM" = (
@@ -6221,8 +6267,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/storage)
 "uS" = (
-/obj/machinery/door/airlock/maintenance/engi,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "uU" = (
@@ -6544,13 +6593,16 @@
 /turf/simulated/floor/reinforced/oxygen,
 /area/engineering/atmos/gas_storage)
 "we" = (
-/obj/machinery/door/airlock/hatch,
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/hatch{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_smes)
 "wf" = (
@@ -6846,8 +6898,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/engineering{
-	name = "Engineering Break Room"
+	name = "Engineering Break Room";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "xf" = (
@@ -7103,7 +7157,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/map_helper/airlock/door/int_door,
 /obj/effect/floor_decal/industrial/warning,
-/obj/machinery/door/airlock/glass_external,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
 "ya" = (
@@ -7148,15 +7205,17 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/engineering{
-	name = "Reactor Control Room"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 1
 	},
+/obj/machinery/door/airlock/engineering{
+	name = "Reactor Control Room";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_monitoring)
 "yr" = (
@@ -7351,8 +7410,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/glass/engineering{
-	name = "Engineering Equipment"
+	name = "Engineering Equipment";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/equipment,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "yS" = (
@@ -7371,12 +7432,14 @@
 /area/engineering/engine_airlock)
 "yV" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/engineeringatmos{
-	name = "Atmospherics"
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/glass/engineeringatmos{
+	name = "Atmospherics";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/atmospherics,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "zb" = (
@@ -7522,7 +7585,10 @@
 	master_tag = "deck1_airlock";
 	pixel_x = 24
 	},
-/obj/machinery/door/airlock/glass_external,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
 "zB" = (
@@ -7722,7 +7788,10 @@
 	master_tag = "deck1_airlock2";
 	pixel_x = 24
 	},
-/obj/machinery/door/airlock/glass_external,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos/storage)
 "Ao" = (
@@ -7762,8 +7831,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass/engineeringatmos{
-	name = "Damage Control Storage"
+	name = "Damage Control Storage";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/atmospherics,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/storage)
 "At" = (
@@ -7885,11 +7956,14 @@
 /turf/simulated/floor/tiled/white,
 /area/engineering/foyer_mezzenine)
 "AL" = (
-/obj/machinery/door/airlock/maintenance/engi,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/engineering/engine_monitoring)
 "AN" = (
@@ -9031,7 +9105,10 @@
 "EG" = (
 /obj/machinery/shield_diffuser,
 /obj/map_helper/airlock/door/ext_door,
-/obj/machinery/door/airlock/glass_external,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
 "EI" = (
@@ -9438,10 +9515,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/glass/engineering{
-	name = "Engineering Break Room"
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass/engineering{
+	name = "Engineering Break Room";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/break_room)
 "FZ" = (
@@ -9506,15 +9585,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock/command{
-	name = "Chief Engineer";
-	req_access = list(10)
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor{
 	dir = 8
+	},
+/obj/map_helper/access_helper/airlock/station/head_office/chief_engineer,
+/obj/machinery/door/airlock/command{
+	name = "Chief Engineer";
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
@@ -10021,6 +10101,10 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/monitoring)
 "Ic" = (
+/obj/machinery/door/airlock/hatch{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "Id" = (
@@ -10032,7 +10116,10 @@
 "Ie" = (
 /obj/machinery/shield_diffuser,
 /obj/map_helper/airlock/door/ext_door,
-/obj/machinery/door/airlock/glass_external,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos/storage)
 "Ig" = (
@@ -10336,7 +10423,10 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/hatch{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_airlock)
 "Ji" = (
@@ -10377,10 +10467,13 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/maintenance/engi,
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/tiled/techmaint,
 /area/tcommsat/computer)
 "Jn" = (
@@ -10664,6 +10757,13 @@
 /obj/structure/railing,
 /turf/space,
 /area/space)
+"Ki" = (
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
 "Kl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 8
@@ -11238,11 +11338,13 @@
 /area/maintenance/engineering)
 "Mh" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/engineeringatmos{
-	name = "Damage Control Storage"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass/engineeringatmos{
+	name = "Damage Control Storage";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/atmospherics,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/storage)
 "Mj" = (
@@ -11261,12 +11363,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "Port Nacelle"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 1
 	},
+/obj/machinery/door/airlock/hatch{
+	name = "Port Nacelle";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/portnacelle)
 "Mn" = (
@@ -11394,8 +11498,10 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/glass/engineering{
-	name = "Engineering Equipment"
+	name = "Engineering Equipment";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/equipment,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
 "MK" = (
@@ -11607,8 +11713,10 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/equipment,
 /obj/machinery/door/airlock/glass/engineering{
-	name = "Engineering Equipment"
+	name = "Engineering Equipment";
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
@@ -11979,15 +12087,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
-"OC" = (
-/obj/machinery/door/airlock/glass/engineering{
-	name = "Engineering Equipment"
-	},
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/storage)
 "OD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12498,7 +12597,10 @@
 	master_tag = "deck1_airlock2";
 	pixel_x = 24
 	},
-/obj/machinery/door/airlock/glass_external,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos/storage)
 "Qs" = (
@@ -12659,12 +12761,14 @@
 /turf/space/basic,
 /area/engineering/atmos/gas_storage)
 "QZ" = (
-/obj/machinery/door/airlock/glass/engineering{
-	name = "Telecomms Control Room"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass/engineering{
+	name = "Telecomms Control Room";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
@@ -13076,13 +13180,16 @@
 /area/engineering/atmos/gas_storage)
 "St" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/maintenance/engi,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/equipment,
 /turf/simulated/floor/plating,
 /area/engineering/engine_eva)
 "Su" = (
@@ -13731,12 +13838,14 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/engineeringatmos{
-	name = "Atmospherics"
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/glass/engineeringatmos{
+	name = "Atmospherics";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/atmospherics,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/monitoring)
 "UC" = (
@@ -13878,11 +13987,13 @@
 "Va" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
-	name = "Engineering Storage"
+	name = "Engineering Storage";
+	req_one_access = null
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/equipment,
 /turf/simulated/floor/tiled,
 /area/engineering/storage)
 "Vc" = (
@@ -14080,7 +14191,10 @@
 	master_tag = "deck1_airlock";
 	pixel_x = 24
 	},
-/obj/machinery/door/airlock/glass_external,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
 "VR" = (
@@ -14091,8 +14205,10 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/glass/engineeringatmos{
-	name = "Atmospherics"
+	name = "Atmospherics";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/engineering/atmospherics,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/monitoring)
 "VT" = (
@@ -14329,9 +14445,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
-"Ww" = (
-/turf/simulated/floor/carpet,
-/area/maintenance/dormitory)
 "Wx" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -14551,12 +14664,14 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/glass/engineeringatmos{
-	name = "Damage Control Storage"
-	},
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/glass/engineeringatmos{
+	name = "Damage Control Storage";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/atmospherics,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/monitoring)
 "Xv" = (
@@ -14728,11 +14843,6 @@
 /area/engineering/atmos/monitoring)
 "XY" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Secure Tech Storage";
-	req_access = list(19,23);
-	req_one_access = list()
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -14742,6 +14852,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage";
+	req_one_access = list()
+	},
+/obj/map_helper/access_helper/airlock/station/technical_storage/secure,
 /turf/simulated/floor/tiled/dark,
 /area/storage/tech)
 "XZ" = (
@@ -14926,9 +15041,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/station/stairs_one)
-"Yw" = (
-/turf/simulated/floor,
-/area/storage/tech)
 "Yy" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor{
@@ -15136,10 +15248,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance/engi,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/trash_pit)
 "Zi" = (
@@ -27774,6 +27889,7 @@ LX
 lS
 Uh
 ME
+Ki
 Bq
 Bq
 Bq
@@ -27791,8 +27907,7 @@ Bq
 Bq
 Bq
 Bq
-Bq
-Bq
+Ki
 FZ
 TS
 mL
@@ -30128,7 +30243,7 @@ oy
 st
 lK
 PJ
-Ww
+mk
 mk
 iz
 oy
@@ -30323,7 +30438,7 @@ st
 Bt
 nd
 mk
-Ww
+mk
 iz
 oy
 aw
@@ -30516,8 +30631,8 @@ oy
 st
 Gl
 mk
-Ww
-Ww
+mk
+mk
 iz
 oy
 aw
@@ -30709,8 +30824,8 @@ Ze
 oy
 st
 dQ
-Ww
-Ww
+mk
+mk
 mk
 st
 oy
@@ -31097,9 +31212,9 @@ Ze
 oy
 st
 sB
-gF
-gF
-gF
+dQ
+dQ
+dQ
 st
 oy
 aw
@@ -37865,7 +37980,7 @@ SL
 dN
 dN
 dN
-OC
+MI
 tv
 dN
 dN
@@ -43111,7 +43226,7 @@ cq
 xM
 li
 zb
-Yw
+cq
 wB
 Rc
 oy
@@ -43305,7 +43420,7 @@ cq
 cq
 ty
 cq
-Yw
+cq
 tJ
 Rc
 oy

--- a/maps/triumph/levels/deck2.dmm
+++ b/maps/triumph/levels/deck2.dmm
@@ -9,8 +9,10 @@
 "ac" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/mining{
-	name = "Cargo Bay"
+	name = "Cargo Bay";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "ad" = (
@@ -233,8 +235,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/glass/mining{
-	name = "Mining Stroage"
+	name = "Mining Stroage";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/supply/mining,
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/uxstorage)
 "aI" = (
@@ -1033,11 +1037,14 @@
 	dir = 4;
 	id = "QMLoad"
 	},
-/obj/machinery/door/airlock/glass_external,
 /obj/map_helper/airlock/door/simple,
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/plating,
 /area/quartermaster/warehouse)
 "cW" = (
@@ -1778,23 +1785,25 @@
 "fl" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/mining{
-	name = "Cargo Storage"
+	name = "Cargo Storage";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "fm" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/mining{
-	id_tag = "cargodoor";
-	name = "Cargo Office";
-	req_access = list(31);
-	req_one_access = list()
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass/mining{
+	id_tag = "cargodoor";
+	name = "Cargo Office";
+	req_one_access = list()
+	},
+/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "fn" = (
@@ -1919,8 +1928,10 @@
 	pixel_x = 26
 	},
 /obj/machinery/door/airlock/glass_external{
-	name = "Bar Internal Access"
+	name = "Bar Internal Access";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "fC" = (
@@ -2238,17 +2249,17 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
-/obj/machinery/door/airlock/mining{
-	name = "Quartermaster";
-	req_access = list(41);
-	req_one_access = list()
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/airlock/mining{
+	name = "Quartermaster";
+	req_one_access = list()
+	},
+/obj/map_helper/access_helper/airlock/station/head_office/quartermaster,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "gA" = (
@@ -3180,11 +3191,13 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Prep Room"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/glass/mining{
+	name = "Mining Prep Room";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/supply/mining,
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/storage)
 "jA" = (
@@ -3206,8 +3219,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass_external,
 /obj/map_helper/airlock/door/int_door,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/dormitory)
 "jH" = (
@@ -3363,13 +3378,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
 "kd" = (
-/obj/machinery/door/airlock/glass_external{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "mining_fore_outer";
-	locked = 1;
-	name = "Engineering Fore External Access"
-	},
 /obj/machinery/access_button{
 	command = "cycle_ext";
 	frequency = 1379;
@@ -3381,6 +3389,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "mining_fore_outer";
+	locked = 1;
+	name = "Engineering Fore External Access";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningdock)
 "ke" = (
@@ -3416,15 +3433,15 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/sleep/Dorm_9)
 "km" = (
-/obj/machinery/door/airlock{
-	name = "Custodial Closet";
-	req_access = list(26)
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock{
+	name = "Custodial Closet"
+	},
+/obj/map_helper/access_helper/airlock/station/service/janitor,
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
 "kn" = (
@@ -3821,11 +3838,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock/freezer{
-	name = "Kitchen Cold Room";
-	req_access = list(28)
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/freezer{
+	name = "Kitchen Cold Room"
+	},
+/obj/map_helper/access_helper/airlock/station/service/kitchen,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/freezer)
 "ly" = (
@@ -3892,8 +3909,10 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/glass/mining{
-	name = "Mining Airlock Storage"
+	name = "Mining Airlock Storage";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/eva)
 "lO" = (
@@ -4425,12 +4444,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
 "nL" = (
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Prep Room"
-	},
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/glass/mining{
+	name = "Mining Prep Room";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/supply/mining,
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/storage)
 "nM" = (
@@ -4531,8 +4552,10 @@
 	pixel_x = -24
 	},
 /obj/machinery/door/airlock/glass_external{
-	name = "Bar External Access"
+	name = "Bar Internal Access";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "of" = (
@@ -4627,8 +4650,10 @@
 	icon_state = "door_locked";
 	id_tag = "mining_fore_outer";
 	locked = 1;
-	name = "Engineering Fore External Access"
+	name = "Engineering Fore External Access";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningdock)
 "op" = (
@@ -4859,11 +4884,11 @@
 /turf/simulated/floor/tiled/white,
 /area/station/stairs_two)
 "oX" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen";
-	req_one_access = list(28)
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Kitchen"
+	},
+/obj/map_helper/access_helper/airlock/station/service/kitchen,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "oY" = (
@@ -5347,11 +5372,14 @@
 	dir = 8;
 	id = "QMLoad2"
 	},
-/obj/machinery/door/airlock/glass_external,
 /obj/map_helper/airlock/door/simple,
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/plating,
 /area/quartermaster/warehouse)
 "qw" = (
@@ -5736,12 +5764,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock/glass/mining{
-	name = "Cargo Bay"
-	},
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/glass/mining{
+	name = "Cargo Bay";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/refinery)
 "ry" = (
@@ -5872,7 +5902,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
 "rU" = (
-/obj/machinery/door/airlock/glass/mining,
 /obj/structure/catwalk,
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5880,6 +5909,10 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/glass/mining{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
 "rV" = (
@@ -5887,14 +5920,15 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/coffee_shop)
 "rW" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Cargo Substation";
-	req_one_access = list(11,24,50)
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Cargo Substation";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/supply/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
 "rY" = (
@@ -6218,8 +6252,10 @@
 /obj/machinery/shield_diffuser,
 /obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
-	name = "Bar External Access"
+	name = "Bar Internal Access";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "sT" = (
@@ -6259,8 +6295,10 @@
 	icon_state = "door_locked";
 	id_tag = "mining_fore_inner";
 	locked = 1;
-	name = "Engineering Fore Internal Access"
+	name = "Engineering Fore Internal Access";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/refinery)
 "sY" = (
@@ -7330,10 +7368,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
-	name = "Bar Backroom";
-	req_access = list(25);
-	req_one_access = list(25)
+	name = "Bar Backroom"
 	},
+/obj/map_helper/access_helper/airlock/station/service/bar,
 /turf/simulated/floor/wood,
 /area/triumph/surfacebase/bar_backroom)
 "wb" = (
@@ -8309,9 +8346,9 @@
 /area/maintenance/cargo)
 "yI" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Kitchen Maintenance Access";
-	req_one_access = list(28)
+	name = "Kitchen Maintenance Access"
 	},
+/obj/map_helper/access_helper/airlock/station/service/kitchen,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "yJ" = (
@@ -9014,8 +9051,11 @@
 	id = "QMLoad"
 	},
 /obj/machinery/shield_diffuser,
-/obj/machinery/door/airlock/glass_external,
 /obj/map_helper/airlock/door/simple,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/plating,
 /area/quartermaster/warehouse)
 "AJ" = (
@@ -9044,9 +9084,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Kitchen";
-	req_one_access = list(28)
+	name = "Kitchen"
 	},
+/obj/map_helper/access_helper/airlock/station/service/kitchen,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "AO" = (
@@ -9140,10 +9180,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Bar Backroom";
-	req_access = list(25);
-	req_one_access = list(25)
+	name = "Bar Backroom"
 	},
+/obj/map_helper/access_helper/airlock/station/service/bar,
 /turf/simulated/floor/plating,
 /area/triumph/surfacebase/bar_backroom)
 "Bg" = (
@@ -9404,8 +9443,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/glass/mining{
-	name = "Cargo Bay"
+	name = "Cargo Bay";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "Cj" = (
@@ -9720,8 +9761,11 @@
 "Dg" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/shield_diffuser,
-/obj/machinery/door/airlock/glass_external,
 /obj/map_helper/airlock/door/simple,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "Dh" = (
@@ -10750,7 +10794,10 @@
 /area/crew_quarters/sleep/Dorm_10)
 "GC" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/mining,
+/obj/machinery/door/airlock/glass/mining{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/head_office/quartermaster,
 /turf/simulated/floor/plating,
 /area/quartermaster/qm)
 "GE" = (
@@ -10888,11 +10935,6 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "Hb" = (
-/obj/machinery/door/airlock/freezer{
-	name = "Cafe Backroom";
-	req_access = list(28);
-	req_one_access = list()
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -10908,6 +10950,11 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/freezer{
+	name = "Cafe Backroom";
+	req_one_access = list()
+	},
+/obj/map_helper/access_helper/airlock/station/service/bar,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/lounge/kitchen_freezer)
 "Hd" = (
@@ -11052,16 +11099,17 @@
 /turf/simulated/floor/wood,
 /area/station/stairs_two)
 "Hz" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Cargo Substation";
-	req_one_access = list(11,24,50)
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/engineering{
+	name = "Cargo Substation";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/supply/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
 "HA" = (
@@ -11207,8 +11255,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/glass/mining{
-	name = "Mining Prep Room"
+	name = "Mining Prep Room";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/supply/mining,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "Ia" = (
@@ -11342,9 +11392,9 @@
 /obj/machinery/door/airlock/glass/mining{
 	id_tag = "cargodoor";
 	name = "Cargo Office";
-	req_access = list(31);
 	req_one_access = list()
 	},
+/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "IA" = (
@@ -12217,7 +12267,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance/engi,
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
 "KY" = (
@@ -12312,16 +12365,21 @@
 	id = "QMLoad2"
 	},
 /obj/machinery/shield_diffuser,
-/obj/machinery/door/airlock/glass_external,
 /obj/map_helper/airlock/door/simple,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/plating,
 /area/quartermaster/warehouse)
 "Ls" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass_external,
 /obj/map_helper/airlock/door/ext_door,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/dormitory)
 "Lv" = (
@@ -12415,12 +12473,14 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Prep Room"
-	},
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/glass/mining{
+	name = "Mining Prep Room";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/supply/mining,
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/storage)
 "LL" = (
@@ -12566,8 +12626,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/glass/mining{
-	name = "Cargo Storage"
+	name = "Cargo Storage";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "Mk" = (
@@ -12872,19 +12934,21 @@
 	pixel_y = -23;
 	req_one_access = list(48)
 	},
-/obj/machinery/door/airlock/glass_external{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "mining_fore_inner";
-	locked = 1;
-	name = "Engineering Fore Internal Access"
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "mining_fore_inner";
+	locked = 1;
+	name = "Engineering Fore Internal Access";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/refinery)
 "Nm" = (
@@ -13031,9 +13095,10 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/map_helper/access_helper/airlock/station/mining_operations,
 /obj/machinery/door/airlock/glass/mining{
 	name = "Magmatic Rift Leap Pad";
-	req_one_access = list(1,5,31,38,47,48)
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -13687,8 +13752,10 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/map_helper/access_helper/airlock/station/supply/mining,
 /obj/machinery/door/airlock/glass/mining{
-	name = "Magmatic Rift Leap Pad"
+	name = "Magmatic Rift Leap Pad";
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -14183,8 +14250,10 @@
 /obj/machinery/door/firedoor,
 /obj/map_helper/airlock/door/int_door,
 /obj/machinery/door/airlock/glass_external{
-	name = "Bar Internal Access"
+	name = "Bar Internal Access";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "Rl" = (
@@ -14505,8 +14574,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
-/obj/machinery/door/airlock/maintenance/engi,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
 "Sb" = (
@@ -14772,12 +14844,14 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/glass/mining{
-	name = "Cargo Bay"
-	},
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/glass/mining{
+	name = "Cargo Bay";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
 /turf/simulated/floor/tiled,
 /area/triumph/surfacebase/mining_main/refinery)
 "SS" = (
@@ -14901,9 +14975,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock{
-	name = "Hydroponics";
-	req_one_access = list(28)
+	name = "Hydroponics"
 	},
+/obj/map_helper/access_helper/airlock/station/service/botany,
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "Tl" = (
@@ -15353,13 +15427,13 @@
 /area/hallway/primary/port)
 "UJ" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass{
-	name = "Hydroponics";
-	req_one_access = list(28)
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics"
+	},
+/obj/map_helper/access_helper/airlock/station/service/botany,
 /turf/simulated/floor/tiled/monotile,
 /area/hydroponics)
 "UK" = (
@@ -16209,9 +16283,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock{
-	name = "Custodial Closet";
-	req_access = list(26)
+	name = "Custodial Closet"
 	},
+/obj/map_helper/access_helper/airlock/station/service/janitor,
 /turf/simulated/floor/plating,
 /area/janitor)
 "Xh" = (
@@ -16327,9 +16401,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(28)
-	},
+/obj/machinery/door/airlock/maintenance,
+/obj/map_helper/access_helper/airlock/station/service/bar,
 /turf/simulated/floor/plating,
 /area/crew_quarters/coffee_shop)
 "XD" = (
@@ -16670,9 +16743,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
 	name = "Quartermaster";
-	req_access = list(41);
 	req_one_access = list()
 	},
+/obj/map_helper/access_helper/airlock/station/head_office/quartermaster,
 /turf/simulated/floor/tiled,
 /area/quartermaster/qm)
 "YH" = (
@@ -16790,11 +16863,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
 "Zb" = (
-/obj/machinery/door/airlock/glass_external,
 /obj/map_helper/airlock/door/simple,
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "Zc" = (

--- a/maps/triumph/levels/deck3.dmm
+++ b/maps/triumph/levels/deck3.dmm
@@ -1431,8 +1431,10 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/glass/research{
-	name = "XenoArcheology"
+	name = "XenoArcheology";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/science/xenoarcheology,
 /turf/simulated/floor/tiled,
 /area/rnd/anomaly_lab)
 "bkU" = (
@@ -2600,8 +2602,9 @@
 	},
 /obj/machinery/door/airlock/glass/research{
 	name = "Xenoflora Research";
-	req_one_access = list(30,35,47,77)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/science/xenobotany,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora_storage)
 "coN" = (
@@ -2680,8 +2683,9 @@
 	},
 /obj/machinery/door/airlock/glass/research{
 	name = "Research Lounge";
-	req_access = list(47)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/science/department,
 /turf/simulated/floor/tiled,
 /area/rnd/breakroom)
 "cqX" = (
@@ -2814,8 +2818,9 @@
 	},
 /obj/machinery/door/airlock/glass/research{
 	name = "Xenoflora Research";
-	req_one_access = list(30,35,47,77)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/science/xenobotany,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora/lab_atmos)
 "cvM" = (
@@ -3462,10 +3467,9 @@
 	},
 /obj/machinery/door/airlock/research{
 	id_tag = "researchdoor";
-	name = "Robotics Lab";
-	req_access = list(29,47);
-	req_one_access = list(47)
+	name = "Robotics Lab"
 	},
+/obj/map_helper/access_helper/airlock/station/science/robotics,
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/assembly/robotics)
 "cYH" = (
@@ -4427,8 +4431,9 @@
 	},
 /obj/machinery/door/airlock/glass/research{
 	name = "Xenoflora Research";
-	req_one_access = list(30,35,47,77)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/science/xenobiology,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "dQp" = (
@@ -4941,10 +4946,12 @@
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/emt/general)
 "efT" = (
-/obj/machinery/door/airlock/glass_external{
-	name = "Public Airlock"
-	},
 /obj/map_helper/airlock/door/int_door,
+/obj/machinery/door/airlock/glass_external{
+	name = "Public Airlock";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
@@ -5707,13 +5714,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/research{
-	name = "Research Entrance";
-	req_access = list(47);
-	req_one_access = list(47)
+	name = "Research Entrance"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/map_helper/access_helper/airlock/station/science/department,
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer)
 "eUu" = (
@@ -5997,8 +6003,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance/rnd{
-	req_access = list(47)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/science/department,
 /turf/simulated/floor/tiled,
 /area/maintenance/research)
 "fcX" = (
@@ -6417,8 +6424,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/research{
 	name = "Xenoflora Research";
-	req_one_access = list(30,35,47,77)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/science/xenobiology,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "fxj" = (
@@ -6866,8 +6874,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance/engi,
 /obj/structure/catwalk,
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical_science)
 "fPK" = (
@@ -7340,7 +7351,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance/engi,
+/obj/machinery/door/airlock/maintenance/rnd{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/science/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
 "gkl" = (
@@ -8214,16 +8228,17 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
 "gZv" = (
-/obj/machinery/door/airlock/glass/research{
-	name = "Weapons Testing Range";
-	req_access = list(47)
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/glass/research{
+	name = "Weapons Testing Range";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/science/department,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/testingrange)
 "gZZ" = (
@@ -8453,10 +8468,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room/exam_1)
 "hjX" = (
-/obj/machinery/door/airlock/research{
-	name = "Toxins Lab";
-	req_access = list(8)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -8469,6 +8480,10 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/research{
+	name = "Toxins Lab"
+	},
+/obj/map_helper/access_helper/airlock/station/science/toxins,
 /turf/simulated/floor/tiled,
 /area/rnd/test_area)
 "hkx" = (
@@ -9036,8 +9051,9 @@
 /obj/machinery/door/airlock/command{
 	id_tag = "RDdoor";
 	name = "Research Director";
-	req_access = list(30)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/head_office/research_director,
 /turf/simulated/floor/tiled,
 /area/rnd/rdoffice)
 "hDL" = (
@@ -9068,10 +9084,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	id_tag = "researchdoor";
-	name = "Robotics Morgue";
-	req_access = list(29,47);
-	req_one_access = list(47)
+	name = "Robotics Morgue"
 	},
+/obj/map_helper/access_helper/airlock/station/science/robotics,
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/assembly/robotics)
 "hEJ" = (
@@ -9161,10 +9176,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
 "hHa" = (
-/obj/machinery/door/airlock/maintenance/rnd{
-	req_access = list(47)
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance/rnd{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/science/department,
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
 "hJE" = (
@@ -9339,11 +9355,13 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora/lab_atmos)
 "hQc" = (
-/obj/machinery/door/airlock/glass_external{
-	name = "Public Airlock"
-	},
 /obj/machinery/shield_diffuser,
 /obj/map_helper/airlock/door/ext_door,
+/obj/machinery/door/airlock/glass_external{
+	name = "Public Airlock";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
@@ -9363,8 +9381,9 @@
 	},
 /obj/machinery/door/airlock/glass/research{
 	name = "Xenoflora Research";
-	req_one_access = list(30,35,47,77)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/science/xenobotany,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora/lab_atmos)
 "hQy" = (
@@ -10176,13 +10195,13 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
-/obj/machinery/door/airlock/research{
-	name = "Research Lab";
-	req_one_access = list(8,44)
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/machinery/door/airlock/research{
+	name = "Research Lab"
+	},
+/obj/map_helper/access_helper/airlock/station/science/research_lab,
 /turf/simulated/floor/tiled,
 /area/rnd/reception_desk)
 "iyW" = (
@@ -11331,11 +11350,6 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
-/obj/machinery/door/airlock/command{
-	id_tag = "RDdoor";
-	name = "Research Director";
-	req_access = list(30)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -11348,6 +11362,12 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/machinery/door/airlock/command{
+	id_tag = "RDdoor";
+	name = "Research Director";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/head_office/research_director,
 /turf/simulated/floor/tiled,
 /area/rnd/rdoffice)
 "jsT" = (
@@ -12527,13 +12547,12 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	id_tag = "researchdoor";
-	name = "Robotics Prep";
-	req_access = list(29,47);
-	req_one_access = list(47)
+	name = "Robotics Prep"
 	},
-/obj/machinery/door/firedoor,
+/obj/map_helper/access_helper/airlock/station/science/robotics,
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer_auxiliary)
 "ktI" = (
@@ -13143,10 +13162,9 @@
 	},
 /obj/machinery/door/airlock/research{
 	id_tag = "researchdoor";
-	name = "Robotics Surgery";
-	req_access = list(29,47);
-	req_one_access = list(47)
+	name = "Robotics Surgery"
 	},
+/obj/map_helper/access_helper/airlock/station/science/robotics,
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer_auxiliary)
 "kWR" = (
@@ -13481,8 +13499,11 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/maintenance/engi,
 /obj/structure/catwalk,
+/obj/machinery/door/airlock/maintenance/rnd{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/science/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
 "lnu" = (
@@ -14707,13 +14728,12 @@
 /turf/simulated/floor/tiled,
 /area/medical/sleeper)
 "mqr" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Entrance";
-	req_access = list(47);
-	req_one_access = list(47)
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/research{
+	name = "Research Entrance"
+	},
+/obj/map_helper/access_helper/airlock/station/science/department,
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer)
 "mqD" = (
@@ -15351,10 +15371,9 @@
 	},
 /obj/machinery/door/airlock/research{
 	id_tag = "researchdoor";
-	name = "Robotics Lab";
-	req_access = list(29,47);
-	req_one_access = list(47)
+	name = "Robotics Lab"
 	},
+/obj/map_helper/access_helper/airlock/station/science/robotics,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics)
 "mUK" = (
@@ -16371,10 +16390,13 @@
 /area/rnd/reception_desk)
 "nON" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance/engi,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "nOX" = (
@@ -16509,8 +16531,9 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance/rnd{
-	req_access = list(47)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/science/department,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
 "nTO" = (
@@ -17336,8 +17359,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance/rnd{
-	req_access = list(47)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/science/department,
 /turf/simulated/floor/tiled,
 /area/maintenance/fore)
 "oFh" = (
@@ -17465,13 +17489,13 @@
 "oIU" = (
 /obj/machinery/door/airlock/glass_external{
 	name = "Isolation Room 1";
-	req_access = list(65);
-	req_one_access = list(47)
+	req_one_access = null
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/map_helper/access_helper/airlock/station/science/xenoarcheology,
 /turf/simulated/floor/tiled,
 /area/rnd/anomaly_lab/containment_one)
 "oJw" = (
@@ -18072,11 +18096,13 @@
 /turf/simulated/floor/tiled,
 /area/rnd/test_area)
 "pfe" = (
-/obj/machinery/door/airlock/glass_external{
-	name = "Public Airlock"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/map_helper/airlock/door/int_door,
+/obj/machinery/door/airlock/glass_external{
+	name = "Public Airlock";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
@@ -18157,9 +18183,9 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab";
-	req_access = list();
-	req_one_access = list(7,29)
+	req_access = list()
 	},
+/obj/map_helper/access_helper/airlock/station/science/xenobiology,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "pho" = (
@@ -18845,7 +18871,10 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance/engi,
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "pIC" = (
@@ -19303,15 +19332,16 @@
 /area/medical/ward)
 "pXQ" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/research{
-	name = "Research Lounge";
-	req_access = list(47)
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/glass/research{
+	name = "Research Lounge";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/science/department,
 /turf/simulated/floor/tiled,
 /area/rnd/breakroom)
 "pYs" = (
@@ -20770,9 +20800,9 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_external{
 	name = "Isolation Room 2";
-	req_access = list(65);
-	req_one_access = list(47)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/science/xenoarcheology,
 /turf/simulated/floor/tiled,
 /area/rnd/anomaly_lab/containment_two)
 "rdw" = (
@@ -22369,7 +22399,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/maintenance/engi,
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical_science)
 "sBd" = (
@@ -22943,10 +22976,9 @@
 	},
 /obj/machinery/door/airlock/research{
 	id_tag = "researchdoor";
-	name = "Robotics Morgue";
-	req_access = list(29,47);
-	req_one_access = list(47)
+	name = "Robotics Morgue"
 	},
+/obj/map_helper/access_helper/airlock/station/science/robotics,
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
 "tbM" = (
@@ -25843,11 +25875,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
 "vya" = (
-/obj/machinery/door/airlock/glass/research{
-	name = "Circuitry Workshop";
-	req_access = list(7);
-	req_one_access = list(7)
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -25858,6 +25885,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/glass/research{
+	name = "Circuitry Workshop";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/science/fabrication,
 /turf/simulated/floor/tiled,
 /area/rnd/workshop)
 "vyp" = (
@@ -25927,9 +25959,9 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/research{
-	name = "Toxins Storage";
-	req_access = list(8)
+	name = "Toxins Storage"
 	},
+/obj/map_helper/access_helper/airlock/station/science/toxins,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
 "vBL" = (
@@ -26100,14 +26132,14 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_d)
 "vHH" = (
-/obj/machinery/door/airlock/research{
-	name = "Xenobiology Emergecy Flood Storage";
-	req_access = list();
-	req_one_access = list(7,29)
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/research{
+	name = "Xenobiology Emergecy Flood Storage";
+	req_access = list()
+	},
+/obj/map_helper/access_helper/airlock/station/science/xenobiology,
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer_auxiliary)
 "vIj" = (
@@ -27042,12 +27074,13 @@
 /area/crew_quarters/medical_restroom)
 "wvF" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance/rnd{
-	req_access = list(47)
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/maintenance/rnd{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/science/department,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "wwu" = (
@@ -27648,8 +27681,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/maintenance/engi,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "wWa" = (
@@ -28752,9 +28788,9 @@
 "xTR" = (
 /obj/machinery/door/airlock/science{
 	name = "Circuitry Workshop";
-	req_access = list(7);
-	req_one_access = list(7)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/science/fabrication,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "xTU" = (
@@ -29073,13 +29109,14 @@
 /turf/simulated/floor/airless/ceiling,
 /area/rnd/research_foyer_auxiliary)
 "ymb" = (
-/obj/machinery/door/airlock/maintenance/rnd{
-	req_access = list(47)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance/rnd{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/science/department,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 

--- a/maps/triumph/levels/deck3.dmm
+++ b/maps/triumph/levels/deck3.dmm
@@ -449,10 +449,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/multi_tile/metal{
-	name = "Infectious Diseases & Treatment Center";
-	req_access = list(5)
-	},
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -460,6 +456,10 @@
 /obj/effect/floor_decal/corner/green/border{
 	dir = 8
 	},
+/obj/machinery/door/airlock/multi_tile/metal{
+	name = "Infectious Diseases & Treatment Center"
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyaccess)
 "avn" = (
@@ -747,7 +747,6 @@
 /area/crew_quarters/heads/cmo)
 "aFj" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_external,
 /obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button/airlock_interior{
 	dir = 1;
@@ -755,6 +754,10 @@
 	master_tag = "emt_shuttle_dock";
 	pixel_y = 24
 	},
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
 "aFA" = (
@@ -1145,16 +1148,16 @@
 /area/triumph/station/stairs_three)
 "aXF" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/multi_tile/metal{
-	name = "Medbay Employee Entrance";
-	req_access = list(5)
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 8
 	},
+/obj/machinery/door/airlock/multi_tile/metal{
+	name = "Medbay Employee Entrance"
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "aXN" = (
@@ -1748,11 +1751,18 @@
 /turf/simulated/wall/r_wall/prepainted/medical,
 /area/medical/ward)
 "bCS" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
+	},
 /obj/machinery/door/airlock/multi_tile/glass{
 	id_tag = "MedbayEmergency";
-	name = "Medbay Emergency Access";
-	req_access = list(5)
+	name = "Medbay Emergency Access"
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -1760,13 +1770,6 @@
 	id = "medbayquar";
 	name = "Medbay Emergency Lockdown Shutters";
 	opacity = 0
-	},
-/obj/machinery/door/firedoor/glass,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
@@ -2204,8 +2207,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
-	name = "Rest Room"
+	name = "Rest Room";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
 "bWC" = (
@@ -2632,10 +2637,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance/medical,
 /obj/machinery/door/firedoor/glass{
 	dir = 4
 	},
+/obj/machinery/door/airlock/maintenance/medical{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "cps" = (
@@ -2731,6 +2739,7 @@
 	pixel_y = 10
 	},
 /obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
 "csz" = (
@@ -2916,13 +2925,14 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/medical{
-	name = "Pre-Revival Processing";
-	req_access = list(6)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/machinery/door/airlock/medical{
+	name = "Pre-Revival Processing";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/morgue,
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
 "cBb" = (
@@ -3603,17 +3613,17 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyisolation)
 "ddG" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4;
-	id_tag = "MedbayFoyer";
-	name = "Recovery Wing";
-	req_access = list(5)
-	},
 /obj/machinery/door/firedoor/glass{
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/blue/border,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4;
+	id_tag = "MedbayFoyer";
+	name = "Recovery Wing"
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
 "ddX" = (
@@ -3676,8 +3686,9 @@
 /obj/machinery/door/airlock/medical{
 	id_tag = "mentaldoor";
 	name = "Mental Health";
-	req_access = list(64)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/psychiatry,
 /turf/simulated/floor/wood,
 /area/medical/psych/psych_2)
 "dgF" = (
@@ -3992,15 +4003,16 @@
 /area/medical/ward)
 "dxA" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass/medical{
-	name = "Medbay Reception";
-	req_access = list(5)
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass/medical{
+	name = "Medbay Reception";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled,
 /area/medical/reception)
 "dyF" = (
@@ -4138,8 +4150,10 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/medical{
 	id_tag = "er1";
-	name = "Exam Room 1"
+	name = "Exam Room 1";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room/exam_1)
 "dEU" = (
@@ -5132,7 +5146,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/medical{
-	name = "Patient Ward D"
+	name = "Patient Ward D";
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_d)
@@ -5263,6 +5278,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
 "ezI" = (
@@ -5455,15 +5471,17 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 4
 	},
-/obj/machinery/door/airlock/glass/medical{
-	name = "Paramedic Storage"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/door/airlock/glass/medical{
+	name = "Paramedic Storage";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_emt_bay)
 "eLb" = (
@@ -6612,12 +6630,15 @@
 /turf/simulated/floor/tiled,
 /area/medical/psych_ward)
 "fHl" = (
-/obj/machinery/door/airlock/glass_external,
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/map_helper/airlock/door/ext_door,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
 "fIn" = (
@@ -7669,13 +7690,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/medical{
-	name = "Surgeon Rest Area";
-	req_access = list(45)
-	},
 /obj/machinery/door/firedoor/glass{
 	dir = 4
 	},
+/obj/machinery/door/airlock/medical{
+	name = "Surgeon Rest Area";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak/surgery)
 "gvw" = (
@@ -9024,15 +9046,15 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/beige/border,
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4;
 	id_tag = "PsycheFoyer";
 	name = "Psychiatric Wing";
-	req_access = list();
-	req_one_access = list(5)
+	req_access = list()
 	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/beige/border,
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "hDD" = (
@@ -9630,12 +9652,14 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 4
 	},
-/obj/machinery/door/airlock/medical{
-	name = "Virology Labs"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
+/obj/machinery/door/airlock/medical{
+	name = "Virology Labs";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyisolation)
 "ibB" = (
@@ -10075,14 +10099,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass/medical{
-	name = "Chemistry";
-	req_access = list();
-	req_one_access = list(33)
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/glass/medical{
+	name = "Chemistry";
+	req_access = list();
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/chemistry,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "iui" = (
@@ -10394,8 +10419,9 @@
 	},
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre 1";
-	req_access = list(45)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/surgery,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
 "iEo" = (
@@ -10585,8 +10611,10 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/medical{
 	id_tag = "er2";
-	name = "Exam Room 2"
+	name = "Exam Room 2";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room/exam_2)
 "iLd" = (
@@ -10726,6 +10754,7 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/blue/border,
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
 "iRX" = (
@@ -12559,10 +12588,6 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 4
 	},
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre 2";
-	req_access = list(45)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -12572,6 +12597,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre 2";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/surgery,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
 "kuF" = (
@@ -13276,9 +13306,9 @@
 /obj/structure/catwalk,
 /obj/machinery/door/airlock/maintenance/medical{
 	name = "Virology Maintenance Access";
-	req_access = list(39);
 	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/virology,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay/fore)
 "las" = (
@@ -13396,10 +13426,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
 "liz" = (
-/obj/machinery/door/airlock/maintenance/medical{
-	name = "Washing Machine & Maintenance"
-	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/medical{
+	name = "Washing Machine & Maintenance";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
 "liB" = (
@@ -14193,11 +14225,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "lPc" = (
+/obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
-	req_access = list(6)
+	req_one_access = null
 	},
-/obj/machinery/door/firedoor/glass,
+/obj/map_helper/access_helper/airlock/station/medical/morgue,
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
 "lPw" = (
@@ -15601,8 +15634,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/medical{
 	id_tag = "er1";
-	name = "Exam Room 1"
+	name = "Exam Room 1";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room/exam_1)
 "nbQ" = (
@@ -15781,8 +15816,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
 "nnb" = (
-/obj/machinery/door/airlock/maintenance/medical,
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/medical{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/psychiatry,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay/fore)
 "nnE" = (
@@ -17136,15 +17174,6 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 4
 	},
-/obj/machinery/door/airlock/medical{
-	autoclose = 0;
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "virology_airlock_interior";
-	locked = 1;
-	name = "Virology Interior Airlock";
-	req_access = list(39)
-	},
 /obj/machinery/access_button{
 	command = "cycle_int";
 	frequency = 1379;
@@ -17153,6 +17182,16 @@
 	pixel_y = 24;
 	req_access = list(39)
 	},
+/obj/machinery/door/airlock/medical{
+	autoclose = 0;
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "virology_airlock_interior";
+	locked = 1;
+	name = "Virology Interior Airlock";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/virology,
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyaccess)
 "ouz" = (
@@ -17442,12 +17481,14 @@
 /turf/simulated/floor/wood,
 /area/rnd/breakroom)
 "oIt" = (
-/obj/machinery/door/airlock/maintenance/medical{
-	name = "Emergency Maintenance Access Use Only"
-	},
 /obj/machinery/door/firedoor/glass{
 	dir = 4
 	},
+/obj/machinery/door/airlock/maintenance/medical{
+	name = "Emergency Maintenance Access Use Only";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/plating,
 /area/medical/surgery2)
 "oIB" = (
@@ -18276,6 +18317,7 @@
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 8
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled,
 /area/medical/sleeper)
 "pkD" = (
@@ -18324,8 +18366,10 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/glass/medical{
-	name = "Patient Psychiatric Ward A"
+	name = "Patient Psychiatric Ward A";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 4;
@@ -18506,6 +18550,7 @@
 	pixel_y = -5
 	},
 /obj/map_helper/airlock/door/int_door,
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
 "ptn" = (
@@ -18639,8 +18684,9 @@
 /obj/machinery/door/airlock/medical{
 	id_tag = "mentaldoor2";
 	name = "Mental Health";
-	req_access = list(64)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/psychiatry,
 /turf/simulated/floor/wood,
 /area/medical/psych/psych_1)
 "pBY" = (
@@ -18648,12 +18694,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "pCc" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	id_tag = "MedbayFoyer";
-	name = "Chem & Offices";
-	req_access = list();
-	req_one_access = list(5)
-	},
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -18661,6 +18701,12 @@
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 8
 	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	id_tag = "MedbayFoyer";
+	name = "Chem & Offices";
+	req_access = list()
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "pCA" = (
@@ -18839,15 +18885,6 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 4
 	},
-/obj/machinery/door/airlock/medical{
-	autoclose = 0;
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "virology_airlock_exterior";
-	locked = 1;
-	name = "Virology Exterior Airlock";
-	req_access = list(39)
-	},
 /obj/machinery/access_button{
 	command = "cycle_ext";
 	frequency = 1379;
@@ -18856,6 +18893,16 @@
 	pixel_y = 23;
 	req_access = list(39)
 	},
+/obj/machinery/door/airlock/medical{
+	autoclose = 0;
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "virology_airlock_exterior";
+	locked = 1;
+	name = "Virology Exterior Airlock";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/virology,
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyaccess)
 "pHO" = (
@@ -19098,8 +19145,9 @@
 /obj/machinery/door/airlock/command{
 	id_tag = "cmodoor";
 	name = "CMO's Office";
-	req_access = list(40)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/head_office/chief_medical_officer,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/cmo)
 "pRS" = (
@@ -19253,8 +19301,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/medical{
 	name = "Medical Storage";
-	req_access = list(6)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled,
 /area/medical/medbay_primary_storage)
 "pWl" = (
@@ -19688,12 +19737,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "qnn" = (
-/obj/machinery/door/airlock/maintenance/medical{
-	name = "Emergency Maintenance Access Use Only"
-	},
 /obj/machinery/door/firedoor/glass{
 	dir = 4
 	},
+/obj/machinery/door/airlock/maintenance/medical{
+	name = "Emergency Maintenance Access Use Only";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/plating,
 /area/medical/surgery)
 "qnO" = (
@@ -20001,11 +20052,6 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 4
 	},
-/obj/machinery/door/airlock/medical{
-	id_tag = "MedicalResleeving";
-	name = "Resleeving Lab";
-	req_access = list(5)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -20015,6 +20061,12 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/medical{
+	id_tag = "MedicalResleeving";
+	name = "Resleeving Lab";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
 "qBd" = (
@@ -20350,8 +20402,9 @@
 /obj/machinery/door/airlock/medical{
 	id_tag = "MedicalResleeving";
 	name = "Resleeving Lab";
-	req_access = list(5)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
 "qOj" = (
@@ -20507,11 +20560,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/multi_tile/metal{
-	name = "Infectious Diseases & Treatment Center";
-	req_access = list(5)
-	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/multi_tile/metal{
+	name = "Infectious Diseases & Treatment Center"
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyaccess)
 "qSo" = (
@@ -20616,16 +20669,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/corner/beige{
+	dir = 9
+	},
 /obj/machinery/door/airlock/glass/medical{
-	name = "Psychiatric Play-Area Access"
+	name = "Psychiatric Play-Area Access";
+	req_one_access = null
 	},
 /obj/machinery/door/blast/regular{
 	id = "psyche-doc-access";
 	name = "Play Area Access"
 	},
-/obj/effect/floor_decal/corner/beige{
-	dir = 9
-	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "qXw" = (
@@ -20862,8 +20917,9 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/highsecurity{
 	name = "High-Risk Containment Ward";
-	req_one_access = list(5)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "rfs" = (
@@ -21097,9 +21153,6 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 4
 	},
-/obj/machinery/door/airlock/medical{
-	name = "Medical Break Room"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -21112,13 +21165,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/machinery/door/airlock/medical{
+	name = "Medical Break Room";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "rsU" = (
-/obj/machinery/door/airlock/maintenance/medical{
-	name = "Emergency Maintenance Access Use Only"
-	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/medical{
+	name = "Emergency Maintenance Access Use Only";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/psychiatry,
 /turf/simulated/floor/plating,
 /area/medical/psych/psych_2)
 "rtG" = (
@@ -21218,10 +21278,13 @@
 /turf/simulated/floor/plating,
 /area/shuttle/emt/general)
 "rxP" = (
-/obj/machinery/door/airlock/maintenance/medical,
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/maintenance/medical{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay/aft)
 "rxV" = (
@@ -21419,7 +21482,6 @@
 /area/crew_quarters/medbreak)
 "rIa" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_external,
 /obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button/airlock_exterior{
 	dir = 1;
@@ -21427,6 +21489,10 @@
 	master_tag = "emt_shuttle_dock";
 	pixel_x = 24
 	},
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
 "rIl" = (
@@ -22109,8 +22175,10 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/glass/medical{
-	name = "Psychiatric Play-Area Access"
+	name = "Psychiatric Play-Area Access";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "snE" = (
@@ -22204,9 +22272,9 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	id_tag = "PsycheFoyer";
 	name = "Psychiatric Processing";
-	req_access = list();
-	req_one_access = list(5)
+	req_access = list()
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "sue" = (
@@ -22318,10 +22386,12 @@
 /turf/simulated/floor/wood,
 /area/medical/psych/psych_2)
 "sxt" = (
-/obj/machinery/door/airlock/medical{
-	name = "Psychiatric Ward"
-	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/medical{
+	name = "Psychiatric Ward";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled,
 /area/medical/psych_ward)
 "sxx" = (
@@ -22474,13 +22544,15 @@
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
 "sCJ" = (
-/obj/machinery/door/airlock/glass/medical{
-	name = "Paramedic Storage"
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass/medical{
+	name = "Paramedic Storage";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_emt_bay)
 "sCN" = (
@@ -22622,14 +22694,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4;
-	name = "Medbay Surgery";
-	req_access = list(5)
-	},
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/blue/border,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4;
+	name = "Medbay Surgery"
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled,
 /area/medical/sleeper)
 "sIj" = (
@@ -22710,12 +22782,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/test_area)
 "sME" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	id_tag = "MedbayFoyer";
-	name = "Treatment Centre";
-	req_access = list();
-	req_one_access = list(5)
-	},
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -22723,6 +22789,12 @@
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 8
 	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	id_tag = "MedbayFoyer";
+	name = "Treatment Centre";
+	req_access = list()
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "sNF" = (
@@ -23478,9 +23550,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
 /obj/machinery/door/airlock/maintenance/medical{
 	name = "Virology Maintenance Access";
-	req_access = list(39);
 	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/virology,
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "twI" = (
@@ -24548,13 +24620,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock/medical{
-	name = "Medical Storage";
-	req_access = list(6)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/machinery/door/airlock/medical{
+	name = "Medical Storage";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled,
 /area/medical/medbay_primary_storage)
 "unq" = (
@@ -25317,8 +25390,11 @@
 /turf/space,
 /area/space)
 "uYk" = (
-/obj/machinery/door/airlock/maintenance/medical,
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/medical{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/plating,
 /area/medical/psych_ward)
 "uZs" = (
@@ -25633,18 +25709,18 @@
 /area/rnd/xenobiology/xenoflora/lab_atmos)
 "vqe" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/multi_tile/glass{
-	id_tag = "PsycheFoyer";
-	name = "Psychiatric Wing";
-	req_access = list();
-	req_one_access = list(5)
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
 	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	id_tag = "PsycheFoyer";
+	name = "Psychiatric Wing";
+	req_access = list()
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "vqf" = (
@@ -26260,11 +26336,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_c)
 "vNt" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4;
-	name = "Chem & Offices";
-	req_access = list(5)
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -26279,6 +26350,11 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/blue/border,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4;
+	name = "Chem & Offices"
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled,
 /area/medical/sleeper)
 "vOc" = (
@@ -26626,9 +26702,9 @@
 	},
 /obj/machinery/door/airlock/multi_tile/metal{
 	dir = 4;
-	name = "Psychiatric Ward";
-	req_access = list(5)
+	name = "Psychiatric Ward"
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "wbO" = (
@@ -26815,6 +26891,7 @@
 /obj/machinery/door/airlock/voidcraft/vertical{
 	frequency = 1380
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
 "whu" = (
@@ -26861,6 +26938,7 @@
 /obj/machinery/door/airlock/voidcraft/vertical{
 	frequency = 1380
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
 "wkf" = (
@@ -27431,7 +27509,9 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "wLE" = (
-/obj/machinery/door/airlock/glass_external,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -27440,6 +27520,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
 "wLV" = (
@@ -27605,7 +27686,8 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/glass/medical{
-	name = "Patient Psychiatric Ward B"
+	name = "Patient Psychiatric Ward B";
+	req_one_access = null
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -27615,6 +27697,7 @@
 	name = "Ward A";
 	opacity = 0
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "wRr" = (
@@ -28281,6 +28364,7 @@
 /obj/machinery/door/airlock/research,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/map_helper/access_helper/airlock/station/science/department,
 /turf/simulated/floor/tiled,
 /area/rnd/misc_lab)
 "xyo" = (
@@ -28700,8 +28784,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/medical{
 	id_tag = "er2";
-	name = "Exam Room 2"
+	name = "Exam Room 2";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room/exam_2)
 "xQF" = (

--- a/maps/triumph/levels/deck4.dmm
+++ b/maps/triumph/levels/deck4.dmm
@@ -310,9 +310,10 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
+/obj/map_helper/access_helper/airlock/station/hangar,
 /obj/machinery/door/airlock/glass_external{
 	name = "Exploration Emergency Exit";
-	req_one_access = list(1,2,5,19,43,67)
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/excursion_dock)
@@ -363,9 +364,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/aft)
 "apg" = (
-/obj/machinery/door/airlock/glass_external{
-	name = "Docking Port Airlock"
-	},
 /obj/machinery/shield_diffuser,
 /obj/map_helper/airlock/door/ext_door,
 /obj/machinery/access_button/airlock_exterior{
@@ -374,6 +372,10 @@
 	master_tag = "deck4_dockarm2";
 	pixel_x = -24
 	},
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "apu" = (
@@ -557,12 +559,13 @@
 /area/ai_upload)
 "avH" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass/security{
-	name = "Holding Room";
-	req_one_access = list(1,2,4,38)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass/security{
+	name = "Holding Room";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/monotile,
 /area/security/hallway)
 "avM" = (
@@ -631,8 +634,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/exploration)
 "axv" = (
-/obj/machinery/door/airlock/maintenance/command,
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/command{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/head_office/head_of_personnel,
 /turf/simulated/floor/plating,
 /area/maintenance/central)
 "axR" = (
@@ -669,10 +675,11 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass/security{
 	name = "Locker Room";
-	req_one_access = list(2)
+	req_one_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/map_helper/access_helper/airlock/station/security/brig,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
 "azU" = (
@@ -898,13 +905,16 @@
 "aFa" = (
 /obj/machinery/shield_diffuser,
 /obj/map_helper/airlock/door/ext_door,
-/obj/machinery/door/airlock/glass_external,
 /obj/machinery/access_button/airlock_exterior{
 	dir = 1;
 	frequency = 1380;
 	master_tag = "civvie_dock";
 	pixel_y = 24
 	},
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "aFj" = (
@@ -1002,7 +1012,7 @@
 /obj/machinery/door/airlock/command{
 	id_tag = "HoSdoor";
 	name = "Head of Security";
-	req_access = list(58)
+	req_one_access = null
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/firedoor/glass,
@@ -1011,6 +1021,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/map_helper/access_helper/airlock/station/head_office/head_of_security,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "aIj" = (
@@ -1088,15 +1099,16 @@
 /area/gateway/prep_room)
 "aJi" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass/security{
-	name = "Shuttle Bay";
-	req_one_access = list(2)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/glass/security{
+	name = "Shuttle Bay";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/brig,
 /turf/simulated/floor/tiled/dark,
 /area/security/hanger)
 "aJP" = (
@@ -1200,8 +1212,7 @@
 /area/maintenance/security/starboard)
 "aMl" = (
 /obj/machinery/door/airlock{
-	name = "Internal Affairs";
-	req_access = list(38)
+	name = "Internal Affairs"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1209,6 +1220,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/map_helper/access_helper/airlock/station/head_office/internal_affairs,
 /turf/simulated/floor/tiled/dark,
 /area/lawoffice)
 "aMu" = (
@@ -1242,23 +1254,24 @@
 /area/bridge/meeting_room)
 "aMX" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/security{
-	name = "Interrogation";
-	req_one_access = list(1,2,4,38)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/security{
+	name = "Interrogation";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/interrogation)
 "aNv" = (
 /obj/machinery/door/airlock/silver{
-	name = "Mime's Office";
-	req_one_access = list(138)
+	name = "Mime's Office"
 	},
 /obj/structure/cable/green{
 	dir = 1;
 	icon_state = "4-8"
 	},
+/obj/map_helper/access_helper/airlock/station/service/mime,
 /turf/simulated/floor/plating,
 /area/crew_quarters/mimeoffice)
 "aNE" = (
@@ -1608,15 +1621,16 @@
 /area/bridge/meeting_room)
 "bbz" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass/security{
-	name = "Warden's Office";
-	req_access = list(3)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/glass/security{
+	name = "Warden's Office";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/armory,
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "bcd" = (
@@ -1631,7 +1645,8 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/security{
 	name = "Equipment Storage";
-	req_access = list()
+	req_access = list();
+	req_one_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1639,6 +1654,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/map_helper/access_helper/airlock/station/security/equipment,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "bcg" = (
@@ -2035,10 +2051,6 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
-/obj/machinery/door/airlock/glass/security{
-	name = "Firing Range";
-	req_one_access = list(1,2,4)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -2048,6 +2060,11 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
+/obj/machinery/door/airlock/glass/security{
+	name = "Firing Range";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/security/range)
 "btC" = (
@@ -2266,13 +2283,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "bFk" = (
-/obj/machinery/door/airlock/maintenance/command,
 /obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/maintenance/command{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/command/bridge,
 /turf/simulated/floor/plating,
 /area/bridge/hallway)
 "bFn" = (
@@ -2560,10 +2580,10 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 8;
 	name = "Exploration Prep";
-	req_access = list();
-	req_one_access = list(19,43,67)
+	req_access = list()
 	},
 /obj/machinery/door/firedoor,
+/obj/map_helper/access_helper/airlock/station/exploration/department,
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "bMt" = (
@@ -2617,9 +2637,9 @@
 "bOq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/glass{
-	name = "Pilot Prep";
-	req_one_access = list(19,43,67)
+	name = "Pilot Prep"
 	},
+/obj/map_helper/access_helper/airlock/station/exploration/department,
 /turf/simulated/floor/tiled,
 /area/exploration/pilot_prep)
 "bOF" = (
@@ -2921,11 +2941,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
 	name = "Security Substation";
-	secured_wires = 1
+	secured_wires = 1;
+	req_one_access = null
 	},
-/obj/machinery/door/firedoor,
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/security)
 "cbd" = (
@@ -3335,10 +3357,6 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
-/obj/machinery/door/airlock/glass/security{
-	name = "Permanent Confinement";
-	req_access = list(2)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3348,6 +3366,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/glass/security{
+	name = "Permanent Confinement";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "coH" = (
@@ -3945,7 +3968,7 @@
 "cSe" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "High Security Lockup";
-	req_one_access = list(3)
+	req_one_access = null
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3954,6 +3977,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/map_helper/access_helper/airlock/station/security/armory,
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence_storage)
 "cSS" = (
@@ -4111,13 +4135,16 @@
 "cUV" = (
 /obj/machinery/shield_diffuser,
 /obj/map_helper/airlock/door/ext_door,
-/obj/machinery/door/airlock/glass_external,
 /obj/machinery/access_button/airlock_exterior{
 	dir = 1;
 	frequency = 1380;
 	master_tag = "deck4_dockarm1";
 	pixel_x = -24
 	},
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "cVf" = (
@@ -4268,8 +4295,9 @@
 	},
 /obj/machinery/door/airlock/command{
 	name = "Bridge Meeting Room";
-	req_access = list(19)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/command/bridge,
 /turf/simulated/floor/tiled,
 /area/bridge/meeting_room)
 "dbE" = (
@@ -4438,12 +4466,14 @@
 /turf/simulated/floor/tiled,
 /area/exploration/showers)
 "dfr" = (
+/obj/machinery/shield_diffuser,
 /obj/machinery/door/airlock/glass_external{
 	frequency = 1379;
 	icon_state = "door_locked";
 	id_tag = "sec_shuttle_outer";
 	locked = 1;
-	name = "Shuttle Exterior Access"
+	name = "Shuttle Exterior Access";
+	req_one_access = null
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -4452,7 +4482,7 @@
 	name = "Security Blast Doors";
 	opacity = 0
 	},
-/obj/machinery/shield_diffuser,
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/plating,
 /area/security/hanger)
 "dfP" = (
@@ -4794,25 +4824,25 @@
 /area/triumph/surfacebase/sauna)
 "dod" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/multi_tile/glass{
-	id_tag = "BrigFoyer";
-	name = "Security";
-	req_one_access = list(1,38)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	id_tag = "BrigFoyer";
+	name = "Security"
+	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
 	id = "security_lockdown";
 	name = "Security Blast Doors";
 	opacity = 0
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
@@ -5035,13 +5065,16 @@
 /area/maintenance/tool_storage)
 "dry" = (
 /obj/map_helper/airlock/door/int_door,
-/obj/machinery/door/airlock/glass_external,
 /obj/machinery/access_button/airlock_interior{
 	dir = 1;
 	frequency = 1380;
 	master_tag = "deck4_dockarm1";
 	pixel_x = 24
 	},
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "dsk" = (
@@ -5049,8 +5082,9 @@
 	icon_state = "door_locked";
 	locked = 1;
 	name = "AI Core";
-	req_access = list(16)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/command/ai_core,
 /turf/simulated/floor/tiled/dark,
 /area/ai)
 "dsD" = (
@@ -6200,13 +6234,14 @@
 /turf/simulated/floor/wood,
 /area/library)
 "efp" = (
-/obj/machinery/door/airlock/glass/security{
-	name = "Shuttle Bay Control Room";
-	req_one_access = list(2,4)
-	},
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/glass/security{
+	name = "Shuttle Bay Control Room";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/brig,
 /turf/simulated/floor/tiled,
 /area/security/hanger)
 "egZ" = (
@@ -6709,8 +6744,9 @@
 /obj/machinery/door/airlock/command{
 	id_tag = "cmodoor";
 	name = "CMO's Living Quarters";
-	req_access = list(40)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/head_office/chief_medical_officer,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/CMO_quarters)
 "eDF" = (
@@ -7421,10 +7457,6 @@
 /area/security/range)
 "ffl" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass/security{
-	name = "Light Armory";
-	req_access = list(3)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -7434,6 +7466,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/glass/security{
+	name = "Light Armory";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/armory,
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "ffV" = (
@@ -7948,6 +7985,7 @@
 "fvk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/maintenance,
+/obj/map_helper/access_helper/airlock/station/exploration/department,
 /turf/simulated/floor/plating,
 /area/exploration/explorer_prep)
 "fvy" = (
@@ -8235,7 +8273,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance/engi,
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/exploration)
 "fIV" = (
@@ -8515,8 +8556,9 @@
 /obj/machinery/door/firedoor,
 /obj/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
-	req_one_access = list(19,43,67)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/exploration/department,
 /turf/simulated/floor/tiled,
 /area/exploration/pilot_prep)
 "fSO" = (
@@ -8545,13 +8587,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/command{
-	name = "Nanotrasen Official On-Site Office";
-	req_access = list(19)
-	},
 /obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
+/obj/machinery/door/airlock/command{
+	name = "Nanotrasen Official On-Site Office";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/command/bridge,
 /turf/simulated/floor/tiled,
 /area/bridge/office)
 "fUE" = (
@@ -8896,11 +8939,6 @@
 /area/security/security_equiptment_storage)
 "gfA" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/security{
-	id_tag = "detdoor";
-	name = "Forensics Lab";
-	req_access = list(4)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8910,6 +8948,12 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/glass/security{
+	id_tag = "detdoor";
+	name = "Forensics Lab";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/forensics,
 /turf/simulated/floor/tiled/dark,
 /area/security/forensics)
 "ggg" = (
@@ -9120,10 +9164,6 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
-/obj/machinery/door/airlock/glass/security{
-	name = "Brig";
-	req_one_access = list(2)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -9139,6 +9179,11 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
+/obj/machinery/door/airlock/glass/security{
+	name = "Brig";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "gnD" = (
@@ -9151,7 +9196,10 @@
 	},
 /obj/machinery/shield_diffuser,
 /obj/map_helper/airlock/door/ext_door,
-/obj/machinery/door/airlock/glass_external,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "gpv" = (
@@ -9224,7 +9272,7 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass/security{
 	name = "Recreation Room";
-	req_one_access = list(1,2,4)
+	req_one_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9249,11 +9297,6 @@
 /area/exploration/explorer_prep)
 "gsu" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass/security{
-	layer = 2.8;
-	name = "Security";
-	req_one_access = list(1,38)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -9263,6 +9306,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -9270,7 +9314,12 @@
 	name = "Security Blast Doors";
 	opacity = 0
 	},
-/obj/effect/floor_decal/borderfloorblack,
+/obj/machinery/door/airlock/glass/security{
+	layer = 2.8;
+	name = "Security";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "gsD" = (
@@ -9743,7 +9792,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Detective";
-	req_access = list(4)
+	req_one_access = null
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -9752,14 +9801,16 @@
 	name = "Security Blast Doors";
 	opacity = 0
 	},
+/obj/map_helper/access_helper/airlock/station/security/forensics,
 /turf/simulated/floor/lino,
 /area/security/detectives_office)
 "gKK" = (
-/obj/machinery/door/airlock/glass_external{
-	name = "Docking Port Airlock"
-	},
 /obj/machinery/shield_diffuser,
 /obj/map_helper/airlock/door/ext_door,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "gLm" = (
@@ -9917,8 +9968,9 @@
 /obj/machinery/door/airlock/glass/security{
 	id_tag = "detdoor";
 	name = "Forensics Lab";
-	req_access = list(4)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/forensics,
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/evidence_storage)
 "gSE" = (
@@ -10013,18 +10065,20 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass/security{
 	name = "Holding Room";
-	req_one_access = list(1,2,4,38)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/monotile,
 /area/security/hallway)
 "gUH" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass/security{
 	name = "Cell Block";
-	req_one_access = list(1,38)
+	req_one_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/dark,
 /area/prison/cell_block)
 "gUN" = (
@@ -10262,9 +10316,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
 "hdp" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(19,43,67)
-	},
 /obj/machinery/access_button/airlock_interior{
 	frequency = 1380;
 	master_tag = "courser_dock";
@@ -10273,6 +10324,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/map_helper/airlock/door/int_door,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/exploration/department,
 /turf/simulated/floor/tiled,
 /area/exploration/pilot_prep)
 "hdt" = (
@@ -10580,12 +10635,12 @@
 /area/security/tactical)
 "hkL" = (
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/glass/security{
 	layer = 2.8;
 	name = "Security Tool Storage";
-	req_one_access = list(1,38)
+	req_one_access = null
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -10594,6 +10649,7 @@
 	name = "Security Blast Doors";
 	opacity = 0
 	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
 "hkO" = (
@@ -11050,10 +11106,6 @@
 /area/security/hanger)
 "hGh" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass/security{
-	name = "Confinement Processing";
-	req_access = list(2)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -11062,6 +11114,11 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/glass/security{
+	name = "Confinement Processing";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "hGB" = (
@@ -11591,8 +11648,9 @@
 	},
 /obj/machinery/door/airlock/command{
 	name = "Teleport Access";
-	req_access = list(17)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/command/teleporter,
 /turf/simulated/floor/tiled,
 /area/teleporter)
 "hYO" = (
@@ -11602,8 +11660,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "hYU" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance/sec{
-	req_one_access = list(4)
+	req_one_access = null
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -11612,10 +11674,7 @@
 	name = "Security Blast Doors";
 	opacity = 0
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
+/obj/map_helper/access_helper/airlock/station/security/forensics,
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
 "hZk" = (
@@ -12349,8 +12408,9 @@
 	},
 /obj/machinery/door/airlock/glass/security{
 	name = "Solitary Confinement 1";
-	req_access = list(2)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/brig,
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "iAm" = (
@@ -12447,12 +12507,13 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
-/obj/machinery/door/airlock/glass/security{
-	name = "Brig";
-	req_one_access = list(2)
-	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/red/border,
+/obj/machinery/door/airlock/glass/security{
+	name = "Brig";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "iCl" = (
@@ -13098,7 +13159,9 @@
 /area/security/detectives_office)
 "jch" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance/engi,
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/lounge)
 "jcv" = (
@@ -13123,7 +13186,7 @@
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Reception";
 	req_access = list();
-	req_one_access = list(2,4)
+	req_one_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13140,6 +13203,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
 "jcQ" = (
@@ -13281,14 +13345,14 @@
 /area/maintenance/security/starboard)
 "jhJ" = (
 /obj/machinery/door/airlock/silver{
-	name = "Clown's Office";
-	req_one_access = list(136)
+	name = "Clown's Office"
 	},
 /obj/structure/cable/green{
 	dir = 1;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/map_helper/access_helper/airlock/station/service/clown,
 /turf/simulated/floor/plating,
 /area/crew_quarters/clownoffice)
 "jje" = (
@@ -13397,12 +13461,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
-"jnF" = (
-/obj/machinery/shield_diffuser,
-/obj/map_helper/airlock/door/ext_door,
-/obj/machinery/door/airlock/glass_external,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/secondary/docking_hallway)
 "jnZ" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/bcarpet,
@@ -13739,12 +13797,12 @@
 /area/security/range)
 "jvK" = (
 /obj/machinery/door/airlock{
-	name = "Chapel Morgue";
-	req_access = list(27)
+	name = "Chapel Morgue"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/glass,
+/obj/map_helper/access_helper/airlock/station/service/chapel/cremator,
 /turf/simulated/floor/tiled,
 /area/chapel/main)
 "jvT" = (
@@ -14408,6 +14466,7 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Gateway Prep"
 	},
+/obj/map_helper/access_helper/airlock/station/exploration/department,
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
 "jRW" = (
@@ -14918,8 +14977,9 @@
 	pixel_y = 8
 	},
 /obj/machinery/door/airlock/glass_external{
-	req_one_access = list(19,43,67)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/exploration/department,
 /turf/simulated/floor/tiled,
 /area/exploration/pilot_prep)
 "kim" = (
@@ -16226,6 +16286,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/exploration)
+"laV" = (
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "sec_shuttle_outer";
+	locked = 1;
+	name = "Shuttle Exterior Access";
+	req_one_access = null
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/shield_diffuser,
+/obj/map_helper/access_helper/airlock/station/external_airlock,
+/turf/simulated/floor/plating,
+/area/security/hanger)
 "lbH" = (
 /obj/machinery/computer/ship/navigation{
 	dir = 1
@@ -16363,8 +16443,9 @@
 /obj/machinery/door/airlock/glass/security{
 	id_tag = "detdoor";
 	name = "Forensics Lab";
-	req_access = list(4)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/forensics,
 /turf/simulated/floor/lino,
 /area/security/forensics)
 "lhx" = (
@@ -16560,10 +16641,11 @@
 /obj/machinery/door/airlock/security{
 	name = "Interrogation view room";
 	req_access = list();
-	req_one_access = list(1,2,4,38)
+	req_one_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/interrogation)
 "lsW" = (
@@ -16626,11 +16708,6 @@
 /area/library)
 "lue" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass/security{
-	layer = 2.8;
-	name = "Security";
-	req_one_access = list(1,38)
-	},
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -16638,6 +16715,12 @@
 	name = "Security Blast Doors";
 	opacity = 0
 	},
+/obj/machinery/door/airlock/glass/security{
+	layer = 2.8;
+	name = "Security";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "lus" = (
@@ -17442,8 +17525,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Chief Engineer's Living Quarters";
-	req_access = list(10)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/head_office/chief_engineer,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/CE_quarters)
 "meE" = (
@@ -17764,7 +17848,10 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
-/obj/machinery/door/airlock/maintenance/rnd,
+/obj/machinery/door/airlock/maintenance/rnd{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/exploration/department,
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "mqp" = (
@@ -17829,9 +17916,10 @@
 "msB" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
-	req_access = list(57)
+	req_one_access = null
 	},
 /obj/machinery/door/firedoor,
+/obj/map_helper/access_helper/airlock/station/head_office/head_of_personnel,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hop)
 "mts" = (
@@ -17914,7 +18002,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "mwt" = (
-/obj/machinery/door/airlock/maintenance/sec,
+/obj/machinery/door/airlock/maintenance/sec{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/plating,
 /area/maintenance/security/port)
 "mwK" = (
@@ -18015,8 +18106,10 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/command{
-	name = "Bridge"
+	name = "Bridge";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/command/bridge,
 /turf/simulated/floor/tiled/dark,
 /area/triumph/station/stairs_four)
 "mzK" = (
@@ -18551,7 +18644,8 @@
 "mTE" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/security{
-	name = "Private Quarters"
+	name = "Private Quarters";
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -19032,11 +19126,11 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/library/study)
 "npu" = (
-/obj/machinery/door/airlock{
-	name = "Chapel Morgue";
-	req_access = list(27)
-	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock{
+	name = "Chapel Morgue"
+	},
+/obj/map_helper/access_helper/airlock/station/service/chapel/cremator,
 /turf/simulated/floor/tiled,
 /area/chapel/main)
 "npx" = (
@@ -19164,13 +19258,16 @@
 "nuU" = (
 /obj/machinery/shield_diffuser,
 /obj/map_helper/airlock/door/ext_door,
-/obj/machinery/door/airlock/glass_external,
 /obj/machinery/access_button/airlock_exterior{
 	dir = 8;
 	frequency = 1380;
 	master_tag = "triumph_specops_dock";
 	pixel_y = 24
 	},
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "nve" = (
@@ -19743,14 +19840,15 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(19,43,67)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/firedoor,
 /obj/map_helper/airlock/door/int_door,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/exploration/department,
 /turf/simulated/floor/tiled,
 /area/exploration/pilot_prep)
 "nMY" = (
@@ -19972,14 +20070,14 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "AI Chamber";
-	req_access = list(16);
-	req_one_access = list()
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Chamber";
+	req_one_access = list()
+	},
+/obj/map_helper/access_helper/airlock/station/command/ai_core,
 /turf/simulated/floor/bluegrid,
 /area/ai_upload)
 "nSI" = (
@@ -20532,10 +20630,6 @@
 /turf/simulated/floor/tiled,
 /area/exploration/showers)
 "ooD" = (
-/obj/machinery/door/airlock/command{
-	name = "Head of Personnel's Living Quarters";
-	req_access = list(57)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -20548,6 +20642,11 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
+/obj/machinery/door/airlock/command{
+	name = "Head of Personnel's Living Quarters";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/head_office/head_of_personnel,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/HOP_quarters)
 "ooL" = (
@@ -21080,12 +21179,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access";
-	req_access = list(16);
 	req_one_access = list()
 	},
-/obj/machinery/door/firedoor,
+/obj/map_helper/access_helper/airlock/station/command/ai_upload,
 /turf/simulated/floor/tiled/techfloor,
 /area/ai/foyer)
 "oKo" = (
@@ -21623,7 +21722,6 @@
 /area/maintenance/tool_storage)
 "pcR" = (
 /obj/map_helper/airlock/door/int_door,
-/obj/machinery/door/airlock/glass_external,
 /obj/machinery/access_button/airlock_interior{
 	dir = 1;
 	frequency = 1380;
@@ -21633,6 +21731,10 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "pdu" = (
@@ -21950,9 +22052,9 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4;
 	name = "Exploration Prep";
-	req_access = list();
-	req_one_access = list(19,43,67)
+	req_access = list()
 	},
+/obj/map_helper/access_helper/airlock/station/exploration/department,
 /turf/simulated/floor/tiled,
 /area/exploration/meeting)
 "pog" = (
@@ -22315,12 +22417,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload";
-	req_access = list(16);
 	req_one_access = list()
 	},
-/obj/machinery/door/firedoor,
+/obj/map_helper/access_helper/airlock/station/command/ai_upload,
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload)
 "pzy" = (
@@ -22471,8 +22573,9 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/security{
 	name = "Interrogation";
-	req_one_access = list(1,2,4,38)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/dark,
 /area/security/interrogation)
 "pEt" = (
@@ -22752,9 +22855,10 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
+/obj/map_helper/access_helper/airlock/station/hangar,
 /obj/machinery/door/airlock/glass_external{
 	name = "Exploration Emergency Exit";
-	req_one_access = list(1,2,5,19,43,67)
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/excursion_dock)
@@ -23157,13 +23261,14 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
-/obj/machinery/door/airlock/glass/security{
-	name = "Firing Range";
-	req_one_access = list(1,2,4)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/door/airlock/glass/security{
+	name = "Firing Range";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/security/range)
 "qgU" = (
@@ -23190,7 +23295,7 @@
 /obj/machinery/door/airlock/command{
 	id_tag = "captaindoor";
 	name = "Facility Director's Office";
-	req_access = list(20)
+	req_one_access = null
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -23200,6 +23305,7 @@
 	name = "Bridge Lockdown";
 	opacity = 0
 	},
+/obj/map_helper/access_helper/airlock/station/head_office/captain,
 /turf/simulated/floor/tiled/steel_grid,
 /area/bridge)
 "qhA" = (
@@ -23249,13 +23355,15 @@
 /area/hallway/secondary/docking_hallway)
 "qjv" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/security{
-	name = "Equipment Storage";
-	req_access = list()
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/door/airlock/security{
+	name = "Equipment Storage";
+	req_access = list();
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/equipment,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "qjG" = (
@@ -23313,8 +23421,9 @@
 /obj/machinery/door/airlock/command{
 	id_tag = "captaindoor";
 	name = "Facility Director's Office";
-	req_access = list(20)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/head_office/captain,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/captain)
 "qkY" = (
@@ -23334,8 +23443,9 @@
 "qln" = (
 /obj/machinery/door/airlock/command{
 	name = "Bridge Meeting Room";
-	req_access = list(19)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/command/bridge,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "qlw" = (
@@ -24058,7 +24168,7 @@
 	id_tag = "Checkpoint";
 	layer = 2.8;
 	name = "Security";
-	req_one_access = list(1,38)
+	req_one_access = null
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -24067,6 +24177,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled,
 /area/exploration/excursion_dock)
 "qQg" = (
@@ -24158,11 +24269,11 @@
 /turf/simulated/floor/wood,
 /area/library)
 "qTb" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Bridge";
-	req_access = list(19)
+	req_one_access = null
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 4;
@@ -24171,6 +24282,7 @@
 	name = "Bridge Lockdown";
 	opacity = 0
 	},
+/obj/map_helper/access_helper/airlock/station/command/bridge,
 /turf/simulated/floor/tiled,
 /area/bridge)
 "qTj" = (
@@ -24210,9 +24322,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Exploration Prep";
-	req_access = list();
-	req_one_access = list(19,43,67)
+	req_access = list()
 	},
+/obj/map_helper/access_helper/airlock/station/exploration/department,
 /turf/simulated/floor/tiled,
 /area/exploration)
 "qWg" = (
@@ -24267,10 +24379,13 @@
 /area/shuttle/excursion/general)
 "qXp" = (
 /obj/structure/catwalk,
-/obj/machinery/door/airlock/maintenance/medical,
+/obj/machinery/door/airlock/maintenance/medical{
+	req_one_access = null
+	},
 /obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/plating,
 /area/maintenance/security/starboard)
 "qXE" = (
@@ -24536,10 +24651,6 @@
 /area/maintenance/security/starboard)
 "rhi" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/security{
-	name = "Evidence Storage";
-	req_one_access = list(1,2,4)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -24549,6 +24660,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/evidence_storage)
 "rhp" = (
@@ -24622,11 +24738,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
 "rjY" = (
+/obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/security{
 	name = "Security Restroom";
-	req_one_access = list(1,2,4)
+	req_one_access = null
 	},
-/obj/machinery/door/firedoor/glass,
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/simulated/floor/tiled/white,
 /area/security/security_lockerroom)
 "rkb" = (
@@ -24717,8 +24834,9 @@
 	},
 /obj/machinery/door/airlock/glass/security{
 	name = "Processing";
-	req_one_access = list(1,2,4,38)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/security_processing)
 "rmY" = (
@@ -24735,8 +24853,10 @@
 "rnz" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/security{
-	name = "Private Quarters"
+	name = "Private Quarters";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/head_office/head_of_security,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "rnI" = (
@@ -25089,15 +25209,16 @@
 /area/security/lobby)
 "rDw" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass/security{
-	name = "Processing";
-	req_one_access = list(1,2,4,38)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/glass/security{
+	name = "Processing";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/security_processing)
 "rDY" = (
@@ -25211,7 +25332,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance/engi,
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/exploration)
 "rHx" = (
@@ -25302,10 +25426,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(19,43,67)
-	},
 /obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/access_helper/airlock/station/exploration/department,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "rKA" = (
@@ -25377,13 +25502,14 @@
 /area/security/security_processing)
 "rOw" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass/security{
-	name = "Locker Room";
-	req_one_access = list(2)
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/glass/security{
+	name = "Locker Room";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/brig,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
 "rOD" = (
@@ -25428,9 +25554,11 @@
 	icon_state = "door_locked";
 	id_tag = "sec_shuttle_inner";
 	locked = 1;
-	name = "Shuttle Internal Access"
+	name = "Shuttle Internal Access";
+	req_one_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/hanger)
 "rRi" = (
@@ -25751,9 +25879,9 @@
 	},
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4;
-	name = "Shuttle Triage and Restroom";
-	req_one_access = list(19,43,67)
+	name = "Shuttle Triage and Restroom"
 	},
+/obj/map_helper/access_helper/airlock/station/exploration/department,
 /turf/simulated/floor/tiled,
 /area/exploration/medical)
 "sav" = (
@@ -25861,16 +25989,16 @@
 /area/chapel/office)
 "seD" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/security{
-	name = "Security EVA";
-	req_access = list(2,18);
-	req_one_access = null
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/glass/security{
+	name = "Security EVA";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/brig,
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "seH" = (
@@ -26066,8 +26194,9 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass/security{
 	name = "Shuttle Bay";
-	req_one_access = list(2)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/brig,
 /turf/simulated/floor/tiled/dark,
 /area/security/hanger)
 "sly" = (
@@ -26256,11 +26385,13 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
 	name = "Security Substation";
-	secured_wires = 1
+	secured_wires = 1;
+	req_one_access = null
 	},
-/obj/machinery/door/firedoor,
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/security)
 "suA" = (
@@ -26508,6 +26639,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hop)
 "sFr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/command{
+	name = "Facility Director's Quarters";
+	req_one_access = null
+	},
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 4;
@@ -26516,13 +26654,7 @@
 	name = "Facility Director Lockdown";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/command{
-	name = "Facility Director's Quarters";
-	req_access = list(20)
-	},
-/obj/machinery/door/firedoor/glass,
+/obj/map_helper/access_helper/airlock/station/head_office/captain,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "sFu" = (
@@ -26536,14 +26668,18 @@
 "sFB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_external{
-	req_one_access = list(19,43,67)
+	req_one_access = null
 	},
 /obj/map_helper/airlock/door/ext_door,
+/obj/map_helper/access_helper/airlock/station/exploration/department,
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "sFX" = (
-/obj/machinery/door/airlock/maintenance/engi,
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
 /obj/machinery/door/firedoor,
+/obj/map_helper/access_helper/airlock/station/hangar,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/triumph/surfacebase/tram)
 "sGG" = (
@@ -27144,6 +27280,17 @@
 "tgY" = (
 /turf/simulated/floor/tiled/dark,
 /area/gateway)
+"thc" = (
+/obj/structure/catwalk,
+/obj/machinery/door/firedoor/glass{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance/medical{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
+/turf/simulated/floor/plating,
+/area/maintenance/security/starboard)
 "thM" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 5
@@ -27211,9 +27358,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/CE_quarters)
 "tkc" = (
-/obj/machinery/door/airlock/glass_external{
-	name = "Docking Port Airlock"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/map_helper/airlock/door/int_door,
 /obj/machinery/access_button/airlock_interior{
@@ -27222,6 +27366,10 @@
 	master_tag = "deck4_dockarm2";
 	pixel_x = -24
 	},
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "tkI" = (
@@ -27318,10 +27466,11 @@
 /area/maintenance/central)
 "toF" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(19,43,67)
-	},
 /obj/map_helper/airlock/door/int_door,
+/obj/map_helper/access_helper/airlock/station/exploration/department,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "tps" = (
@@ -27564,7 +27713,6 @@
 	dir = 4
 	},
 /obj/map_helper/airlock/door/int_door,
-/obj/machinery/door/airlock/glass_external,
 /obj/machinery/access_button/airlock_interior{
 	dir = 4;
 	frequency = 1380;
@@ -27574,12 +27722,19 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "tyc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/map_helper/airlock/door/int_door,
-/obj/machinery/door/airlock/glass_external,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "tye" = (
@@ -27741,10 +27896,11 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass/security{
 	name = "Visitation";
-	req_access = list(2)
+	req_one_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "tDB" = (
@@ -27854,13 +28010,14 @@
 /area/bridge)
 "tHc" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass/security{
-	name = "Cell Block";
-	req_one_access = list(1,38)
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/glass/security{
+	name = "Cell Block";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/dark,
 /area/prison/cell_block)
 "tHl" = (
@@ -27924,14 +28081,15 @@
 /area/triumph/surfacebase/tram)
 "tJK" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/security{
-	name = "Interrogation view room";
-	req_access = list();
-	req_one_access = list(1,2,4,38)
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/security{
+	name = "Interrogation view room";
+	req_access = list();
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/dark,
 /area/security/interrogation)
 "tKm" = (
@@ -28721,13 +28879,14 @@
 /area/triumph/surfacebase/sauna)
 "uld" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass/security{
-	name = "Shuttle Bay Control Room";
-	req_one_access = list(2,4)
-	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
+/obj/machinery/door/airlock/glass/security{
+	name = "Shuttle Bay Control Room";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/brig,
 /turf/simulated/floor/tiled/dark,
 /area/security/hanger)
 "ult" = (
@@ -29119,11 +29278,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/civilian_hallway_mid)
 "uxl" = (
-/obj/machinery/door/airlock/command{
-	id_tag = "blueshielddoor";
-	name = "Blueshield";
-	req_access = list(69)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -29136,6 +29290,12 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/machinery/door/airlock/command{
+	id_tag = "blueshielddoor";
+	name = "Blueshield";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/head_office/blueshield,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/blueshield)
 "uxn" = (
@@ -29235,11 +29395,6 @@
 /area/crew_quarters/captain)
 "uBu" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/security{
-	id_tag = "detdoor";
-	name = "Detective";
-	req_access = list(4)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -29249,6 +29404,12 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/glass/security{
+	id_tag = "detdoor";
+	name = "Detective";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/forensics,
 /turf/simulated/floor/lino,
 /area/security/detectives_office)
 "uBH" = (
@@ -29286,10 +29447,11 @@
 /turf/simulated/floor/plating,
 /area/security/brig)
 "uCU" = (
-/obj/machinery/door/airlock/glass_external{
-	name = "Docking Port Airlock"
-	},
 /obj/map_helper/airlock/door/int_door,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "uCX" = (
@@ -29755,9 +29917,9 @@
 	},
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4;
-	name = "Shuttle Bay";
-	req_one_access = list(19,43,67)
+	name = "Shuttle Bay"
 	},
+/obj/map_helper/access_helper/airlock/station/exploration/department,
 /turf/simulated/floor/tiled/monofloor,
 /area/exploration)
 "uUm" = (
@@ -29819,9 +29981,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock{
-	name = "Chapel Office";
-	req_access = list(27)
+	name = "Chapel Office"
 	},
+/obj/map_helper/access_helper/airlock/station/service/chapel,
 /turf/simulated/floor/lino,
 /area/chapel/office)
 "uWQ" = (
@@ -30628,10 +30790,11 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/medical{
 	name = "Checkpoint Airlock";
-	req_one_access = list(1,2,5,19,43,67)
+	req_one_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/map_helper/access_helper/airlock/station/hangar,
 /turf/simulated/floor/tiled,
 /area/exploration/excursion_dock)
 "vEi" = (
@@ -30904,6 +31067,11 @@
 /area/hallway/secondary/docking_hallway)
 "vMF" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass/security{
+	layer = 2.8;
+	name = "Security Tool Storage";
+	req_one_access = null
+	},
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -30911,11 +31079,7 @@
 	name = "Security Blast Doors";
 	opacity = 0
 	},
-/obj/machinery/door/airlock/glass/security{
-	layer = 2.8;
-	name = "Security Tool Storage";
-	req_one_access = list(1,38)
-	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/lobby)
 "vMW" = (
@@ -31495,8 +31659,9 @@
 /obj/machinery/door/airlock/command{
 	id_tag = "captaindoor";
 	name = "Facility Director's Office";
-	req_access = list(20)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/head_office/captain,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "wgE" = (
@@ -31585,7 +31750,7 @@
 	},
 /obj/machinery/door/airlock/vault/bolted{
 	id_tag = "vault";
-	req_access = list(53)
+	req_one_access = null
 	},
 /obj/machinery/door/firedoor/glass{
 	dir = 8
@@ -31595,6 +31760,7 @@
 	id = "VaultAc";
 	name = "\improper Vault"
 	},
+/obj/map_helper/access_helper/airlock/station/command/vault,
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
 "wnV" = (
@@ -32685,8 +32851,10 @@
 	icon_state = "door_locked";
 	id_tag = "sec_shuttle_inner";
 	locked = 1;
-	name = "Shuttle Internal Access"
+	name = "Shuttle Internal Access";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/hanger)
 "xbM" = (
@@ -33033,9 +33201,9 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/research{
-	name = "Pathfinder's Office";
-	req_access = list(44)
+	name = "Pathfinder's Office"
 	},
+/obj/map_helper/access_helper/airlock/station/head_office/pathfinder,
 /turf/simulated/floor/tiled,
 /area/exploration/pathfinder_office)
 "xlI" = (
@@ -33460,7 +33628,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/secondary/civilian_hallway_mid)
 "xwP" = (
-/obj/machinery/door/airlock/maintenance/sec,
+/obj/machinery/door/airlock/maintenance/sec{
+	req_one_access = null
+	},
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -33468,6 +33638,7 @@
 	name = "Security Blast Doors";
 	opacity = 0
 	},
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/simulated/floor/plating,
 /area/maintenance/security/port)
 "xwU" = (
@@ -33533,11 +33704,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(19,43,67)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/map_helper/airlock/door/int_door,
+/obj/map_helper/access_helper/airlock/station/exploration/department,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "xzG" = (
@@ -34016,10 +34188,13 @@
 	dir = 4
 	},
 /obj/map_helper/airlock/door/int_door,
-/obj/machinery/door/airlock/glass_external,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
 /obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway)
 "xQm" = (
@@ -44911,7 +45086,7 @@ xbb
 xou
 mKN
 eaM
-dfr
+laV
 ftm
 jNg
 jNg
@@ -56077,7 +56252,7 @@ jNg
 jNg
 jNg
 jNg
-jnF
+gKK
 kFe
 dry
 hja
@@ -57125,7 +57300,7 @@ wzh
 wzh
 wzh
 wzh
-qXp
+thc
 wzh
 dNv
 jdj

--- a/maps/triumph/levels/flagship.dmm
+++ b/maps/triumph/levels/flagship.dmm
@@ -3996,12 +3996,13 @@
 /obj/machinery/door/airlock/vault/bolted{
 	id_tag = "the_end";
 	name = "RESTRICTED";
-	req_access = list(109)
+	req_one_access = null
 	},
 /obj/machinery/door/blast/regular{
 	id = "ADMINFUN";
 	name = "RESTRICTED"
 	},
+/obj/map_helper/access_helper/airlock/station/command/vault,
 /turf/simulated/floor/reinforced,
 /area/centcom/command)
 "mH" = (
@@ -16280,12 +16281,13 @@
 /obj/machinery/door/airlock/vault/bolted{
 	id_tag = "the_end";
 	name = "RESTRICTED";
-	req_access = list(109)
+	req_one_access = null
 	},
 /obj/machinery/door/blast/regular{
 	id = "ADMINFUN";
 	name = "RESTRICTED"
 	},
+/obj/map_helper/access_helper/airlock/station/command/vault,
 /turf/simulated/floor/reinforced,
 /area/centcom/security)
 "ZL" = (

--- a/maps/triumph/levels/flagship.dmm
+++ b/maps/triumph/levels/flagship.dmm
@@ -3,6 +3,7 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4
 	},
+/obj/map_helper/access_helper/airlock/station/centcom,
 /turf/unsimulated/floor/steel,
 /area/centcom/command)
 "ae" = (
@@ -139,15 +140,6 @@
 	icon_state = "dark"
 	},
 /area/centcom/security)
-"aB" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Teleporter";
-	req_access = list(103)
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/centcom/specops)
 "aC" = (
 /obj/structure/table/reinforced,
 /turf/unsimulated/floor{
@@ -581,6 +573,15 @@
 /obj/effect/floor_decal/corner/blue/border,
 /turf/unsimulated/floor/steel,
 /area/centcom/holding)
+"bQ" = (
+/obj/machinery/door/airlock/glass/security{
+	name = "Security";
+	req_access = list();
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/equipment,
+/turf/unsimulated/floor/steel,
+/area/centcom/security)
 "bV" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light{
@@ -631,9 +632,9 @@
 "cb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/metal{
-	name = "Nanotrasen Offices";
-	req_one_access = list(101)
+	name = "Nanotrasen Offices"
 	},
+/obj/map_helper/access_helper/airlock/station/centcom,
 /turf/unsimulated/floor/steel,
 /area/centcom/command)
 "cc" = (
@@ -776,9 +777,11 @@
 	},
 /area/centcom/bar)
 "cA" = (
+/obj/map_helper/access_helper/airlock/station/security/general,
 /obj/machinery/door/airlock/glass/security{
 	name = "Security";
-	req_access = list()
+	req_access = list();
+	req_one_access = null
 	},
 /turf/unsimulated/floor/steel,
 /area/centcom/security)
@@ -1220,6 +1223,7 @@
 /area/centcom/specops)
 "dI" = (
 /obj/machinery/door/airlock,
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/unsimulated/floor/steel,
 /area/centcom/security)
 "dK" = (
@@ -1522,8 +1526,10 @@
 /area/centcom/security)
 "eG" = (
 /obj/machinery/door/airlock/security{
-	name = "Security"
+	name = "Security";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/unsimulated/floor{
 	icon_state = "steel"
 	},
@@ -2244,9 +2250,9 @@
 "gN" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Secure Armoury Section";
-	req_access = list(58);
-	req_one_access = list(19)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/head_office/head_of_security,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -2759,8 +2765,9 @@
 /obj/machinery/door/airlock/command{
 	id_tag = "HoSdoor";
 	name = "Head of Security";
-	req_access = list(58)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/head_office/head_of_security,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -2898,8 +2905,10 @@
 /area/centcom/bar)
 "jq" = (
 /obj/machinery/door/airlock/security{
-	name = "Security"
+	name = "Security";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -3176,8 +3185,9 @@
 "kk" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Special Operations";
-	req_access = list(103)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/centcom/ert,
 /turf/unsimulated/floor/steel,
 /area/centcom/specops)
 "kl" = (
@@ -3364,6 +3374,15 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
+/turf/unsimulated/floor/steel,
+/area/centcom/security)
+"kV" = (
+/obj/machinery/door/airlock/glass/security{
+	name = "Security";
+	req_access = list();
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/unsimulated/floor/steel,
 /area/centcom/security)
 "kW" = (
@@ -3687,9 +3706,10 @@
 /area/centcom/control)
 "lS" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Commander";
-	req_access = list(103)
+	name = "Teleporter";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/centcom/ert,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -3720,8 +3740,9 @@
 "lY" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Warden's Office";
-	req_access = list(3)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/armory,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -4106,8 +4127,10 @@
 "na" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Security";
-	req_access = list()
+	req_access = list();
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -4355,11 +4378,22 @@
 	icon_state = "dark"
 	},
 /area/centcom/security)
+"nH" = (
+/obj/machinery/door/airlock/security{
+	name = "Security";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/department,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/security)
 "nI" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "Robotics Lab";
-	req_access = list(29,47)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/science/robotics,
 /turf/unsimulated/floor/steel{
 	icon_state = "white"
 	},
@@ -4376,9 +4410,9 @@
 "nL" = (
 /obj/machinery/door/airlock/research{
 	id_tag = "researchdoor";
-	name = "Research Division Access";
-	req_access = list(47)
+	name = "Research Division Access"
 	},
+/obj/map_helper/access_helper/airlock/station/science/department,
 /turf/unsimulated/floor/steel{
 	icon_state = "white"
 	},
@@ -4872,6 +4906,14 @@
 /obj/structure/flora/pottedplant,
 /turf/unsimulated/floor/steel,
 /area/centcom/main_hall)
+"pA" = (
+/obj/machinery/door/airlock/security{
+	name = "Security";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/general,
+/turf/unsimulated/floor/steel,
+/area/centcom/security)
 "pB" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/borderfloor,
@@ -5363,6 +5405,15 @@
 	icon_state = "dark"
 	},
 /area/centcom/security)
+"rn" = (
+/obj/machinery/door/airlock/glass/security{
+	name = "Security";
+	req_access = list();
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/general,
+/turf/unsimulated/floor/steel,
+/area/centcom/security)
 "ro" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/floor_decal/borderfloorblack{
@@ -5461,6 +5512,19 @@
 	dir = 9
 	},
 /obj/machinery/camera/network/crescent,
+/turf/unsimulated/floor/steel,
+/area/centcom/security)
+"rz" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	req_access = list(63);
+	req_one_access = list(1)
+	},
 /turf/unsimulated/floor/steel,
 /area/centcom/security)
 "rA" = (
@@ -5836,8 +5900,9 @@
 	},
 /obj/machinery/door/airlock/hatch{
 	name = "Engine Bay";
-	req_one_access = list(103)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/centcom/ert,
 /turf/simulated/floor/plating,
 /area/shuttle/specops/engine)
 "sw" = (
@@ -6164,7 +6229,10 @@
 /turf/unsimulated/floor/steel,
 /area/centcom/main_hall)
 "tp" = (
-/obj/machinery/door/airlock/glass_external,
+/obj/map_helper/access_helper/airlock/station/external_airlock,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
 /turf/unsimulated/floor/steel,
 /area/centcom/evac)
 "tr" = (
@@ -6416,8 +6484,10 @@
 "uq" = (
 /obj/machinery/door/airlock/security{
 	id_tag = "front";
-	name = "Security"
+	name = "Security";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/simulated/shuttle/floor/darkred,
 /area/shuttle/escape)
 "uu" = (
@@ -6598,9 +6668,9 @@
 /area/centcom/specops)
 "uY" = (
 /obj/machinery/door/airlock/freezer{
-	name = "Kitchen cold room";
-	req_access = list(28)
+	name = "Kitchen cold room"
 	},
+/obj/map_helper/access_helper/airlock/station/service/kitchen,
 /turf/unsimulated/floor/steel{
 	icon_state = "white"
 	},
@@ -7351,6 +7421,21 @@
 	},
 /turf/unsimulated/floor/steel,
 /area/centcom/security)
+"xn" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass/security{
+	name = "Security";
+	req_access = list();
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/department,
+/turf/unsimulated/floor/steel,
+/area/centcom/security)
 "xp" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -7369,6 +7454,14 @@
 	icon_state = "dark"
 	},
 /area/tdome/tdome1)
+"xv" = (
+/obj/machinery/door/airlock/centcom{
+	name = "General Access";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/centcom,
+/turf/unsimulated/floor/steel,
+/area/centcom/control)
 "xw" = (
 /obj/item/storage/box/flashshells,
 /obj/item/storage/box/flashshells,
@@ -7745,6 +7838,19 @@
 	icon_state = "dark"
 	},
 /area/centcom/command)
+"yI" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner{
+	dir = 1
+	},
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access = list(63);
+	req_one_access = list(1)
+	},
+/turf/unsimulated/floor/steel,
+/area/centcom/security)
 "yJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/skills,
@@ -7810,8 +7916,9 @@
 "yY" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
-	req_access = list(45)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/unsimulated/floor/steel{
 	icon_state = "white"
 	},
@@ -7843,8 +7950,10 @@
 /area/centcom/medical)
 "zb" = (
 /obj/machinery/door/airlock/security{
-	name = "Security"
+	name = "Security";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/unsimulated/floor/steel,
 /area/centcom/security)
 "zc" = (
@@ -8127,6 +8236,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Brig Dormitories"
 	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -8292,8 +8402,9 @@
 "Au" = (
 /obj/machinery/door/airlock/centcom{
 	name = "General Access";
-	req_access = list(101)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/centcom,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -8774,9 +8885,9 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/glass{
-	name = "Kitchen";
-	req_access = list(28)
+	name = "Kitchen"
 	},
+/obj/map_helper/access_helper/airlock/station/service/kitchen,
 /turf/unsimulated/floor/steel{
 	icon_state = "white"
 	},
@@ -8784,8 +8895,9 @@
 "Cl" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "Research and Development";
-	req_access = list(7)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/science/research_lab,
 /turf/unsimulated/floor/steel{
 	icon_state = "white"
 	},
@@ -8836,8 +8948,9 @@
 "Cw" = (
 /obj/machinery/door/airlock/medical{
 	name = "Shuttle Medbay";
-	req_access = list(45)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
 "Cx" = (
@@ -8895,8 +9008,9 @@
 	},
 /obj/machinery/door/airlock/hatch{
 	name = "Cockpit";
-	req_one_access = list(103)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/centcom/ert,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/specops/cockpit)
 "CD" = (
@@ -9970,8 +10084,9 @@
 "Go" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Processing";
-	req_access = list(1)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/general,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -10059,13 +10174,15 @@
 	dir = 4
 	},
 /obj/map_helper/airlock/door/int_door,
-/obj/machinery/door/airlock/glass_external{
-	frequency = null;
-	name = "Ship Hatch"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/glass_external{
+	frequency = null;
+	name = "Ship Hatch";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/specops/general)
 "GC" = (
@@ -10112,7 +10229,10 @@
 	},
 /area/centcom/medical)
 "GJ" = (
-/obj/machinery/door/airlock/glass_external,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/unsimulated/floor/steel,
 /area/centcom/terminal)
 "GK" = (
@@ -10308,8 +10428,9 @@
 /obj/machinery/door/airlock/command{
 	id_tag = "HoSdoor";
 	name = "Head of Security";
-	req_access = list(58)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/head_office/head_of_security,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -10374,8 +10495,10 @@
 /area/centcom/medical)
 "HQ" = (
 /obj/machinery/door/airlock/glass/medical{
-	name = "Virology Laboratory"
+	name = "Virology Laboratory";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/virology,
 /turf/unsimulated/floor/steel{
 	icon_state = "white"
 	},
@@ -10472,8 +10595,9 @@
 "Ia" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Special Operations";
-	req_access = list(103)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/centcom/ert,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -10539,13 +10663,15 @@
 	pixel_y = 26
 	},
 /obj/map_helper/airlock/door/ext_door,
-/obj/machinery/door/airlock/glass_external{
-	frequency = null;
-	name = "Ship Hatch"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/glass_external{
+	frequency = null;
+	name = "Ship Hatch";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/specops/general)
 "Ih" = (
@@ -10651,8 +10777,9 @@
 "Ix" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Living Quarters";
-	req_access = list(105)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/centcom,
 /turf/unsimulated/floor{
 	icon_state = "carpet"
 	},
@@ -10885,8 +11012,10 @@
 	dir = 6
 	},
 /obj/machinery/door/airlock/security{
-	name = "Security"
+	name = "Security";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/unsimulated/floor/steel,
 /area/centcom/security)
 "Jj" = (
@@ -11197,7 +11326,10 @@
 	},
 /area/centcom/control)
 "Kg" = (
-/obj/machinery/door/airlock/command,
+/obj/machinery/door/airlock/command{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/command/bridge,
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/escape)
 "Kh" = (
@@ -12150,9 +12282,9 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/glass{
-	name = "Kitchen";
-	req_access = list(28)
+	name = "Kitchen"
 	},
+/obj/map_helper/access_helper/airlock/station/service/kitchen,
 /turf/unsimulated/floor/steel{
 	icon_state = "white"
 	},
@@ -12295,6 +12427,16 @@
 	icon_state = "white"
 	},
 /area/centcom/control)
+"NA" = (
+/obj/machinery/door/airlock/security{
+	name = "Security";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/equipment,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/security)
 "NC" = (
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 8
@@ -12391,8 +12533,9 @@
 "NU" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Confiscated Items";
-	req_access = list(3)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/armory,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -12565,9 +12708,9 @@
 /area/centcom/terminal)
 "Op" = (
 /obj/machinery/door/airlock/freezer{
-	name = "Kitchen cold room";
-	req_access = list(28)
+	name = "Kitchen cold room"
 	},
+/obj/map_helper/access_helper/airlock/station/service/kitchen,
 /turf/unsimulated/floor/steel{
 	icon_state = "white"
 	},
@@ -13105,8 +13248,9 @@
 "PW" = (
 /obj/machinery/door/airlock/medical{
 	name = "Virology Access";
-	req_access = list(5)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/virology,
 /turf/unsimulated/floor/steel{
 	icon_state = "white"
 	},
@@ -13406,20 +13550,19 @@
 	icon_state = "white"
 	},
 /area/centcom/medical)
+"QT" = (
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
+/turf/unsimulated/floor/steel,
+/area/centcom/evac)
 "QU" = (
 /obj/machinery/camera/network/crescent{
 	dir = 4
 	},
 /turf/unsimulated/floor/steel,
 /area/centcom/security)
-"QW" = (
-/obj/machinery/door/airlock/multi_tile/metal{
-	name = "Nanotrasen Offices";
-	req_one_access = list(101)
-	},
-/obj/machinery/door/firedoor,
-/turf/unsimulated/floor/steel,
-/area/centcom/command)
 "QX" = (
 /obj/machinery/shieldwallgen,
 /turf/unsimulated/floor{
@@ -13473,6 +13616,21 @@
 /obj/structure/bed/chair,
 /turf/unsimulated/floor/steel,
 /area/centcom/main_hall)
+"Ri" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
+	},
+/obj/machinery/door/airlock/glass/security{
+	name = "Security";
+	req_access = list();
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/department,
+/turf/unsimulated/floor/steel,
+/area/centcom/security)
 "Rj" = (
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 8
@@ -13661,8 +13819,9 @@
 /obj/machinery/door/airlock/glass/security{
 	id_tag = "innerS";
 	name = "Colonial Security Airlock";
-	req_access = list(63)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -13745,8 +13904,10 @@
 "RW" = (
 /obj/machinery/door/airlock/security{
 	id_tag = "front";
-	name = "Security"
+	name = "Security";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -14085,6 +14246,15 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/blue/bordercorner2,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/security)
+"Tf" = (
+/obj/machinery/door/airlock/security{
+	name = "Security";
+	req_one_access = null
+	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -14718,8 +14888,9 @@
 "Vy" = (
 /obj/machinery/door/airlock/centcom{
 	name = "SpecOps Hangar";
-	req_access = list(103)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/centcom/ert,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -15001,11 +15172,10 @@
 /turf/unsimulated/floor/wood,
 /area/centcom/restaurant)
 "Wy" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	req_access = list(5)
-	},
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/unsimulated/floor/steel{
 	icon_state = "white"
 	},
@@ -15460,15 +15630,6 @@
 	},
 /turf/unsimulated/floor/steel,
 /area/centcom/security)
-"Yb" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Silicon's Living Quarters";
-	req_access = list(105)
-	},
-/turf/unsimulated/floor{
-	icon_state = "carpet"
-	},
-/area/centcom/control)
 "Yd" = (
 /obj/machinery/lathe/autolathe{
 	desc = "Your typical Autolathe. It appears to have much more options than your regular one, however...";
@@ -15588,8 +15749,9 @@
 "Yt" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Commander";
-	req_access = list(103)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/centcom/ert,
 /turf/unsimulated/floor/wood,
 /area/centcom/specops)
 "Yu" = (
@@ -15631,8 +15793,10 @@
 /area/centcom/security)
 "Yy" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Nanotrasen Offices"
+	name = "Nanotrasen Offices";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/centcom,
 /turf/unsimulated/floor/steel,
 /area/centcom/command)
 "Yz" = (
@@ -16081,8 +16245,9 @@
 "ZC" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
-	req_access = list(6)
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/medical/morgue,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -33921,7 +34086,7 @@ vc
 vc
 vc
 vc
-tp
+QT
 wi
 wi
 tp
@@ -34115,10 +34280,10 @@ vc
 vc
 vc
 vc
-tp
+QT
 wi
 wi
-tp
+QT
 wi
 wi
 wi
@@ -37633,7 +37798,7 @@ dj
 DF
 gp
 nc
-mz
+nH
 Bx
 ri
 Bx
@@ -37830,7 +37995,7 @@ WK
 WK
 WK
 WK
-mz
+nH
 WK
 Zs
 Zs
@@ -41884,7 +42049,7 @@ sm
 sm
 sm
 sm
-QW
+cb
 sm
 sm
 sm
@@ -43033,7 +43198,7 @@ Ld
 Ld
 Ld
 Ld
-sB
+xv
 Ld
 Ld
 hE
@@ -43219,7 +43384,7 @@ es
 es
 lR
 lR
-sB
+xv
 lR
 lR
 es
@@ -44003,7 +44168,7 @@ es
 ht
 Ld
 Ld
-sB
+xv
 Ld
 Ld
 Az
@@ -44775,11 +44940,11 @@ Ld
 Ld
 Ld
 Ld
-sB
+xv
 Ld
 Ld
 Ld
-sB
+xv
 Ld
 Ld
 it
@@ -45017,7 +45182,7 @@ Jf
 Jf
 rs
 WK
-mz
+nH
 WK
 WK
 WK
@@ -45168,7 +45333,7 @@ Ld
 Ld
 Ld
 es
-sB
+xv
 lR
 es
 Qu
@@ -45539,7 +45704,7 @@ oF
 UF
 xS
 zd
-Yb
+Ix
 Ld
 Ld
 Ld
@@ -45555,7 +45720,7 @@ Ld
 Ld
 Ld
 Ld
-sB
+xv
 Ld
 PC
 gc
@@ -45987,19 +46152,19 @@ rp
 rp
 rp
 WK
-mz
+nH
 WK
 WK
 WK
 WK
-mz
+nH
 WK
 WK
 WK
 WK
 WK
 WK
-mz
+nH
 WK
 Ic
 Ic
@@ -46735,8 +46900,8 @@ WK
 WK
 WK
 wp
-zb
-zb
+pA
+pA
 wp
 dj
 dj
@@ -47299,7 +47464,7 @@ Bx
 Bx
 Bx
 Bx
-Bx
+gN
 Bx
 Bx
 sP
@@ -47333,10 +47498,10 @@ cT
 AW
 Bx
 Bx
-mz
+NA
 Bx
 Bx
-mz
+Tf
 Xd
 Xd
 Xd
@@ -47493,7 +47658,7 @@ Bx
 Bx
 Bx
 Bx
-Bx
+gN
 Bx
 Bx
 sP
@@ -48112,7 +48277,7 @@ ee
 WK
 VW
 Bx
-mz
+nH
 Bx
 XO
 Cq
@@ -48286,7 +48451,7 @@ cS
 kE
 kT
 YP
-cA
+rn
 Xd
 Xd
 Ji
@@ -48861,7 +49026,7 @@ bm
 HA
 Xd
 Xd
-Xd
+kV
 Xd
 Xd
 Xd
@@ -49255,7 +49420,7 @@ WK
 WK
 WK
 LS
-Xd
+WK
 WV
 WK
 WK
@@ -50216,10 +50381,10 @@ Xd
 Xd
 Xd
 Xd
-cA
+bQ
 Xd
 jR
-LJ
+Ri
 Tr
 Xd
 LU
@@ -50229,7 +50394,7 @@ yR
 BX
 Xd
 jR
-Tr
+yI
 Xd
 iu
 rK
@@ -50410,10 +50575,10 @@ Xd
 Xd
 Xd
 Xd
-cA
+bQ
 Xd
 Zb
-TN
+xn
 TD
 Xd
 LU
@@ -50423,7 +50588,7 @@ Ds
 BX
 Xd
 Zb
-TD
+rz
 Xd
 iu
 rK
@@ -50574,7 +50739,7 @@ Hp
 xa
 xa
 xa
-aB
+lS
 lS
 es
 lE

--- a/maps/triumph/levels/misc.dmm
+++ b/maps/triumph/levels/misc.dmm
@@ -425,8 +425,10 @@
 	icon_state = "door_locked";
 	id_tag = "supply_shuttle_hatch";
 	locked = 1;
-	name = "Shuttle Hatch"
+	name = "Shuttle Hatch";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/shuttle/floor,
 /area/shuttle/supply)
 "la" = (
@@ -635,8 +637,10 @@
 	icon_state = "door_locked";
 	id_tag = "supply_shuttle_hatch";
 	locked = 1;
-	name = "Shuttle Hatch"
+	name = "Shuttle Hatch";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "qd" = (
@@ -1244,9 +1248,6 @@
 /obj/structure/table/woodentable/holotable,
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_courtroom)
-"CU" = (
-/turf/simulated/floor/holofloor/desert,
-/area/holodeck/source_picnicarea)
 "Dl" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/holofloor/grass,
@@ -2045,8 +2046,10 @@
 	icon_state = "door_locked";
 	id_tag = "supply_shuttle_hatch";
 	locked = 1;
-	name = "Shuttle Hatch"
+	name = "Shuttle Hatch";
+	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "Ws" = (
@@ -26654,8 +26657,8 @@ Ob
 Nr
 xe
 kC
-CU
-CU
+At
+At
 xv
 xe
 Nr
@@ -26848,8 +26851,8 @@ Dl
 xe
 Nr
 nx
-CU
-CU
+At
+At
 vt
 Nr
 xe
@@ -27042,8 +27045,8 @@ Ob
 Nr
 SA
 GF
-CU
-CU
+At
+At
 Xu
 TZ
 Nr
@@ -27236,8 +27239,8 @@ Dl
 xe
 kC
 At
-CU
-CU
+At
+At
 At
 xv
 xe
@@ -27817,10 +27820,10 @@ AP
 Dl
 Nr
 nx
-CU
-CU
-CU
-CU
+At
+At
+At
+At
 vt
 Nr
 Dl


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR is a continuation of #6462 and aims to replace each and every access var with access helpers. This is the 2nd of 3.

Also adds `research_lab` access helper and grants Pathfinders access to Rift's RnD (and every map's RnD from now on).

- [x] [Deck 1](https://www.upload.ee/image/16715103/deck_1.png)
- [x] [Deck 2](https://www.upload.ee/image/16715139/deck_2.png)
- [x] [Deck 3](https://www.upload.ee/image/16715188/deck_3.png)
- [x] [Deck 4](https://www.upload.ee/image/16718583/deck_4.png)
- [x] [Flagship](https://www.upload.ee/image/16718647/flagship.png)
- [x] Misc
- [x] Burn engine
- [x] Fission engine
- [x] Rust engine
- [x] Supermatter engine

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Access vars are obsolete and really complicated for mappers to use.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added access helpers to every airlock on Triumph.
add: Added additional maintenance airlocks & hatches to Triumph's engine chamber.
add: Pathfinders now have access to Rift's RnD
del: Removed Triumph's airlocks access vars, and replaced them with access helpers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
