### PR TITLE
Ore Silo door accessible by Science :3

### DIFF
--- a/maps/rift/levels/rift-02-underground2.dmm
+++ b/maps/rift/levels/rift-02-underground2.dmm
@@ -10025,7 +10025,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/glass/mining{
 	name = "Mining Operations";
-	req_one_access = list()
+	req_one_access = list(47,48)
 	},
 /obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
 /turf/simulated/floor/tiled,


### PR DESCRIPTION
## About The Pull Request

The ore silo is a good idea on paper but it sucks because it is an extra menu to click through (though its not as bad its just not efficient aaaaa) and science still need to wait for a miner to open the door or risk that one fun police member (security) decides they shouldn't be hacking in to get their materials so they can do work that actually has merit unlike Xenoarcheology. This fixes the "You still need mining to access the silo as somebody who is the main consoomer"

## Why It's Good For The Game

"Premats done. Upgraded the Geothermals. I am heading home because no miners and Xenoarcheology, Xenobotany and Xenobiology are not real science" gets prevented maybe, at least somewhat. Note that this does NOT fix a ton of other underlying issues with both cargo and science gameplay that often involve getting degraded to equipment printers during event and **completely** left out for any interaction let alone event rewards.

## Testing bro?!?!?!?

I tested it locally bro trust me bro I am not a bad bro bro and it works after wrestling with CitRP to NOT load tether... Though I did have issues getting it to upload with github desktop for some reason. Probs time for a fresh install again I guess. Or actually invest time fixing that issue proper. Keeps cropping up every few months. 

## Tarjarans??

You still owe the entire science department medals for the catskinner arc. Cargo/Mining too. Medical got fucking medals and they didnt directly partake. Probably the most unhinged PR in ages of mine.

## Changelog


:cl:
tweak: Science can now access the ore silo cutely.
/:cl:

