### PR TITLE
Allows doors/airlocks to be bump-opened when their panel is open

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -97,7 +97,7 @@
 
 /obj/machinery/door/Bumped(atom/AM)
 	. = ..()
-	if(panel_open || operating)
+	if(operating)
 		return
 	if(ismob(AM))
 		var/mob/M = AM


### PR DESCRIPTION
## About The Pull Request
![dreamseeker_RBgAwqa7Ae](https://github.com/Citadel-Station-13/Citadel-Station-13-RP/assets/6356337/b09ed6d5-1a7a-4b11-bbeb-6d3008773f07)


## Why It's Good For The Game

It's rly silly that screwdrivering a door makes it impossible for anyone without a screwdriver to get past it. Waist-high fence type beat

## Changelog

:cl: Bhijn and Myr
qol: Doors/airlocks can now be bump-opened while their panel is open
/:cl:
