### PR TITLE
prototype ids

### DIFF
--- a/citadel.dme
+++ b/citadel.dme
@@ -616,6 +616,7 @@
 #include "code\controllers\subsystem\persistence\bunker.dm"
 #include "code\controllers\subsystem\persistence\entity_operations.dm"
 #include "code\controllers\subsystem\persistence\persistence.dm"
+#include "code\controllers\subsystem\persistence\prototype_lookup.dm"
 #include "code\controllers\subsystem\persistence\world.dm"
 #include "code\controllers\subsystem\persistence\modules\bulk_entity.dm"
 #include "code\controllers\subsystem\persistence\modules\level_objects.dm"

--- a/code/controllers/subsystem/persistence/persistence.dm
+++ b/code/controllers/subsystem/persistence/persistence.dm
@@ -18,7 +18,13 @@ SUBSYSTEM_DEF(persistence)
 	//  todo: interface on subsystem panel
 	var/static/world_non_canon = FALSE
 
+	/// prototype id to typepath
+	var/list/prototype_id_to_path
+
 /datum/controller/subsystem/persistence/Initialize()
+	/// build prototype lookup list
+	build_prototype_id_lookup()
+
 	LoadPersistence()
 
 	// todo: should this be here? save_the_world is in ticker.

--- a/code/controllers/subsystem/persistence/prototype_lookup.dm
+++ b/code/controllers/subsystem/persistence/prototype_lookup.dm
@@ -1,7 +1,7 @@
 //* This file is explicitly licensed under the MIT license. *//
 //* Copyright (c) 2024 silicons                             *//
 
-/datum/controller/subsystem/persistence/build_prototype_id_lookup()
+/datum/controller/subsystem/persistence/proc/build_prototype_id_lookup()
 	var/list/constructing = list()
 
 	var/last

--- a/code/controllers/subsystem/persistence/prototype_lookup.dm
+++ b/code/controllers/subsystem/persistence/prototype_lookup.dm
@@ -1,0 +1,25 @@
+//* This file is explicitly licensed under the MIT license. *//
+//* Copyright (c) 2024 silicons                             *//
+
+/datum/controller/subsystem/persistence/build_prototype_id_lookup()
+	var/list/constructing = list()
+
+	var/last
+
+	for(var/path in subtypesof(/atom))
+		// so the key here is in most but not all cases,
+		// if there's a case of intentional set-multiple-as-one-id,
+		// they'll be relatively adjacent to each other
+		// so we remember 'last' as an optimization since a comparison
+		// is cheaper than a list lookup
+		var/atom/casted = path
+		var/casted_id = initial(casted.prototype_id)
+
+		if(casted_id == last)
+			continue
+		if(constructing[casted_id])
+			continue
+		constructing[casted_id] = path
+		last = path
+
+	prototype_id_to_path = constructing

--- a/code/game/atoms/atom.dm
+++ b/code/game/atoms/atom.dm
@@ -8,9 +8,13 @@
 	SET_APPEARANCE_FLAGS(TILE_MOVER)
 	layer = TURF_LAYER
 
-	//? Core
+	//* Core *//
 	/// Atom flags.
 	var/atom_flags = NONE
+	/// Prototype ID; persistence uses this to know what atom to load, even if the path changes in a refactor.
+	///
+	/// * this is very much a 'set this on type and all subtypes or don't set it at all' situation.
+	var/prototype_id
 
 	//? Interaction
 	/// Intearaction flags.

--- a/code/game/objects/items/id_cards/emag.dm
+++ b/code/game/objects/items/id_cards/emag.dm
@@ -1,4 +1,5 @@
 /obj/item/card/emag_broken
+	prototype_id = "cryptographic-sequencer-broken"
 	desc = "It's a card with a magnetic strip attached to some circuitry. It looks too busted to be used for anything but salvage."
 	name = "broken cryptographic sequencer"
 	icon_state = "emag-spent"
@@ -6,12 +7,22 @@
 	origin_tech = list(TECH_MAGNET = 2, TECH_ILLEGAL = 2)
 
 /obj/item/card/emag
+	prototype_id = "crytographic-sequencer"
 	desc = "It's a card with a magnetic strip attached to some circuitry."
 	name = "cryptographic sequencer"
 	icon_state = "emag"
 	item_state = "card-id"
 	origin_tech = list(TECH_MAGNET = 2, TECH_ILLEGAL = 2)
 	var/uses = 10
+
+/obj/item/card/emag/serialize()
+	. = ..()
+	.["uses"] = uses
+
+/obj/item/card/emag/deserialize(list/data)
+	if(isnum(data["uses"]))
+		uses = max(0, floor(data["uses"]))
+	return ..()
 
 /obj/item/card/emag/resolve_attackby(atom/W, mob/user, params, attack_modifier = 1)
 	var/used_uses = W.emag_act(uses, user, src)

--- a/code/game/objects/items/stream_projector/medichine.dm
+++ b/code/game/objects/items/stream_projector/medichine.dm
@@ -17,6 +17,7 @@ GLOBAL_LIST_EMPTY(medichine_cell_datums)
  * todo: should we use reagents instead..?
  */
 /obj/item/stream_projector/medichine
+	prototype_id = "medichine-projector"
 	name = "medichine stream projector"
 	desc = "A specialized, locked-down variant of a nanite stream projector. Deploys medichines from a cartridge onto a target's surface."
 	icon = 'icons/items/stream_projector/medichine.dmi'
@@ -361,6 +362,7 @@ GLOBAL_LIST_EMPTY(medichine_cell_datums)
  * medical beamgun cell
  */
 /obj/item/medichine_cell
+	prototype_id = "medichine-cell"
 	name = "medichine cartridge (EMPTY)"
 	desc = "A cartridge meant to hold medicinal nanites."
 	icon = 'icons/items/stream_projector/medichine.dmi'
@@ -399,6 +401,26 @@ GLOBAL_LIST_EMPTY(medichine_cell_datums)
 		var/image/I = image(icon, "[base_icon_state]-[number]")
 		I.color = cell_datum.color
 		add_overlay(I, TRUE)
+
+/obj/item/medichine_cell/serialize()
+	. = ..()
+	// todo: id
+	.["cell"] = "[cell_datum.type]"
+	.["volume"] = volume
+	// todo: how do we know when we should serialize varedits? we have a serious potential desync issue otherwise
+	.["max_volume"] = max_volume
+
+/obj/item/medichine_cell/deserialize(list/data)
+	// todo: id
+	if(data["cell"])
+		var/datum/medichine_cell/cell_found = fetch_cached_medichine_cell_datum(text2path(data["cell"]))
+		if(cell_found)
+			cell_datum = cell_found
+	if(!isnull(data["volume"]))
+		volume = data["volume"]
+	if(!isnull(data["max_volume"]))
+		max_volume = data["max_volume"]
+	return ..()
 
 /obj/item/medichine_cell/proc/fill(amount)
 	. = min(amount, volume)

--- a/code/game/objects/items/stream_projector/stream_projector.dm
+++ b/code/game/objects/items/stream_projector/stream_projector.dm
@@ -9,6 +9,7 @@
  * processing uses SSprocessing.
  */
 /obj/item/stream_projector
+	abstract_type = /obj/item/stream_projector
 	/// locked targets; associated value must be truthy but is reserved by visual construction.
 	var/list/atom/active_targets
 	/// drop all targets on attack self

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -87,6 +87,7 @@
 		icon_state = "waterballoon-e"
 
 /obj/item/toy/syndicateballoon
+	prototype_id = "balloon-syndicate"
 	name = "criminal balloon"
 	desc = "There is a tag on the back that reads \"FUK NT!11!\"."
 	throw_force = 0
@@ -98,6 +99,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/toy/nanotrasenballoon
+	prototype_id = "balloon-nanotrasen"
 	name = "criminal balloon"
 	desc = "Across the balloon the following is printed: \"Man, I love Nanotrasen soooo much. I use only NT products. You have NO idea.\""
 	throw_force = 0
@@ -112,6 +114,7 @@
  * Fake telebeacon
  */
 /obj/item/toy/blink
+	prototype_id = "toy-teleporter-beacon"
 	name = "electronic blink toy game"
 	desc = "Blink.  Blink.  Blink. Ages 8 and up."
 	icon = 'icons/obj/machines/teleporter.dmi'
@@ -126,6 +129,7 @@
  * Fake singularity
  */
 /obj/item/toy/spinningtoy
+	prototype_id = "toy-singularity"
 	name = "gravitational singularity"
 	desc = "\"Singulo\" brand spinning toy."
 	icon = 'icons/obj/singularity.dmi'


### PR DESCRIPTION
Adds a system for persistence to bind to things without requiring the type to never change

## but, why?

Usually we to finalize stuff like typepaths before persisting because that's the smart thing to do

But for volatile things like organs that are under constant refactoring by necessity this doesn't work

So we do this to allow type changes to not throw out data

At some point we'll also need a versioning system for serialize / deserialize and semantics on when to "full serialize" / "full load", as an example if someone serialized an organ with 100 maxhealth but code changes made it 200, what then?