### PR TITLE
Adds Cargo-only permission to the entrance into Mining Refinery on Atlas

### DIFF
--- a/maps/rift/levels/rift-02-underground2.dmm
+++ b/maps/rift/levels/rift-02-underground2.dmm
@@ -6452,9 +6452,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/maintenance/cargo{
-	req_one_access = null
-	},
+/obj/machinery/door/airlock/maintenance/cargo,
 /obj/map_helper/access_helper/airlock/station/supply/department,
 /turf/simulated/floor/plating,
 /area/quartermaster/miningdock)
@@ -8757,9 +8755,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/cargo{
-	req_one_access = null
-	},
+/obj/machinery/door/airlock/maintenance/cargo,
 /obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningdock)
@@ -10345,9 +10341,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/cargo{
-	req_one_access = null
-	},
+/obj/machinery/door/airlock/maintenance/cargo,
+/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/refinery)
 "MC" = (
@@ -12737,9 +12732,7 @@
 /turf/simulated/floor/wood,
 /area/chapel/observation)
 "VC" = (
-/obj/machinery/door/airlock/maintenance/cargo{
-	req_one_access = null
-	},
+/obj/machinery/door/airlock/maintenance/cargo,
 /obj/machinery/door/firedoor/glass,
 /obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
 /turf/simulated/floor/plating,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds the cargo permission to the maintenance airlock into the mining refinery on Riftmap
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because we don't want people going in and just swiping everything from the refinery, or stealing unclaimed points.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
Can no longer enter refinery from the back as anything but cargo.
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed maintenance airlock permissions for mining refinery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
