### PR TITLE
Electronic Clothing now displays on action bar.

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies/clothing.dm
+++ b/code/modules/integrated_electronics/core/assemblies/clothing.dm
@@ -15,9 +15,6 @@
 /obj/item/electronic_assembly/clothing/ui_host()
 	return clothing.ui_host()
 
-/obj/item/electronic_assembly/clothing/ui_action_click(datum/action/action, datum/event_args/actor/actor)
-	clothing.action_circuit.do_work()
-
 // This is 'small' relative to the size of regular clothing assemblies.
 /obj/item/electronic_assembly/clothing/small
 	name = "small electronic clothing parts"
@@ -83,6 +80,11 @@
 /obj/item/clothing/on_loc_moved(oldloc)
 	EA ? EA.on_loc_moved(oldloc) : ..()
 
+/obj/item/clothing/ui_action_click(datum/action/action, datum/event_args/actor/actor)
+	. = ..()
+	if(EA && action_circuit)
+		action_circuit.do_work()
+
 // Does most of the repeatative setup.
 /obj/item/clothing/proc/setup_integrated_circuit(new_type)
 	// Set up the internal circuit holder.
@@ -94,8 +96,7 @@
 	EA.add_component(action_circuit)
 	var/obj/item/integrated_circuit/built_in/self_sensor/S = new(src.EA)
 	EA.add_component(S)
-	EA.item_action_name = "Activate [name]"
-
+	item_action_name = "Activate [name]"
 
 
 /obj/item/clothing/Destroy()


### PR DESCRIPTION
## About The Pull Request

circuit assemblies with an action circuit didn't work because the action bar didn't create a spot. After all, you don't have the electronic assembly equipped, but rather the clothing itself. this rectifies that, and attaches the behavior to the electronic clothing instead.

## Why It's Good For The Game

it fixes an otherwise non-functional circuit.

## Changelog

:cl:
fix: Electronic Clothing will now properly show on the action bar.
/:cl:
