### PR TITLE
"Nitrogen Filling my Engines", AI Upload Floating Camera and Noded Engine PowerNet Sensors 

### DIFF
--- a/maps/rift/engines/burn.dmm
+++ b/maps/rift/engines/burn.dmm
@@ -90,9 +90,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "dT" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -111,9 +109,7 @@
 /obj/structure/window/phoronreinforced{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "eB" = (
 /obj/structure/cable/yellow{
@@ -132,9 +128,7 @@
 	id_tag = "engine_out";
 	frequency = 1437
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "eU" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
@@ -152,9 +146,7 @@
 	dir = 1
 	},
 /obj/structure/grille,
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "gF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -173,9 +165,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "gL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
@@ -201,9 +191,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "ho" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -263,9 +251,7 @@
 	dir = 4
 	},
 /obj/structure/grille,
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "lf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -327,9 +313,7 @@
 /obj/structure/window/phoronreinforced{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "oe" = (
 /turf/template_noop,
@@ -354,9 +338,7 @@
 	dir = 4
 	},
 /obj/structure/grille,
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "pM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
@@ -406,9 +388,7 @@
 	dir = 1
 	},
 /obj/structure/grille,
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "sH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -517,9 +497,7 @@
 /obj/structure/window/phoronreinforced{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "xI" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
@@ -591,9 +569,7 @@
 	dir = 1;
 	frequency = 1437
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "BU" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
@@ -608,9 +584,7 @@
 	id_tag = "engine_sensor";
 	output = 63
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "Cy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -656,6 +630,7 @@
 	name = "Powernet Sensor - Engine Output";
 	name_tag = "Engine Output"
 	},
+/obj/structure/cable/yellow,
 /turf/simulated/floor,
 /area/engineering/engine_room)
 "Fi" = (
@@ -664,9 +639,7 @@
 	dir = 4
 	},
 /obj/structure/grille,
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "Fw" = (
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -684,9 +657,7 @@
 /obj/structure/window/phoronreinforced{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "FW" = (
 /obj/structure/cable/yellow{
@@ -733,6 +704,7 @@
 	name = "Powernet Sensor - Engine Power";
 	name_tag = "Engine Power"
 	},
+/obj/structure/cable/cyan,
 /turf/simulated/floor,
 /area/engineering/engine_room)
 "HU" = (
@@ -758,18 +730,14 @@
 	id = "engine_in";
 	volume_rate = 100
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "Ji" = (
 /obj/structure/window/phoronreinforced/full{
 	dir = 8
 	},
 /obj/structure/grille,
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "JK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
@@ -788,9 +756,7 @@
 	dir = 4
 	},
 /obj/structure/grille,
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "JS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -888,18 +854,14 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "MK" = (
 /obj/machinery/igniter{
 	id = "engine_igniter";
 	on = 0
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "MZ" = (
 /obj/machinery/atmospherics/component/unary/heat_exchanger,
@@ -945,9 +907,7 @@
 	dir = 1
 	},
 /obj/structure/grille,
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "Pz" = (
 /obj/machinery/atmospherics/component/unary/heat_exchanger{
@@ -1002,9 +962,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "Tl" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
@@ -1031,9 +989,7 @@
 "Vi" = (
 /obj/structure/window/phoronreinforced/full,
 /obj/structure/grille,
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "Vl" = (
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -1062,9 +1018,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "VX" = (
 /obj/effect/floor_decal/industrial/warning{

--- a/maps/rift/engines/rust.dmm
+++ b/maps/rift/engines/rust.dmm
@@ -10,9 +10,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "aQ" = (
 /obj/machinery/air_alarm{
@@ -74,9 +72,7 @@
 	id_tag = "engine_sensor";
 	output = 63
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "ea" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -250,7 +246,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/greengrid/nitrogen,
+/turf/simulated/floor/greengrid/airless,
 /area/engineering/engine_room)
 "kN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -372,9 +368,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "qc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -451,9 +445,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "tR" = (
 /obj/structure/cable/yellow{
@@ -580,9 +572,7 @@
 	pump_direction = 0;
 	on = 1
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "Al" = (
 /obj/structure/cable/yellow{
@@ -630,9 +620,7 @@
 	id = "cooling_in";
 	use_power = 1
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "Bg" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -849,9 +837,7 @@
 	pump_direction = 0;
 	on = 1
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "LL" = (
 /turf/template_noop,
@@ -936,9 +922,7 @@
 	id = "cooling_in";
 	use_power = 1
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "NN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -1044,9 +1028,7 @@
 /turf/simulated/floor,
 /area/template_noop)
 "Ta" = (
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "Th" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
@@ -1078,9 +1060,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	initial_gas_mix = "n2=82.1472;TEMP=293.15"
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
 "WC" = (
 /obj/structure/cable/cyan{

--- a/maps/rift/engines/rust.dmm
+++ b/maps/rift/engines/rust.dmm
@@ -121,6 +121,7 @@
 	name = "Powernet Sensor - Engine Power";
 	name_tag = "Engine Power"
 	},
+/obj/structure/cable/cyan,
 /turf/simulated/floor,
 /area/engineering/engine_room)
 "gu" = (
@@ -582,6 +583,7 @@
 	name = "Powernet Sensor - Engine Output";
 	name_tag = "Engine Output"
 	},
+/obj/structure/cable/yellow,
 /turf/simulated/floor,
 /area/engineering/engine_room)
 "Am" = (

--- a/maps/rift/engines/sme.dmm
+++ b/maps/rift/engines/sme.dmm
@@ -246,6 +246,7 @@
 	name = "Powernet Sensor - Engine Power";
 	name_tag = "Engine Power"
 	},
+/obj/structure/cable/cyan,
 /turf/simulated/floor,
 /area/engineering/engine_room)
 "lT" = (
@@ -267,6 +268,7 @@
 	name = "Powernet Sensor - Engine Output";
 	name_tag = "Engine Output"
 	},
+/obj/structure/cable/yellow,
 /turf/simulated/floor,
 /area/engineering/engine_room)
 "mz" = (

--- a/maps/rift/levels/rift-06-surface3.dmm
+++ b/maps/rift/levels/rift-06-surface3.dmm
@@ -6447,7 +6447,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/network/command{
-	dir = 10
+	dir = 1
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR drains the nitrogen filling the hot loop, burn chamber and core of the combustion engine twice and tokamak respectively, fixes a camera in AI upload and nodes unnoded PowerNet Sensors in the engine bay for the three engines
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's QOL for Engineers, if they want the Nitrogen in, it's easier to put it in than remove it if they don't want it. The PowerNet Sensors were meant to be noded, they were already in the map but they weren't connected to the grid. Fixes a floating camera in AI Upload, nobody ever goes there so it went unnoticed probably.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
Switched all engine chambers tiles for airless tiles in the R-UST and Burn Chamber.
Fixed Camera orientation in AI Upload.
Noded Engine Power and Engine Output power sensors in all three engines.
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: added nodes under the two sensors in all engine maps
tweak: tweaked air in rust engine map
tweak: tweaked air in burn engine map
fix: fixed AI Upload camera orientation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
