### PR TITLE
Facility Director's/Officer's Sabre changes

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -522,12 +522,16 @@
 	icon_state = "sheath-sabre"
 	max_items = 1
 	insertion_whitelist = list(
-		/obj/item/melee/sabre,
+		/obj/item/material/sword/sabre,
 		/obj/item/melee/baton/stunsword,
 		)
 	starts_with = list(
-		/obj/item/melee/sabre,
+		/obj/item/material/sword/sabre,
 		)
+
+/obj/item/storage/belt/sheath/initialize_storage()
+	. = ..()
+	obj_storage.update_icon_on_item_change = TRUE
 
 /obj/item/storage/belt/sheath/update_icon()
 	icon_state = "sheath"
@@ -539,6 +543,7 @@
 		var/mob/living/L = loc
 		L.regenerate_icons()
 	..()
+
 /obj/item/storage/belt/ranger
 	name = "ranger belt"
 	desc = "The fancy utility-belt holding the tools, cuffs and gadgets of the Go Go ERT-Rangers. The belt buckle is not real phoron, but it is still surprisingly comfortable to wear."

--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -45,3 +45,58 @@
 
 /obj/item/material/sword/katana/durasteel
 	material_parts = /datum/material/durasteel
+
+/obj/item/material/sword/sabre
+	name = "officer's sabre"
+	desc = "An elegant weapon, its monomolecular edge is capable of cutting through flesh and bone with ease."
+	attack_sound = "swing_hit"
+	icon_state = "sabre"
+	attack_sound = 'sound/weapons/rapierhit.ogg'
+	pickup_sound = 'sound/items/pickup/knife.ogg'
+	drop_sound = 'sound/items/drop/knife.ogg'
+	//initially damage was at 30. Damage now starts at around 25 until someone messes with material code again (hi Sili)
+	material_parts = /datum/material/plasteel
+	material_color = FALSE
+	origin_tech = list(TECH_COMBAT = 4)
+	item_icons = list(
+			SLOT_ID_LEFT_HAND = 'icons/mob/items/lefthand_melee.dmi',
+			SLOT_ID_RIGHT_HAND = 'icons/mob/items/righthand_melee.dmi',
+			)
+
+/obj/item/material/sword/sabre/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
+	if(default_parry_check(user, attacker, damage_source) && prob(60))
+		user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
+
+		playsound(user.loc, 'sound/items/drop/knife.ogg', 50, 1)
+		return 1
+	if(unique_parry_check(user, attacker, damage_source) && prob(50))
+		user.visible_message("<span class='danger'>\The [user] deflects [attack_text] with \the [src]!</span>")
+
+		playsound(user.loc, 'sound/weapons/plasma_cutter.ogg', 50, 1)
+		return 1
+
+	return 0
+
+/obj/item/material/sword/sabre/unique_parry_check(mob/user, mob/attacker, atom/damage_source)
+	if(user.incapacitated() || !istype(damage_source, /obj/projectile/))
+		return 0
+
+	var/bad_arc = global.reverse_dir[user.dir]
+	if(!check_shield_arc(user, bad_arc, damage_source, attacker))
+		return 0
+
+	return 1
+
+//meant to play when unsheathing the blade from the sabre sheath.
+/obj/item/material/sword/sabre/on_enter_storage(datum/object_system/storage/storage)
+	. = ..()
+	playsound(loc, 'sound/effects/holster/sheathin.ogg', 50, 1)
+
+/obj/item/material/sword/sabre/on_exit_storage(datum/object_system/storage/storage)
+	. = ..()
+	playsound(loc, 'sound/effects/holster/sheathout.ogg', 50, 1)
+
+/obj/item/material/sword/sabre/suicide_act(mob/user)
+	var/datum/gender/TU = GLOB.gender_datums[user.get_visible_gender()]
+	visible_message(SPAN_DANGER("[user] is slitting [TU.his] stomach open with \the [src.name]! It looks like [TU.hes] trying to commit seppuku."), SPAN_DANGER("You slit your stomach open with \the [src.name]!"), SPAN_DANGER("You hear the sound of flesh tearing open.")) // gory, but it gets the point across
+	return(BRUTELOSS)

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -15,23 +15,6 @@
 	user.visible_message(SPAN_DANGER("\The [user] [T.is] strangling [T.himself] with \the [src]! It looks like [T.he] [T.is] trying to commit suicide."), SPAN_DANGER("You start to strangle yourself with \the [src]!"), SPAN_DANGER("You hear the sound of someone choking!"))
 	return (OXYLOSS)
 
-/obj/item/melee/sabre
-	name = "officer's sabre"
-	desc = "An elegant weapon, its monomolecular edge is capable of cutting through flesh and bone with ease."
-	attack_sound = "swing_hit"
-	icon_state = "sabre"
-	attack_sound = 'sound/weapons/rapierhit.ogg'
-	damage_force = 35
-	throw_force = 15
-	w_class = WEIGHT_CLASS_NORMAL
-	origin_tech = list(TECH_COMBAT = 4)
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-
-/obj/item/melee/sabre/suicide_act(mob/user)
-	var/datum/gender/TU = GLOB.gender_datums[user.get_visible_gender()]
-	visible_message(SPAN_DANGER("[user] is slitting [TU.his] stomach open with \the [src.name]! It looks like [TU.hes] trying to commit seppuku."), SPAN_DANGER("You slit your stomach open with \the [src.name]!"), SPAN_DANGER("You hear the sound of flesh tearing open.")) // gory, but it gets the point across
-	return(BRUTELOSS)
-
 /obj/item/melee/umbrella
 	name = "umbrella"
 	desc = "To keep the rain off you. Use with caution on windy days."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- The Officer's Sabre is now a material item, which means it can be upgraded with better materials. It starts off as plasteel, with a base damage of around 25 due to funny material calculations. That does mean the starting damage does get nerfed a little from the original 30. But it can go up to around 44 if upgraded with durasteel.
- The sabre now has a 60% chance of parrying melee attacks, and a 50% chance of deflecting projectiles. For reference, the energy sword has a 65% chance of projectile blocking. Should the captain encounter someone trying to kill them, they can perhaps depend on the sabre to defend themselves.
- Fixed the sabre not being sharp (now causes bleeding, now can butcher mobs). Fixed the sabre's sheath not updating their icon.
- Drawing the sabre from a storage (usually the sheathe) plays the appropriate noise. En-garde!

## Why It's Good For The Game

The sabre isn't really that great of a weapon to use if the facility director for some reason has to get into a fight. Sure, the FD shouldn't actively be putting themselves in danger, but it should make things more interesting should they find themselves in such danger to begin with. Like getting shot at by Kynde representatives in a meeting room, for instance.

Central gave the FD a cool sword for some reason. Might as well make it actually cool.

This probably could also incentivize exploration to try out the colonial equipment pack some more too, since the sabre does appear in that equipment pack.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The Officer's Sabre is now a material weapon, which means it can be upgraded. It starts off as plasteel with around 25 damage.
balance: The Officer's Sabre now has a 60% chance to deflect melee attacks, and 50% chance to deflect projectiles, for as long as you are facing your enemy.
fix: The sabre sheath updates its icon when removing or adding the sabre.
fix: The officer's sabre is now sharp like it should be.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
