### PR TITLE
Integrated circuit removal bug

### DIFF
--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -271,7 +271,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 					examined.ui_interact(usr)
 
 		if("remove")
-			remove(usr, index = params["index"])
+			remove(usr, FALSE, index = params["index"])
 			return
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Clicking on remove in the circuit component UI itself (not the assembly) would end up not properly removing the component like how clicking remove in the assembly would.

## Why It's Good For The Game

It fixes a bug.

## Changelog

:cl:
fix: Clicking on remove in a circuit component's UI will now properly remove it from a assembly.
/:cl: