### PR TITLE
A variety of circuit fucky wuckys fixes.

### DIFF
--- a/code/modules/integrated_electronics/core/helpers.dm
+++ b/code/modules/integrated_electronics/core/helpers.dm
@@ -61,9 +61,13 @@
 
 /datum/integrated_io/proc/get_data()
 	if(islist(data))
-		for(var/i in 1 to length(data))
-			if(isweakref(data[i]))
-				data[i] = data[i].resolve()
+		var/list/d = data
+		var/list/new_data = d.Copy(max(1,d.len - IC_MAX_LIST_LENGTH+1),0)
+		for(var/i in 1 to length(new_data))
+			var/datum/dataRef = new_data[i]
+			if(istype(dataRef) && !isweakref(dataRef))
+				new_data[i] = WEAKREF(dataRef)
+		return new_data
 	if(isweakref(data))
 		return data.resolve()
 	return data

--- a/code/modules/integrated_electronics/core/pins.dm
+++ b/code/modules/integrated_electronics/core/pins.dm
@@ -158,14 +158,15 @@ list[](
 		var/list/new_list = new_data
 		data = new_list.Copy(max(1,new_list.len - IC_MAX_LIST_LENGTH+1),0)
 		for(var/i in 1 to length(data))
-			if (istype(data[i]) && !isweakref(data[i]))
-				data[i] = WEAKREF(data[i])
+			var/datum/dataRef = data[i]
+			if(istype(dataRef) && !isweakref(dataRef))
+				data[i] = WEAKREF(dataRef)
 		holder.on_data_written()
 
 /datum/integrated_io/proc/push_data()
 	for(var/k in 1 to linked.len)
 		var/datum/integrated_io/io = linked[k]
-		io.write_data_to_pin(data)
+		io.write_data_to_pin(get_data())
 
 /datum/integrated_io/activate/push_data()
 	for(var/k in 1 to linked.len)

--- a/code/modules/integrated_electronics/core/pins.dm
+++ b/code/modules/integrated_electronics/core/pins.dm
@@ -147,10 +147,6 @@ list[](
 */
 
 /datum/integrated_io/proc/write_data_to_pin(datum/new_data)
-	if(islist(new_data))
-		for(var/i in 1 to length(new_data))
-			if (istype(new_data) && !isweakref(new_data))
-				new_data[i] = WEAKREF(new_data[i])
 	if (istype(new_data) && !isweakref(new_data))
 		new_data = WEAKREF(new_data)
 	if(isnull(new_data) || isnum(new_data) || istext(new_data) || isweakref(new_data)) // Anything else is a type we don't want.
@@ -161,6 +157,9 @@ list[](
 	else if(islist(new_data))
 		var/list/new_list = new_data
 		data = new_list.Copy(max(1,new_list.len - IC_MAX_LIST_LENGTH+1),0)
+		for(var/i in 1 to length(data))
+			if (istype(data[i]) && !isweakref(data[i]))
+				data[i] = WEAKREF(data[i])
 		holder.on_data_written()
 
 /datum/integrated_io/proc/push_data()

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -376,8 +376,8 @@
 		if(!initial(component_path.removable))
 			continue
 		var/obj/item/integrated_circuit/component = new component_path(assembly)
-		assembly.add_component(component)
 		component.load(component_params)
+		assembly.add_component(component)
 
 
 	// Block 3.  Wires.

--- a/code/modules/integrated_electronics/core/special_pins/lists_pin.dm
+++ b/code/modules/integrated_electronics/core/special_pins/lists_pin.dm
@@ -113,6 +113,10 @@
 	if(islist(new_data))
 		var/list/new_list = new_data
 		data = new_list.Copy(max(1,new_list.len - IC_MAX_LIST_LENGTH+1),0)
+		for(var/i in 1 to length(data))
+			var/datum/dataRef = data[i]
+			if(istype(dataRef) && !isweakref(dataRef))
+				data[i] = WEAKREF(dataRef)
 		holder.on_data_written()
 	else if(isnull(new_data))	// Clear the list
 		var/list/my_list = data

--- a/code/modules/integrated_electronics/core/special_pins/ref_pin.dm
+++ b/code/modules/integrated_electronics/core/special_pins/ref_pin.dm
@@ -5,9 +5,12 @@
 /datum/integrated_io/ref/ask_for_pin_data(mob/user) // This clears the pin.
 	write_data_to_pin(null)
 
-/datum/integrated_io/ref/write_data_to_pin(var/new_data)
-	if(isnull(new_data) || isweakref(new_data))
+/datum/integrated_io/ref/write_data_to_pin(datum/new_data)
+	if(isnull(new_data))
 		data = new_data
+		holder.on_data_written()
+	else if(istype(new_data))
+		data = WEAKREF(new_data)
 		holder.on_data_written()
 
 /datum/integrated_io/ref/display_pin_type()

--- a/code/modules/integrated_electronics/subtypes/filters.dm
+++ b/code/modules/integrated_electronics/subtypes/filters.dm
@@ -17,16 +17,15 @@
 	inputs = list( "input" = IC_PINTYPE_REF )
 	outputs = list("result" = IC_PINTYPE_BOOLEAN, "self ref" = IC_PINTYPE_SELFREF)
 
-/obj/item/integrated_circuit/filter/ref/may_pass(var/datum/weakref/data)
-	if(!(filter_type && isweakref(data)))
+/obj/item/integrated_circuit/filter/ref/may_pass(var/datum/data)
+	if(!(filter_type && data))
 		return FALSE
-	var/datum/weakref/wref = data
-	return istype(wref.resolve(), filter_type)
+	return istype(data, filter_type)
 
 /obj/item/integrated_circuit/filter/ref/do_work()
-	var/datum/integrated_io/A = inputs[1]
-	var/datum/integrated_io/O = outputs[1]
-	O.data = may_pass(A.data) ? TRUE : FALSE
+	var/A = get_pin_data(IC_INPUT, 1)
+	get_pin_data(IC_INPUT, 1)
+	set_pin_data(IC_OUTPUT, 1, may_pass(A) ? TRUE : FALSE)
 
 	if(get_pin_data(IC_OUTPUT, 1))
 		activate_pin(2)
@@ -92,25 +91,19 @@
 
 /obj/item/integrated_circuit/filter/ref/custom
 	name = "custom filter"
-	desc = "Allows custom filtering.  It will match type against a stored reference."
+	desc = "Allows custom filtering.  It will match type against a stored reference; it will also take a type string."
 	icon_state = "filter_custom"
-	inputs = list( "input" = IC_PINTYPE_REF, "expected type" = IC_PINTYPE_REF )
+	inputs = list( "input" = IC_PINTYPE_REF, "expected type" = IC_PINTYPE_ANY)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/filter/ref/custom/may_pass(var/datum/weakref/data, var/datum/weakref/typedata)
-	if(!isweakref(data) || !isweakref(typedata))
-		return FALSE
-	var/datum/weakref/wref = data
-	var/datum/weakref/wref2 = typedata
-	var/atom/A = wref.resolve()
-	var/atom/B = wref2.resolve()
-	return (A && B && (istype(A, B.type)))
+/obj/item/integrated_circuit/filter/ref/custom/may_pass(var/datum/data, var/datum/typedata)
+	if(!istype(typedata) && !istext(typedata)) return FALSE
+	return (data && typedata && (istype(data, typedata)))
 
 /obj/item/integrated_circuit/filter/ref/custom/do_work()
-	var/datum/integrated_io/A = inputs[1]
-	var/datum/integrated_io/T = inputs[2]
-	var/datum/integrated_io/O = outputs[1]
-	O.data = may_pass(A.data, T.data) ? TRUE : FALSE
+	var/A = get_pin_data(IC_INPUT, 1)
+	var/T = get_pin_data(IC_INPUT, 2)
+	set_pin_data(IC_OUTPUT, 1, may_pass(A, T) ? TRUE : FALSE)
 
 	if(get_pin_data(IC_OUTPUT, 1))
 		activate_pin(2)
@@ -132,13 +125,12 @@
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
 /obj/item/integrated_circuit/filter/string/may_pass(var/datum/integrated_io/A, var/datum/integrated_io/B)
-	return A.data == B.data
+	return A == B
 
 /obj/item/integrated_circuit/filter/string/do_work()
-	var/datum/integrated_io/A = inputs[1]
-	var/datum/integrated_io/B = inputs[2]
-	var/datum/integrated_io/O = outputs[1]
-	O.data = may_pass(A, B) ? TRUE : FALSE
+	var/A = get_pin_data(IC_INPUT, 1)
+	var/B = get_pin_data(IC_INPUT, 2)
+	set_pin_data(IC_OUTPUT, 1, may_pass(A, B) ? TRUE : FALSE)
 
 	if(get_pin_data(IC_OUTPUT, 1))
 		activate_pin(2)

--- a/code/modules/integrated_electronics/subtypes/lists.dm
+++ b/code/modules/integrated_electronics/subtypes/lists.dm
@@ -13,7 +13,7 @@
 		)
 	category_text = "Lists"
 	power_draw_per_use = 20
-	cooldown_per_use = 10
+	cooldown_per_use = 1
 
 /obj/item/integrated_circuit/lists/pick
 	name = "pick circuit"
@@ -29,7 +29,6 @@
 		"on failure" = IC_PINTYPE_PULSE_OUT,
 		)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	cooldown_per_use = 1
 
 /obj/item/integrated_circuit/lists/pick/do_work()
 	var/list/input_list = get_pin_data(IC_INPUT, 1) // List pins guarantee that there is a list inside, even if just an empty one.
@@ -86,7 +85,6 @@
 	icon_state = "addition"
 	complexity = 2
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	cooldown_per_use = 1
 
 /obj/item/integrated_circuit/lists/search/do_work()
 	var/list/input_list = get_pin_data(IC_INPUT, 1)
@@ -204,7 +202,6 @@
 		)
 	icon_state = "addition"
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	cooldown_per_use = 1
 
 /obj/item/integrated_circuit/lists/at/do_work()
 	var/list/input_list = get_pin_data(IC_INPUT, 1)
@@ -308,7 +305,6 @@
 	set_pin_data(IC_OUTPUT, 1, input_list.len)
 	push_data()
 	activate_pin(2)
-	cooldown_per_use = 1
 
 
 /obj/item/integrated_circuit/lists/jointext
@@ -331,7 +327,6 @@
 		)
 	icon_state = "addition"
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	cooldown_per_use = 1
 
 /obj/item/integrated_circuit/lists/jointext/do_work()
 	var/list/input_list = get_pin_data(IC_INPUT, 1)

--- a/code/modules/integrated_electronics/subtypes/logic.dm
+++ b/code/modules/integrated_electronics/subtypes/logic.dm
@@ -16,10 +16,9 @@
 	activators = list("compare" = IC_PINTYPE_PULSE_IN, "on true result" = IC_PINTYPE_PULSE_OUT, "on false result" = IC_PINTYPE_PULSE_OUT)
 
 /obj/item/integrated_circuit/logic/binary/do_work()
-	var/datum/integrated_io/A = inputs[1]
-	var/datum/integrated_io/B = inputs[2]
-	var/datum/integrated_io/O = outputs[1]
-	O.data = do_compare(A, B) ? TRUE : FALSE
+	var/A = get_pin_data(IC_INPUT, 1)
+	var/B = get_pin_data(IC_INPUT, 2)
+	set_pin_data(IC_OUTPUT, 1, do_compare(A, B) ? TRUE : FALSE)
 
 	if(get_pin_data(IC_OUTPUT, 1))
 		activate_pin(2)
@@ -27,24 +26,24 @@
 		activate_pin(3)
 	..()
 
-/obj/item/integrated_circuit/logic/binary/proc/do_compare(var/datum/integrated_io/A, var/datum/integrated_io/B)
+/obj/item/integrated_circuit/logic/binary/proc/do_compare(var/datum/A, var/datum/B)
 	return FALSE
 
-/obj/item/integrated_circuit/logic/binary/proc/comparable(var/datum/integrated_io/A, var/datum/integrated_io/B)
-	return (isnum(A.data) && isnum(B.data)) || (istext(A.data) && istext(B.data))
+/obj/item/integrated_circuit/logic/binary/proc/comparable(var/datum/A, var/datum/B)
+	return (isnum(A) && isnum(B)) || (istext(A) && istext(B))
 
 /obj/item/integrated_circuit/logic/unary
 	inputs = list("A" = IC_PINTYPE_ANY)
 	activators = list("compare" = IC_PINTYPE_PULSE_IN, "on compare" = IC_PINTYPE_PULSE_OUT)
 
 /obj/item/integrated_circuit/logic/unary/do_work()
-	var/datum/integrated_io/A = inputs[1]
-	var/datum/integrated_io/O = outputs[1]
-	O.data = do_check(A) ? TRUE : FALSE
+	var/A = get_pin_data(IC_INPUT, 1)
+	set_pin_data(IC_OUTPUT, 1, do_check(A) ? TRUE : FALSE)
+
 	..()
 	activate_pin(2)
 
-/obj/item/integrated_circuit/logic/unary/proc/do_check(var/datum/integrated_io/A)
+/obj/item/integrated_circuit/logic/unary/proc/do_check(var/datum/A)
 	return FALSE
 
 /obj/item/integrated_circuit/logic/binary/equals
@@ -53,8 +52,8 @@
 	icon_state = "equal"
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/logic/binary/equals/do_compare(var/datum/integrated_io/A, var/datum/integrated_io/B)
-	return A.data == B.data
+/obj/item/integrated_circuit/logic/binary/equals/do_compare(var/datum/A, var/datum/B)
+	return A == B
 
 /obj/item/integrated_circuit/logic/binary/jklatch
 	name = "JK latch"
@@ -67,20 +66,18 @@
 	var/lstate=FALSE
 
 /obj/item/integrated_circuit/logic/binary/jklatch/do_work()
-	var/datum/integrated_io/A = inputs[1]
-	var/datum/integrated_io/B = inputs[2]
-	var/datum/integrated_io/O = outputs[1]
-	var/datum/integrated_io/Q = outputs[2]
-	if(A.data)
-		if(B.data)
+	var/A = get_pin_data(IC_INPUT, 1)
+	var/B = get_pin_data(IC_INPUT, 2)
+	if(A)
+		if(B)
 			lstate=!lstate
 		else
 			lstate = TRUE
 	else
-		if(B.data)
+		if(B)
 			lstate=FALSE
-	O.data = lstate ? TRUE : FALSE
-	Q.data = !lstate ? TRUE : FALSE
+	set_pin_data(IC_OUTPUT, 1, lstate ? TRUE : FALSE)
+	set_pin_data(IC_OUTPUT, 2, !lstate ? TRUE : FALSE)
 	if(get_pin_data(IC_OUTPUT, 1))
 		activate_pin(2)
 	else
@@ -98,18 +95,16 @@
 	var/lstate=FALSE
 
 /obj/item/integrated_circuit/logic/binary/rslatch/do_work()
-	var/datum/integrated_io/A = inputs[1]
-	var/datum/integrated_io/B = inputs[2]
-	var/datum/integrated_io/O = outputs[1]
-	var/datum/integrated_io/Q = outputs[2]
-	if(A.data)
-		if(!B.data)
+	var/A = get_pin_data(IC_INPUT, 1)
+	var/B = get_pin_data(IC_INPUT, 2)
+	if(A)
+		if(!B)
 			lstate=TRUE
 	else
-		if(B.data)
+		if(B)
 			lstate=FALSE
-	O.data = lstate ? TRUE : FALSE
-	Q.data = !lstate ? TRUE : FALSE
+	set_pin_data(IC_OUTPUT, 1, lstate ? TRUE : FALSE)
+	set_pin_data(IC_OUTPUT, 2, !lstate ? TRUE : FALSE)
 	if(get_pin_data(IC_OUTPUT, 1))
 		activate_pin(2)
 	else
@@ -127,18 +122,16 @@
 	var/lstate=FALSE
 
 /obj/item/integrated_circuit/logic/binary/gdlatch/do_work()
-	var/datum/integrated_io/A = inputs[1]
-	var/datum/integrated_io/B = inputs[2]
-	var/datum/integrated_io/O = outputs[1]
-	var/datum/integrated_io/Q = outputs[2]
-	if(B.data)
-		if(A.data)
+	var/A = get_pin_data(IC_INPUT, 1)
+	var/B = get_pin_data(IC_INPUT, 2)
+	if(B)
+		if(A)
 			lstate=TRUE
 		else
 			lstate=FALSE
 
-	O.data = lstate ? TRUE : FALSE
-	Q.data = !lstate ? TRUE : FALSE
+	set_pin_data(IC_OUTPUT, 1, lstate ? TRUE : FALSE)
+	set_pin_data(IC_OUTPUT, 2, !lstate ? TRUE : FALSE)
 	if(get_pin_data(IC_OUTPUT, 1))
 		activate_pin(2)
 	else
@@ -151,8 +144,8 @@
 	icon_state = "not_equal"
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/logic/binary/not_equals/do_compare(var/datum/integrated_io/A, var/datum/integrated_io/B)
-	return A.data != B.data
+/obj/item/integrated_circuit/logic/binary/not_equals/do_compare(var/datum/A, var/datum/B)
+	return A != B
 
 /obj/item/integrated_circuit/logic/binary/and
 	name = "and gate"
@@ -160,8 +153,8 @@
 	icon_state = "and"
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/logic/binary/and/do_compare(var/datum/integrated_io/A, var/datum/integrated_io/B)
-	return A.data && B.data
+/obj/item/integrated_circuit/logic/binary/and/do_compare(var/datum/A, var/datum/B)
+	return A && B
 
 /obj/item/integrated_circuit/logic/binary/or
 	name = "or gate"
@@ -169,8 +162,8 @@
 	icon_state = "or"
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/logic/binary/or/do_compare(var/datum/integrated_io/A, var/datum/integrated_io/B)
-	return A.data || B.data
+/obj/item/integrated_circuit/logic/binary/or/do_compare(var/datum/A, var/datum/B)
+	return A || B
 
 /obj/item/integrated_circuit/logic/binary/less_than
 	name = "less than gate"
@@ -178,9 +171,9 @@
 	icon_state = "less_than"
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/logic/binary/less_than/do_compare(var/datum/integrated_io/A, var/datum/integrated_io/B)
+/obj/item/integrated_circuit/logic/binary/less_than/do_compare(var/datum/A, var/datum/B)
 	if(comparable(A, B))
-		return A.data < B.data
+		return A < B
 
 /obj/item/integrated_circuit/logic/binary/less_than_or_equal
 	name = "less than or equal gate"
@@ -188,9 +181,9 @@
 	icon_state = "less_than_or_equal"
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/logic/binary/less_than_or_equal/do_compare(var/datum/integrated_io/A, var/datum/integrated_io/B)
+/obj/item/integrated_circuit/logic/binary/less_than_or_equal/do_compare(var/datum/A, var/datum/B)
 	if(comparable(A, B))
-		return A.data <= B.data
+		return A <= B
 
 /obj/item/integrated_circuit/logic/binary/greater_than
 	name = "greater than gate"
@@ -198,9 +191,9 @@
 	icon_state = "greater_than"
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/logic/binary/greater_than/do_compare(var/datum/integrated_io/A, var/datum/integrated_io/B)
+/obj/item/integrated_circuit/logic/binary/greater_than/do_compare(var/datum/A, var/datum/B)
 	if(comparable(A, B))
-		return A.data > B.data
+		return A > B
 
 /obj/item/integrated_circuit/logic/binary/greater_than_or_equal
 	name = "greater than or equal gate"
@@ -208,9 +201,9 @@
 	icon_state = "greater_than_or_equal"
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/logic/binary/greater_than_or_equal/do_compare(var/datum/integrated_io/A, var/datum/integrated_io/B)
+/obj/item/integrated_circuit/logic/binary/greater_than_or_equal/do_compare(var/datum/A, var/datum/B)
 	if(comparable(A, B))
-		return A.data >= B.data
+		return A >= B
 
 /obj/item/integrated_circuit/logic/unary/not
 	name = "not gate"
@@ -219,5 +212,5 @@
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	activators = list("invert" = IC_PINTYPE_PULSE_IN, "on inverted" = IC_PINTYPE_PULSE_OUT)
 
-/obj/item/integrated_circuit/logic/unary/not/do_check(var/datum/integrated_io/A)
-	return !A.data
+/obj/item/integrated_circuit/logic/unary/not/do_check(var/datum/A)
+	return !A

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -875,41 +875,41 @@
 	if(!installed_gun)
 		return
 
-	var/datum/integrated_io/target_x = inputs[1]
-	var/datum/integrated_io/target_y = inputs[2]
+	var/target_x = get_pin_data(IC_INPUT, 1)
+	var/target_y = get_pin_data(IC_INPUT, 2)
 
 	if(src.assembly)
-		if(isnum(target_x.data))
-			target_x.data = round(target_x.data)
-		if(isnum(target_y.data))
-			target_y.data = round(target_y.data)
+		if(isnum(target_x))
+			set_pin_data(IC_INPUT, 1, round(target_x))
+		if(isnum(target_y))
+			set_pin_data(IC_INPUT, 2, round(target_y))
 
 		var/turf/T = get_turf(src.assembly)
 
-		if(target_x.data == 0 && target_y.data == 0) // Don't shoot ourselves.
+		if(target_x == 0 && target_y == 0) // Don't shoot ourselves.
 			return
 
 		// We need to do this in order to enable relative coordinates, as locate() only works for absolute coordinates.
 		var/i
-		if(target_x.data > 0)
-			i = abs(target_x.data)
+		if(target_x > 0)
+			i = abs(target_x)
 			while(i > 0)
 				T = get_step(T, EAST)
 				i--
 		else
-			i = abs(target_x.data)
+			i = abs(target_x)
 			while(i > 0)
 				T = get_step(T, WEST)
 				i--
 
 		i = 0
-		if(target_y.data > 0)
-			i = abs(target_y.data)
+		if(target_y > 0)
+			i = abs(target_y)
 			while(i > 0)
 				T = get_step(T, NORTH)
 				i--
-		else if(target_y.data < 0)
-			i = abs(target_y.data)
+		else if(target_y < 0)
+			i = abs(target_y)
 			while(i > 0)
 				T = get_step(T, SOUTH)
 				i--

--- a/code/modules/integrated_electronics/subtypes/memory.dm
+++ b/code/modules/integrated_electronics/subtypes/memory.dm
@@ -22,22 +22,16 @@
 	. = ..()
 	var/i
 	for(i = 1, i <= outputs.len, i++)
-		var/datum/integrated_io/O = outputs[i]
+		var/O = get_pin_data(IC_OUTPUT, i)
 		var/data = "nothing"
-		if(isweakref(O.data))
-			var/datum/d = O.data_as_type(/datum)
-			if(d)
-				data = "[d]"
-		else if(!isnull(O.data))
-			data = O.data
+		if(!isnull(O))
+			data = O
 		. += "\The [src] has [data] saved to address [i]."
 
 /obj/item/integrated_circuit/memory/do_work()
 	for(var/i = 1 to inputs.len)
-		var/datum/integrated_io/I = inputs[i]
-		var/datum/integrated_io/O = outputs[i]
-		O.data = I.data
-		push_data()
+		set_pin_data(IC_OUTPUT, i, get_pin_data(IC_INPUT, i))
+	push_data()
 	activate_pin(2)
 
 /obj/item/integrated_circuit/memory/tiny
@@ -101,26 +95,26 @@
 			accepting_refs = 0
 			new_data = input(usr, "Now type in a string.","[src] string writing") as null|text
 			if(istext(new_data) && CanInteract(user, GLOB.physical_state))
-				O.data = new_data
+				O.write_data_to_pin(new_data)
 				to_chat(user, "<span class='notice'>You set \the [src]'s memory to [O.display_data(O.data)].</span>")
 		if("number")
 			accepting_refs = 0
 			new_data = input(usr, "Now type in a number.","[src] number writing") as null|num
 			if(isnum(new_data) && CanInteract(user, GLOB.physical_state))
-				O.data = new_data
+				O.write_data_to_pin(new_data)
 				to_chat(user, "<span class='notice'>You set \the [src]'s memory to [O.display_data(O.data)].</span>")
 		if("ref")
 			accepting_refs = 1
 			to_chat(user, "<span class='notice'>You turn \the [src]'s ref scanner on.  Slide it across \
 			an object for a ref of that object to save it in memory.</span>")
 		if("null")
-			O.data = null
+			O.write_data_to_pin(null)
 			to_chat(user, "<span class='notice'>You set \the [src]'s memory to absolutely nothing.</span>")
 
 /obj/item/integrated_circuit/memory/constant/afterattack(atom/target, mob/user, clickchain_flags, list/params)
 	if(accepting_refs && (clickchain_flags & CLICKCHAIN_HAS_PROXIMITY))
 		var/datum/integrated_io/O = outputs[1]
-		O.data = WEAKREF(target)
+		O.write_data_to_pin(target)
 		visible_message("<span class='notice'>[user] slides \a [src]'s over \the [target].</span>")
 		to_chat(user, "<span class='notice'>You set \the [src]'s memory to a reference to [O.display_data(O.data)].  The ref scanner is \
 		now off.</span>")

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -314,7 +314,10 @@
 /obj/item/integrated_circuit/input/beaker_connector/ask_for_input(mob/living/user, obj/item/I,  a_intent)
 	if(!isobj(I))
 		return FALSE
-	attackby_react(I, user, a_intent)
+	if(!current_beaker)
+		attack_self(user)
+	else
+		attackby_react(I, user, a_intent)
 
 /obj/item/integrated_circuit/input/beaker_connector/attackby_react(var/obj/item/reagent_containers/I, var/mob/living/user)
 	//Check if it truly is a reagent container
@@ -341,11 +344,6 @@
 	push_data()
 	activate_pin(1)
 	activate_pin(3)
-
-
-/obj/item/integrated_circuit/input/beaker_connector/ask_for_input(mob/user)
-	attack_self(user)
-
 
 /obj/item/integrated_circuit/input/beaker_connector/attack_self(mob/user)
 	. = ..()

--- a/tgui/packages/tgui/interfaces/ICCircuit.js
+++ b/tgui/packages/tgui/interfaces/ICCircuit.js
@@ -83,7 +83,7 @@ export const ICCircuit = (props, context) => {
           </Flex>
           <Section title="Triggers">
             {activators.map(activator => (
-              <LabeledList.Item key={activator.name} label={activator.displayed_name}>
+              <LabeledList.Item key={activator.name} label={activator.name}>
                 <Button
                   onClick={() => act("pin_name", { pin: activator.ref })}>
                   {activator.pulse_out ? "<PULSE OUT>" : "<PULSE IN>"}


### PR DESCRIPTION
## About The Pull Request

This fixes a few problems that still remained (or got implemented by bugged behavior being fixed) with circuits.
Particularly, it makes sure pins display their output text properly; a bug I accidentally introduced earlier.
Circuit components loading will also load their data before being put in a assembly proper. (that way, names display correctly.)
It also makes sure that where applicable, circuits will actually use the helpers for data screwyness.
As a side effect, the above (with a few tweaks) also fixes an issue where raw references were getting stored in lists.
Finally, list cooldowns were reduced to the standard (otherwise this makes them *very* awkward to work with.)
Theoretically I could atomize this PR further, but, uh, a lot of it was just bug fixes.

## Why It's Good For The Game

fixes a variety of bugs.
For the list cooldown tweaks, some of them would have 0.1 CD, some would have 1, and there was no real correlation to which had what. I don't really think the cooldown feature should limit circuits realistically (which this would do.) if they are wholly internal.

## Changelog

:cl:
tweak: Circuit list component cooldowns are now universally 0.1.
fix: Circuit lists won't sneak full references in when transferred.
fix: Circuit components will now properly use helpers for IO input/output.
fix: Circuit names will load properly if from a custom import.
fix: Circuit input/outputs will display their text once again.
/:cl:
