### PR TITLE
Circuit bug fixes & data untyping

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -256,7 +256,7 @@
 			var/obj/item/integrated_circuit/C = locate(params["ref"]) in assembly_components
 			if(!istype(C))
 				return
-			C.remove(usr, TRUE, index = params["index"])
+			C.remove(usr, FALSE, index = params["index"])
 			return TRUE
 
 		if("bottom_circuit")

--- a/code/modules/integrated_electronics/core/helpers.dm
+++ b/code/modules/integrated_electronics/core/helpers.dm
@@ -69,7 +69,8 @@
 				new_data[i] = WEAKREF(dataRef)
 		return new_data
 	if(isweakref(data))
-		return data.resolve()
+		var/datum/weakref/d = data
+		return d.resolve()
 	return data
 
 /// Returns a list of parameters necessary to locate a pin in the assembly: component number, pin type and pin number

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -269,7 +269,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 					examined.ui_interact(usr)
 
 		if("remove")
-			remove(usr, FALSE, index = params["index"])
+			remove(usr, FALSE)
 			return
 	return FALSE
 
@@ -285,6 +285,11 @@ a creative player the means to solve many problems.  Circuits are held inside an
 
 	power_fail()
 	disconnect_all()
+
+	// in case we can't easily get the index, we want to be able to get it still.
+	if(!index && A)
+		index = A.ui_circuit_props.Find(src)
+
 	// Remove from helper and TGUI lists
 	A.ui_circuit_props.Cut(index, index + 1)
 	A.assembly_components.Cut(index, index + 1)

--- a/code/modules/integrated_electronics/core/pins.dm
+++ b/code/modules/integrated_electronics/core/pins.dm
@@ -21,7 +21,7 @@ D [1]/  ||
 /datum/integrated_io
 	var/name = "input/output"
 	var/obj/item/integrated_circuit/holder
-	var/datum/weakref/data  // This is a weakref, to reduce typecasts.  Note that oftentimes numbers and text may also occupy this.
+	var/data
 	var/list/linked = list()
 	var/io_type = DATA_CHANNEL
 	var/pin_type			// IC_INPUT, IC_OUTPUT, IC_ACTIVATOR - used in saving assembly wiring
@@ -156,11 +156,12 @@ list[](
 		holder.on_data_written()
 	else if(islist(new_data))
 		var/list/new_list = new_data
-		data = new_list.Copy(max(1,new_list.len - IC_MAX_LIST_LENGTH+1),0)
-		for(var/i in 1 to length(data))
-			var/datum/dataRef = data[i]
+		new_list = new_list.Copy(max(1,new_list.len - IC_MAX_LIST_LENGTH+1),0)
+		for(var/i in 1 to length(new_list))
+			var/datum/dataRef = new_list[i]
 			if(istype(dataRef) && !isweakref(dataRef))
-				data[i] = WEAKREF(dataRef)
+				new_list[i] = WEAKREF(dataRef)
+		data = new_list
 		holder.on_data_written()
 
 /datum/integrated_io/proc/push_data()

--- a/code/modules/integrated_electronics/core/special_pins/lists_pin.dm
+++ b/code/modules/integrated_electronics/core/special_pins/lists_pin.dm
@@ -112,11 +112,12 @@
 /datum/integrated_io/lists/write_data_to_pin(var/new_data)
 	if(islist(new_data))
 		var/list/new_list = new_data
-		data = new_list.Copy(max(1,new_list.len - IC_MAX_LIST_LENGTH+1),0)
-		for(var/i in 1 to length(data))
-			var/datum/dataRef = data[i]
+		new_list = new_list.Copy(max(1,new_list.len - IC_MAX_LIST_LENGTH+1),0)
+		for(var/i in 1 to length(new_list))
+			var/datum/dataRef = new_list[i]
 			if(istype(dataRef) && !isweakref(dataRef))
-				data[i] = WEAKREF(dataRef)
+				new_list[i] = WEAKREF(dataRef)
+		data = new_list
 		holder.on_data_written()
 	else if(isnull(new_data))	// Clear the list
 		var/list/my_list = data

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -106,7 +106,8 @@
 	outputs = list(
 		"registered name" = IC_PINTYPE_STRING,
 		"assignment" = IC_PINTYPE_STRING,
-		"passkey" = IC_PINTYPE_STRING
+		"passkey" = IC_PINTYPE_STRING,
+		"rank" = IC_PINTYPE_STRING
 	)
 	activators = list(
 		"on read" = IC_PINTYPE_PULSE_OUT
@@ -125,11 +126,12 @@
 	if(card) // An ID card.
 		set_pin_data(IC_OUTPUT, 1, card.registered_name)
 		set_pin_data(IC_OUTPUT, 2, card.assignment)
+		set_pin_data(IC_OUTPUT, 4, card.rank)
 
 	else if(length(access))	// A non-card object that has access levels.
 		set_pin_data(IC_OUTPUT, 1, null)
 		set_pin_data(IC_OUTPUT, 2, null)
-
+		set_pin_data(IC_OUTPUT, 4, null)
 	else
 		return FALSE
 

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -113,7 +113,11 @@
 	)
 
 /obj/item/integrated_circuit/input/card_reader/attackby_react(obj/item/I, mob/living/user, intent)
-	var/obj/item/card/id/card = I.GetIdCard()
+	var/obj/item/card/id/card
+	if(istype(I,/obj/item/card/id))
+		card = I
+	else
+		card = I.GetIdCard()
 	var/list/access = I.GetAccess()
 	var/json_access = json_encode(access)
 	var/passkey = add_data_signature(json_access)

--- a/code/modules/integrated_electronics/subtypes/smart.dm
+++ b/code/modules/integrated_electronics/subtypes/smart.dm
@@ -21,7 +21,8 @@
 	if(!isweakref(I.data))
 		activate_pin(3)
 		return
-	var/atom/A = I.data.resolve()
+	var/datum/weakref/d = I.data
+	var/atom/A = d.resolve()
 	if(!A)
 		activate_pin(3)
 		return


### PR DESCRIPTION
## About The Pull Request

Fixes a few bugs, notably with ID card readers not properly filling info out from an ID. Also it untypes the data from /datum/weakref. This wasn't always a /datum/weakref, but was typed as it for ??? reasons, primarily relevant for Zandario who was having issues while trying to do some stuff.

## Why It's Good For The Game

fixes bugs. also doesnt have something randomly typed as something it's not.

## Changelog

:cl:
tweak: Circuit data isn't typed as /datum/weakref anymore.
tweak: ID card readers now have a data output of rank, which is the non-alternative job title.
fix: ID card readers now properly read a job and assignment from an ID.
fix: Removing a circuit component by its own 'remove' ui button now properly removes it from the assembly UI.
tweak: Removing a component from the UI doesn't brick a UI component in place in circuit tgui.
/:cl: