### PR TITLE
Makes restrained mobs carriable

### DIFF
--- a/code/datums/components/riding/mob/human.dm
+++ b/code/datums/components/riding/mob/human.dm
@@ -31,7 +31,6 @@
 /datum/component/riding_handler/mob/human
 	expected_typepath = /mob/living/carbon/human
 	riding_handler_flags = CF_RIDING_HANDLER_EPHEMERAL
-	rider_check_flags = CF_RIDING_CHECK_INCAPACITATED
 	ridden_check_flags = CF_RIDING_CHECK_INCAPACITATED | CF_RIDING_CHECK_LYING
 	rider_offsets = list(
 		list(0, 6, 1, null),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

as title

## Why It's Good For The Game

"you can't fireman carry someone who's handcuffed" - words of the utterly deranged

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can now fireman carry incapacitated people--you know, the ones fireman carry was designed for
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
