### PR TITLE
Buffs the Precursor Sidearm

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -102,7 +102,7 @@
 	icon_state = "alienpistol"
 	item_state = "alienpistol"
 	fire_delay = 10 // Handguns should be inferior to two-handed weapons. Even alien ones I suppose.
-	charge_cost = 240 // Five shots.
+	charge_cost = 240 // Ten shots.
 
 	projectile_type = /obj/projectile/beam/cyan
 	cell_type = /obj/item/cell/device/weapon/recharge/alien // Self charges.

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -88,8 +88,8 @@
 	<br><br>\
 	An interesting note about this weapon, when compared to contemporary energy weapons, is \
 	that this gun appears to utilize some sort of exotic particle beam instead of being a laser \
-	or plasma. The beam fired has decently capability of harm, and the power consumption appears to be \
-	comparable to a human-made energy side-arm. One possible explaination is that the creators of this \
+	or plasma. The beam fired is decently capable of causing damage, and the power consumption is close \
+	to that of a human-made energy side-arm. One possible explaination is that the creators of this \
 	weapon, in their later years, had less of a need to optimize their capability for war, \
 	and instead focused on other endeavors. Another explaination is that vast age of the weapon \
 	may have caused it to degrade, yet still remain functional at a reduced capability."

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -87,9 +87,9 @@
 	unlikely.\
 	<br><br>\
 	An interesting note about this weapon, when compared to contemporary energy weapons, is \
-	that this gun appears to be inferior to modern laser weapons. The beam fired has less \
-	of an ability to harm, and the power consumption appears to be higher than average for \
-	a human-made energy side-arm. One possible explaination is that the creators of this \
+	that this gun appears to utilize some sort of exotic particle beam instead of being a laser \
+	or plasma. The beam fired has decently capability of harm, and the power consumption appears to be \
+	comparable to a human-made energy side-arm. One possible explaination is that the creators of this \
 	weapon, in their later years, had less of a need to optimize their capability for war, \
 	and instead focused on other endeavors. Another explaination is that vast age of the weapon \
 	may have caused it to degrade, yet still remain functional at a reduced capability."
@@ -102,7 +102,7 @@
 	icon_state = "alienpistol"
 	item_state = "alienpistol"
 	fire_delay = 10 // Handguns should be inferior to two-handed weapons. Even alien ones I suppose.
-	charge_cost = 480 // Five shots.
+	charge_cost = 240 // Five shots.
 
 	projectile_type = /obj/projectile/beam/cyan
 	cell_type = /obj/item/cell/device/weapon/recharge/alien // Self charges.


### PR DESCRIPTION

## About The Pull Request

I always found it weird how this gun gets outclassed easily by even the dinky explo holdout phasers. Reason for it being is its stupid low energy efficiency. You can squeeze out 5 shots out of it. This is laughably low. I suggest therefor the capacity is doubled and the exploration flavor text for the gun is slightly altered. Degraded yes, but not underperforming and being outclassed by shit explo has as backup.

## Why It's Good For The Game

Kinda rare find and usually only brought by traders. Dissappointing energy efficiency. Yeah comes with a voidcell but that too has attrocious charging rates. Feels more like a silly trophy instead of something you'd use.

## Changelog

:cl:
balance: Halfs energy cost per shot for precursor sidearm, effectively doubling its capacity on a weapon cell. Cutely.
/:cl:

