### PR TITLE
Circuit demux fix & data to pin ref fixes

### DIFF
--- a/code/modules/integrated_electronics/core/helpers.dm
+++ b/code/modules/integrated_electronics/core/helpers.dm
@@ -21,12 +21,6 @@
 
 
 /obj/item/integrated_circuit/proc/set_pin_data(pin_type, pin_number, datum/new_data)
-	if(islist(new_data))
-		for(var/i in 1 to length(new_data))
-			if (istype(new_data) && !isweakref(new_data))
-				new_data[i] = WEAKREF(new_data[i])
-	if (istype(new_data) && !isweakref(new_data))
-		new_data = WEAKREF(new_data)
 	var/datum/integrated_io/pin = get_pin_ref(pin_type, pin_number)
 	return pin.write_data_to_pin(new_data)
 

--- a/code/modules/integrated_electronics/core/pins.dm
+++ b/code/modules/integrated_electronics/core/pins.dm
@@ -146,7 +146,13 @@ list[](
 	return FALSE
 */
 
-/datum/integrated_io/proc/write_data_to_pin(new_data)
+/datum/integrated_io/proc/write_data_to_pin(datum/new_data)
+	if(islist(new_data))
+		for(var/i in 1 to length(new_data))
+			if (istype(new_data) && !isweakref(new_data))
+				new_data[i] = WEAKREF(new_data[i])
+	if (istype(new_data) && !isweakref(new_data))
+		new_data = WEAKREF(new_data)
 	if(isnull(new_data) || isnum(new_data) || istext(new_data) || isweakref(new_data)) // Anything else is a type we don't want.
 		if(istext(new_data))
 			new_data = sanitizeSafe(new_data, MAX_MESSAGE_LEN, 0, 0)

--- a/code/modules/integrated_electronics/subtypes/converters.dm
+++ b/code/modules/integrated_electronics/subtypes/converters.dm
@@ -76,6 +76,10 @@
 
 /obj/item/integrated_circuit/converter/refcode/do_work()
 	var/result = null
+	var/datum/data = get_pin_data(IC_INPUT, 1)
+
+	if(!istype(data)) return
+
 	var/atom/A = get_pin_data(IC_INPUT, 1)
 	if(A && istype(A))
 		result = add_data_signature("\ref[A]")
@@ -94,8 +98,11 @@
 	var/dec
 
 /obj/item/integrated_circuit/converter/refdecode/do_work()
+	var/data = get_pin_data(IC_INPUT, 1)
 
-	var/list/signature_and_data = splittext(get_pin_data(IC_INPUT, 1), ":")
+	if(!istext(data)) return
+
+	var/list/signature_and_data = splittext(data, ":")
 	var/signature = signature_and_data[1]
 	var/dec = signature_and_data[2]
 

--- a/code/modules/integrated_electronics/subtypes/data_transfer.dm
+++ b/code/modules/integrated_electronics/subtypes/data_transfer.dm
@@ -76,9 +76,8 @@
 /obj/item/integrated_circuit/transfer/demultiplexer/do_work()
 	var/output_index = get_pin_data(IC_INPUT, 1)
 	if(!isnull(output_index) && (output_index >= 1 && output_index <= outputs.len))
-		var/datum/integrated_io/O = outputs[output_index]
-		O.data = get_pin_data(IC_INPUT, 2)
-		O.push_data()
+		set_pin_data(IC_OUTPUT,output_index,get_pin_data(IC_INPUT, 2))
+		push_data()
 
 	activate_pin(2)
 


### PR DESCRIPTION
## About The Pull Request

This fixes a issue with data writing to circuit component pins where it would store a raw reference instead of a weakref. This also fixes an issue with demux's where they would write a raw reference.

## Why It's Good For The Game

less random refs instead of weakrefs in circuits. also bug fixz

## Changelog

:cl:
fix: Demux pins write valid weakrefs to outputs.
fix: Circuit data written will always be in a weakref state instead of a ref.
tweak: Circuit ref converters will check if the data is a valid input before attempting conversions.
/:cl: