### PR TITLE
circuit debugger ref copy UI fixes

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -245,7 +245,7 @@
 			if(istype(held_item, /obj/item/integrated_electronics/debugger))
 				var/obj/item/integrated_electronics/debugger/D = held_item
 				if(D.accepting_refs)
-					D.afterattack(C, usr, TRUE)
+					D.afterattack(C, usr, CLICKCHAIN_HAS_PROXIMITY)
 				else
 					to_chat(usr, SPAN_WARNING("The Debugger's 'ref scanner' needs to be on."))
 			else

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -255,7 +255,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 			if(istype(held_item, /obj/item/integrated_electronics/debugger))
 				var/obj/item/integrated_electronics/debugger/D = held_item
 				if(D.accepting_refs)
-					D.afterattack(src, usr, TRUE)
+					D.afterattack(src, usr, CLICKCHAIN_HAS_PROXIMITY)
 				else
 					to_chat(usr, SPAN_WARNING("The Debugger's 'ref scanner' needs to be on."))
 			else


### PR DESCRIPTION
## About The Pull Request

Circuit debugger on ref mode wouldn't copy a circuit reference if you pressed debugger scan because of invalid clickchain flags

## Why It's Good For The Game

less bug. Also lets you use circuit debugger on built-in components as it should be able to easily.

## Changelog

cl:
fix: Circuit Ref debugger will now properly copy references inside a circuit.
/:cl: