### PR TITLE
Makes the font for a vote notification more noticeable

### DIFF
--- a/code/__DEFINES/spans.dm
+++ b/code/__DEFINES/spans.dm
@@ -144,6 +144,7 @@
 #define SPAN_TINYNOTICEITAL(str) ("<span class='tinynoticeital'>[str]</span>")
 #define SPAN_UNCONSCIOUS(str) ("<span class='unconscious'>[str]</span>")
 #define SPAN_USERDANGER(str) ("<span class='userdanger'>[str]</span>")
+#define SPAN_VOTENOTIFICATION(str) ("<span class='votenotification'>[str]</span>")
 #define SPAN_WARNING(str) ("<span class='warning'>[str]</span>")
 #define SPAN_YELL(str) ("<span class='yell'>[str]</span>")
 #define SPAN_YELLOWTEAMRADIO(str) ("<span class='yellowteamradio'>[str]</span>")

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -208,7 +208,7 @@ SUBSYSTEM_DEF(vote)
 			text += SPAN_NOTICE("\nGhosts are excluded from the vote.")
 		log_vote(text)
 
-		to_chat(world, SPAN_INFOPLAIN("<con<b>[text]</b>\nType <b>vote</b> or click <a href='?src=\ref[src]'>here</a> to place your votes.\nYou have [config_legacy.vote_period / 10] seconds to vote."))
+		to_chat(world, SPAN_INFOPLAIN("<font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='?src=\ref[src]'>here</a> to place your votes.\nYou have [config_legacy.vote_period / 10] seconds to vote.</font>"))
 		if(vote_type == VOTE_CREW_TRANSFER || vote_type == VOTE_GAMEMODE)
 			SEND_SOUND(world, sound('sound/ambience/alarm4.ogg', repeat = 0, wait = 0, volume = 50, channel = 3))
 

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -201,14 +201,14 @@ SUBSYSTEM_DEF(vote)
 		initiator = initiator_key
 		started_time = world.time
 		duration = time
-		var/text = "[capitalize(mode)] vote started by [initiator]."
+		var/text = SPAN_VOTENOTIFICATION("[capitalize(mode)] vote started by [initiator].")
 		if(mode == VOTE_CUSTOM)
-			text += "\n[question]"
+			text += SPAN_VOTENOTIFICATION("\n[question]")
 		if(ghost_weight_percent <= 0)
 			text += SPAN_NOTICE("\nGhosts are excluded from the vote.")
 		log_vote(text)
 
-		to_chat(world, "<span class='infoplain'><font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='?src=\ref[src]'>here</a> to place your votes.\nYou have [config_legacy.vote_period / 10] seconds to vote.</font>")
+		to_chat(world, SPAN_INFOPLAIN("<con<b>[text]</b>\nType <b>vote</b> or click <a href='?src=\ref[src]'>here</a> to place your votes.\nYou have [config_legacy.vote_period / 10] seconds to vote."))
 		if(vote_type == VOTE_CREW_TRANSFER || vote_type == VOTE_GAMEMODE)
 			SEND_SOUND(world, sound('sound/ambience/alarm4.ogg', repeat = 0, wait = 0, volume = 50, channel = 3))
 

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -193,6 +193,12 @@ h1.alert, h2.alert		{color: #000000;}
 .clown					{color: #FF69Bf;	font-size: 3;	font-family: "Comic Sans MS", cursive, sans-serif;	font-weight: bold;}
 .singing				{font-family: "Trebuchet MS", cursive, sans-serif; font-style: italic;}
 .his_grace				{color: #15D512;	font-family: "Courier New", cursive, sans-serif;	font-style: italic;}
+.votenotification 		{color: #490049;	font-size: 3; 	font-weight: bold;		animation: votenotification 3000ms infinite;	}
+	@keyframes votenotification {
+		0% 		{color: #490049;}
+		50% 	{color: #ff00ff;}
+		100% 	{color: #490049;}
+}
 .hypnophrase			{color: #3bb5d3;	font-weight: bold;	animation: hypnocolor 1500ms infinite; animation-direction: alternate;}
 	@keyframes hypnocolor {
 		0%		{color: #0d0d0d;}

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -1001,6 +1001,28 @@ blockquote.brass {
   color: #FF9100;
 }
 
+/*pay attention to the votes.*/
+.votenotification {
+  color: #ff00ff;
+  font-size: 125%;
+  font-weight: bold;
+  animation: votenotification 5000ms infinite;
+}
+
+@keyframes votenotification {
+  0% {
+    color: #ff00ff;
+  }
+
+  50% {
+    color: #490049;
+  }
+
+  100% {
+    color: #ff00ff;
+  }
+}
+
 .hypnophrase {
   color: #202020;
   font-weight: bold;

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -1037,6 +1037,28 @@ blockquote.brass {
   color: #FF9100;
 }
 
+/*pay attention to the votes.*/
+.votenotification {
+  color: #490049;
+  font-size: 125%;
+  font-weight: bold;
+  animation: votenotification 3000ms infinite;
+}
+
+@keyframes votenotification {
+  0% {
+    color: #490049;
+  }
+
+  50% {
+    color: #ff00ff;
+  }
+
+  100% {
+    color: #490049;
+  }
+}
+
 .hypnophrase {
   color: #0d0d0d;
   font-weight: bold;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![pulsingtext](https://github.com/Citadel-Station-13/Citadel-Station-13-RP/assets/57083662/121f1e63-3f11-41d9-80c2-98e1927a4325)
Adds a slightly bigger, slow pulsing title text for the vote notification. It's animated, making it stand out a bit more.

## Why It's Good For The Game

Some players were saying that the vote notification wasn't noticeable enough. Let's try this.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: The vote notification text should be slightly more noticeable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
