### PR TITLE
Adds Donut & Condiment Supply Packs for Cargo

### DIFF
--- a/code/modules/cargo/supplypacks/hospitality.dm
+++ b/code/modules/cargo/supplypacks/hospitality.dm
@@ -46,6 +46,30 @@
 	container_type = /obj/structure/closet/crate/corporate/gilthari
 	container_name = "crate of bar supplies"
 
+/datum/supply_pack/hospitality/condiments
+	contains = list(
+		/obj/item/reagent_containers/food/condiment/enzyme,
+		/obj/item/reagent_containers/food/condiment/ketchup,
+		/obj/item/reagent_containers/food/condiment/ketchup,
+		/obj/item/reagent_containers/food/condiment/sugar,
+		/obj/item/reagent_containers/food/condiment/hotsauce,
+		/obj/item/reagent_containers/food/condiment/coldsauce,
+		/obj/item/reagent_containers/food/condiment/soysauce,
+		/obj/item/reagent_containers/food/condiment/small/saltshaker,
+		/obj/item/reagent_containers/food/condiment/small/saltshaker,
+		/obj/item/reagent_containers/food/condiment/small/saltshaker,
+		/obj/item/reagent_containers/food/condiment/small/peppermill,
+		/obj/item/reagent_containers/food/condiment/small/peppermill,
+		/obj/item/reagent_containers/food/condiment/small/peppermill,
+		/obj/item/reagent_containers/food/condiment/spacespice,
+		/obj/item/reagent_containers/food/condiment/spacespice,
+		/obj/item/reagent_containers/food/condiment/spacespice,
+	)
+	name = "Condiment crate"
+	cost = 20
+	container_type = /obj/structure/closet/crate/corporate/centauri
+	container_name = "Condiment crate"
+
 /datum/supply_pack/randomised/hospitality/
 	group = "Hospitality"
 
@@ -58,7 +82,7 @@
 			/obj/item/pizzabox/vegetable
 			)
 	name = "Surprise pack of five pizzas"
-	cost = 15
+	cost = 50
 	container_type = /obj/structure/closet/crate/corporate/centauri
 	container_name = "Pizza crate"
 
@@ -100,7 +124,6 @@
 			/obj/item/reagent_containers/food/snacks/cherrypie,
 			/obj/item/reagent_containers/food/snacks/cookie,
 			/obj/item/reagent_containers/food/snacks/croissant,
-			/obj/item/reagent_containers/food/snacks/donut/normal,
 			/obj/item/reagent_containers/food/snacks/donut/jelly,
 			/obj/item/reagent_containers/food/snacks/donut/cherryjelly,
 			/obj/item/reagent_containers/food/snacks/muffin,
@@ -134,6 +157,18 @@
 	container_type = /obj/structure/closet/crate/corporate/centauri
 	container_name = "Cake crate"
 
+/datum/supply_pack/hospitality/donuts
+	contains = list(
+		/obj/item/storage/box/donut,
+		/obj/item/storage/box/donut,
+		/obj/item/storage/box/donut,
+	)
+	name = "Donut resupply crate"
+	cost = 25
+	container_type = /obj/structure/closet/crate/corporate/centauri
+	container_name = "Donut Resupply Crate"
+	container_desc = "For all your emergency donut resupply needs, Centauri Provision's got you."
+
 /datum/supply_pack/randomised/hospitality/mexican
 	num_contained = 5
 	contains = list(
@@ -157,9 +192,6 @@
 	cost = 50
 	container_type = /obj/structure/closet/crate/corporate/centauri
 	container_name = "Chinese takeout crate"
-
-/datum/supply_pack/randomised/hospitality/pizza
-	cost = 50
 
 /datum/supply_pack/hospitality/cookingoil
 	name = "Tallow tank crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The donut supply crate contains 3 donut boxes.
The condiment supply crate contains several condiments.  View the code to see which ones, since there's a good bit of them. Salt, pepper, and space spice are provided 3 times.

## Why It's Good For The Game
A few of the condiments included in the condiment box currently isn't renewable at all during a shift. This is one solution that's provided until hydroponics gets some plants coded in that can involve that.

As for the donut boxes - donuts are a common thing from stores. It'd also make sense that NT would let you order more donuts since they tend to stock the crew with several donuts shiftstart already.


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Donuts and condiments can now be ordered from Cargo in the hospitality category.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
