### PR TITLE
Kills off Baymiss and RNG misses making you look like a doofus at random similar to how ANY other bay derivative has done.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -372,10 +372,13 @@ meteor_act
 			zone = ran_zone(BP_TORSO,75)	//Hits a random part of the body, geared towards the chest
 
 		//check if we hit
+		/*
 		var/miss_chance = 15
 		var/distance = get_dist(TT.initial_turf, loc)
 		miss_chance = max(5 * (distance - 2), 0)
 		zone = get_zone_with_miss_chance(zone, src, miss_chance, ranged_attack=1)
+		*/
+		//Removes baymiss.
 
 		if(zone && TT.thrower != src)
 			var/shield_check = check_shields(throw_damage, O, TT.thrower, zone, "[O]")

--- a/code/modules/mob/living/defense.dm
+++ b/code/modules/mob/living/defense.dm
@@ -276,13 +276,13 @@
 		var/dtype = O.damtype
 		var/throw_damage = O.throw_force * TT.get_damage_multiplier(src)
 
-		var/miss_chance = 15
+		/*var/miss_chance = 15
 		var/distance = get_dist(TT.initial_turf, loc)
 		miss_chance = max(5 * (distance - 2), 0)
 
 		if (prob(miss_chance))
 			visible_message("<font color=#4F49AF>\The [O] misses [src] narrowly!</font>")
-			return COMPONENT_THROW_HIT_PIERCE | COMPONENT_THROW_HIT_NEVERMIND
+			return COMPONENT_THROW_HIT_PIERCE | COMPONENT_THROW_HIT_NEVERMIND */ //Removes baymiss
 
 		src.visible_message("<font color='red'>[src] has been hit by [O].</font>")
 		var/armor = run_armor_check(null, "melee")

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -190,10 +190,12 @@
 		miss_chance = base_miss_chance[zone]
 	if (zone == "eyes" || zone == "mouth")
 		miss_chance = base_miss_chance["head"]
-	miss_chance = max(miss_chance + miss_chance_mod, 0)
+	//miss_chance = max(miss_chance + miss_chance_mod, 0) --Removes baymiss--
+	if(prob(miss_chance_mod)) //this is here in case I missed any baymiss removal fringe cases or if anyone makes uses of the evasion stat e.g. in mobs otherwise removal very similar to other bay adapted servers
+		return null
 	if(prob(miss_chance))
-		if(prob(70))
-			return null
+		//if(prob(70))
+		//	return null --Baymiss removal--
 		return pick(base_miss_chance)
 	return zone
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -551,7 +551,7 @@
 		return
 
 	//roll to-hit
-	miss_modifier = max(15*(distance-2) - accuracy + miss_modifier + target_mob.get_evasion(), 0)
+	miss_modifier = max(miss_modifier + target_mob.get_evasion(), -100) //Altered to remove baymiss components, hopefully this doesnt break anything with the fifty or so gun refactors we got -Irkalla
 	var/hit_zone = get_zone_with_miss_chance(def_zone, target_mob, miss_modifier, ranged_attack=(distance > 1 || original != target_mob)) //if the projectile hits a target we weren't originally aiming at then retain the chance to miss
 
 	var/result = PROJECTILE_FORCE_MISS


### PR DESCRIPTION
A percent chance to miss shots and throws even if you click on the guy or lead your shots are just not good gameplay. 

I have missed at near point blank ranges already.

## About The Pull Request

Removes baymiss. This should have been done a long time ago to be honest. Shit "mechanic". I think removal was attempted in one of the gun refactors but theres still residue in human_defense etc. that still makes me miss with an AEG at point blank range while two handing.

I think I hit every single instance of baymiss. Evasion stat for mobs **should** (TM) still work. Removal is very similar to baycode baymiss removal. I think Chomp did a similar thing a year ago. 

		var/distance = get_dist(TT.initial_turf, loc)
		miss_chance = max(5 * (distance - 2), 0) 

Let me get this straight: Its 20% at 6 tiles distance. 15% at 5. So basically even if you as the player have god aim and god clicks you still are bound to miss relatively often no matter the gun you use, no matter the character. Amazing.

## Why It's Good For The Game

Actually having people being good at clicking matter. Actually having an actual ammo count instead of having 50 rounds P90 mag out of which 7.5 rounds are bound to miss.

## Changelog


:cl:
del: Baymiss wont be missed.
/:cl:


