### PR TITLE
Makes lighters require oxidizer

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -605,6 +605,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(!base_state)
 		base_state = icon_state
 	if(!lit)
+		if(return_air_immutable()?.moles_by_flag(GAS_FLAG_OXIDIZER)<0.01)
+			user.visible_message("<span class='notice'>The [name] fails to light.")
+			return
 		lit = 1
 		icon_state = "[base_state]on"
 		item_state = "[base_state]on"
@@ -660,6 +663,15 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/flame/lighter/process(delta_time)
 	var/turf/location = get_turf(src)
 	if(location)
+		var/datum/gas_mixture/env=location.return_air_immutable()
+		if(env?.moles_by_flag(GAS_FLAG_OXIDIZER)<0.01)
+			visible_message("<span class='notice'>The [name] suddenly goes out.")
+			lit=0
+			icon_state = "[base_state]"
+			item_state = "[base_state]"
+			set_light(0)
+			STOP_PROCESSING(SSobj, src)
+			return
 		location.hotspot_expose(700, 5)
 	return
 

--- a/code/modules/atmospherics/environmental/atom.dm
+++ b/code/modules/atmospherics/environmental/atom.dm
@@ -76,6 +76,7 @@
  * this allows us to micro-optimize accesses without activating zones.
  */
 /atom/proc/return_air_immutable()
+	RETURN_TYPE(/datum/gas_mixture)
 	return return_air()
 
 /**
@@ -84,4 +85,5 @@
  * this should always trigger updates/checks like making a zone active
  */
 /atom/proc/return_air_mutable()
+	RETURN_TYPE(/datum/gas_mixture)
 	return return_air()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Right now, lighters work anywhere. It's a bit silly.

## Why It's Good For The Game

there's an entire atmos system with fuel gases and oxidizers, i'm using it (and yes, this is my only justification)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Lighters no longer work in oxygenless environments
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
