### PR TITLE
Window tint controls now have a in-game construction process.

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -94,3 +94,38 @@
 		if(D.glass && (D.id_tint == src.id))
 			spawn(0)
 				D.toggle()
+
+/obj/item/frame/window_tint_control
+	name = "window tint control frame"
+	desc = "Used for building a window tint controller."
+	icon = 'icons/obj/power_vr.dmi'
+	icon_state = "lightswitch-s1"
+	build_machine_type = /obj/structure/construction/window_tint_control
+
+/obj/structure/construction/window_tint_control
+	name = "window tint control frame"
+	desc = "A window tint controller under construction."
+	icon = 'icons/obj/power_vr.dmi'
+	icon_state = "lightswitch-s1"
+	base_icon = "lightswitch-s"
+	build_machine_type = /obj/machinery/button/windowtint
+	x_offset = 26
+	y_offset = 26
+
+/obj/machinery/button/windowtint/attackby(obj/item/W, mob/user, params)
+	src.add_fingerprint(user)
+	if(default_deconstruction_screwdriver(user, W))
+		return
+	if(default_deconstruction_crowbar(user, W))
+		return
+	return ..()
+
+/obj/machinery/button/windowtint/dismantle()
+	playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
+	var/obj/structure/construction/window_tint_control/A = new(src.loc, src.dir)
+	A.stage = FRAME_WIRED
+	A.pixel_x = pixel_x
+	A.pixel_y = pixel_y
+	A.update_icon()
+	qdel(src)
+	return 1

--- a/code/modules/materials/definitions/metals/steel.dm
+++ b/code/modules/materials/definitions/metals/steel.dm
@@ -258,6 +258,12 @@
 		cost = 4,
 		time = 3 SECONDS,
 	)
+	. += create_stack_recipe_datum(
+		category = "frames",
+		name = "window tint control frame",
+		product = /obj/item/frame/window_tint_control,
+		cost = 4,
+	)
 
 /datum/material/steel/hull
 	id = "steel_hull"


### PR DESCRIPTION
## About The Pull Request

This allows window tint controls to be makeable by using 4 steel sheets, and the same construction process as a light fixture.

## Why It's Good For The Game

You can make electrochromatic windows, but not the actual switch / control which seems whatever. By adding it, it also adds a little bit of fashionable flair someone can use to make cute little rooms.

## Changelog

:cl:
add: Window Tint Control is makeable by using 4 steel sheets and the same construction process as a light fixture.
/:cl: