### PR TITLE
Makes you not able to swap guest passes into guest pass terminals

### DIFF
--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -210,8 +210,12 @@
 				usr.action_feedback(SPAN_NOTICE("You insert [the_card] into [src]."), src)
 				return TRUE
 			var/obj/item/card/id/the_card = usr.get_active_held_item()
-			if(istype(the_card) && !usr.attempt_void_item_for_installation(the_card))
-				return FALSE
+			if(istype(the_card))
+				if(istype(the_card, /obj/item/card/id/guest))
+					usr.action_feedback(SPAN_NOTICE("You try to swap [the_card] into \the [src], but it won't accept guest passes."))
+					return FALSE
+				if(!usr.attempt_void_item_for_installation(the_card))
+					return FALSE
 			usr.grab_item_from_interacted_with(giver, src)
 			eject_id()
 			if(istype(the_card))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As of right now, guest passes can be placed into terminals by swapping. This is clearly not intentional, since just putting guest passes in doesn't work.

## Why It's Good For The Game

bugfix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Can no longer swap guest passes into guest pass terminals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
