### PR TITLE
Cutely buffs AEG (Lethal shot count from 5 to 10)

### DIFF
--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -88,8 +88,8 @@
 	one_handed_penalty = 30 // It's rather bulky at the fore, so holding it in one hand is harder than with two.
 
 	firemodes = list(
-		list(mode_name="stun", projectile_type=/obj/projectile/beam/stun, modifystate="nucgunstun", charge_cost = 240),
-		list(mode_name="lethal", projectile_type=/obj/projectile/beam, modifystate="nucgunkill", charge_cost = 480),
+		list(mode_name="stun", projectile_type=/obj/projectile/beam/stun, modifystate="nucgunstun", charge_cost = 240), //10 shots
+		list(mode_name="lethal", projectile_type=/obj/projectile/beam, modifystate="nucgunkill", charge_cost = 240),    //10 shots
 		)
 
 /obj/item/gun/energy/gun/multiphase


### PR DESCRIPTION
The AEG currently is pretty much hot garbage. Yeah LTL mode is 10 shots sure. But lethal? 5 shots. Which suffer through bay missing (not for long anymore). Which also suffer from attrocious recharge rates (This is the real issue). A bit more micro and a stock G40 laser carbine with a inducer outclasses this gun in every way for lethal applications. This gun is unfortunately one of the many currently useless guns in the RnD Roster.  The thing is also not small in size and cannot be onehanded nor fit in holsters....... so whats the point on printing it ever in its current state with 5 shots lethal mode. The cell revolver has the same is more versatile can reload on the fly and can also be recharged by an inducer. Theres currently no point in ever using the AEG unless you get emped 50 times a week.


Until the new gun lineup is there I think this thing needs a buff so it actually gets used instead of explo just going straight for G40 and what not. 
## About The Pull Request

Doubles ammo on the lethal mode of the AEG. 5 shots turn it basically into a backup phaser explo gets roundstart except it has an attrociously slow self charge.

## Why It's Good For The Game

Variety is a spice of life. And this gun is cool in concept but sucks due to it being outclassed by stock in every way.
Another awful Irkalla 1 liner PR.

## Changelog


:cl:
balance: Buffs AEG lethal mode to 10 shots of whatever this flashlight laser is it uses.
/:cl:

