### PR TITLE
circuit move to bottom fix

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -265,12 +265,14 @@
 				return
 			// Puts it at the bottom of our contents
 			// Note, this intentionally does *not* use forceMove, because forceMove will stop if it detects the same loc
-			ui_circuit_props.Cut(params["index"], 1 + params["index"])
+			var/index = assembly_components.Find(C)
+			ui_circuit_props.Cut(index, 1 + index)
 			ui_circuit_props.Add(list(list("name" = C.displayed_name,"ref" = REF(C),"removable" = C.removable,"input" = C.can_be_asked_input)))
-			assembly_components.Cut(params["index"], 1 + params["index"])
+			assembly_components.Cut(index, 1 + index)
 			assembly_components.Add(C)
 			C.loc = null
 			C.loc = src
+			return TRUE
 
 		if("input_selection")
 			var/obj/item/integrated_circuit/input/C = locate(params["ref"]) in assembly_components


### PR DESCRIPTION
## About The Pull Request

Moving a circuit to the bottom of the assembly would occasionally overwrite another component's slot with itself as a duplicate; especially if you spammed it. This prevents that behavior entirely.

## Why It's Good For The Game

It makes less of a bug.

## Changelog

:cl:
fix: Moving a circuit component to the bottom of the assembly won't cause the occasional overwrite & duplicate.
/:cl: