### PR TITLE
fast turf reservation lookups & aligned spatial grid lookups

### DIFF
--- a/code/__DEFINES/mapping/system.dm
+++ b/code/__DEFINES/mapping/system.dm
@@ -2,7 +2,9 @@
 #define RESERVED_TURF_TYPE /turf/space/basic
 /// reserved area type
 #define RESERVED_AREA_TYPE /area/space
-/// reservation resolution - this drastically decreases the amount of time used to search for a spot for reservation.
-/// set this to a value that's slightly above average of a common multiplier for reservation sizes.
-#define RESERVED_TURF_RESOLUTION 8
 
+/// Turf chunk resolution
+///
+/// * this is the most granular a turf reservation alloc can be (e.g. 8x8 for '8')
+/// * this is the resolution of spatial gridmaps. why? this way spatial queries are aligned and super fast.
+#define TURF_CHUNK_RESOLUTION 8

--- a/code/controllers/subsystem/mapping/allocation.dm
+++ b/code/controllers/subsystem/mapping/allocation.dm
@@ -22,6 +22,11 @@
 // todo: recover()
 // todo: zclear system will be in this later, for now, this is just a wrapper
 
+/datum/controller/subsystem/mapping/on_max_z_changed(old_z_count, new_z_count)
+	. = ..()
+	// just to make sure order of ops / assumptions are right
+	ASSERT(length(ordered_levels) == world.maxz)
+
 /**
  * gets an reusable level, or increments world.maxz
  * WARNING: AFTER THIS, YOU NEED TO USE THE LEVEL, OR READD TO REUSABLE, OR THIS IS A MEMORY LEAK!

--- a/code/controllers/subsystem/mapping/boot.dm
+++ b/code/controllers/subsystem/mapping/boot.dm
@@ -32,4 +32,5 @@
 	// basically makes allocate_level() grab the first one
 	reusable_levels += 1
 	ordered_levels += null
+	synchronize_datastructures()
 	allocate_reserved_level()

--- a/code/controllers/subsystem/mapping/boot.dm
+++ b/code/controllers/subsystem/mapping/boot.dm
@@ -7,6 +7,9 @@
  * so we snowflaked it by compiling a single empty space level
  * this is called during initial world loading to expand that space level to the size of the world,
  * and init it as our first reserved level.
+ *
+ * width and height exist to init the world's dimensions based on the map being loaded
+ * this must be done before anything like spatial hashes are made, as those depend on world dimensions!
  */
 /datum/controller/subsystem/mapping/proc/load_server_initial_reservation_area(width, height)
 	ASSERT(world.maxz == 1)

--- a/code/controllers/subsystem/mapping/boot.dm
+++ b/code/controllers/subsystem/mapping/boot.dm
@@ -13,10 +13,11 @@
  */
 /datum/controller/subsystem/mapping/proc/load_server_initial_reservation_area(width, height)
 	ASSERT(world.maxz == 1)
+	world.maxx = width
+	world.maxy = height
 	ASSERT(length(reserve_levels) == 0)
 	reserved_level_count = 1
 	reserve_levels = list(1)
-	world.maxx = width
-	world.maxy = height
 	ordered_levels = list(new /datum/map_level/reserved)
 	world.max_z_changed(0, 1)
+	initialize_reserved_level(1)

--- a/code/controllers/subsystem/mapping/boot.dm
+++ b/code/controllers/subsystem/mapping/boot.dm
@@ -32,5 +32,6 @@
 	// basically makes allocate_level() grab the first one
 	reusable_levels += 1
 	ordered_levels += null
+	world.max_z_changed(0, 1)
 	synchronize_datastructures()
 	allocate_reserved_level()

--- a/code/controllers/subsystem/mapping/boot.dm
+++ b/code/controllers/subsystem/mapping/boot.dm
@@ -16,8 +16,6 @@
 	world.maxx = width
 	world.maxy = height
 	ASSERT(length(reserve_levels) == 0)
-	reserved_level_count = 1
-	reserve_levels = list(1)
-	ordered_levels = list(new /datum/map_level/reserved)
-	world.max_z_changed(0, 1)
-	initialize_reserved_level(1)
+	// basically makes allocate_level() grab the first one
+	reusable_levels += 1
+	allocate_reserved_level()

--- a/code/controllers/subsystem/mapping/boot.dm
+++ b/code/controllers/subsystem/mapping/boot.dm
@@ -10,6 +10,19 @@
  *
  * width and height exist to init the world's dimensions based on the map being loaded
  * this must be done before anything like spatial hashes are made, as those depend on world dimensions!
+ *
+ * this proc is hilariously, hilariously unstable and changes as backend changes
+ * why?
+ *
+ * because the backend is generally extremely tightly coupled
+ * as an example, the backend API assumes all level allocs are done through SSmapping,
+ * so it doesn't even allow for the existnece of an unmanaged level already being there;
+ * such a thing is impossible outside of severe bugs
+ *
+ * so in this proc, we're basically hard-setting variables - with potential issues, because
+ * this can get desynced with the rest of the subsystem's code - to 'fake' such a proper init cycle.
+ *
+ * at some point, SSmapping will be better coded, but for now, it's pretty messy.
  */
 /datum/controller/subsystem/mapping/proc/load_server_initial_reservation_area(width, height)
 	ASSERT(world.maxz == 1)
@@ -18,4 +31,5 @@
 	ASSERT(length(reserve_levels) == 0)
 	// basically makes allocate_level() grab the first one
 	reusable_levels += 1
+	ordered_levels += null
 	allocate_reserved_level()

--- a/code/controllers/subsystem/mapping/levels.dm
+++ b/code/controllers/subsystem/mapping/levels.dm
@@ -233,27 +233,30 @@
 		SSplanets.legacy_planet_assert(z_index, level_or_path.planet_path)
 
 	//! LEGACY
-	if((level_or_path.flags & LEGACY_LEVEL_STATION) || level_or_path.has_trait(ZTRAIT_STATION))
-		loaded_station.station_levels += z_index
-	if((level_or_path.flags & LEGACY_LEVEL_ADMIN) || level_or_path.has_trait(ZTRAIT_ADMIN))
-		loaded_station.admin_levels += z_index
-	if((level_or_path.flags & LEGACY_LEVEL_CONTACT) || level_or_path.has_trait(ZTRAIT_STATION))
-		loaded_station.contact_levels += z_index
-	if((level_or_path.flags & LEGACY_LEVEL_SEALED))
-		loaded_station.sealed_levels += z_index
-	if((level_or_path.flags & LEGACY_LEVEL_CONSOLES) || level_or_path.has_trait(ZTRAIT_STATION))
-		loaded_station.map_levels += z_index
-	// Holomaps
-	// Auto-center the map if needed (Guess based on maxx/maxy)
-	if (level_or_path.holomap_offset_x < 0)
-		level_or_path.holomap_offset_x = ((HOLOMAP_ICON_SIZE - world.maxx) / 2)
-	if (level_or_path.holomap_offset_x < 0)
-		level_or_path.holomap_offset_y = ((HOLOMAP_ICON_SIZE - world.maxy) / 2)
-	// Assign them to the map lists
-	LIST_NUMERIC_SET(loaded_station.holomap_offset_x, z_index, level_or_path.holomap_offset_x)
-	LIST_NUMERIC_SET(loaded_station.holomap_offset_y, z_index, level_or_path.holomap_offset_y)
-	LIST_NUMERIC_SET(loaded_station.holomap_legend_x, z_index, level_or_path.holomap_legend_x)
-	LIST_NUMERIC_SET(loaded_station.holomap_legend_y, z_index, level_or_path.holomap_legend_y)
+	// the fact that this exists is stupid but this check
+	// make sure we're not loading system maps like reserved levels before station loads.
+	if(loaded_station)
+		if((level_or_path.flags & LEGACY_LEVEL_STATION) || level_or_path.has_trait(ZTRAIT_STATION))
+			loaded_station.station_levels += z_index
+		if((level_or_path.flags & LEGACY_LEVEL_ADMIN) || level_or_path.has_trait(ZTRAIT_ADMIN))
+			loaded_station.admin_levels += z_index
+		if((level_or_path.flags & LEGACY_LEVEL_CONTACT) || level_or_path.has_trait(ZTRAIT_STATION))
+			loaded_station.contact_levels += z_index
+		if((level_or_path.flags & LEGACY_LEVEL_SEALED))
+			loaded_station.sealed_levels += z_index
+		if((level_or_path.flags & LEGACY_LEVEL_CONSOLES) || level_or_path.has_trait(ZTRAIT_STATION))
+			loaded_station.map_levels += z_index
+		// Holomaps
+		// Auto-center the map if needed (Guess based on maxx/maxy)
+		if (level_or_path.holomap_offset_x < 0)
+			level_or_path.holomap_offset_x = ((HOLOMAP_ICON_SIZE - world.maxx) / 2)
+		if (level_or_path.holomap_offset_x < 0)
+			level_or_path.holomap_offset_y = ((HOLOMAP_ICON_SIZE - world.maxy) / 2)
+		// Assign them to the map lists
+		LIST_NUMERIC_SET(loaded_station.holomap_offset_x, z_index, level_or_path.holomap_offset_x)
+		LIST_NUMERIC_SET(loaded_station.holomap_offset_y, z_index, level_or_path.holomap_offset_y)
+		LIST_NUMERIC_SET(loaded_station.holomap_legend_x, z_index, level_or_path.holomap_legend_x)
+		LIST_NUMERIC_SET(loaded_station.holomap_legend_y, z_index, level_or_path.holomap_legend_y)
 	//! END
 
 /**

--- a/code/controllers/subsystem/mapping/reservations.dm
+++ b/code/controllers/subsystem/mapping/reservations.dm
@@ -25,7 +25,7 @@
 	/// * null means that a level isn't a reservation level
 	/// * this also means that we can't zclear / 'free' reserved levels; they're effectively immovable due to this datastructure
 	/// * if it is a reserved level, it returns the spatial grid
-	/// * to get a chunk, do `spatial_lookup[floor(where.x / TURF_CHUNK_RESOLUTION) + (floor(where.y / TURF_CHUNK_RESOLUTION) - 1) * floor(world.maxx / TURF_CHUNK_RESOLUTION)]`
+	/// * to get a chunk, do `spatial_lookup[ceil(where.x / TURF_CHUNK_RESOLUTION) + (ceil(where.y / TURF_CHUNK_RESOLUTION) - 1) * ceil(world.maxx / TURF_CHUNK_RESOLUTION)]`
 	var/static/list/reservation_spatial_lookups = list()
 
 /datum/controller/subsystem/mapping/on_max_z_changed(old_z_count, new_z_count)
@@ -101,7 +101,7 @@
 	var/list/spatial_lookup = reservation_spatial_lookups[where.z]
 	if(!spatial_lookup)
 		return
-	return spatial_lookup[floor(where.x / TURF_CHUNK_RESOLUTION) + (floor(where.y / TURF_CHUNK_RESOLUTION) - 1) * floor(world.maxx / TURF_CHUNK_RESOLUTION)]
+	return spatial_lookup[ceil(where.x / TURF_CHUNK_RESOLUTION) + (ceil(where.y / TURF_CHUNK_RESOLUTION) - 1) * ceil(world.maxx / TURF_CHUNK_RESOLUTION)]
 
 /area/unused_reservation_area
 	name = "Unused Reservation Area"

--- a/code/controllers/subsystem/mapping/reservations.dm
+++ b/code/controllers/subsystem/mapping/reservations.dm
@@ -44,10 +44,11 @@
 	if(reserved_level_count && ((world.maxx * world.maxy * (reserved_level_count + 1)) > reserved_turfs_max))
 		log_and_message_admins(SPAN_USERDANGER("Out of dynamic reservation allocations. Is there a memory leak with turf reservations?"))
 		return FALSE
-	log_and_message_admins(SPAN_USERDANGER("Allocating new reserved level. Now at [reserved_level_count]. This is probably not a good thing if the server is not at high load right now."))
+	if(reserved_level_count)
+		log_and_message_admins(SPAN_USERDANGER("Allocating new reserved level. Now at [reserved_level_count + 1]. This is probably not a good thing if the server is not at high load right now."))
+	reserved_level_count++
 	var/datum/map_level/reserved/level_struct = new
 	ASSERT(allocate_level(level_struct))
-	reserved_level_count++
 	initialize_reserved_level(level_struct.z_index)
 	reserve_levels |= level_struct.z_index
 	// make a list with a predetermined size for the lookup

--- a/code/controllers/subsystem/mapping/reservations.dm
+++ b/code/controllers/subsystem/mapping/reservations.dm
@@ -18,6 +18,14 @@
 	/// singleton area holding all free reservation turfs
 	var/static/area/unused_reservation_area/reservation_unallocated_area = new
 	/// spatial grid of turf reservations. the owner of a chunk is the bottom left tile's owner.
+	///
+	/// this is a list with length of world.maxz, with the actual spatial grid list being at the index of the z
+	/// e.g. to grab a reserved level's lookup, do `reservation_spatia_lookups[z_index]`
+	///
+	/// * null means that a level isn't a reservation level
+	/// * this also means that we can't zclear / 'free' reserved levels; they're effectively immovable due to this datastructure
+	/// * if it is a reserved level, it returns the spatial grid
+	/// * to get a chunk, do `spatial_lookup[floor(where.x / TURF_CHUNK_RESOLUTION) + (floor(where.y / TURF_CHUNK_RESOLUTION) - 1) * floor(world.maxx / TURF_CHUNK_RESOLUTION)]`
 	var/static/list/reservation_spatial_lookups = list()
 
 /datum/controller/subsystem/mapping/on_max_z_changed(old_z_count, new_z_count)

--- a/code/controllers/subsystem/spatial_grids.dm
+++ b/code/controllers/subsystem/spatial_grids.dm
@@ -27,7 +27,7 @@ SUBSYSTEM_DEF(spatial_grids)
 	living.sync_world_z(new_z_count)
 
 /**
- * index = ceil(x / resolution) + width * ceil(y / resolution)
+ * index = ceil(x / resolution) + width * (ceil(y / resolution) - 1)
  *
  * * at time of writing, spatial grids are intentionally aligned with turf reservation resolution. this is intentional so looking stuff up in grids on a reservation is lightning-fast.
  */
@@ -101,9 +101,9 @@ SUBSYSTEM_DEF(spatial_grids)
 /datum/spatial_grid/proc/range_query(turf/epicenter, distance)
 	. = list()
 	var/min_x = ceil((epicenter.x - distance) / TURF_CHUNK_RESOLUTION)
-	var/min_y = floor((epicenter.y - distance) / TURF_CHUNK_RESOLUTION)
+	var/min_y = ceil((epicenter.y - distance) / TURF_CHUNK_RESOLUTION)
 	var/max_x = ceil((epicenter.x + distance) / TURF_CHUNK_RESOLUTION)
-	var/max_y = floor((epicenter.y + distance) / TURF_CHUNK_RESOLUTION)
+	var/max_y = ceil((epicenter.y + distance) / TURF_CHUNK_RESOLUTION)
 	var/list/grid = src.grids[epicenter.z]
 	for(var/x in max(1, min_x) to min(src.width, max_x))
 		for(var/y in max(1, min_y) to min(src.height, max_y))
@@ -144,9 +144,9 @@ SUBSYSTEM_DEF(spatial_grids)
 	ASSERT(reservation.spatial_z == epicenter.z)
 	. = list()
 	var/min_x = ceil((epicenter.x - distance) / TURF_CHUNK_RESOLUTION)
-	var/min_y = floor((epicenter.y - distance) / TURF_CHUNK_RESOLUTION)
+	var/min_y = ceil((epicenter.y - distance) / TURF_CHUNK_RESOLUTION)
 	var/max_x = ceil((epicenter.x + distance) / TURF_CHUNK_RESOLUTION)
-	var/max_y = floor((epicenter.y + distance) / TURF_CHUNK_RESOLUTION)
+	var/max_y = ceil((epicenter.y + distance) / TURF_CHUNK_RESOLUTION)
 	var/list/grid = src.grids[epicenter.z]
 	for(var/x in max(1, min_x, reservation.spatial_bl_x) to min(src.width, max_x, reservation.spatial_tr_x))
 		for(var/y in max(1, min_y, reservation.spatial_bl_y) to min(src.height, max_y, reservation.spatial_tr_y))
@@ -180,7 +180,7 @@ SUBSYSTEM_DEF(spatial_grids)
 		// we're not on a reserved level, use normal
 		return range_query(epicenter, distance)
 	// we're on a reserve level
-	var/datum/turf_reservation/reservation = spatial_lookup[floor(epicenter.x / TURF_CHUNK_RESOLUTION) + (floor(epicenter.y / TURF_CHUNK_RESOLUTION) - 1) * floor(world.maxx / TURF_CHUNK_RESOLUTION)]
+	var/datum/turf_reservation/reservation = spatial_lookup[ceil(epicenter.x / TURF_CHUNK_RESOLUTION) + (ceil(epicenter.y / TURF_CHUNK_RESOLUTION) - 1) * ceil(world.maxx / TURF_CHUNK_RESOLUTION)]
 	// check if reservation exists
 	if(reservation)
 		// it does, get stuff in reservation

--- a/code/controllers/subsystem/spatial_grids.dm
+++ b/code/controllers/subsystem/spatial_grids.dm
@@ -28,6 +28,8 @@ SUBSYSTEM_DEF(spatial_grids)
 
 /**
  * index = ceil(x / resolution) + width * ceil(y / resolution)
+ *
+ * * at time of writing, spatial grids are intentionally aligned with turf reservation resolution. this is intentional so looking stuff up in grids on a reservation is lightning-fast.
  */
 /datum/spatial_grid
 	/// our grid; list[z] = grid: list()

--- a/code/controllers/subsystem/spatial_grids.dm
+++ b/code/controllers/subsystem/spatial_grids.dm
@@ -167,3 +167,22 @@ SUBSYSTEM_DEF(spatial_grids)
 			if(!grid[index])
 				continue
 			. += grid[index]
+
+//* basically the above but only within a certain turf reservation, if reservation exists; otherwise, proceed as normal *//
+//* if on a reservation level, but no reservation, we return nothing.                                                   *//
+
+/datum/spatial_grid/proc/automatic_range_query(turf/epicenter, distance)
+	// check if we're on a reserved level
+	var/list/spatial_lookup = SSmapping.reservation_spatial_lookups[epicenter.z]
+	if(!spatial_lookup)
+		// we're not on a reserved level, use normal
+		return range_query(epicenter, distance)
+	// we're on a reserve level
+	var/datum/turf_reservation/reservation = spatial_lookup[floor(epicenter.x / TURF_CHUNK_RESOLUTION) + (floor(epicenter.y / TURF_CHUNK_RESOLUTION) - 1) * floor(world.maxx / TURF_CHUNK_RESOLUTION)]
+	// check if reservation exists
+	if(reservation)
+		// it does, get stuff in reservation
+		return reservation_range_query(reservation, epicenter, distance)
+	else
+		// it doesn't, return nothing
+		return list()

--- a/code/controllers/subsystem/spatial_grids.dm
+++ b/code/controllers/subsystem/spatial_grids.dm
@@ -36,21 +36,14 @@ SUBSYSTEM_DEF(spatial_grids)
 	var/width
 	/// our grid height
 	var/height
-	/// our grid resolution in tiles
-	var/resolution = 16
 	/// expected type
 	var/expected_type = /atom/movable
 
-/datum/spatial_grid/New(expected_type, resolution)
-	// make sure resolution is reasonable
-	if(resolution <= 8 || resolution >= 128)
-		stack_trace("invalid resolution: [resolution]")
-		resolution = 16
+/datum/spatial_grid/New(expected_type)
 	// initialize grid
-	src.width = ceil(world.maxx / resolution)
-	src.height = ceil(world.maxy / resolution)
+	src.width = ceil(world.maxx / TURF_CHUNK_RESOLUTION)
+	src.height = ceil(world.maxy / TURF_CHUNK_RESOLUTION)
 	src.grids = list()
-	src.resolution = resolution
 	src.expected_type = expected_type
 
 	sync_world_z(world.maxz)
@@ -105,10 +98,10 @@ SUBSYSTEM_DEF(spatial_grids)
  */
 /datum/spatial_grid/proc/range_query(turf/epicenter, distance)
 	. = list()
-	var/min_x = ceil((epicenter.x - distance) / src.resolution)
-	var/min_y = floor((epicenter.y - distance) / src.resolution)
-	var/max_x = ceil((epicenter.x + distance) / src.resolution)
-	var/max_y = floor((epicenter.y + distance) / src.resolution)
+	var/min_x = ceil((epicenter.x - distance) / TURF_CHUNK_RESOLUTION)
+	var/min_y = floor((epicenter.y - distance) / TURF_CHUNK_RESOLUTION)
+	var/max_x = ceil((epicenter.x + distance) / TURF_CHUNK_RESOLUTION)
+	var/max_y = floor((epicenter.y + distance) / TURF_CHUNK_RESOLUTION)
 	var/list/grid = src.grids[epicenter.z]
 	for(var/x in max(1, min_x) to min(src.width, max_x))
 		for(var/y in max(1, min_y) to min(src.height, max_y))

--- a/code/datums/components/movable/spatial_grid.dm
+++ b/code/datums/components/movable/spatial_grid.dm
@@ -9,8 +9,6 @@
 	registered_type = /datum/component/spatial_grid
 	/// target spatial grid
 	var/datum/spatial_grid/grid
-	/// target grid resolution
-	var/grid_resolution
 	/// target grid width
 	var/grid_width
 	/// last grid index
@@ -24,7 +22,6 @@
 		return COMPONENT_INCOMPATIBLE
 
 	src.grid = grid
-	src.grid_resolution = grid.resolution
 	src.grid_width = grid.width
 
 /datum/component/spatial_grid/RegisterWithParent()
@@ -43,7 +40,7 @@
 		RegisterSignal(root, COMSIG_MOVABLE_MOVED, PROC_REF(update))
 		root = root.loc
 	if(isturf(root))
-		var/idx = ceil(root.x / grid_resolution) + grid_width * floor(root.y / grid_resolution)
+		var/idx = ceil(root.x / TURF_CHUNK_RESOLUTION) + grid_width * floor(root.y / TURF_CHUNK_RESOLUTION)
 		grid.direct_insert(parent, root.z, idx)
 		current_index = idx
 
@@ -61,7 +58,7 @@
 		return
 	// turf --> turf, try to do an optimized, lazy update
 	if(isturf(oldloc) && isturf(newloc) && (oldloc.z == newloc.z))
-		var/new_index = ceil(newloc.x / grid_resolution) + grid_width * floor(newloc.y / grid_resolution)
+		var/new_index = ceil(newloc.x / TURF_CHUNK_RESOLUTION) + grid_width * floor(newloc.y / TURF_CHUNK_RESOLUTION)
 		var/z = oldloc.z
 		if(new_index != current_index)
 			grid.direct_remove(parent, z, current_index)

--- a/code/datums/components/movable/spatial_grid.dm
+++ b/code/datums/components/movable/spatial_grid.dm
@@ -40,7 +40,7 @@
 		RegisterSignal(root, COMSIG_MOVABLE_MOVED, PROC_REF(update))
 		root = root.loc
 	if(isturf(root))
-		var/idx = ceil(root.x / TURF_CHUNK_RESOLUTION) + grid_width * floor(root.y / TURF_CHUNK_RESOLUTION)
+		var/idx = ceil(root.x / TURF_CHUNK_RESOLUTION) + grid_width * (ceil(root.y / TURF_CHUNK_RESOLUTION) - 1)
 		grid.direct_insert(parent, root.z, idx)
 		current_index = idx
 
@@ -58,7 +58,7 @@
 		return
 	// turf --> turf, try to do an optimized, lazy update
 	if(isturf(oldloc) && isturf(newloc) && (oldloc.z == newloc.z))
-		var/new_index = ceil(newloc.x / TURF_CHUNK_RESOLUTION) + grid_width * floor(newloc.y / TURF_CHUNK_RESOLUTION)
+		var/new_index = ceil(newloc.x / TURF_CHUNK_RESOLUTION) + grid_width * (ceil(newloc.y / TURF_CHUNK_RESOLUTION) - 1)
 		var/z = oldloc.z
 		if(new_index != current_index)
 			grid.direct_remove(parent, z, current_index)

--- a/code/modules/mapping/turf_reservation.dm
+++ b/code/modules/mapping/turf_reservation.dm
@@ -52,7 +52,7 @@
 
 	// unegister from lookup
 	var/list/spatial_lookup = SSmapping.reservation_spatial_lookups[spatial_z]
-	var/spatial_width = floor(world.maxx / TURF_CHUNK_RESOLUTION)
+	var/spatial_width = ceil(world.maxx / TURF_CHUNK_RESOLUTION)
 	for(var/spatial_x in spatial_bl_x to spatial_tr_x)
 		for(var/spatial_y in spatial_bl_y to spatial_tr_y)
 			var/index = spatial_x + (spatial_y - 1) * spatial_width
@@ -80,11 +80,14 @@
 	var/list/turf/final
 	var/area/area_path = area_type
 	var/area/area_instance = initial(area_path.unique)? (GLOB.areas_by_type[area_path] || new area_path) : new area_path
+
 	var/found_a_spot = FALSE
-	var/how_many_wide = FLOOR(width / TURF_CHUNK_RESOLUTION, 1)
-	var/how_many_high = FLOOR(height / TURF_CHUNK_RESOLUTION, 1)
-	var/total_many_wide = FLOOR(world.maxx / TURF_CHUNK_RESOLUTION, 1)
-	var/total_many_high = FLOOR(world.maxy / TURF_CHUNK_RESOLUTION, 1)
+
+	var/how_many_wide = ceil(width / TURF_CHUNK_RESOLUTION)
+	var/how_many_high = ceil(height / TURF_CHUNK_RESOLUTION)
+	var/total_many_wide = floor(world.maxx / TURF_CHUNK_RESOLUTION)
+	var/total_many_high = floor(world.maxy / TURF_CHUNK_RESOLUTION)
+
 	// the dreaded 5 deep for loop
 	while((level_index = z_override) || (level_index = pick_n_take(possible_levels)))
 		/**
@@ -92,14 +95,20 @@
 		 * because reservations are aligned to TURF_CHUNK_RESOLUTION,
 		 * we just have to check the start spots, since we always align to them.
 		 *
-		 * bottom-right turfs on reservations align to 0 * TURF_CHUNK_RESOLUTION + 1, 1 * TURF_CHUNK_RESOLUTION + 1, 2 * TURF_CHUNK_RESOLUTION + 1, ...
+		 * bottom-left turfs on reservations align to
+		 * (chunk_x - 1) * TURF_CHUNK_RESOLUTION + 1
+		 * (chunk_y - 1) * TURF_CHUNK_RESOLUTION + 1
 		 */
 		for(var/outer_x in 1 to (total_many_wide - how_many_wide + 1))
 			for(var/outer_y in 1 to (total_many_high - how_many_high + 1))
 				var/passing = TRUE
 				for(var/inner_x in outer_x to outer_x + how_many_wide - 1)
 					for(var/inner_y in outer_y to outer_y + how_many_high - 1)
-						var/turf/checking = locate(1 + TURF_CHUNK_RESOLUTION * (inner_x - 1), 1 + TURF_CHUNK_RESOLUTION * (inner_y - 1), level_index)
+						var/turf/checking = locate(
+							1 + (inner_x - 1) * TURF_CHUNK_RESOLUTION,
+							1 + (inner_y - 1) * TURF_CHUNK_RESOLUTION,
+							level_index,
+						)
 						if(!(checking.turf_flags & UNUSED_RESERVATION_TURF))
 							passing = FALSE
 							break
@@ -141,12 +150,12 @@
 
 	// register in lookup
 	ASSERT(bottom_left_coords[3] == top_right_coords[3]) // just to make sure assumptions made at time of writing are still true
-	src.spatial_bl_x = floor(bottom_left_coords[1] / TURF_CHUNK_RESOLUTION)
-	src.spatial_bl_y = floor(top_right_coords[1] / TURF_CHUNK_RESOLUTION)
-	src.spatial_tr_x = floor(bottom_left_coords[2] / TURF_CHUNK_RESOLUTION)
-	src.spatial_tr_y = floor(top_right_coords[2] / TURF_CHUNK_RESOLUTION)
+	src.spatial_bl_x = ceil(bottom_left_coords[1] / TURF_CHUNK_RESOLUTION)
+	src.spatial_bl_y = ceil(bottom_left_coords[2] / TURF_CHUNK_RESOLUTION)
+	src.spatial_tr_x = ceil(top_right_coords[1] / TURF_CHUNK_RESOLUTION)
+	src.spatial_tr_y = ceil(top_right_coords[2] / TURF_CHUNK_RESOLUTION)
 	src.spatial_z = bottom_left_coords[3]
-	var/spatial_width = floor(world.maxx / TURF_CHUNK_RESOLUTION)
+	var/spatial_width = ceil(world.maxx / TURF_CHUNK_RESOLUTION)
 	var/list/spatial_lookup = SSmapping.reservation_spatial_lookups[spatial_z]
 	for(var/spatial_x in src.spatial_bl_x to src.spatial_tr_x)
 		for(var/spatial_y in src.spatial_bl_y to src.spatial_tr_y)


### PR DESCRIPTION
# why?

non-player facing

we're going to need fast lookups for "is this thing in range of this other thing" at some point, for things like telecomms

this current solution consumes about 16KB per reservation level

we also add the capability to use spatial grids to quickly get atoms on a level.
spatial grids are also at 16KB per grid, per world level

all in all worth it in my opinion.