### PR TITLE
Adds a link to the examine tab when examining things that have extra examine info

### DIFF
--- a/code/game/atoms/atom.dm
+++ b/code/game/atoms/atom.dm
@@ -479,7 +479,7 @@
 	. += get_name_chaser(user)
 	if(desc)
 		. += "<hr>[desc]"
-	if(get_description_info() || get_description_fluff() || get_description_interaction(user))
+	if(get_description_info() || get_description_fluff() || length(get_description_interaction(user)))
 		. += SPAN_TINYNOTICE("<a href='byond://winset?command=.statpanel_goto_tab \"Examine\"'>For more information, click here.</a>") //This feels VERY HACKY but eh its PROBABLY fine
 	if(integrity_flags & INTEGRITY_INDESTRUCTIBLE)
 		. += SPAN_NOTICE("It doesn't look like it can be damaged through common means.")

--- a/code/game/atoms/atom.dm
+++ b/code/game/atoms/atom.dm
@@ -479,6 +479,8 @@
 	. += get_name_chaser(user)
 	if(desc)
 		. += "<hr>[desc]"
+	if(get_description_info() || get_description_fluff() || get_description_interaction(user))
+		. += SPAN_TINYNOTICE("<a href='byond://winset?command=.statpanel_goto_tab \"Examine\"'>For more information, click here.</a>") //This feels VERY HACKY but eh its PROBABLY fine
 	if(integrity_flags & INTEGRITY_INDESTRUCTIBLE)
 		. += SPAN_NOTICE("It doesn't look like it can be damaged through common means.")
 /*

--- a/code/modules/client/statpanel.dm
+++ b/code/modules/client/statpanel.dm
@@ -349,6 +349,15 @@
 
 	statpanel_tab = tab
 
+/**
+ * This cleanly and gracefully attempts to go to a specific tab via , for the hyperspecific purpose of interacting with the statpanel from other HTML UI
+ */
+/client/verb/hook_statpanel_goto_tab(tab as text)
+	set name = ".statpanel_goto_tab"
+	set hidden = TRUE
+	set instant = TRUE
+	src << output(tab, "statbrowser:change_tab")
+
 //! verb hooks - byond stat
 
 //! verb hooks - tab switcher


### PR DESCRIPTION
## About The Pull Request
![dreamseeker_k3TNlM68aV](https://github.com/Citadel-Station-13/Citadel-Station-13-RP/assets/6356337/00f9ec5d-dcc4-47d2-b618-fd8d2c110e55)


## Why It's Good For The Game
![krita_GRHFVqsQ49](https://github.com/Citadel-Station-13/Citadel-Station-13-RP/assets/6356337/5bf8f7d2-aa83-420e-91fd-f860d05650a8)

(There's currently no notice at all that something has extra examine information. Which in turn means it's *very* easy to miss information that would otherwise prevent incidents like what the above image represents the prelude of)

## Changelog

:cl: Bhijn and Myr
qol: When examining something that has extra info, the examine box will now contain a link that opens up the examine tab
/:cl:
