### PR TITLE
Circuit displayed name fixes & tweaks

### DIFF
--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -113,17 +113,17 @@ a creative player the means to solve many problems.  Circuits are held inside an
 /obj/item/integrated_circuit/proc/check_interactivity(mob/user)
 	return (ui_status(user, GLOB.physical_state) == UI_INTERACTIVE) && (!assembly || assembly.opened)
 
-/obj/item/integrated_circuit/verb/rename_component()
-	set name = "Rename Circuit"
-	set category = VERB_CATEGORY_OBJECT
-	set desc = "Rename your circuit, useful to stay organized."
-	set src in usr
-
-	var/mob/M = usr
-	var/input = tgui_input_text(usr, "What do you want to name this circuit?", "Rename", src.name, MAX_NAME_LEN)
-	if(src && input)
-		to_chat(M, SPAN_NOTICE("The circuit '[src.name]' is now labeled '[input]'."))
+/obj/item/integrated_circuit/proc/rename_component(mob/user)
+	var/input = tgui_input_text(user, "What do you want to name this circuit?", "Rename", src.displayed_name, MAX_NAME_LEN)
+	if(input)
+		to_chat(user, SPAN_NOTICE("The circuit '[displayed_name] ([name])' is now labeled '[input]'."))
 		displayed_name = input
+		if(assembly)
+			var/index = assembly.assembly_components.Find(src)
+			assembly.ui_circuit_props.Cut(index, 1 + index)
+			for(var/i in assembly.ui_circuit_props)
+				to_chat(user, "[index] - [1+index] : [i]")
+			assembly.ui_circuit_props.Insert(index, list(list("name" = displayed_name,"ref" = REF(src),"removable" = removable,"input" = can_be_asked_input)))
 
 /obj/item/integrated_circuit/ui_state()
 	return GLOB.physical_state

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -121,8 +121,6 @@ a creative player the means to solve many problems.  Circuits are held inside an
 		if(assembly)
 			var/index = assembly.assembly_components.Find(src)
 			assembly.ui_circuit_props.Cut(index, 1 + index)
-			for(var/i in assembly.ui_circuit_props)
-				to_chat(user, "[index] - [1+index] : [i]")
 			assembly.ui_circuit_props.Insert(index, list(list("name" = displayed_name,"ref" = REF(src),"removable" = removable,"input" = can_be_asked_input)))
 
 /obj/item/integrated_circuit/ui_state()

--- a/tgui/packages/tgui/interfaces/ICAssembly.js
+++ b/tgui/packages/tgui/interfaces/ICAssembly.js
@@ -104,7 +104,7 @@ const ICAssemblyCircuits = (props, context) => {
         {circuits.map((circuit, i) => (
           <LabeledList.Item key={circuit.ref} label={circuit.name} >
             <Button icon="eye" onClick={() => act("open_circuit", { ref: circuit.ref })}>View</Button>
-            <Button icon="eye" onClick={() => act("rename_circuit", { ref: circuit.ref, index: ++i })}>Rename</Button>
+            <Button icon="eye" onClick={() => act("rename_circuit", { ref: circuit.ref })}>Rename</Button>
             <Button icon="eye" onClick={() => act("scan_circuit", { ref: circuit.ref })}>Debugger Scan</Button>
             <Button icon="eye" disabled={!circuit.removable} onClick={() => act("remove_circuit", { ref: circuit.ref, index: ++i })}>Remove</Button>
             <Button icon="eye" onClick={() => act("bottom_circuit", { ref: circuit.ref, index: ++i })}>Move to Bottom</Button>

--- a/tgui/packages/tgui/interfaces/ICAssembly.js
+++ b/tgui/packages/tgui/interfaces/ICAssembly.js
@@ -104,7 +104,7 @@ const ICAssemblyCircuits = (props, context) => {
         {circuits.map((circuit, i) => (
           <LabeledList.Item key={circuit.ref} label={circuit.name} >
             <Button icon="eye" onClick={() => act("open_circuit", { ref: circuit.ref })}>View</Button>
-            <Button icon="eye" onClick={() => act("rename_circuit", { ref: circuit.ref })}>Rename</Button>
+            <Button icon="eye" onClick={() => act("rename_circuit", { ref: circuit.ref, index: ++i })}>Rename</Button>
             <Button icon="eye" onClick={() => act("scan_circuit", { ref: circuit.ref })}>Debugger Scan</Button>
             <Button icon="eye" disabled={!circuit.removable} onClick={() => act("remove_circuit", { ref: circuit.ref, index: ++i })}>Remove</Button>
             <Button icon="eye" onClick={() => act("bottom_circuit", { ref: circuit.ref, index: ++i })}>Move to Bottom</Button>

--- a/tgui/packages/tgui/interfaces/ICCircuit.js
+++ b/tgui/packages/tgui/interfaces/ICCircuit.js
@@ -83,7 +83,7 @@ export const ICCircuit = (props, context) => {
           </Flex>
           <Section title="Triggers">
             {activators.map(activator => (
-              <LabeledList.Item key={activator.name} label={activator.name}>
+              <LabeledList.Item key={activator.name} label={activator.displayed_name}>
                 <Button
                   onClick={() => act("pin_name", { pin: activator.ref })}>
                   {activator.pulse_out ? "<PULSE OUT>" : "<PULSE IN>"}


### PR DESCRIPTION
## About The Pull Request

This lets you rename circuit components and have the UI reflect their changed name where important. This includes in button displays on the assembly itself, and in wire connections in the circuits.

Previously, the behavior was bugged to either not update; or not display the renamed component's new name as it should.

i also didn't really see a reason rename_component should have been a verb; as it was wholly being used like a proc anyway.

## Why It's Good For The Game

It makes it a lot easier to make sense of circuits if you can rename circuits and have easy connections of 'this addition circuit goes to this specifically named list'. It was also questionably bugged to not update before in most cases.
it was also just partially bugged to not update.

## Changelog

:cl:
tweak: Circuit wire connections will display displayed_name instead of name
fix: Renaming circuits now updates the assembly UI elements.
tweak: Rename_component is now a proc instead of a verb.
/:cl: