### PR TITLE
Fixes relating to hallucinations, and prommie blobform

### DIFF
--- a/code/datums/components/horror_aura.dm
+++ b/code/datums/components/horror_aura.dm
@@ -33,7 +33,7 @@ It also serves the purposes of portraying the Lore accurate effect of "Acausal L
 /datum/component/horror_aura/proc/aura_effect()
 	for(var/mob/living/carbon/human/H in range(radius, parent))
 		if(!iscultist(H) && !istype(H.head, /obj/item/clothing/head/helmet/para))
-			H.hallucination += 15
+			H.adjustHallucination(15)
 	var/turf/T = get_turf(parent)
 	empulse(T, 0, 0, 0, emp_radius)
 

--- a/code/game/gamemodes/changeling/powers/lsd_sting.dm
+++ b/code/game/gamemodes/changeling/powers/lsd_sting.dm
@@ -15,6 +15,6 @@
 	if(!T)	return 0
 	add_attack_logs(src,T,"Hallucination sting (changeling)")
 	spawn(rand(300,600))
-		if(T)	T.hallucination += 400
+		if(T)	T.adjustHallucination(400)
 	feedback_add_details("changeling_powers","HS")
 	return 1

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -149,14 +149,14 @@ var/list/sacrificed = list()
 					//broken mind - 5000 may seem like a lot I wanted the effect to really stand out for maxiumum losing-your-mind-spooky
 					//hallucination is reduced when the step off as well, provided they haven't hit the last stage...
 
-					//5000 is waaaay too much, in practice.
-					target.hallucination = min(target.hallucination + 100, 500)
+					//5000 is waaaay too much, in practice. (what the actual fuck were these coders thinking?!)
+					target.adjustHallucination(100)
 					target.apply_effect(10, STUTTER)
 					target.adjustBrainLoss(1)
 				if(100 to INFINITY)
 					to_chat(target, "<span class='cult'>Your entire broken soul and being is engulfed in corruption and flames as your mind shatters away into nothing.</span>")
 					//5000 is waaaay too much, in practice.
-					target.hallucination = min(target.hallucination + 100, 500)
+					target.adjustHallucination(100)
 					target.apply_effect(15, STUTTER)
 					target.adjustBrainLoss(1)
 
@@ -181,7 +181,7 @@ var/list/sacrificed = list()
 				if(choice == "Submit") //choosing 'Resist' does nothing of course.
 					cult.add_antagonist(target.mind)
 					converting -= target
-					target.hallucination = 0 //sudden clarity
+					target.setHallucination(0) //sudden clarity
 
 		sleep(100) //proc once every 10 seconds
 	return 1

--- a/code/game/machinery/computer/arcade/orion_event.dm
+++ b/code/game/machinery/computer/arcade/orion_event.dm
@@ -260,7 +260,7 @@
 /datum/orion_event/raiders/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/carbon/gamer)
 	if(prob(50-gamer_skill))
 		to_chat(usr, "<span class='userdanger'>You hear battle shouts. The tramping of boots on cold metal. Screams of agony. The rush of venting air. Are you going insane?</span>")
-		gamer.hallucination += 30
+		gamer.adjustHallucination(30)
 	else
 		to_chat(usr, "<span class='userdanger'>Something strikes you from behind! It hurts like hell and feel like a blunt weapon, but nothing is there...</span>")
 		gamer.take_bodypart_damage(30)

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -156,7 +156,7 @@
 
 /mob/living/carbon/brain/handle_regular_hud_updates()
 	if (healths)
-		if (stat != 2)
+		if (stat != DEAD)
 			switch(health)
 				if(100 to INFINITY)
 					healths.icon_state = "health0"
@@ -175,16 +175,16 @@
 		else
 			healths.icon_state = "health7"
 
-	if (stat == 2 || (MUTATION_XRAY in src.mutations))
+	if (stat == DEAD || (MUTATION_XRAY in src.mutations))
 		AddSightSelf(SEE_TURFS | SEE_MOBS | SEE_OBJS)
 		self_perspective?.legacy_force_set_hard_darkvision(0)
 		SetSeeInvisibleSelf(SEE_INVISIBLE_LEVEL_ONE)
-	else if (stat != 2)
+	else if (stat != DEAD)
 		RemoveSightSelf(SEE_TURFS | SEE_MOBS | SEE_OBJS)
 		self_perspective?.legacy_force_set_hard_darkvision(null)
 		SetSeeInvisibleSelf(SEE_INVISIBLE_LIVING)
 
-	if (stat != 2)
+	if (stat != DEAD)
 		//Blindness is handled by the modifier
 		if(disabilities & DISABILITY_NEARSIGHTED)
 			overlay_fullscreen("impaired", /atom/movable/screen/fullscreen/scaled/impaired, 1)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -266,6 +266,18 @@
 	else
 		..()
 
+/mob/living/carbon/human/adjustHallucination(amount)
+	if(species.species_flags & NO_HALLUCINATION || isSynthetic())
+		hallucination = 0
+	else
+		..(amount)
+
+/mob/living/carbon/human/setHallucination(amount)
+	if(species.species_flags & NO_HALLUCINATION || isSynthetic())
+		hallucination = 0
+	else
+		..(amount)
+
 ////////////////////////////////////////////
 
 //Returns a list of damaged organs

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1141,7 +1141,7 @@
 				if(!handling_hal)
 					spawn handle_hallucinations() //The not boring kind!
 
-			hallucination = max(0, hallucination - 2)
+			adjustHallucination(-2)
 		else
 			for(var/atom/a in hallucinations)
 				qdel(a)
@@ -1164,6 +1164,7 @@
 			apply_status_effect(/datum/status_effect/sight/blindness, 5 SECOND)
 			animate_tail_reset()
 			adjustHalLoss(-3)
+			adjustHallucination(-3)
 
 		if(is_sleeping())
 			handle_dreams()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -299,6 +299,18 @@ default behaviour is:
 	halloss = min(max(halloss + amount, 0),(getMaxHealth()*2))
 	update_health()
 
+/mob/living/proc/adjustHallucination(amount)
+	if(status_flags & STATUS_GODMODE)
+		hallucination = 0
+		return 0	//godmode
+	hallucination = clamp(hallucination + amount, 0, 400) //cap at 400, any higher is just obnoxious
+
+/mob/living/proc/setHallucination(amount)
+	if(status_flags & STATUS_GODMODE)
+		hallucination = 0
+		return 0	//godmode
+	hallucination = clamp(amount, 0, 400) //cap at 400, any higher is just obnoxious
+
 /mob/living/proc/setHalLoss(var/amount)
 	if(status_flags & STATUS_GODMODE)	return 0	//godmode
 	halloss = amount
@@ -332,18 +344,6 @@ default behaviour is:
 			if(!isnull(M.disable_duration_percent))
 				amount = round(amount * M.disable_duration_percent)
 	..(amount)
-
-/mob/living/adjustHallucination(amount)
-	if(status_flags & STATUS_GODMODE)
-		hallucination = 0
-		return 0	//godmode
-	hallucination = clamp(hallucination + amount, 0, 400) //cap at 400, any higher is just obnoxious
-
-/mob/living/setHallucination(amount)
-	if(status_flags & STATUS_GODMODE)
-		hallucination = 0
-		return 0	//godmode
-	hallucination = clamp(amount, 0, 400) //cap at 400, any higher is just obnoxious
 
 // ++++ROCKDTBEN++++ MOB PROCS //END
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -333,6 +333,18 @@ default behaviour is:
 				amount = round(amount * M.disable_duration_percent)
 	..(amount)
 
+/mob/living/adjustHallucination(amount)
+	if(status_flags & STATUS_GODMODE)
+		hallucination = 0
+		return 0	//godmode
+	hallucination = clamp(hallucination + amount, 0, 400) //cap at 400, any higher is just obnoxious
+
+/mob/living/setHallucination(amount)
+	if(status_flags & STATUS_GODMODE)
+		hallucination = 0
+		return 0	//godmode
+	hallucination = clamp(amount, 0, 400) //cap at 400, any higher is just obnoxious
+
 // ++++ROCKDTBEN++++ MOB PROCS //END
 
 // Applies direct "cold" damage while checking protection against the cold.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -299,6 +299,10 @@ default behaviour is:
 	halloss = min(max(halloss + amount, 0),(getMaxHealth()*2))
 	update_health()
 
+/mob/living/proc/setHalLoss(var/amount)
+	if(status_flags & STATUS_GODMODE)	return 0	//godmode
+	halloss = amount
+
 /mob/living/proc/adjustHallucination(amount)
 	if(status_flags & STATUS_GODMODE)
 		hallucination = 0
@@ -310,10 +314,6 @@ default behaviour is:
 		hallucination = 0
 		return 0	//godmode
 	hallucination = clamp(amount, 0, 400) //cap at 400, any higher is just obnoxious
-
-/mob/living/proc/setHalLoss(var/amount)
-	if(status_flags & STATUS_GODMODE)	return 0	//godmode
-	halloss = amount
 
 // Use this to get a mob's max health whenever possible.  Reading maxHealth directly will give inaccurate results if any modifiers exist.
 /mob/living/proc/getMaxHealth()

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -125,7 +125,7 @@ var/list/fusion_reactions
 		if(T && (holder.z == T.z))
 			if(istype(mob, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = mob
-				H.hallucination += rand(100,150)
+				H.adjustHallucination(rand(100,150))
 
 	for(var/obj/machinery/fusion_fuel_injector/I in range(world.view, origin))
 		if(I.cur_assembly && I.cur_assembly.fuel_type == "supermatter")

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -181,7 +181,7 @@
 				var/mob/living/carbon/human/H = mob
 				if(H.isSynthetic())
 					continue
-				H.hallucination += max(50, min(300, DETONATION_HALLUCINATION * sqrt(1 / (get_dist(mob, src) + 1)) ) )
+				H.adjustHallucination(DETONATION_HALLUCINATION * sqrt(1 / (get_dist(mob, src) + 1)))
 	spawn(pull_time)
 		explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1)
 		sleep(5) //to allow the explosion to finish
@@ -361,7 +361,7 @@
 		if(l.isSynthetic())
 			continue
 		if(!istype(l.glasses, /obj/item/clothing/glasses/meson)) // Only mesons can protect you!
-			l.hallucination = max(0, min(200, l.hallucination + power * config_hallucination_power * sqrt( 1 / max(1,get_dist(l, src)) ) ) )
+			l.adjustHallucination(power * config_hallucination_power * sqrt( 1 / max(1,get_dist(l, src)) ) )
 
 	//! uh oh!
 	radiation_pulse(src, clamp(power * 4, 0, 50000), RAD_FALLOFF_ENGINE_SUPERMATTER)

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Dispenser.dm
@@ -136,7 +136,7 @@
 		M.bodytemperature = min(targ_temp, M.bodytemperature - (adj_temp * TEMPERATURE_DAMAGE_COEFFICIENT))
 
 	if(halluci)
-		M.hallucination = max(M.hallucination, halluci)
+		M.setHallucination(max(M.hallucination, halluci))
 	return
 
 /datum/reagent/ethanol/touch_obj(obj/O)

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Medicine.dm
@@ -193,7 +193,7 @@
 			M.druggy = max(M.druggy, 5)
 	if(alien != IS_DIONA)
 		M.drowsyness = max(0, M.drowsyness - 6 * removed * chem_effective)//reduces drowsyness to zero
-		M.hallucination = max(0, M.hallucination - 9 * removed * chem_effective)//reduces hallucination to 0
+		M.adjustHallucination(-9 * removed * chem_effective) //reduces hallucination to 0
 		M.adjustToxLoss(-4 * removed * chem_effective)//Removes toxin damage
 		if(prob(10))
 			M.remove_a_modifier_of_type(/datum/modifier/poisoned)//Removes the poisoned effect, which is super rare of its own
@@ -469,7 +469,7 @@
 	..()
 	if(alien == IS_SLIME)
 		M.add_chemical_effect(CE_SLOWDOWN, 1)
-	M.hallucination = max(M.hallucination, 2)
+	M.setHallucination(max(M.hallucination, 2))
 
 /datum/reagent/tramadol
 	name = "Tramadol"
@@ -492,7 +492,7 @@
 
 /datum/reagent/tramadol/overdose(mob/living/carbon/M, alien)
 	..()
-	M.hallucination = max(M.hallucination, 2)
+	M.setHallucination(max(M.hallucination, 2))
 
 /datum/reagent/oxycodone
 	name = "Oxycodone"
@@ -518,7 +518,7 @@
 /datum/reagent/oxycodone/overdose(mob/living/carbon/M, alien)
 	..()
 	M.druggy = max(M.druggy, 10)
-	M.hallucination = max(M.hallucination, 3)
+	M.setHallucination(max(M.hallucination, 3))
 
 /datum/reagent/numbing_enzyme//Moved from Chemistry-Reagents-Medicine_vr.dm
 	name = "Numbing Enzyme"//Obtained from vore bellies, and numbing bite trait custom species
@@ -553,7 +553,7 @@
 				H.adjustOxyLoss(5)
 		if(prob(2))
 			to_chat(H,"<span class='warning'>You feel a dull pain behind your eyes and at the back of your head...</span>")
-			H.hallucination += 20 //It messes with your mind for some reason.
+			H.adjustHallucination(20) //It messes with your mind for some reason.
 			H.eye_blurry += 20 //Groggy vision for a small bit.
 		if(prob(3))
 			to_chat(H,"<span class='warning'>You shiver, your body continually being assaulted by the sensation of pins and needles.</span>")
@@ -591,7 +591,7 @@
 	M.adjust_stunned(20 * -1)
 	M.adjust_paralyzed(20 * -1)
 	holder.remove_reagent("mindbreaker", 5)
-	M.hallucination = max(0, M.hallucination - 10)//Primary use
+	M.adjustHallucination(-10) //Primary use
 	M.adjustToxLoss(5 * removed * chem_effective) // It used to be incredibly deadly due to an oversight. Not anymore!
 	M.ceiling_chemical_effect(CE_PAINKILLER, 20 * chem_effective)
 
@@ -1187,7 +1187,7 @@
 	if(prob(20))
 		M.make_dizzy(5)
 	if(prob(20))
-		M.hallucination = max(M.hallucination, 10)
+		M.setHallucination(max(M.hallucination, 10))
 
 	//One of the levofloxacin side effects is 'spontaneous tendon rupture', which I'll immitate here. 1:1000 chance, so, pretty darn rare.
 	if(ishuman(M) && rand(1,10000) == 1)
@@ -1422,7 +1422,7 @@
 			data = world.time
 			if(prob(1))
 				to_chat(M, "<span class='warning'>Your mind breaks apart...</span>")
-				M.hallucination += 200
+				M.adjustHallucination(200)
 			else
 				to_chat(M, "<span class='notice'>Your mind feels much more stable.</span>")
 
@@ -1522,7 +1522,7 @@
 	M.adjustHalLoss(1)
 	if(!M.confused) M.confused = 1
 	M.confused = max(M.confused, 20)
-	M.hallucination += 15
+	M.adjustHallucination(15)
 
 	for(var/belly in M.vore_organs)
 		var/obj/belly/B = belly
@@ -1628,4 +1628,4 @@
 /datum/reagent/neuratrextate/overdose(mob/living/carbon/M)
 	..()
 	M.druggy += 30
-	M.hallucination += 20
+	M.adjustHallucination(20)

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Other.dm
@@ -207,7 +207,8 @@
 	M.radiation = 0
 	M.heal_organ_damage(20,20)
 	M.adjustToxLoss(-20)
-	M.hallucination = 0
+	M.setHallucination(0)
+	M.setHalLoss(0)
 	M.setBrainLoss(0)
 	M.disabilities = 0
 	M.sdisabilities = 0

--- a/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/Chemistry-Reagents-Toxins.dm
@@ -946,7 +946,7 @@
 	if(alien == IS_SLIME)
 		drug_strength *= 1.2
 
-	M.hallucination = max(M.hallucination, drug_strength)
+	M.setHallucination(max(M.hallucination, drug_strength))
 
 /datum/reagent/psilocybin
 	name = "Psilocybin"

--- a/code/modules/species/promethean/promethean_blob.dm
+++ b/code/modules/species/promethean/promethean_blob.dm
@@ -361,8 +361,12 @@
 
 	if(l_hand)
 		blob.prev_left_hand = WEAKREF(l_hand) //Won't save them if dropped above, but necessary if handdrop is disabled.
+	else
+		blob.prev_left_hand = null //make it so prommies can't just "recall" items magically if they had nothing in their hand.
 	if(r_hand)
 		blob.prev_right_hand = WEAKREF(r_hand)
+	else
+		blob.prev_right_hand = null //make it so prommies can't just "recall" items magically if they had nothing in their hand.
 
 	//Put our owner in it (don't transfer var/mind)
 	blob.transforming = TRUE

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -366,7 +366,7 @@
 	stage = 3
 
 /datum/disease2/effect/hallucinations/activate(var/mob/living/carbon/mob,var/multiplier)
-	mob.hallucination += 25
+	mob.adjustHallucination(25)
 
 /datum/disease2/effect/minordeaf
 	name = "Hearing Loss"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Functionalizes hallucination adjustment to firmly establish rules on hallucinations. Any code that changes hallucinations uses this function now.
- Caps hallucination at 400. It's annoying until it gets a rework.
- Synthetics will no longer experience hallucinations. (Horror aura causes EMPs, so synthetics already have a shitty end of the stick when dealing with horror mobs. Also this is intentional Sili recommendation.)
- Species that aren't meant to receive hallucinations will no longer experience hallucinations effects at all. 
- There was some comment somewhere saying that hallucinations should be reduced faster when you're sleeping/unconscious, so I made it do that.
- Prometheans can no longer "recall" items using promethean blobform. They were able to just teleport items from a distance previously.

## Why It's Good For The Game

Hallucinations are shit. Let's cap them.

Otherwise, fixes good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Hallucinations are capped at 400.
fix: Synthetics will no longer experience hallucinations.
fix: Species that aren't meant to receive hallucinations will no longer experience hallucinations effects at all. 
fix: Prometheans can no longer magically recall items using blobform.
code: Hallucination adjustment code has been established.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
