### PR TITLE
admin stealth mode now works while deadminned

### DIFF
--- a/citadel.dme
+++ b/citadel.dme
@@ -2377,6 +2377,7 @@
 #include "code\modules\catalogue\cataloguer.dm"
 #include "code\modules\catalogue\cataloguer_visuals.dm"
 #include "code\modules\catalogue\cataloguer_vr.dm"
+#include "code\modules\client\client-admin.dm"
 #include "code\modules\client\client.dm"
 #include "code\modules\client\client_procs.dm"
 #include "code\modules\client\connection.dm"

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -361,7 +361,7 @@ GLOBAL_LIST_INIT(testing_global_profiler, list("_PROFILE_NAME" = "Global"))
 		include_link = FALSE
 
 	if(key)
-		if(C && C.holder && C.holder.fakekey && !include_name)
+		if(C.is_under_stealthmin() && !include_name)
 			if(include_link)
 				. += "<a href='?priv_msg=[REF(C)]'>"
 			. += "Administrator"

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -361,7 +361,7 @@ GLOBAL_LIST_INIT(testing_global_profiler, list("_PROFILE_NAME" = "Global"))
 		include_link = FALSE
 
 	if(key)
-		if(C.is_under_stealthmin() && !include_name)
+		if(C?.is_under_stealthmin() && !include_name)
 			if(include_link)
 				. += "<a href='?priv_msg=[REF(C)]'>"
 			. += "Administrator"

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -427,7 +427,7 @@
 	var/list/creatures = list()
 	var/list/namecounts = list()
 	for(var/mob/M in mobs)
-		if(isobserver(M) && ghostfollow && M.client?.holder && M.client.holder.fakekey && M.get_preference_toggle(/datum/game_preference_toggle/admin/stealth_hides_ghost))
+		if(isobserver(M) && ghostfollow && M.client.is_under_stealthmin() && M.get_preference_toggle(/datum/game_preference_toggle/admin/stealth_hides_ghost))
 			continue
 		var/name = M.name
 		if (name in names)

--- a/code/datums/variable_settings/variable_setting_controller.dm
+++ b/code/datums/variable_settings/variable_setting_controller.dm
@@ -94,7 +94,7 @@
 	if(announce == "Cancel")
 		return
 	else if(announce == "Yes")
-		to_chat(world, "<span class='boldnotice'>[user?.client?.holder?.fakekey? "Administrator" : user.key] applied preset [input] to [src].</span>")
+		to_chat(world, "<span class='boldnotice'>[user?.client?.is_under_stealthmin()? "Administrator" : user.key] applied preset [input] to [src].</span>")
 	message_admins(logstr)
 	log_admin(logstr)
 	if(input == initial_preset_name)

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -98,10 +98,7 @@
 /datum/world_topic/jsonplayers/Run(list/input, addr)
 	. = list()
 	for(var/client/C in GLOB.clients)
-		if(C.holder?.fakekey)
-			. += C.holder.fakekey
-			continue
-		. += C.key
+		. += C.get_public_ckey()
 	return json_encode(.)
 
 /datum/world_topic/jsonmanifest

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -98,7 +98,7 @@
 /datum/world_topic/jsonplayers/Run(list/input, addr)
 	. = list()
 	for(var/client/C in GLOB.clients)
-		. += C.get_public_ckey()
+		. += C.get_public_key()
 	return json_encode(.)
 
 /datum/world_topic/jsonmanifest

--- a/code/game/verbs/advanced_who.dm
+++ b/code/game/verbs/advanced_who.dm
@@ -62,7 +62,10 @@
 				entry += "[C.ckey] - <b><font color='red'>Uninitialized</font></b>"
 				Lines += entry
 				continue
-			entry += "[C.get_public_key()]"
+			if(C == src)
+				entry += "[C.get_revealed_key()]"
+			else
+				entry += "[C.get_public_key()]"
 			if(C.get_preference_toggle(/datum/game_preference_toggle/presence/show_advanced_who))
 				if(isobserver(C.mob))
 					entry += " - <font color='gray'>Observing</font>"

--- a/code/game/verbs/advanced_who.dm
+++ b/code/game/verbs/advanced_who.dm
@@ -11,13 +11,11 @@
 
 	if(holder && (R_ADMIN & holder.rights || R_MOD & holder.rights))
 		for(var/client/C in GLOB.clients)
-			var/entry = "\t[C.key]"
+			var/entry = "\t[C.get_revealed_key()]"
 			if(!C.initialized)
 				entry += " - <b><font color='red'>Uninitialized</font></b>"
 				Lines += entry
 				continue
-			if(C.holder && C.holder.fakekey)
-				entry += " <i>(as [C.holder.fakekey])</i>"
 			entry += " - Playing as [C.mob.real_name]"
 			switch(C.mob.stat)
 				if(UNCONSCIOUS)
@@ -64,10 +62,7 @@
 				entry += "[C.ckey] - <b><font color='red'>Uninitialized</font></b>"
 				Lines += entry
 				continue
-			if(C.holder && C.holder.fakekey)
-				entry += "[C.holder.fakekey]"
-			else
-				entry += "[C.key]"
+			entry += "[C.get_public_key()]"
 			if(C.get_preference_toggle(/datum/game_preference_toggle/presence/show_advanced_who))
 				if(isobserver(C.mob))
 					entry += " - <font color='gray'>Observing</font>"

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -11,13 +11,11 @@
 
 	if(holder && (R_ADMIN & holder.rights || R_MOD & holder.rights))
 		for(var/client/C in GLOB.clients)
-			var/entry = "\t[C.key]"
+			var/entry = "\t[C.get_public_key()]"
 			if(!C.initialized)
 				entry += "[C.ckey] - <b><font color='red'>Uninitialized</font></b>"
 				Lines += entry
 				continue
-			if(C.holder && C.holder.fakekey)
-				entry += " <i>(as [C.holder.fakekey])</i>"
 			if(!C.initialized)
 				entry += " - [SPAN_BOLDANNOUNCE("UNINITIALIZED!")]"
 				continue
@@ -64,10 +62,7 @@
 			Lines += entry
 	else
 		for(var/client/C in GLOB.clients)
-			if(C.holder && C.holder.fakekey)
-				Lines += C.holder.fakekey
-			else
-				Lines += C.key
+			Lines += C.get_public_key()
 
 	for(var/line in sortList(Lines))
 		msg += "[line]\n"
@@ -86,13 +81,10 @@
 			if(!C.initialized)
 				continue
 
-			if(C.holder.fakekey && !((R_ADMIN|R_MOD) & holder.rights))
+			if(C.holder.is_under_stealthmin() && !((R_ADMIN|R_MOD) & holder.rights))
 				continue
 
-			msg += "\t[C] is a [C.holder.rank]"
-
-			if(C.holder.fakekey)
-				msg += " <i>(as [C.holder.fakekey])</i>"
+			msg += "\t[C.get_revealed_key()] is a [C.holder.rank]"
 
 			if(isobserver(C.mob))
 				msg += " - Observing"
@@ -113,7 +105,7 @@
 		for(var/client/C in GLOB.admins)
 			if(!C.initialized)
 				continue
-			if(C.holder.fakekey)
+			if(C.is_under_stealthmin())
 				continue	// hidden
 			msg += "\t[C] is a [C.holder.rank]"
 			num_admins_online++

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -11,7 +11,7 @@
 
 	if(holder && (R_ADMIN & holder.rights || R_MOD & holder.rights))
 		for(var/client/C in GLOB.clients)
-			var/entry = "\t[C.get_public_key()]"
+			var/entry = "\t[C.get_revealed_key()]"
 			if(!C.initialized)
 				entry += "[C.ckey] - <b><font color='red'>Uninitialized</font></b>"
 				Lines += entry
@@ -62,7 +62,7 @@
 			Lines += entry
 	else
 		for(var/client/C in GLOB.clients)
-			Lines += C.get_public_key()
+			Lines += (C == src)? C.get_revealed_key() : C.get_public_key()
 
 	for(var/line in sortList(Lines))
 		msg += "[line]\n"

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -81,7 +81,7 @@
 			if(!C.initialized)
 				continue
 
-			if(C.holder.is_under_stealthmin() && !((R_ADMIN|R_MOD) & holder.rights))
+			if(C.is_under_stealthmin() && !((R_ADMIN|R_MOD) & holder.rights))
 				continue
 
 			msg += "\t[C.get_revealed_key()] is a [C.holder.rank]"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -653,7 +653,7 @@ var/global/floorIsLava = 0
 		if(!check_rights(R_SERVER,0))
 			message = sanitize(message, 500, extra = 0)
 		message = replacetext(message, "\n", "<br>") // required since we're putting it in a <p> tag
-		to_chat(world, "<span class=notice><b>[usr.client.holder.fakekey ? "Administrator" : usr.key] Announces:</b><p style='text-indent: 50px'>[message]</p></span>")
+		to_chat(world, "<span class=notice><b>[usr.client.is_under_stealthmin() ? "Administrator" : usr.key] Announces:</b><p style='text-indent: 50px'>[message]</p></span>")
 		log_admin("Announce: [key_name(usr)] : [message]")
 	feedback_add_details("admin_verb","A") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -779,7 +779,7 @@ var/list/admin_verbs_event_manager = list(
 		deadmin()
 		to_chat(src, "<span class='interface'>You are now a normal player.</span>")
 		if(deadmin_holder?.fakekey)
-			to_chat(src, SPAN_BIG(SPAN_ANNOUNCE("Your ckey is still obfuscated as '[deadmin_holder.fakekey]' due to de-adminning while stealthed.")))
+			to_chat(src, SPAN_RED(SPAN_BIG(SPAN_ANNOUNCE("Your ckey is still obfuscated as '[deadmin_holder.fakekey]' due to de-adminning while stealthed."))))
 		add_verb(src, /client/proc/readmin_self)
 	feedback_add_details("admin_verb","DAS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -778,6 +778,8 @@ var/list/admin_verbs_event_manager = list(
 		message_admins("[src] deadmined themself.", 1)
 		deadmin()
 		to_chat(src, "<span class='interface'>You are now a normal player.</span>")
+		if(deadmin_holder?.fakekey)
+			to_chat(src, SPAN_BIG(SPAN_ANNOUNCE("Your ckey is still obfuscated as '[deadmin_holder.fakekey]' due to de-adminning while stealthed.")))
 		add_verb(src, /client/proc/readmin_self)
 	feedback_add_details("admin_verb","DAS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -7,7 +7,9 @@ GLOBAL_PROTECT(href_token)
 	var/rank			= "Temporary Admin"
 	var/client/owner	= null
 	var/rights = 0
-	var/fakekey			= null
+	// todo: rework
+	/// If set, we are under stealth-mode with this as our public ckey.
+	var/fakekey = null
 
 	var/datum/marked_datum
 

--- a/code/modules/admin/verbs/antag-ooc.dm
+++ b/code/modules/admin/verbs/antag-ooc.dm
@@ -21,10 +21,7 @@
 		return
 
 	// Name shown to admins.
-	var/display_name = src.key
-	if(holder)
-		if(holder.fakekey)
-			display_name = usr.client.holder.fakekey
+	var/display_name = get_public_key()
 
 	// Name shown to other players.  Admins whom are not also antags have their rank displayed.
 	var/player_display = (is_admin && !is_antag) ? "[display_name]([usr.client.holder.rank])" : display_name

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -26,13 +26,10 @@ GLOBAL_LIST_INIT(stealthmin_nicknames, world.file2list("[global.config.directory
 		return
 
 	var/key
-	if(holder.fakekey)
-		if(get_preference_toggle(/datum/game_preference_toggle/admin/obfuscate_stealth_dsay))
+	if(is_under_stealthmin() && get_preference_toggle(/datum/game_preference_toggle/admin/obfuscate_stealth_dsay))
 			key = pick(GLOB.stealthmin_nicknames)
-		else
-			key = holder.fakekey
 	else
-		key = src.key
+		key = get_public_key()
 
 	msg = emoji_parse(msg)
 

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_INIT(stealthmin_nicknames, world.file2list("[global.config.directory
 
 	var/key
 	if(is_under_stealthmin() && get_preference_toggle(/datum/game_preference_toggle/admin/obfuscate_stealth_dsay))
-			key = pick(GLOB.stealthmin_nicknames)
+		key = pick(GLOB.stealthmin_nicknames)
 	else
 		key = get_public_key()
 

--- a/code/modules/admin/verbs/server/admin_reboot.dm
+++ b/code/modules/admin/verbs/server/admin_reboot.dm
@@ -17,7 +17,7 @@
 	var/result = input(usr, "Select reboot method", "World Reboot", options[1]) as null|anything in options
 	if(result)
 		// SSblackbox.record_feedback("tally", "admin_verb", 1, "Reboot World") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-		var/init_by = "Initiated by [usr.client.holder.fakekey ? "Admin" : usr.key]."
+		var/init_by = "Initiated by [usr.key]."
 		switch(result)
 			if("Regular Restart")
 				if(!(isnull(usr.client.address) || (usr.client.address in localhost_addresses)))

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -532,7 +532,7 @@
 			return
 		message_admins("[key_name_admin(usr)] Showed [key_name_admin(C)] a <a href='?_src_=vars;datumrefresh=\ref[thing]'>VV window</a>")
 		log_admin("Admin [key_name(usr)] Showed [key_name(C)] a VV window of a [src]")
-		to_chat(C, "[holder.fakekey ? "an Administrator" : "[usr.client.key]"] has granted you access to view a View Variables window")
+		to_chat(C, "[is_under_stealthmin() ? "an Administrator" : "[usr.client.key]"] has granted you access to view a View Variables window")
 		C.debug_variables(thing)
 
 	if(href_list["datumrefresh"])

--- a/code/modules/admin/view_variables/topic_basic.dm
+++ b/code/modules/admin/view_variables/topic_basic.dm
@@ -38,7 +38,7 @@
 				return
 			message_admins("[key_name_admin(usr)] Showed [key_name_admin(C)] a <a href='?_src_=vars;datumrefresh=[REF(target)]'>VV window</a>")
 			log_admin("Admin [key_name(usr)] Showed [key_name(C)] a VV window of a [target]")
-			to_chat(C, "[holder.fakekey ? "an Administrator" : "[usr.client.key]"] has granted you access to view a View Variables window")
+			to_chat(C, "[is_under_stealthmin() ? "an Administrator" : "[usr.client.key]"] has granted you access to view a View Variables window")
 			C.debug_variables(target)
 	if(check_rights(R_DEBUG))
 		if(href_list[VV_HK_DELETE])

--- a/code/modules/client/client-admin.dm
+++ b/code/modules/client/client-admin.dm
@@ -1,0 +1,25 @@
+//* This file is explicitly licensed under the MIT license. *//
+//* Copyright (c) 2024 silicons                             *//
+
+//* Stealthmin *//
+
+/**
+ * get effective ckey for render, respecting stealth keys
+ */
+/client/proc/get_public_key()
+	return holder?.fakekey || deadmin_holder?.fakekey || key
+
+/**
+ * gets effective ckey & stealth key for render
+ */
+/client/proc/get_revealed_key()
+	if(!(holder?.fakekey || deadmin_holder?.fakekey))
+		return key
+	var/fake_ckey = holder?.fakekey || deadmin_holder?.fakekey || "INVALID-KEY"
+	return "[fake_ckey]/([key])"
+
+/**
+ * should we be under stealthmin
+ */
+/client/proc/is_under_stealthmin()
+	return !!(holder?.fakekey || deadmin_holder?.fakekey)

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -150,7 +150,7 @@
 			if(target.is_key_ignored(key)) // If we're ignored by this person, then do nothing.
 				continue
 			var/display_name
-			if(target.holder)
+			if(target.holder || target == src)
 				display_name = get_revealed_key()
 			else
 				display_name = get_public_key()

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -129,7 +129,7 @@
 		return
 
 	var/ooc_style = "everyone"
-	if(holder && !holder.fakekey)
+	if(holder && !is_under_stealthmin())
 		ooc_style = "elevated"
 		if(holder.rights & R_EVENT)
 			ooc_style = "event_manager"
@@ -149,13 +149,11 @@
 		if(target.get_preference_toggle(/datum/game_preference_toggle/chat/ooc))
 			if(target.is_key_ignored(key)) // If we're ignored by this person, then do nothing.
 				continue
-			var/display_name = src.key
-			if(holder)
-				if(holder.fakekey)
-					if(target.holder)
-						display_name = "[holder.fakekey]/([src.key])"
-					else
-						display_name = holder.fakekey
+			var/display_name
+			if(target.holder)
+				display_name = get_revealed_key()
+			else
+				display_name = get_public_key()
 			if(effective_color) // keeping this for the badmins
 				to_chat(target, "<span class='prefix [ooc_style]'><span class='ooc'><font color='[effective_color]'>" + "OOC: " + "<EM>[display_name]: </EM><span class='linkify'>[msg]</span></span></span></font>")
 			else
@@ -224,9 +222,7 @@
 	var/list/receivers = list() //Clients, not mobs.
 	var/list/r_receivers = list()
 
-	var/display_name = key
-	if(holder && holder.fakekey)
-		display_name = holder.fakekey
+	var/display_name = get_public_key()
 	if(mob.stat != DEAD)
 		display_name = mob.name
 	// Resleeving shenanigan prevention.

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -285,7 +285,7 @@ var/list/intents = list(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM)
 	var/keyname
 	if(subject && subject.client)
 		var/client/C = subject.client
-		keyname = (C.holder && C.holder.fakekey) ? C.holder.fakekey : C.key
+		keyname = C.get_public_key()
 		if(C.mob) //Most of the time this is the observer/dead mob; we can totally use him if there is no better name
 			var/mindname
 			var/realname = C.mob.real_name
@@ -363,7 +363,7 @@ var/list/intents = list(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM)
 			C = M.original.client
 
 	if(C)
-		if(!isnull(C.holder?.fakekey) || !C.get_preference_toggle(/datum/game_preference_toggle/presence/announce_ghost_joinleave))
+		if(C.is_under_stealthmin() || !C.get_preference_toggle(/datum/game_preference_toggle/presence/announce_ghost_joinleave))
 			return
 		var/name
 		if(C.mob)
@@ -376,7 +376,7 @@ var/list/intents = list(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM)
 				else
 					name = M.real_name
 		if(!name)
-			name = (C.holder && C.holder.fakekey) ? C.holder.fakekey : C.key
+			name = C.get_public_key()
 		if(joined_ghosts)
 			say_dead_direct("The ghost of <span class='name'>[name]</span> now [pick("skulks","lurks","prowls","creeps","stalks")] among [pick("the dead","the spirits","the graveyard","the deceased","us")]. [message]")
 		else


### PR DESCRIPTION
this is admittedly not a usual use of stealth mode but it's nice to not pop on/off the list when deadminned

(this is nice for event rounds since you're supposed to deadmin if in a conflict role)