### PR TITLE
Circuit advanced signaler changes

### DIFF
--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -768,27 +768,21 @@
 	The two input pins are to configure the integrated signaler's settings.  Note that the frequency should not have a decimal in it.  \
 	Meaning the default frequency is expressed as 1457, not 145.7.  To send a signal, pulse the 'send signal' activator pin. Set the command output to set the message received."
 	complexity = 8
-	inputs = list("frequency" = IC_PINTYPE_NUMBER, "id tag" = IC_PINTYPE_STRING, "command" = IC_PINTYPE_STRING)
+	inputs = list("frequency" = IC_PINTYPE_NUMBER, "id tag" = IC_PINTYPE_NUMBER, "command" = IC_PINTYPE_STRING)
 	outputs = list("received command" = IC_PINTYPE_STRING)
 	var/command
-	code = "Integrated_Circuits"
+	code = 30
 	simple = 0
 
 /obj/item/integrated_circuit/input/signaler/advanced/on_data_written()
 	..()
 	command = get_pin_data(IC_INPUT,3)
 
-/obj/item/integrated_circuit/input/signaler/advanced/signal_good(datum/signal/signal)
-	if(!..() || signal.data["tag"] != code)
-		return FALSE
-	return TRUE
-
 /obj/item/integrated_circuit/input/signaler/advanced/create_signal()
 	var/datum/signal/signal = new()
 	signal.transmission_method = 1
-	signal.data["tag"] = code
 	signal.data["command"] = command
-	signal.encryption = 0
+	signal.encryption = code
 	return signal
 
 /obj/item/integrated_circuit/input/signaler/advanced/treat_signal(datum/signal/signal)

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -764,11 +764,11 @@
 	name = "advanced integrated signaler"
 	icon_state = "signal_advanced"
 	desc = "Signals from a signaler can be received with this, allowing for remote control.  Additionally, it can send signals as well."
-	extended_desc = "When a signal is received from another signaler with the right id tag, the 'on signal received' activator pin will be pulsed and the command output is updated.  \
+	extended_desc = "When a signal is received from another signaler with the right code, the 'on signal received' activator pin will be pulsed and the command output is updated.  \
 	The two input pins are to configure the integrated signaler's settings.  Note that the frequency should not have a decimal in it.  \
 	Meaning the default frequency is expressed as 1457, not 145.7.  To send a signal, pulse the 'send signal' activator pin. Set the command output to set the message received."
 	complexity = 8
-	inputs = list("frequency" = IC_PINTYPE_NUMBER, "id tag" = IC_PINTYPE_NUMBER, "command" = IC_PINTYPE_STRING)
+	inputs = list("frequency" = IC_PINTYPE_NUMBER, "code" = IC_PINTYPE_NUMBER, "command" = IC_PINTYPE_STRING)
 	outputs = list("received command" = IC_PINTYPE_STRING)
 	var/command
 	code = 30


### PR DESCRIPTION
## About The Pull Request

It changes the tag used on circuit advanced signalers to use a number like the normal signaler. 
This improves reliability and fixes a few core bugs with the advanced signaler design such as non-responsive outputs in some scenarios.

This **will** minorly break pre-existing JSON exports for circuits that use advanced signalers, but is easily gotten around by printing the assembly and adding a number to where the ID tag previously went.

## Why It's Good For The Game

It makes advanced signalers far more reliable and standardized than how they were before. Primarily, it also fixes a few issues with getting circuits to output and receive data when using advanced signalers reliably.

## Changelog

:cl:
tweak: Circuit's Advanced Signaler now uses a number for its ID Tag; which is now labeled code.
fix: Advanced signalers are now more reliable in use.
/:cl: