### PR TITLE
Fix hovering fire alarms, refactor DMM rotation code

### DIFF
--- a/code/game/atoms/atom.dm
+++ b/code/game/atoms/atom.dm
@@ -265,7 +265,7 @@
  *
  * return FALSE to override maploader automatic rotation
  */
-/atom/proc/preloading_dir(datum/dmm_preloader/preloader)
+/atom/proc/preloading_dir(datum/dmm_context/context)
 	return TRUE
 
 /**

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -19,7 +19,7 @@
 	stripe_file = 'icons/obj/doors/double/stripe.dmi'
 	stripe_fill_file = 'icons/obj/doors/double/fill_stripe.dmi'
 
-/obj/machinery/door/airlock/multi_tile/preloading_dir(datum/dmm_preloader/preloader)
+/obj/machinery/door/airlock/multi_tile/preloading_dir(datum/dmm_context/context)
 	. = ..()
 	SetBounds()
 

--- a/code/game/machinery/fire_alarm.dm
+++ b/code/game/machinery/fire_alarm.dm
@@ -30,10 +30,6 @@ CREATE_WALL_MOUNTING_TYPES_SHIFTED(/obj/machinery/fire_alarm/alarms_hidden, 21)
 /obj/machinery/fire_alarm/alarms_hidden
 	alarms_hidden = TRUE
 
-/obj/machinery/fire_alarm/preloading_dir(datum/dmm_preloader/preloader)
-	dir = turn(dir, -preloader.turn_angle)
-	return FALSE
-
 /obj/machinery/fire_alarm/Initialize(mapload, dir = src.dir)
 	. = ..()
 	if(z in (LEGACY_MAP_DATUM).contact_levels)

--- a/code/modules/mapping/dmm_suite/dmm_context.dm
+++ b/code/modules/mapping/dmm_suite/dmm_context.dm
@@ -46,6 +46,8 @@
 	///
 	/// * natural orientation is SOUTH
 	var/loaded_orientation
+
+	//* reexports of dmm_orientation variables *//
 	var/loaded_orientation_invert_x
 	var/loaded_orientation_invert_y
 	var/loaded_orientation_swap_xy

--- a/code/modules/mapping/dmm_suite/dmm_context.dm
+++ b/code/modules/mapping/dmm_suite/dmm_context.dm
@@ -46,6 +46,13 @@
 	///
 	/// * natural orientation is SOUTH
 	var/loaded_orientation
+	var/loaded_orientation_invert_x
+	var/loaded_orientation_invert_y
+	var/loaded_orientation_swap_xy
+	var/loaded_orientation_xi
+	var/loaded_orientation_yi
+	var/loaded_orientation_turn_angle
+
 	/// the dmm_parsed we loaded from
 	var/datum/dmm_parsed/loaded_dmm
 

--- a/code/modules/mapping/dmm_suite/dmm_parsed.dm
+++ b/code/modules/mapping/dmm_suite/dmm_parsed.dm
@@ -548,7 +548,7 @@
 			T.underlays += underlay
 			index++
 
-	//finally instance all remainings objects/mobsinvert_x
+	//finally instance all remainings objects/mobs
 	for(index in 1 to first_turf_index-1)
 		instance_atom(members[index],members_attributes[index],crds,no_changeturf,placeOnTop)
 

--- a/code/modules/mapping/dmm_suite/dmm_parsed.dm
+++ b/code/modules/mapping/dmm_suite/dmm_parsed.dm
@@ -281,8 +281,6 @@
 
 	_populate_orientation(context, orientation)
 
-	ASSERT(!isnull(context))
-
 	global.dmm_preloader.loading_context = context
 	var/list/loaded_bounds = _load_impl(x, y, z, x_lower, x_upper, y_lower, y_upper, z_lower, z_upper, no_changeturf, place_on_top, area_cache, context)
 	global.dmm_preloader.loading_orientation = null
@@ -307,8 +305,6 @@
 // todo: verify that when rotating, things load in the same way when cropped e.g. aligned to lower left
 //       as opposed to rotating to somewhere else
 /datum/dmm_parsed/proc/_load_impl(x, y, z, x_lower, x_upper, y_lower, y_upper, z_lower, z_upper, no_changeturf, place_on_top, list/area_cache = list(), datum/dmm_context/context)
-	ASSERT(!isnull(context))
-
 	var/list/model_cache = build_cache(no_changeturf)
 	var/space_key = model_cache[SPACE_KEY]
 

--- a/code/modules/mapping/dmm_suite/dmm_parsed.dm
+++ b/code/modules/mapping/dmm_suite/dmm_parsed.dm
@@ -280,6 +280,7 @@
 	Master.StartLoadingMap()
 
 	_populate_orientation(context, orientation)
+	context.loaded_dmm = src
 
 	global.dmm_preloader.loading_context = context
 	var/list/loaded_bounds = _load_impl(x, y, z, x_lower, x_upper, y_lower, y_upper, z_lower, z_upper, no_changeturf, place_on_top, area_cache, context)

--- a/code/modules/mapping/dmm_suite/dmm_preloader.dm
+++ b/code/modules/mapping/dmm_suite/dmm_preloader.dm
@@ -60,9 +60,9 @@ GLOBAL_REAL_VAR(dmm_preloader_target)
 	var/turn_angle = loading_context_local.loaded_orientation_turn_angle
 	if(turn_angle != 0 && what.preloading_dir(preloader_local))
 		var/multi_tile = ismovable(what) && ((what:bound_width > WORLD_ICON_SIZE) || (what:bound_height > WORLD_ICON_SIZE)) && (what.appearance_flags & TILE_MOVER)
-		var/invert_x=loading_context_local.loaded_orientation_invert_x
-		var/invert_y=loading_context_local.loaded_orientation_invert_y
-		var/swap_xy=loading_context_local.loaded_orientation_swap_xy
+		var/invert_x = loading_context_local.loaded_orientation_invert_x
+		var/invert_y = loading_context_local.loaded_orientation_invert_y
+		var/swap_xy = loading_context_local.loaded_orientation_swap_xy
 
 		if(multi_tile)
 			// normal multi tile rotation can only handle things that are 'centered' on their bound width/height

--- a/code/modules/mapping/dmm_suite/dmm_preloader.dm
+++ b/code/modules/mapping/dmm_suite/dmm_preloader.dm
@@ -25,10 +25,6 @@ GLOBAL_REAL_VAR(dmm_preloader_target)
 
 	//* --      set per atom      -- *//
 	var/list/attributes
-	var/turn_angle
-	var/swap_x
-	var/swap_y
-	var/swap_xy
 
 // todo: OPTIMIZE THE SHIT OUT OF ALL OF THIS
 // because citrp is so quirky and funny we now call this for every fucking atom
@@ -37,16 +33,11 @@ GLOBAL_REAL_VAR(dmm_preloader_target)
 // maybe we can get all the swap stuff compounded down? who knows lol
 // fucked.
 
-/world/proc/preloader_setup(list/the_attributes, path, turn_angle, swap_x, swap_y, swap_xy)
+/world/proc/preloader_setup(list/the_attributes, path)
 	global.dmm_preloader_active = TRUE
 	global.dmm_preloader_target = path
 	var/datum/dmm_preloader/preloader_local = global.dmm_preloader
 	preloader_local.attributes = the_attributes
-	if(turn_angle != 0)
-		preloader_local.turn_angle = turn_angle
-		preloader_local.swap_x = swap_x
-		preloader_local.swap_y = swap_y
-		preloader_local.swap_xy = swap_xy
 
 /world/proc/preloader_load(atom/what)
 	global.dmm_preloader_active = FALSE
@@ -65,10 +56,14 @@ GLOBAL_REAL_VAR(dmm_preloader_target)
 
 	// handle post processing, so things like directions on subtypes don't break.
 	// only do everything if necessary.
-	if(preloader_local.turn_angle != 0 && what.preloading_dir(preloader_local))
+	var/datum/dmm_context/loading_context_local = preloader_local.loading_context
+	var/turn_angle = loading_context_local.loaded_orientation_turn_angle
+	if(turn_angle != 0 && what.preloading_dir(preloader_local))
 		var/multi_tile = ismovable(what) && ((what:bound_width > WORLD_ICON_SIZE) || (what:bound_height > WORLD_ICON_SIZE)) && (what.appearance_flags & TILE_MOVER)
-		var/dx
-		var/dy
+		var/invert_x=loading_context_local.loaded_orientation_invert_x
+		var/invert_y=loading_context_local.loaded_orientation_invert_y
+		var/swap_xy=loading_context_local.loaded_orientation_swap_xy
+
 		if(multi_tile)
 			// normal multi tile rotation can only handle things that are 'centered' on their bound width/height
 			// if something needs to change that every rotation, it needs to override preloading_dir
@@ -76,11 +71,11 @@ GLOBAL_REAL_VAR(dmm_preloader_target)
 			// deal with their bounds
 			var/bx = casted.bound_x
 			var/by = casted.bound_y
-			if(preloader_local.swap_y)			//same order of operations as the load rotation, mirror and then x/y swapping.
+			if(invert_y)			//same order of operations as the load rotation, mirror and then x/y swapping.
 				by = -by
-			if(preloader_local.swap_x)
+			if(invert_x)
 				bx = -bx
-			if(preloader_local.swap_xy)
+			if(swap_xy)
 				var/obx = bx
 				bx = by
 				by = obx
@@ -90,24 +85,24 @@ GLOBAL_REAL_VAR(dmm_preloader_target)
 			casted.bound_x = bx
 			casted.bound_y = by
 			// not a pixel mover, we can assume it's multiples of world icon size
-			dx = round((casted.bound_width / WORLD_ICON_SIZE) - (casted.bound_x / (WORLD_ICON_SIZE / 2)) - 1)
-			dy = round((casted.bound_height / WORLD_ICON_SIZE) - (casted.bound_y / (WORLD_ICON_SIZE / 2)) - 1)
-			casted.x -= dx * ((preloader_local.swap_x ^ preloader_local.swap_xy)? 1 : 0)
-			casted.y -= dy * ((preloader_local.swap_y ^ preloader_local.swap_xy)? 1 : 0)
+			var/dx = round((casted.bound_width / WORLD_ICON_SIZE) - (casted.bound_x / (WORLD_ICON_SIZE / 2)) - 1)
+			var/dy = round((casted.bound_height / WORLD_ICON_SIZE) - (casted.bound_y / (WORLD_ICON_SIZE / 2)) - 1)
+			casted.x -= dx * ((invert_x ^ swap_xy)? 1 : 0)
+			casted.y -= dy * ((invert_y ^ swap_xy)? 1 : 0)
 
-		what.dir = turn(what.dir, preloader_local.turn_angle)
+		what.dir = turn(what.dir, turn_angle)
 		var/px = what.pixel_x
 		var/py = what.pixel_y
-		if(preloader_local.swap_y)			//same order of operations as the load rotation, mirror and then x/y swapping.
+		if(invert_y)			//same order of operations as the load rotation, mirror and then x/y swapping.
 			py = -py
-		if(preloader_local.swap_x)
+		if(invert_x)
 			px = -px
-		if(preloader_local.swap_xy)
+		if(swap_xy)
 			var/opx = px
 			px = py
 			py = opx
 		what.pixel_x = px
 		what.pixel_y = py
 
-	what.preloading_instance(preloader_local.loading_context)
+	what.preloading_instance(loading_context_local)
 

--- a/code/modules/mapping/dmm_suite/dmm_preloader.dm
+++ b/code/modules/mapping/dmm_suite/dmm_preloader.dm
@@ -58,7 +58,7 @@ GLOBAL_REAL_VAR(dmm_preloader_target)
 	// only do everything if necessary.
 	var/datum/dmm_context/loading_context_local = preloader_local.loading_context
 	var/turn_angle = loading_context_local.loaded_orientation_turn_angle
-	if(turn_angle != 0 && what.preloading_dir(preloader_local))
+	if(turn_angle != 0 && what.preloading_dir(loading_context_local))
 		var/multi_tile = ismovable(what) && ((what:bound_width > WORLD_ICON_SIZE) || (what:bound_height > WORLD_ICON_SIZE)) && (what.appearance_flags & TILE_MOVER)
 		var/invert_x = loading_context_local.loaded_orientation_invert_x
 		var/invert_y = loading_context_local.loaded_orientation_invert_y

--- a/code/modules/multiz/structures/stairs.dm
+++ b/code/modules/multiz/structures/stairs.dm
@@ -398,8 +398,8 @@
 
 	return INITIALIZE_HINT_QDEL
 
-/obj/structure/stairs/spawner/preloading_dir(datum/dmm_preloader/preloader)
-	dir = turn(dir, preloader.loading_context.loaded_orientation_turn_angle)
+/obj/structure/stairs/spawner/preloading_dir(datum/dmm_context/context)
+	dir = turn(dir, context.loaded_orientation_turn_angle)
 	return FALSE
 
 // For ease of spawning. While you *can* spawn the base type and set its dir, this is useful for adminbus and a little bit quicker to map in

--- a/code/modules/multiz/structures/stairs.dm
+++ b/code/modules/multiz/structures/stairs.dm
@@ -399,7 +399,7 @@
 	return INITIALIZE_HINT_QDEL
 
 /obj/structure/stairs/spawner/preloading_dir(datum/dmm_preloader/preloader)
-	dir = turn(dir, preloader.turn_angle)
+	dir = turn(dir, preloader.loading_context.loaded_orientation_turn_angle)
 	return FALSE
 
 // For ease of spawning. While you *can* spawn the base type and set its dir, this is useful for adminbus and a little bit quicker to map in

--- a/code/modules/turbolift/turbolift_map.dm
+++ b/code/modules/turbolift/turbolift_map.dm
@@ -20,7 +20,7 @@
 
 /obj/turbolift_map_holder/preloading_dir(datum/dmm_preloader/preloader)
 	. = ..()
-	got_rotated_by_maploader = preloader.loading_orientation
+	got_rotated_by_maploader = preloader.loading_context.loaded_orientation
 
 /obj/turbolift_map_holder/Initialize(mapload)
 	. = ..()

--- a/code/modules/turbolift/turbolift_map.dm
+++ b/code/modules/turbolift/turbolift_map.dm
@@ -18,9 +18,9 @@
 	// rotated
 	var/got_rotated_by_maploader
 
-/obj/turbolift_map_holder/preloading_dir(datum/dmm_preloader/preloader)
+/obj/turbolift_map_holder/preloading_dir(datum/dmm_context/context)
 	. = ..()
-	got_rotated_by_maploader = preloader.loading_context.loaded_orientation
+	got_rotated_by_maploader = context.loaded_orientation
 
 /obj/turbolift_map_holder/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Previously:

- A lot of unnecessary code to thread and repeatedly add orientation-related variables to the preloader.
- dmm_parsed previously modified its own args, then used arglist(args) This is bad energy -- as far as I can tell, this was was relying on the fact that _load_impl didn't use the modified values.
- Fire alarms were hardcoded to deal with east/west incorrectly

Now:

- These variables now live in the dmm_context.
- _load_impl takes fewer unnecessary args, and all its args are explicit
- A few variables have been removed or had their scope limited.
- Fire alarms aren't hardcoded to do that anymore.

Bugs I didn't fix:

- When a map is rotated EAST or WEST, signs spawn in an overlapping fashion that's really ugly.

## Why It's Good For The Game

### Correctness

Fire alarms were spawning sideways when rotated EAST or WEST and probably shouldn't be. I've fixed this behavior now.

### Style

Threading a lot of variables in DM is pretty rough -- DM doesn't actually warn if you do this wrong. Silicons specifically flagged this as a rough spot for code quality, which is why I attacked it.

These variables never change during the load process, so threading them as arguments creates the false implication that they can be different per map object.

### Performance

My goal wasn't to make performance better, just to make the code more readable without making it worse. Brief profiling implies it might be faster, but the difference is marginal and possibly explained by bad test conditions:

- map loading took 24.0, 24.3, 24.6 seconds before the change
- map loading took 23.0, 23.6, 23.8 seconds after this change

All tests were done with rotated Triumph. (I haven't profiled non-rotated yet.)

Back of the envelope calculation implies the number of variable-on-object lookups in the hot loop phase of the map load should be pretty close to the original number -- maybe a little lower, since I've turned some into locals.

The one lookup that looks new (where we get the context from the preloader in preloader_load) was actually one that happened unconditionally at the end of the procedure in the previous code.

## Images

Sign bug: I didn't fix this or introduce this.

![image](https://github.com/user-attachments/assets/47debb5e-00e4-4bf7-a404-94d315f07607)

Fire alarm bug living its best life. I fixed this:

![image](https://github.com/user-attachments/assets/f1db22d4-921c-4a1d-827f-cb49c76a2cb9)

Fire alarm is Tethered. (Post-fix):

![image](https://github.com/user-attachments/assets/b939842f-8dfc-45c3-bfcb-e6faf3a90ee8)

## Changelog

:cl: Pyrex
refactor: DMM rotation code is a little tidier
fix: fire alarms have a 0% chance of hovering
/:cl: