### PR TITLE
non-tgui age gate

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -144,6 +144,9 @@
 		if(QDELETED(real_src))
 			return
 
+	if(href_list["month"] && !(player.player_flags & PLAYER_FLAG_AGE_VERIFIED))
+		handle_age_gate(href_list["month"], href_list["year"])
+
 	..()	//redirect to hsrc.Topic()
 
 

--- a/code/modules/client/onboarding/age_verification.dm
+++ b/code/modules/client/onboarding/age_verification.dm
@@ -14,12 +14,9 @@
 		return TRUE
 	if(is_age_verified())
 		return TRUE
-	// make absolute goddamn sure tgui is sent
-	SSassets.send_asset_pack(src, /datum/asset_pack/simple/tgui)
-	asset_cache_flush_browse_queue()
-	// wait a moment just to be sure too
-	spawn(5)
-		GLOB.age_verify_menu.ui_interact(mob)
+
+	prompt_age_verification()
+
 	return TRUE
 
 /client/proc/set_age_verified()
@@ -39,33 +36,48 @@
 	if(!.)
 		to_chat(src, SPAN_DANGER("Age verification must be completed before doing that."))
 
-GLOBAL_DATUM_INIT(age_verify_menu, /datum/age_verify_menu, new)
+/client/proc/prompt_age_verification()
+	var/list/dat = list("<center>")
+	dat += "Enter your date of birth here, to confirm that you are over 18.<BR>"
+	dat += "<b>Your date of birth is not saved, only the fact that you are over/under 18 is.</b><BR>"
+	dat += "</center>"
 
-/datum/age_verify_menu
+	dat += "<form action='?src=[REF(src)]'>"
+	dat += "<input type='hidden' name='src' value='[REF(src)]'>"
+	dat += HrefTokenFormField()
+	dat += "<select name = 'month'>"
+	var/monthList = list("January" = 1, "February" = 2, "March" = 3, "April" = 4, "May" = 5, "June" = 6, "July" = 7, "August" = 8, "September" = 9, "October" = 10, "November" = 11, "December" = 12)
+	for(var/month in monthList)
+		dat += "<option value = [monthList[month]]>[month]</option>"
+	dat += "</select>"
+	dat += "<select name = 'year' style = 'float:right'>"
+	var/current_year = text2num(time2text(world.realtime, "YYYY"))
+	var/start_year = 1920
+	for(var/year in start_year to current_year)
+		var/reverse_year = 1920 + (current_year - year)
+		dat += "<option value = [reverse_year]>[reverse_year]</option>"
+	dat += "</select>"
+	dat += "<center><input type='submit' value='Submit information'></center>"
+	dat += "</form>"
 
-/datum/age_verify_menu/ui_interact(mob/user, datum/tgui/ui, datum/tgui/parent_ui)
-	ui = SStgui.try_update_ui(user, src, ui)
-	if(!ui)
-		ui = new(user, src, "UIAgeVerifyMenu")
-		ui.open()
+	winshow(src, "age_gate", TRUE)
+	var/datum/browser/popup = new(src, "age_gate", "<div align='center'>Age Gate</div>", 400, 250)
+	popup.set_window_options("can_close=0")
+	popup.set_content(dat.Join())
+	popup.open(FALSE)
+	onclose(src, "age_gate")
 
-/datum/age_verify_menu/ui_status(mob/user, datum/ui_state/state)
-	return UI_INTERACTIVE
-
-/datum/age_verify_menu/ui_act(action, list/params, datum/tgui/ui)
-	. = ..()
-	if(.)
-		return
+/client/proc/handle_age_gate(player_month, player_year)
+	player_month = text2num(player_month)
+	player_year = text2num(player_year)
 
 	if(usr.client.is_age_verified())
-		qdel(ui)
 		return TRUE
-
-	var/player_month = text2num(params["month"])
-	var/player_year = text2num(params["year"])
 
 	if(isnull(player_month) || isnull(player_year))
 		return TRUE
+
+	message_admins("yippeeee")
 
 	var/current_time = world.realtime
 	var/current_month = text2num(time2text(current_time, "MM"))
@@ -93,7 +105,7 @@ GLOBAL_DATUM_INIT(age_verify_menu, /datum/age_verify_menu, new)
 			var/list/days = list()
 			for(var/number in 1 to total_days_in_player_month)
 				days += number
-			var/player_day = text2num(params["day"])
+			var/player_day = input("Enter the day of the month you were born on.", "Age Verification", src) as num|null
 			if(isnull(player_day))
 				return TRUE
 			if(player_day <= current_day)
@@ -105,16 +117,11 @@ GLOBAL_DATUM_INIT(age_verify_menu, /datum/age_verify_menu, new)
 	return TRUE
 
 /client/proc/age_gate_internal_failed()
-	var/datum/tgui/found = SStgui.get_open_ui(usr, GLOB.age_verify_menu)
-	if(!isnull(found))
-		found.close()
 	if(CONFIG_GET(flag/age_verification_autoban))
 		security_ban("Age verification failed. Appeal this on the Discord after you are 18 years of age or older.")
 	else
 		security_kick("Age verification failed. This server is for 18+ only.", TRUE)
 
 /client/proc/age_gate_internal_succeeded()
-	var/datum/tgui/found = SStgui.get_open_ui(usr, GLOB.age_verify_menu)
-	if(!isnull(found))
-		found.close()
 	set_age_verified()
+	src << browse(null, "window=age_gate")

--- a/code/modules/client/onboarding/age_verification.dm
+++ b/code/modules/client/onboarding/age_verification.dm
@@ -77,8 +77,6 @@
 	if(isnull(player_month) || isnull(player_year))
 		return TRUE
 
-	message_admins("yippeeee")
-
 	var/current_time = world.realtime
 	var/current_month = text2num(time2text(current_time, "MM"))
 	var/current_year = text2num(time2text(current_time, "YYYY"))


### PR DESCRIPTION
## About The Pull Request
title

our options are:
1. wait an arbitrary amount of time and then make the tgui input
2. use a non-tgui age gate

testmerge only for the sake of i want to be able to throw a test account at it on the server which has DB access because i'm not setting up a local db connection for this (see: i'm lazy)

## Why It's Good For The Game
fix issues with the prompt loading with tgui

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes loading issues with the age gate (new players can just get stuck and unable to join)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
