### PR TITLE
Buff floor dirtying to take 75 steps instead of 500.

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -103,7 +103,7 @@
 		if(M.dirties_floor())
 			// Dirt overlays.
 			// todo: currently nerfed
-			update_dirt(0.2)
+			update_dirt(1.5)
 
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M


### PR DESCRIPTION
Laziest PR ever because the janitor mains need work.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Dirtying happens sooner, at 75 steps instead of 500.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
