### PR TITLE
turf reservations - borders

### DIFF
--- a/citadel.dme
+++ b/citadel.dme
@@ -757,6 +757,7 @@
 #include "code\datums\components\riding\mob\robot.dm"
 #include "code\datums\components\riding\simple\_simple.dm"
 #include "code\datums\components\riding\vehicle\_vehicle.dm"
+#include "code\datums\components\turfs\reservation_border.dm"
 #include "code\datums\components\turfs\transition_border.dm"
 #include "code\datums\design\design.dm"
 #include "code\datums\design\design_holder.dm"

--- a/code/__DEFINES/controllers/spatial_grids.dm
+++ b/code/__DEFINES/controllers/spatial_grids.dm
@@ -19,3 +19,7 @@
 	} \
 	AddComponent(/datum/component/spatial_grid, GRID); \
 }
+
+//* init flags to determine behavior *//
+
+#define SPATIAL_GRID_INIT_OPTIMIZE_ALL_Z (1<<0)

--- a/code/controllers/subsystem/spatial_grids.dm
+++ b/code/controllers/subsystem/spatial_grids.dm
@@ -150,8 +150,8 @@ SUBSYSTEM_DEF(spatial_grids)
 			return z_all_atoms[z]:Copy()
 		else
 			var/list/built = list()
-			for(var/z in 1 to world.maxz)
-				built += z_all_atoms[z]
+			for(var/i in 1 to world.maxz)
+				built += z_all_atoms[i]
 			return built
 
 	. = list()

--- a/code/controllers/subsystem/spatial_grids.dm
+++ b/code/controllers/subsystem/spatial_grids.dm
@@ -34,30 +34,46 @@ SUBSYSTEM_DEF(spatial_grids)
 /datum/spatial_grid
 	/// our grid; list[z] = grid: list()
 	var/list/grids = list()
+	/// our z-lookups; list[z] = list()
+	///
+	/// * only made if optimize_get_all_on_z is enabled
+	var/list/z_all_atoms
 	/// our grid width
 	var/width
 	/// our grid height
 	var/height
 	/// expected type
 	var/expected_type = /atom/movable
+	/// optimize get all atoms on z
+	var/optimize_get_all_on_z = FALSE
 
-/datum/spatial_grid/New(expected_type)
+/datum/spatial_grid/New(expected_type, optimize_get_all_on_z)
 	// initialize grid
 	src.width = ceil(world.maxx / TURF_CHUNK_RESOLUTION)
 	src.height = ceil(world.maxy / TURF_CHUNK_RESOLUTION)
 	src.grids = list()
 	src.expected_type = expected_type
 
+	src.optimize_get_all_on_z = optimize_get_all_on_z
+	if(src.optimize_get_all_on_z)
+		src.z_all_atoms = list()
+
 	sync_world_z(world.maxz)
 
 /datum/spatial_grid/proc/sync_world_z(size)
 	src.grids.len = max(src.grids.len, size)
+	src.z_all_atoms?.len = max(src.z_all_atoms.len, size)
 	for(var/i in 1 to size)
 		if(src.grids[i])
 			continue
 		var/list/creating_grid = list()
 		creating_grid.len = src.width * src.height
 		src.grids[i] = creating_grid
+	if(optimize_get_all_on_z)
+		for(var/i in 1 to size)
+			if(src.z_all_atoms[i])
+				continue
+			src.z_all_atoms[i] = list()
 
 /**
  * injects a movable at an index
@@ -72,6 +88,9 @@ SUBSYSTEM_DEF(spatial_grids)
 			grid[index] = list(grid[index], AM)
 	else
 		grid[index] = AM
+
+	if(optimize_get_all_on_z)
+		z_all_atoms[z] += AM
 
 /**
  * removes a movable
@@ -88,6 +107,9 @@ SUBSYSTEM_DEF(spatial_grids)
 				grid[index] = entry[1]
 	else
 		grid[index] = null
+
+	if(optimize_get_all_on_z)
+		z_all_atoms[z] -= AM
 
 /**
  * queries things within distance in tiles
@@ -123,6 +145,15 @@ SUBSYSTEM_DEF(spatial_grids)
  * * somewhat inefficient, why are you doing this?
  */
 /datum/spatial_grid/proc/all_atoms(z)
+	if(optimize_get_all_on_z)
+		if(z)
+			return z_all_atoms[z]:Copy()
+		else
+			var/list/built = list()
+			for(var/z in 1 to world.maxz)
+				built += z_all_atoms[z]
+			return built
+
 	. = list()
 	if(z)
 		var/list/grid = src.grids[z]

--- a/code/controllers/subsystem/spatial_grids.dm
+++ b/code/controllers/subsystem/spatial_grids.dm
@@ -47,14 +47,14 @@ SUBSYSTEM_DEF(spatial_grids)
 	/// optimize get all atoms on z
 	var/optimize_get_all_on_z = FALSE
 
-/datum/spatial_grid/New(expected_type, optimize_get_all_on_z)
+/datum/spatial_grid/New(expected_type, init_flags)
 	// initialize grid
 	src.width = ceil(world.maxx / TURF_CHUNK_RESOLUTION)
 	src.height = ceil(world.maxy / TURF_CHUNK_RESOLUTION)
 	src.grids = list()
 	src.expected_type = expected_type
 
-	src.optimize_get_all_on_z = optimize_get_all_on_z
+	src.optimize_get_all_on_z = !!(init_flags & SPATIAL_GRID_INIT_OPTIMIZE_ALL_Z)
 	if(src.optimize_get_all_on_z)
 		src.z_all_atoms = list()
 

--- a/code/datums/components/turfs/reservation_border.dm
+++ b/code/datums/components/turfs/reservation_border.dm
@@ -31,6 +31,7 @@
 	src.range = range
 	src.dir = dir
 	src.handler_callback = handler_callback
+	src.paired = paired
 	if(!isnull(render))
 		src.render = render
 

--- a/code/datums/components/turfs/reservation_border.dm
+++ b/code/datums/components/turfs/reservation_border.dm
@@ -1,0 +1,167 @@
+//* This file is explicitly licensed under the MIT license. *//
+//* Copyright (c) 2024 silicons                             *//
+
+/**
+ * transition border but for turf reservations
+ *
+ * todo: multi-tile object support
+ * todo: allow simulation of specific atmos instead of just RESERVED_TURF_TYPe
+ */
+/datum/component/reservation_border
+	var/atom/movable/mirage_border/holder1
+	var/atom/movable/mirage_border/holder2
+	var/atom/movable/mirage_border/holder3
+	var/range
+	var/dir
+	var/turf/paired
+	/// do we render visuals?
+	var/render = TRUE
+	/// custom callback to call when something crosses us
+	var/datum/handler_callback
+
+/datum/component/reservation_border/Initialize(range = 10, dir, render, turf/paired, datum/callback/handler_callback)
+	if(!isturf(parent))
+		return COMPONENT_INCOMPATIBLE
+	if(!dir || range < 1)
+		. = COMPONENT_INCOMPATIBLE
+		CRASH("[type] improperly instanced with the following args: direction=\[[dir]\], range=\[[range]\]")
+	if(range > world.maxx || range > world.maxy || range > 20)
+		. = COMPONENT_INCOMPATIBLE
+		CRASH("[range] is too big a range. Max: 20, or the smallest dimension of the world.")
+	src.range = range
+	src.dir = dir
+	src.handler_callback = handler_callback
+	if(!isnull(render))
+		src.render = render
+
+/datum/component/reservation_border/RegisterWithParent()
+	. = ..()
+	var/turf/T = parent
+	T.set_opacity(TRUE)
+	RegisterSignal(parent, COMSIG_ATOM_ENTERED, .proc/transit)
+	rebuild()
+
+/datum/component/reservation_border/UnregisterFromParent()
+	var/turf/T = parent
+	T.set_opacity(FALSE)
+	UnregisterSignal(parent, COMSIG_ATOM_ENTERED)
+	QDEL_NULL(holder1)
+	QDEL_NULL(holder2)
+	QDEL_NULL(holder3)
+	return ..()
+
+/datum/component/reservation_border/proc/transit(datum/source, atom/movable/AM)
+	if(AM.atom_flags & ATOM_ABSTRACT)
+		return // nah.
+	var/turf/our_turf = parent
+	var/z_index = our_turf.z
+	if(isnull(z_index))
+		STACK_TRACE("no z index?! deleting self.")
+		qdel(src)
+		return
+	// todo: this is shit but we have to yield to prevent a Moved() before Moved()
+	spawn(0)
+		if(AM.loc != our_turf)
+			return
+		if(handler_callback)
+			handler_callback.Invoke(AM)
+		if(AM.loc == our_turf)
+			var/turf/target = paired
+			AM.locationTransitForceMove(target, recurse_levels = 2)
+
+/datum/component/reservation_border/proc/rebuild()
+	// reset first
+	holder1?.reset()
+	holder2?.reset()
+	holder3?.reset()
+
+	// "why the hell do you need 3 holders"
+	// because otherwise i can't offset them right, because we want the map to look like it's continuous, not overlapping
+	// i hate byond!
+
+	if(ISDIAGONALDIR(dir))
+		// 1 is NS
+		// 2 is EW
+		// 3 is diag
+		var/list/turfs
+
+		turfs = turfs_in_cardinal(NSCOMPONENT(dir))
+		if(length(turfs))
+			if(!holder1)
+				holder1 = new(parent)
+			holder1.vis_contents = turfs
+			holder1.pixel_y = dir & SOUTH? -world.icon_size * (range - 1) : 0
+
+		turfs = turfs_in_cardinal(EWCOMPONENT(dir))
+		if(length(turfs))
+			if(!holder2)
+				holder2 = new(parent)
+			holder2.vis_contents = turfs
+			holder2.pixel_x = dir & WEST? -world.icon_size * (range - 1) : 0
+
+		turfs = turfs_in_diagonal(dir)
+		if(length(turfs))
+			if(!holder3)
+				holder3 = new(parent)
+			holder3.vis_contents = turfs
+			holder3.pixel_y = dir & SOUTH? -world.icon_size * (range - 1) : 0
+			holder3.pixel_x = dir & WEST? -world.icon_size * (range - 1) : 0
+	else
+		var/list/turfs = turfs_in_cardinal(dir)
+		if(!length(turfs))
+			return
+		if(!holder1)
+			holder1 = new(parent)
+		holder1.vis_contents = turfs
+		holder1.pixel_x = dir == WEST? -world.icon_size * (range - 1) : 0
+		holder1.pixel_y = dir == SOUTH? -world.icon_size * (range - 1) : 0
+
+/datum/component/reservation_border/proc/turfs_in_diagonal(dir)
+	switch(dir)
+		if(NORTHWEST)
+			return block(
+				locate(paired.x - range + 1, paired.y, paired.z),
+				locate(paired.x, paired.y + range - 1, paired.z),
+			)
+		if(NORTHEAST)
+			return block(
+				locate(paired.x, paired.y, paired.z),
+				locate(paired.x + range - 1, paired.y + range - 1, paired.z),
+			)
+		if(SOUTHWEST)
+			return block(
+				locate(paired.x - range + 1, paired.y - range + 1, paired.z),
+				locate(paired.x, paired.y, paired.z),
+			)
+		if(SOUTHEAST)
+			return block(
+				locate(paired.x, paired.y - range + 1, paired.z),
+				locate(paired.x + range - 1, paired.y, paired.z),
+			)
+		else
+			CRASH("what?")
+
+/datum/component/reservation_border/proc/turfs_in_cardinal(dir)
+	switch(dir)
+		if(NORTH)
+			return block(
+				paired,
+				locate(paired.x, paired.y + range - 1, paired.z),
+			)
+		if(SOUTH)
+			return block(
+				locate(paired.x, paired.y - range + 1, paired.z),
+				paired,
+			)
+		if(EAST)
+			return block(
+				paired,
+				locate(paired.x + range - 1, paired.y, paired.z),
+			)
+		if(WEST)
+			return block(
+				locate(paired.x - range + 1, paired.y, paired.z),
+				paired,
+			)
+		else
+			CRASH("what?")

--- a/code/datums/components/turfs/reservation_border.dm
+++ b/code/datums/components/turfs/reservation_border.dm
@@ -17,7 +17,7 @@
 	/// do we render visuals?
 	var/render = TRUE
 	/// custom callback to call when something crosses us
-	var/datum/handler_callback
+	var/datum/callback/handler_callback
 
 /datum/component/reservation_border/Initialize(range = 10, dir, render, turf/paired, datum/callback/handler_callback)
 	if(!isturf(parent))

--- a/code/datums/components/turfs/transition_border.dm
+++ b/code/datums/components/turfs/transition_border.dm
@@ -9,6 +9,8 @@
  *
  * This way, we have *near* perfect native-like simulation with moves without
  * having to do anything too special.
+ *
+ * todo: multi-tile object support
  */
 /datum/component/transition_border
 	var/atom/movable/mirage_border/holder1

--- a/code/modules/mapping/turf_reservation.dm
+++ b/code/modules/mapping/turf_reservation.dm
@@ -310,7 +310,7 @@
 		corner = locate(bottom_left_coords[1] - 1, bottom_left_coords[2] - 1, bottom_left_coords[3])
 		border_initializer?.Invoke(corner)
 		if(needs_component)
-			corner.AddComponent(/datum/component/reservation_border, mirage_range, SOUTHWESt, should_mirage, locate(top_right_coords[1], top_right_coords[2], bottom_left_coords[3]), border_handler)
+			corner.AddComponent(/datum/component/reservation_border, mirage_range, SOUTHWEST, should_mirage, locate(top_right_coords[1], top_right_coords[2], bottom_left_coords[3]), border_handler)
 		immediate_corners += corner
 		// bottom right
 		corner = locate(top_right_coords[1] + 1, bottom_left_coords[2] - 1, bottom_left_coords[3])

--- a/code/modules/mapping/turf_reservation.dm
+++ b/code/modules/mapping/turf_reservation.dm
@@ -243,7 +243,7 @@
 	src.top_right_coords = list(TR.x, TR.y, TR.z)
 
 	if(border)
-		var/mirage_range = max(min(width - 3, height - 3, 7), 0)
+		var/mirage_range = max(min(width - 3, height - 3, 9), 0)
 		var/should_mirage = (border_mirage_anyways || !border_initializer) && mirage_range
 		var/needs_component = border_handler || (should_mirage && !border_initializer)
 
@@ -304,19 +304,19 @@
 		corner = locate(top_right_coords[1] + 1, top_right_coords[2] + 1, bottom_left_coords[3])
 		border_initializer?.Invoke(corner)
 		if(needs_component)
-			corner.AddComponent(/datum/component/reservation_border, mirage_range, NORTHWEST, should_mirage, locate(bottom_left_coords[1], bottom_left_coords[2], bottom_left_coords[3]), border_handler)
+			corner.AddComponent(/datum/component/reservation_border, mirage_range, NORTHEAST, should_mirage, locate(bottom_left_coords[1], bottom_left_coords[2], bottom_left_coords[3]), border_handler)
 		immediate_corners += corner
 		// bottom left
 		corner = locate(bottom_left_coords[1] - 1, bottom_left_coords[2] - 1, bottom_left_coords[3])
 		border_initializer?.Invoke(corner)
 		if(needs_component)
-			corner.AddComponent(/datum/component/reservation_border, mirage_range, NORTHWEST, should_mirage, locate(top_right_coords[1], top_right_coords[2], bottom_left_coords[3]), border_handler)
+			corner.AddComponent(/datum/component/reservation_border, mirage_range, SOUTHWESt, should_mirage, locate(top_right_coords[1], top_right_coords[2], bottom_left_coords[3]), border_handler)
 		immediate_corners += corner
 		// bottom right
 		corner = locate(top_right_coords[1] + 1, bottom_left_coords[2] - 1, bottom_left_coords[3])
 		border_initializer?.Invoke(corner)
 		if(needs_component)
-			corner.AddComponent(/datum/component/reservation_border, mirage_range, NORTHWEST, should_mirage, locate(bottom_left_coords[1], top_right_coords[2], bottom_left_coords[3]), border_handler)
+			corner.AddComponent(/datum/component/reservation_border, mirage_range, SOUTHEAST, should_mirage, locate(bottom_left_coords[1], top_right_coords[2], bottom_left_coords[3]), border_handler)
 		immediate_corners += corner
 
 		final_immediate_border = \

--- a/code/modules/mapping/turf_reservation.dm
+++ b/code/modules/mapping/turf_reservation.dm
@@ -239,6 +239,9 @@
 		if(T.type != turf_type)
 			T.ChangeTurf(turf_type, turf_type)
 
+	src.bottom_left_coords = list(BL.x, BL.y, BL.z)
+	src.top_right_coords = list(TR.x, TR.y, TR.z)
+
 	if(border)
 		var/mirage_range = max(min(width - 3, height - 3, 7), 0)
 		var/should_mirage = (border_mirage_anyways || !border_initializer) && mirage_range
@@ -327,8 +330,6 @@
 	// todo: area.assimilate_turfs?
 	area_instance.contents.Add(final)
 	src.reserved_turfs = final.Copy()
-	src.bottom_left_coords = list(BL.x, BL.y, BL.z)
-	src.top_right_coords = list(TR.x, TR.y, TR.z)
 	src.width = width
 	src.height = height
 	src.border = border

--- a/code/modules/mapping/turf_reservation.dm
+++ b/code/modules/mapping/turf_reservation.dm
@@ -70,9 +70,17 @@
 
 /datum/turf_reservation/proc/release()
 	if(border)
-		SSmapping.reserve_turfs(block(locate(arglist(bottom_left_border_coords)), locate(arglist(top_right_border_coords))))
+		SSmapping.reserve_turfs(block(locate(
+			bottom_left_border_coords[1], bottom_left_border_coords[2], bottom_left_border_coords[3]
+			), locate(
+			top_right_border_coords[1], top_right_border_coords[2], top_right_border_coords[3])
+		))
 	else
-		SSmapping.reserve_turfs(block(locate(arglist(bottom_left_coords)), locate(arglist(top_right_coords))))
+		SSmapping.reserve_turfs(block(locate(
+			bottom_left_coords[1], bottom_left_coords[2], bottom_left_coords[3]
+			), locate(
+			top_right_coords[1], top_right_coords[2], top_right_coords[3])
+		))
 	reserved_turfs = null
 	allocated = FALSE
 	if(border_area)

--- a/code/modules/mapping/turf_reservation.dm
+++ b/code/modules/mapping/turf_reservation.dm
@@ -168,6 +168,11 @@
 				if(!passing)
 					continue
 
+				// calculate non-bordered
+				BL = locate(1 + TURF_CHUNK_RESOLUTION * (outer_x - 1) + border, 1 + TURF_CHUNK_RESOLUTION * (outer_y - 1) + border, level_index)
+				TR = locate(BL.x + real_width - 1 - border, BL.y + real_height - 1 - border, BL.z)
+				final = block(BL, TR)
+
 				// calculate border
 				if(border)
 					final_border = list(
@@ -216,11 +221,6 @@
 								level_index,
 							),
 						)
-
-				// calculate non-bordered
-				BL = locate(1 + TURF_CHUNK_RESOLUTION * (outer_x - 1) + border, 1 + TURF_CHUNK_RESOLUTION * (outer_y - 1) + border, level_index)
-				TR = locate(BL.x + real_width - 1 - border, BL.y + real_height - 1 - border, BL.z)
-				final = block(BL, TR)
 
 				found_a_spot = TRUE
 				break


### PR DESCRIPTION
adds the ability to specify a special border around turf reservations

by default,

1. if the border is specified but no initializer is specified, it's a selflooping border
2. if the border isn't specified, **you can fly out of reservations.**

yes, we have no safety guards anymore by default.

this is because turf reservations are a very low level concept and the user of the API is meant to deal with potential reservation escapes.

reservations are still aligned to chunks; though the actual playable area is no longer chunk-aligned.
this may change in the future. this is the case now because we don't want reservations to take up significantly more chunks than they otherwise would have.
