### PR TITLE
Temporary/silent pose setting

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -1070,7 +1070,7 @@
 		visible_emote("adjusts [T.his] posture.")
 
 /mob/living/carbon/human/verb/timed_pose()
-	set name = "Set Temporary Pose"
+	set name = "Set Pose (Temporary)"
 	set desc = "Sets a description which will be shown when someone examines you, expiring after a given number of seconds."
 	set category = VERB_CATEGORY_IC
 	var/datum/gender/T = GLOB.gender_datums[get_visible_gender()]

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -1053,7 +1053,8 @@
 
 
 
-
+/mob/living/carbon/human/proc/set_pose(new_pose)
+	pose = sanitize(new_pose)
 
 /mob/living/carbon/human/verb/pose()
 	set name = "Set Pose"
@@ -1064,7 +1065,9 @@
 
 	var/old_pose = pose
 
-	pose =  sanitize(input(usr, "This is [src]. [T.he]...", "Pose", null)  as text)
+	var/new_pose =  input(usr, "This is [src]. [T.he]...", "Pose", null)  as text|null
+
+	set_pose(new_pose)
 
 	if (length(pose)>0 && pose != old_pose)
 		visible_emote("adjusts [T.his] posture.")
@@ -1077,15 +1080,16 @@
 
 	var/old_pose = pose
 
-	pose =  sanitize(input(usr, "This is [src]. [T.he]...", "Pose", null)  as text)
+	var/new_pose =  input(usr, "This is [src]. [T.he]...", "Pose", null)  as text|null
 
-	var/time = input(usr, "How long should the pose be visible (in seconds)?","Pose",60)
+	var/time = input(usr, "How long should the pose be visible (in seconds)?","Pose",60) as num|null
+
+	set_pose(new_pose)
 
 	if (length(pose)>0 && pose != old_pose)
 		visible_emote("adjusts [T.his] posture.")
-
-	spawn(time SECONDS)
-		pose=""
+		addtimer(CALLBACK(src,PROC_REF(set_pose),""),time SECONDS)
+	
 
 /mob/living/carbon/human/verb/silent_pose()
 	set name = "Set Pose (Stealth)"
@@ -1093,7 +1097,8 @@
 	set category = VERB_CATEGORY_IC
 	var/datum/gender/T = GLOB.gender_datums[get_visible_gender()]
 
-	pose =  sanitize(input(usr, "This is [src]. [T.he]...", "Pose", null)  as text)
+	var/new_pose=input(usr, "This is [src]. [T.he]...", "Pose", null)  as text|null
+	set_pose(new_pose)
 
 
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -1069,6 +1069,34 @@
 	if (length(pose)>0 && pose != old_pose)
 		visible_emote("adjusts [T.his] posture.")
 
+/mob/living/carbon/human/verb/timed_pose()
+	set name = "Set Temporary Pose"
+	set desc = "Sets a description which will be shown when someone examines you, expiring after a given number of seconds."
+	set category = VERB_CATEGORY_IC
+	var/datum/gender/T = GLOB.gender_datums[get_visible_gender()]
+
+	var/old_pose = pose
+
+	pose =  sanitize(input(usr, "This is [src]. [T.he]...", "Pose", null)  as text)
+
+	var/time = input(usr, "How long should the pose be visible (in seconds)?","Pose",60)
+
+	if (length(pose)>0 && pose != old_pose)
+		visible_emote("adjusts [T.his] posture.")
+
+	spawn(time SECONDS)
+		pose=""
+
+/mob/living/carbon/human/verb/silent_pose()
+	set name = "Set Pose (Stealth)"
+	set desc = "Sets a description which will be shown when someone examines you, without showing an adjustment message."
+	set category = VERB_CATEGORY_IC
+	var/datum/gender/T = GLOB.gender_datums[get_visible_gender()]
+
+	pose =  sanitize(input(usr, "This is [src]. [T.he]...", "Pose", null)  as text)
+
+
+
 /mob/living/carbon/human/verb/set_flavor()
 	set name = "Set Flavour Text"
 	set desc = "Sets an extended description of your character's features."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a couple verbs:

1. Set Pose (Temporary). Lets you set a pose with an automatic expiry time, which it prompts you for, in seconds.
2. Set Pose (Stealth). Lets you set pose without the "adjusts [T.his] posture" message.

## Why It's Good For The Game

1. Forgetting to unset poses can be goofy
2. Sometimes you want everyone to look at you upon setting pose, sometimes you don't

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Two new set pose variations, temporary and stealth
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
