### PR TITLE
Turns off the scrubbers in the nacelles on Triumph

### DIFF
--- a/maps/triumph/levels/deck1.dmm
+++ b/maps/triumph/levels/deck1.dmm
@@ -9756,7 +9756,7 @@
 /turf/simulated/floor/tiled/white,
 /area/engineering/foyer_mezzenine)
 "GS" = (
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/component/unary/vent_scrubber{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -12794,7 +12794,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "Rf" = (
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/component/unary/vent_scrubber{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. The nacelle burn chambers have by-default on scrubbers in them.

## Why It's Good For The Game

What do you do with the burn chambers? You pump in oxygen and phoron, at a 3:2 ratio, to burn into carbon dioxide, which is very hot, to heat up some other phoron so you can use it as fuel.

What does the scrubber do? It pulls out phoron and carbon dioxide and puts it into the scrubbers loop, making it no longer usable and filling the scrubbers loop with hundreds of kPa of thousands-of-kelvin phoron/CO2.

This is not just pointless, it's actively detrimental, a gotcha whose entire point is to dunk on new players for not considering that someone might do something so incredibly stupid as to put a device into a burn chamber whose entire purpose is to remove the fuel and the hot stuff.

## Changelog

:cl:
tweak: Turned off the scrubbers in the nacelles on the Triumph
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
