### PR TITLE
Circuit component blueprint name validation fix

### DIFF
--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -53,7 +53,7 @@
 /obj/item/integrated_circuit/proc/verify_save(list/component_params)
 	var/init_name = initial(name)
 	// Validate name
-	if(component_params["name"] && component_params["name"] != sanitizeName(component_params["name"]))
+	if(component_params["name"] && component_params["name"] != sanitizeSafe(component_params["name"], MAX_MESSAGE_LEN, 0, 0))
 		return "Bad component name at [init_name]."
 
 	// Validate input values
@@ -140,7 +140,7 @@
 // Returns null on success, error name on failure
 /obj/item/electronic_assembly/proc/verify_save(list/assembly_params)
 	// Validate name and color
-	if(assembly_params["name"] && assembly_params["name"] != sanitizeName(assembly_params["name"]))
+	if(assembly_params["name"] && assembly_params["name"] != sanitizeSafe(assembly_params["name"], MAX_MESSAGE_LEN, 0, 0))
 		return "Bad assembly name."
 	if(assembly_params["desc"] && !reject_bad_text(assembly_params["desc"]))
 		return "Bad assembly description."


### PR DESCRIPTION
## About The Pull Request

If you try to load a blueprint as is and have a renamed component in it, it's likely that the component won't output a sanitized text correctly to compare because it uses sanitizeName which capitalizes the first letter; which isn't particularly the correct behavior. sanitizeSafe seems to be the proper one to use here. (correct me if I'm wrong)

Doesn't really make sense that components HAVE to have an uppercase first letter either; so this fixes that.
If I'm using the wrong proc tell me :slime:

## Why It's Good For The Game

Cuts down on confusion regarding circuit names and arbitrary restrictions.

## Changelog

:cl:
change: Circuit components loaded in from a blueprint no longer require an uppercase first letter to load in properly.
/:cl: