### PR TITLE
fix IC fire sound, beaker slot, clothing light

### DIFF
--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -80,10 +80,18 @@
 /obj/item/integrated_circuit/output/light/proc/update_lighting()
 	if(light_toggled)
 		if(assembly)
-			assembly.set_light(l_range = light_brightness, l_power = light_strength, l_color = light_rgb)
+			if(istype(assembly,/obj/item/electronic_assembly/clothing))
+				var/obj/item/electronic_assembly/clothing/assembly_c = assembly
+				assembly_c.clothing.set_light(l_range = light_brightness, l_power = light_strength, l_color = light_rgb)
+			else
+				assembly.set_light(l_range = light_brightness, l_power = light_strength, l_color = light_rgb)
 	else
 		if(assembly)
-			assembly.set_light(0)
+			if(istype(assembly,/obj/item/electronic_assembly/clothing))
+				var/obj/item/electronic_assembly/clothing/assembly_c = assembly
+				assembly_c.clothing.set_light(0)
+			else
+				assembly.set_light(0)
 	power_draw_idle = light_toggled ? light_brightness * light_brightness : 0 // Should be the same draw as regular lights.
 
 /obj/item/integrated_circuit/output/light/power_fail() // Turns off the flashlight if there's no power left.

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -312,16 +312,16 @@
 	var/obj/item/reagent_containers/glass/beaker/current_beaker
 
 /obj/item/integrated_circuit/input/beaker_connector/ask_for_input(mob/living/user, obj/item/I,  a_intent)
-	if(!isobj(I))
-		return FALSE
 	if(!current_beaker)
-		attack_self(user)
-	else
+		if(!isobj(I))
+			return FALSE
 		attackby_react(I, user, a_intent)
+	else
+		attack_self(user)
 
 /obj/item/integrated_circuit/input/beaker_connector/attackby_react(var/obj/item/reagent_containers/I, var/mob/living/user)
 	//Check if it truly is a reagent container
-	if(!istype(I,/obj/item/reagent_containers/glass/beaker))
+	if(!(istype(I,/obj/item/reagent_containers/glass/beaker) || istype(I,/obj/item/reagent_containers/glass/hypovial)))
 		to_chat(user,"<span class='warning'>The [I.name] doesn't seem to fit in here.</span>")
 		return
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -508,11 +508,10 @@
 			P.silenced = silenced
 
 			P.old_style_target(target)
+			play_fire_sound(P = projectile)
 			P.fire()
 
 			last_shot = world.time
-
-			play_fire_sound()
 
 			if(muzzle_flash)
 				set_light(muzzle_flash)
@@ -714,9 +713,9 @@
 		return
 
 	if(silenced)
-		playsound(user, shot_sound, 10, 1)
+		playsound(src, shot_sound, 10, 1)
 	else
-		playsound(user, shot_sound, 50, 1)
+		playsound(src, shot_sound, 50, 1)
 
 //Suicide handling.
 /obj/item/gun/var/mouthshoot = 0 //To stop people from suiciding twice... >.>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
3 bugs and 1 minor QoL change

Fire_userless proc now plays the projectile sounds. This affects circuit guns and sawing off a loaded shotgun.
Beaker slots now works as intended with its UI buttons. Inserting and removing.
Circuit clothing can now emit light with a light component when worn. I tried to cheese it by removing the components and so on, light resets as it should.
Beaker slots now also accept hypovials