### PR TITLE
non standard circuit support

### DIFF
--- a/code/__DEFINES/research/integrated_circuits.dm
+++ b/code/__DEFINES/research/integrated_circuits.dm
@@ -3,3 +3,8 @@
 #define IC_SPAWN_DEFAULT			1
 /// If the circuit design will be available in the IC printer after upgrading it.
 #define IC_SPAWN_RESEARCH 			2
+
+#define NON_STANDARD_CIRCUIT_LIST list(/obj/item/implant/integrated_circuit, /obj/item/clothing/under/circuitry,\
+		/obj/item/clothing/gloves/circuitry, /obj/item/clothing/gloves/ewatch, /obj/item/clothing/glasses/circuitry,\
+		/obj/item/clothing/shoes/circuitry, /obj/item/clothing/head/circuitry, /obj/item/clothing/ears/circuitry,\
+		/obj/item/clothing/suit/circuitry)

--- a/code/controllers/subsystem/processing/circuits.dm
+++ b/code/controllers/subsystem/processing/circuits.dm
@@ -48,6 +48,11 @@ PROCESSING_SUBSYSTEM_DEF(circuit)
 		all_assemblies[name] = path
 		cached_assemblies[A] = new path
 
+	for(var/path in NON_STANDARD_CIRCUIT_LIST)
+		var/obj/item/A = path
+		var/name = initial(A.name)
+		all_assemblies[name] = path
+		cached_assemblies[A] = new path
 
 	circuit_fabricator_recipe_list["Assemblies"] = list(
 		/obj/item/electronic_assembly/tiny/default,

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -119,6 +119,11 @@
 	var/list/assembly_params = list()
 
 	// Save initial name used for differentiating assemblies
+	if(istype(src, /obj/item/electronic_assembly/clothing))
+		var/obj/item/electronic_assembly/clothing/clothingCheck = src
+		if(clothingCheck.clothing)
+			assembly_params["container"] = initial(clothingCheck.clothing.name)
+
 	assembly_params["type"] = initial(name)
 
 	// Save modified name
@@ -239,11 +244,25 @@
 	if(!islist(assembly_params) || !length(assembly_params))
 		return "Invalid assembly data."	// No assembly, damaged assembly or empty assembly
 
+	// Validate any possible container.
+	// Minor note that the only other containers for assemblies are clothing at the moment; this type should be changed if that changes.
+	var/obj/item/clothing/possible_container
+	if(assembly_params["container"])
+		var/container_path = all_assemblies[assembly_params["container"]]
+		possible_container = cached_assemblies[container_path]
+		if(!possible_container)
+			return "Invalid container type."
+
 	// Validate type, get a temporary component
 	var/assembly_path = all_assemblies[assembly_params["type"]]
 	var/obj/item/electronic_assembly/assembly = cached_assemblies[assembly_path]
 	if(!assembly)
 		return "Invalid assembly type."
+
+	// Make sure the container is supposed to have that type of assembly.
+	if(possible_container)
+		if(possible_container.EA.type != assembly.type)
+			return "Invalid assembly in container."
 
 	// Check assembly save data for errors
 	error = assembly.verify_save(assembly_params)
@@ -293,7 +312,9 @@
 
 		// Check if the assembly requires printer upgrades
 		if(!(component.spawn_flags & IC_SPAWN_DEFAULT))
-			blocks["requires_upgrades"] = TRUE
+			// We don't actually care about built in components.
+			if(component.removable)
+				blocks["requires_upgrades"] = TRUE
 
 		// Check if the assembly supports the circucit
 		if((component.action_flags & assembly.allowed_circuit_action_flags) != component.action_flags)
@@ -335,8 +356,16 @@
 
 	// Block 1.  Assembly.
 	var/list/assembly_params = blocks["assembly"]
-	var/obj/item/electronic_assembly/assembly_path = all_assemblies[assembly_params["type"]]
-	var/obj/item/electronic_assembly/assembly = new assembly_path(null)
+	var/obj/item/electronic_assembly/assembly
+	var/obj/item/clothing/clothing
+	if(assembly_params["container"])
+		var/obj/item/clothing/clothing_path = all_assemblies[assembly_params["container"]]
+		clothing = new clothing_path(null)
+		if(clothing.EA)
+			assembly = clothing.EA
+	else
+		var/obj/item/electronic_assembly/assembly_path = all_assemblies[assembly_params["type"]]
+		assembly = new assembly_path(null)
 	assembly.load(assembly_params)
 
 
@@ -344,6 +373,8 @@
 	// Block 2.  Components.
 	for(var/component_params in blocks["components"])
 		var/obj/item/integrated_circuit/component_path = all_components[component_params["type"]]
+		if(!initial(component_path.removable))
+			continue
 		var/obj/item/integrated_circuit/component = new component_path(assembly)
 		assembly.add_component(component)
 		component.load(component_params)
@@ -357,5 +388,8 @@
 			var/datum/integrated_io/IO2 = assembly.get_pin_ref_list(wire[2])
 			IO.connect_pin(IO2)
 
-	assembly.forceMove(loc)
+	if(clothing)
+		clothing.forceMove(loc)
+	else
+		assembly.forceMove(loc)
 	return assembly


### PR DESCRIPTION
## About The Pull Request

If you attempted to make blueprints off of electronic components like an electronic jumpsuit or similar clothing, it would end up not working at all and making a fake assembly object. This lets the component able to be properly put into a blueprint and loaded back in.

## Why It's Good For The Game

It makes it possible to actually use electronic clothing and blueprint it. This means that the item works as needed, and you won't run into issues when you inevitably realize it isn't copying properly, losing 4 hours of work. 💀
 
## Changelog

:cl:
fix: Electronic clothes will now save and load from a blueprint.
/:cl: