### PR TITLE
Triumph Science Mapping changes

### DIFF
--- a/maps/triumph/levels/deck3.dmm
+++ b/maps/triumph/levels/deck3.dmm
@@ -3352,6 +3352,10 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/machinery/seed_storage/xenobotany,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "cRF" = (
@@ -3526,10 +3530,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	dir = 1;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
@@ -11750,20 +11750,13 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
-/obj/machinery/seed_storage/xenobotany,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	dir = 1;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "16-0"
-	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "jCw" = (
@@ -14850,6 +14843,15 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/xenobiology)
+"moN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/xenoflora)
 "mpl" = (
 /obj/structure/flora/tree/jungle_small,
 /turf/simulated/floor/grass,
@@ -15024,14 +15026,14 @@
 "mxS" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
@@ -17082,6 +17084,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "okH" = (
@@ -17260,11 +17265,11 @@
 "orZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/mauve/bordercorner,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "osH" = (
@@ -21348,10 +21353,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	dir = 1;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "rvw" = (
@@ -21551,6 +21552,12 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "rGd" = (
@@ -23359,10 +23366,6 @@
 /obj/item/shovel/spade,
 /obj/item/shovel/spade,
 /obj/item/shovel/spade,
-/obj/structure/cable/green{
-	dir = 1;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -24557,9 +24560,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -28002,6 +28002,9 @@
 "xdh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
@@ -42747,7 +42750,7 @@ ecE
 hdc
 hia
 eQu
-oku
+moN
 thh
 tij
 iyI

--- a/maps/triumph/levels/deck3.dmm
+++ b/maps/triumph/levels/deck3.dmm
@@ -2362,6 +2362,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
 "caz" = (
+/obj/machinery/atmospherics/component/unary/outlet_injector{
+	dir = 8;
+	frequency = 1445;
+	id = "burn_in";
+	volume_rate = 700
+	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -3056,20 +3062,6 @@
 /obj/spawner/window/low_wall/reinforced/full,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"cEN" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/research_foyer_auxiliary)
 "cEY" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -3880,17 +3872,6 @@
 /obj/spawner/window/low_wall/reinforced/full,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora/lab_atmos)
-"dmG" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/research_foyer_auxiliary)
 "dni" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
@@ -4512,8 +4493,8 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "dQf" = (
-/obj/spawner/window/low_wall/reinforced/full/firelocks,
-/turf/space,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "dQp" = (
 /obj/structure/cable/green{
@@ -4952,8 +4933,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "eew" = (
-/turf/simulated/wall/r_wall/prepainted/science,
-/area/space)
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology)
 "efa" = (
 /obj/structure/sign/greencross,
 /turf/simulated/wall/r_wall/prepainted/medical,
@@ -5607,6 +5593,9 @@
 /obj/structure/bed/roller,
 /turf/simulated/floor/tiled/monotile,
 /area/medical/surgeryprep)
+"eMZ" = (
+/turf/simulated/wall/r_wall/prepainted/science,
+/area/space)
 "eNH" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
@@ -10937,12 +10926,6 @@
 	dir = 4;
 	network = list("Xenobiology")
 	},
-/obj/machinery/atmospherics/component/unary/outlet_injector{
-	dir = 8;
-	frequency = 1445;
-	id = "burn_in";
-	volume_rate = 700
-	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "iVW" = (
@@ -10994,6 +10977,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
+"iWZ" = (
+/obj/structure/window/reinforced,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/rnd/xenobiology)
 "iXx" = (
 /obj/machinery/computer/guestpass{
 	dir = 4;
@@ -12908,10 +12902,16 @@
 /turf/simulated/floor/tiled,
 /area/medical/medbay_emt_bay)
 "kDK" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/space/basic,
-/area/space)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/research_foyer_auxiliary)
 "kDN" = (
 /obj/machinery/door/firedoor/glass{
 	dir = 4
@@ -13107,32 +13107,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
-"kNy" = (
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -22
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "xenobio3";
-	name = "Containment Blast Doors";
-	req_access = list(55);
-	pixel_x = -25;
-	pixel_y = -5
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 4;
-	id = "xenobiovs2";
-	name = "Containment Blast Doors";
-	pixel_x = -38;
-	req_access = list(55)
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/rnd/xenobiology)
 "kNK" = (
 /obj/machinery/vending/medical,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -14469,6 +14443,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
+"lTx" = (
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/turf/space,
+/area/rnd/xenobiology)
 "lTF" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -14564,14 +14542,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/sleeper)
-"lYM" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/rnd/xenobiology)
 "lYO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -14939,6 +14909,36 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/virologyaccess)
+"mtC" = (
+/obj/machinery/button/remote/blast_door{
+	id = "xenobio2";
+	name = "Containment Blast Doors";
+	pixel_x = -25;
+	pixel_y = -8;
+	req_access = list(55)
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "xenobio1";
+	name = "Containment Blast Doors";
+	pixel_x = -25;
+	pixel_y = 8;
+	req_access = list(55)
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "xenobiovs";
+	name = "Containment Blast Doors";
+	pixel_x = -38;
+	req_access = list(55)
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/rnd/xenobiology)
 "mtG" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloorwhite,
@@ -15022,9 +15022,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/testingrange)
 "mxS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/mauve/border,
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
-/area/rnd/xenobiology)
+/area/rnd/xenobiology/xenoflora)
 "myq" = (
 /obj/structure/flora/pottedplant/drooping,
 /turf/simulated/floor/wood,
@@ -16081,6 +16091,20 @@
 /obj/structure/sign/department/xenolab,
 /turf/simulated/wall/prepainted/science,
 /area/rnd/xenobiology)
+"ntt" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/research_foyer_auxiliary)
 "nug" = (
 /obj/machinery/ai_status_display{
 	pixel_y = -32
@@ -18488,16 +18512,10 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "poq" = (
-/obj/structure/window/reinforced,
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/rnd/xenobiology)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/space/basic,
+/area/space)
 "poV" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -21054,36 +21072,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/recoveryrestroom)
-"ric" = (
-/obj/machinery/button/remote/blast_door{
-	id = "xenobio2";
-	name = "Containment Blast Doors";
-	pixel_x = -25;
-	pixel_y = -8;
-	req_access = list(55)
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "xenobio1";
-	name = "Containment Blast Doors";
-	pixel_x = -25;
-	pixel_y = 8;
-	req_access = list(55)
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 4;
-	id = "xenobiovs";
-	name = "Containment Blast Doors";
-	pixel_x = -38;
-	req_access = list(55)
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/rnd/xenobiology)
 "rig" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/black{
 	dir = 4
@@ -23758,6 +23746,32 @@
 "tAg" = (
 /turf/simulated/wall/prepainted,
 /area/teleporter/departing)
+"tAo" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -22
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "xenobio3";
+	name = "Containment Blast Doors";
+	req_access = list(55);
+	pixel_x = -25;
+	pixel_y = -5
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "xenobiovs2";
+	name = "Containment Blast Doors";
+	pixel_x = -38;
+	req_access = list(55)
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/rnd/xenobiology)
 "tAS" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -26114,12 +26128,6 @@
 /obj/machinery/power/apc/west_mount,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
-"vzW" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/xenobiology)
 "vAo" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -27587,19 +27595,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "wKj" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/mauve/border,
 /obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/rnd/xenobiology/xenoflora)
+/area/rnd/xenobiology)
 "wKq" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -28125,7 +28125,7 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "xjy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "xjV" = (
@@ -35763,7 +35763,7 @@ mDp
 aDe
 aDe
 aDe
-kDK
+poq
 aDe
 lIp
 mDp
@@ -35948,7 +35948,7 @@ lIp
 mDp
 mDp
 mDp
-eew
+eMZ
 qRu
 qRu
 qRu
@@ -36142,7 +36142,7 @@ lIp
 mDp
 mDp
 mDp
-eew
+eMZ
 qRu
 qRu
 qRu
@@ -36337,7 +36337,7 @@ mDp
 mDp
 mAv
 lmG
-eew
+eMZ
 sun
 thc
 piY
@@ -36530,19 +36530,19 @@ lIp
 mDp
 mDp
 mDp
-eew
+eMZ
 qRu
 rOo
 dwM
-iVG
 caz
+iVG
 mbb
-caz
 iVG
+caz
 uHK
 lCd
-caz
 iVG
+caz
 uHK
 rOo
 aPs
@@ -36725,7 +36725,7 @@ mDp
 mDp
 mDp
 mDp
-eew
+eMZ
 rOo
 kkS
 hbm
@@ -36919,7 +36919,7 @@ lIp
 lIp
 lIp
 lIp
-eew
+eMZ
 rOo
 kkS
 hbm
@@ -37309,7 +37309,7 @@ lIp
 mDp
 mDp
 rOo
-poq
+iWZ
 cLl
 hvb
 qRu
@@ -37506,11 +37506,11 @@ rOo
 kDe
 vAo
 vAo
-ric
+mtC
 vAo
 vAo
 vAo
-kNy
+tAo
 vAo
 vAo
 vAo
@@ -38479,7 +38479,7 @@ aUR
 mow
 xCo
 fSg
-xjy
+dQf
 kvb
 udr
 fzt
@@ -38673,7 +38673,7 @@ qys
 qRu
 qRu
 lpx
-mxS
+xjy
 ade
 qRu
 qRu
@@ -39643,7 +39643,7 @@ jtb
 act
 nhg
 pOm
-xjy
+dQf
 hNl
 nhg
 olF
@@ -39837,7 +39837,7 @@ mFx
 fSf
 fjC
 bNl
-mxS
+xjy
 ezb
 kVv
 dbE
@@ -40419,7 +40419,7 @@ wcQ
 bsW
 rMY
 pnF
-xjy
+dQf
 aVO
 qRu
 jGS
@@ -40613,7 +40613,7 @@ eWW
 eWW
 eAv
 pKi
-vzW
+wKj
 wQy
 qRu
 iyI
@@ -40807,7 +40807,7 @@ cjM
 sJj
 eWW
 bjg
-mxS
+xjy
 ezb
 sQe
 iyI
@@ -41389,7 +41389,7 @@ uDK
 ndm
 hui
 oqZ
-lYM
+eew
 wlm
 phf
 hpE
@@ -41576,7 +41576,7 @@ mDp
 mDp
 lIp
 mDp
-dQf
+lTx
 sQe
 acD
 uCN
@@ -42554,10 +42554,10 @@ hdc
 hia
 eQu
 oku
-wKj
+mxS
 fxa
-cEN
-dmG
+ntt
+kDK
 cIp
 qpQ
 qpQ

--- a/maps/triumph/levels/deck3.dmm
+++ b/maps/triumph/levels/deck3.dmm
@@ -92,7 +92,7 @@
 	},
 /obj/machinery/button/remote/blast_door{
 	dir = 1;
-	id = "xenobiovs6";
+	id = "xenobiovs5";
 	name = "Divider Blast Doors";
 	pixel_y = -38;
 	req_one_access = list(29,47)
@@ -11553,6 +11553,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
+"jwk" = (
+/obj/machinery/light{
+	dir = 4;
+	use_power = 0
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology)
 "jwM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12915,7 +12922,7 @@
 	},
 /obj/machinery/button/remote/blast_door{
 	dir = 4;
-	id = "xenobiovs2";
+	id = "xenobiovs";
 	name = "Containment Blast Doors";
 	pixel_x = -38;
 	req_access = list(55)
@@ -13478,7 +13485,7 @@
 "lcH" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 1;
-	id = "xenobiovs5";
+	id = "xenobiovs6";
 	name = "Divider Blast Doors";
 	pixel_y = -38;
 	req_one_access = list(29,47)
@@ -15002,6 +15009,9 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
@@ -27532,9 +27542,6 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -22
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
@@ -37665,7 +37672,7 @@ xjy
 vjC
 eWW
 kmH
-eWW
+jwk
 rXQ
 eWW
 rOo

--- a/maps/triumph/levels/deck3.dmm
+++ b/maps/triumph/levels/deck3.dmm
@@ -3352,7 +3352,6 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/seed_storage/xenobotany,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -11757,6 +11756,7 @@
 	dir = 8
 	},
 /obj/structure/cable/green,
+/obj/machinery/seed_storage/xenobotany,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "jCw" = (
@@ -14843,15 +14843,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/xenobiology)
-"moN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/xenobiology/xenoflora)
 "mpl" = (
 /obj/structure/flora/tree/jungle_small,
 /turf/simulated/floor/grass,
@@ -27928,6 +27919,15 @@
 /obj/effect/floor_decal/techfloor/corner,
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
+"xav" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/xenoflora)
 "xaP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -42750,7 +42750,7 @@ ecE
 hdc
 hia
 eQu
-moN
+xav
 thh
 tij
 iyI

--- a/maps/triumph/levels/deck3.dmm
+++ b/maps/triumph/levels/deck3.dmm
@@ -3657,6 +3657,12 @@
 /obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
+"ddT" = (
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/assembly/chargebay)
 "ddX" = (
 /obj/structure/table/reinforced,
 /obj/item/paicard,
@@ -5491,6 +5497,9 @@
 	req_access = list(29,47);
 	req_one_access = list(47)
 	},
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/assembly/chargebay)
 "eJc" = (
@@ -6390,6 +6399,8 @@
 	id = "mechbay-inner";
 	name = "Mech Bay"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
 /area/assembly/chargebay)
 "fsS" = (
@@ -8189,6 +8200,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
+"gSR" = (
+/obj/effect/floor_decal/industrial/warning/dust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/assembly/robotics/surgery)
 "gTY" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes,
@@ -13125,6 +13142,18 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"kQP" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/assembly/robotics/surgery)
 "kQU" = (
 /turf/simulated/wall/r_wall/prepainted/science,
 /area/rnd/xenobiology/xenoflora_storage)
@@ -27856,6 +27885,15 @@
 /obj/effect/floor_decal/techfloor/corner,
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
+"xaP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/assembly/chargebay)
 "xbs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
@@ -42493,7 +42531,7 @@ fiD
 idK
 yhE
 ikR
-qog
+ddT
 qog
 ogL
 dbo
@@ -42684,10 +42722,10 @@ sBB
 qpQ
 eJc
 xkd
-vdw
-yhE
+kQP
+gSR
 fsM
-qog
+xaP
 qog
 drq
 dbo

--- a/maps/triumph/levels/deck3.dmm
+++ b/maps/triumph/levels/deck3.dmm
@@ -3056,6 +3056,20 @@
 /obj/spawner/window/low_wall/reinforced/full,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"cEN" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/research_foyer_auxiliary)
 "cEY" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -3514,15 +3528,17 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "cYX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
 /obj/machinery/vending/hydronutrients,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "cZD" = (
@@ -3864,6 +3880,17 @@
 /obj/spawner/window/low_wall/reinforced/full,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora/lab_atmos)
+"dmG" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/research_foyer_auxiliary)
 "dni" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
@@ -4485,19 +4512,9 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "dQf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/glass/research{
-	name = "Xenoflora Research";
-	req_one_access = null
-	},
-/obj/map_helper/access_helper/airlock/station/science/xenobiology,
-/turf/simulated/floor/tiled,
-/area/rnd/xenobiology/xenoflora)
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/turf/space,
+/area/rnd/xenobiology)
 "dQp" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -4935,23 +4952,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "eew" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/research_foyer_auxiliary)
+/turf/simulated/wall/r_wall/prepainted/science,
+/area/space)
 "efa" = (
 /obj/structure/sign/greencross,
 /turf/simulated/wall/r_wall/prepainted/medical,
@@ -6506,6 +6508,11 @@
 	req_one_access = null
 	},
 /obj/map_helper/access_helper/airlock/station/science/xenobiology,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "fxj" = (
@@ -8438,17 +8445,14 @@
 /turf/simulated/wall/prepainted/medical,
 /area/crew_quarters/medbreak/surgery)
 "heX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer_auxiliary)
@@ -11553,13 +11557,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
-"jwk" = (
-/obj/machinery/light{
-	dir = 4;
-	use_power = 0
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/xenobiology)
 "jwM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11754,15 +11751,25 @@
 /area/medical/sleeper)
 "jBH" = (
 /obj/machinery/power/apc/south_mount,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
 /obj/machinery/camera/network/research{
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
 /obj/machinery/seed_storage/xenobotany,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "16-0"
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "jCw" = (
@@ -12547,6 +12554,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/anomaly_lab/containment_one)
 "kmH" = (
+/obj/machinery/light{
+	dir = 4;
+	use_power = 0
+	},
 /obj/machinery/light_switch{
 	dir = 4;
 	pixel_x = 24;
@@ -12897,38 +12908,10 @@
 /turf/simulated/floor/tiled,
 /area/medical/medbay_emt_bay)
 "kDK" = (
-/obj/machinery/button/remote/blast_door{
-	id = "xenobio2";
-	name = "Containment Blast Doors";
-	pixel_x = -25;
-	pixel_y = -8;
-	req_access = list(55)
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "xenobio1";
-	name = "Containment Blast Doors";
-	pixel_x = -25;
-	pixel_y = 8;
-	req_access = list(55)
-	},
-/obj/machinery/camera/network/research{
-	dir = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 4;
-	id = "xenobiovs";
-	name = "Containment Blast Doors";
-	pixel_x = -38;
-	req_access = list(55)
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/rnd/xenobiology)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/space/basic,
+/area/space)
 "kDN" = (
 /obj/machinery/door/firedoor/glass{
 	dir = 4
@@ -13124,6 +13107,32 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
+"kNy" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -22
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "xenobio3";
+	name = "Containment Blast Doors";
+	req_access = list(55);
+	pixel_x = -25;
+	pixel_y = -5
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "xenobiovs2";
+	name = "Containment Blast Doors";
+	pixel_x = -38;
+	req_access = list(55)
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/rnd/xenobiology)
 "kNK" = (
 /obj/machinery/vending/medical,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -14555,6 +14564,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/sleeper)
+"lYM" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology)
 "lYO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -15005,15 +15022,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/testingrange)
 "mxS" = (
-/obj/structure/window/reinforced,
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "myq" = (
 /obj/structure/flora/pottedplant/drooping,
@@ -18478,19 +18488,16 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "poq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/structure/window/reinforced,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/research_foyer_auxiliary)
+/turf/simulated/floor/reinforced,
+/area/rnd/xenobiology)
 "poV" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -19483,9 +19490,6 @@
 /turf/simulated/floor/tiled,
 /area/medical/surgery2)
 "pYM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
@@ -21050,6 +21054,36 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/recoveryrestroom)
+"ric" = (
+/obj/machinery/button/remote/blast_door{
+	id = "xenobio2";
+	name = "Containment Blast Doors";
+	pixel_x = -25;
+	pixel_y = -8;
+	req_access = list(55)
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "xenobio1";
+	name = "Containment Blast Doors";
+	pixel_x = -25;
+	pixel_y = 8;
+	req_access = list(55)
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "xenobiovs";
+	name = "Containment Blast Doors";
+	pixel_x = -38;
+	req_access = list(55)
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/rnd/xenobiology)
 "rig" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/black{
 	dir = 4
@@ -21318,20 +21352,18 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "rvs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "rvw" = (
@@ -23339,6 +23371,16 @@
 /obj/item/shovel/spade,
 /obj/item/shovel/spade,
 /obj/item/shovel/spade,
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "thH" = (
@@ -26072,6 +26114,12 @@
 /obj/machinery/power/apc/west_mount,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
+"vzW" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology)
 "vAo" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -27539,31 +27587,19 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "wKj" = (
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -22
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/mauve/border,
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "xenobio3";
-	name = "Containment Blast Doors";
-	req_access = list(55);
-	pixel_x = -25;
-	pixel_y = -5
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 4;
-	id = "xenobiovs2";
-	name = "Containment Blast Doors";
-	pixel_x = -38;
-	req_access = list(55)
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/rnd/xenobiology)
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/xenoflora)
 "wKq" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -28089,9 +28125,7 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "xjy" = (
-/obj/machinery/camera/network/research{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "xjV" = (
@@ -35147,7 +35181,7 @@ mDp
 mDp
 mDp
 mDp
-mDp
+pRW
 mDp
 mDp
 mDp
@@ -35328,7 +35362,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 lIp
 lIp
 aDe
@@ -35342,6 +35375,7 @@ lIp
 lIp
 mDp
 mDp
+pRW
 mDp
 mDp
 mDp
@@ -35522,7 +35556,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 lIp
 mDp
 mDp
@@ -35536,6 +35569,7 @@ mDp
 lIp
 mDp
 mDp
+pRW
 mDp
 mDp
 mDp
@@ -35716,7 +35750,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 lIp
 mDp
 mDp
@@ -35730,6 +35763,7 @@ mDp
 aDe
 aDe
 aDe
+kDK
 aDe
 lIp
 mDp
@@ -35910,12 +35944,11 @@ mDp
 mDp
 mDp
 mDp
-mDp
 lIp
 mDp
 mDp
 mDp
-qRu
+eew
 qRu
 qRu
 qRu
@@ -35924,6 +35957,7 @@ mDp
 lIp
 mDp
 mDp
+pRW
 mDp
 lIp
 lIp
@@ -36104,12 +36138,11 @@ mDp
 mDp
 mDp
 mDp
-mDp
 lIp
 mDp
 mDp
 mDp
-qRu
+eew
 qRu
 qRu
 qRu
@@ -36118,6 +36151,7 @@ qRu
 lIp
 mDp
 mDp
+pRW
 qyX
 mDp
 mDp
@@ -36298,13 +36332,12 @@ mDp
 mDp
 mDp
 mDp
-mDp
 lIp
 mDp
 mDp
 mAv
 lmG
-qRu
+eew
 sun
 thc
 piY
@@ -36318,6 +36351,7 @@ thc
 piY
 thc
 fGD
+pRW
 mDp
 mDp
 mDp
@@ -36492,12 +36526,11 @@ mDp
 mDp
 mDp
 mDp
-mDp
 lIp
 mDp
 mDp
 mDp
-qRu
+eew
 qRu
 rOo
 dwM
@@ -36512,6 +36545,7 @@ caz
 iVG
 uHK
 rOo
+aPs
 lIp
 lIp
 lIp
@@ -36686,13 +36720,12 @@ mDp
 mDp
 mDp
 mDp
-mDp
 lIp
 mDp
 mDp
 mDp
 mDp
-qRu
+eew
 rOo
 kkS
 hbm
@@ -36706,6 +36739,7 @@ hbm
 hbm
 kkS
 rOo
+pRW
 mDp
 mDp
 mDp
@@ -36880,13 +36914,12 @@ mDp
 mDp
 mDp
 mDp
-mDp
 lIp
 lIp
 lIp
 lIp
 lIp
-qRu
+eew
 rOo
 kkS
 hbm
@@ -36900,6 +36933,7 @@ hbm
 hbm
 kkS
 rOo
+pRW
 mDp
 mDp
 mDp
@@ -37077,7 +37111,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 lIp
 mDp
 mDp
@@ -37094,6 +37127,7 @@ hdd
 kOA
 tGK
 rOo
+pRW
 mDp
 mDp
 mDp
@@ -37271,12 +37305,11 @@ mDp
 mDp
 mDp
 mDp
-mDp
 lIp
 mDp
 mDp
 rOo
-mxS
+poq
 cLl
 hvb
 qRu
@@ -37288,6 +37321,7 @@ bEz
 cLl
 hlM
 rOo
+tKG
 tKG
 mDp
 mDp
@@ -37465,7 +37499,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 mDp
@@ -37473,15 +37506,16 @@ rOo
 kDe
 vAo
 vAo
-kDK
+ric
 vAo
 vAo
 vAo
-wKj
+kNy
 vAo
 vAo
 vAo
 rOo
+tKG
 tKG
 tKG
 mDp
@@ -37659,7 +37693,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 mDp
@@ -37668,14 +37701,15 @@ ljT
 taE
 mmM
 dSY
-xjy
+eWW
 vjC
 eWW
+eWW
 kmH
-jwk
 rXQ
 eWW
 rOo
+tKG
 tKG
 vyp
 mDp
@@ -37853,7 +37887,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 mDp
@@ -37864,6 +37897,7 @@ qRu
 qRu
 qRu
 bpn
+eWW
 eWW
 qRu
 qRu
@@ -38047,7 +38081,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 ikZ
@@ -38058,6 +38091,7 @@ hbm
 wGo
 nhg
 moH
+eWW
 eWW
 nhg
 raK
@@ -38241,7 +38275,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 mDp
@@ -38252,6 +38285,7 @@ hbm
 xiT
 wUw
 moH
+eWW
 eWW
 kVv
 hNe
@@ -38435,7 +38469,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 mDp
@@ -38446,6 +38479,7 @@ aUR
 mow
 xCo
 fSg
+xjy
 kvb
 udr
 fzt
@@ -38629,7 +38663,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 mDp
@@ -38640,6 +38673,7 @@ qys
 qRu
 qRu
 lpx
+mxS
 ade
 qRu
 qRu
@@ -38823,7 +38857,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 mDp
@@ -38834,6 +38867,7 @@ hbm
 kIf
 nhg
 pMc
+eWW
 eWW
 nhg
 iNo
@@ -39017,7 +39051,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 mDp
@@ -39028,6 +39061,7 @@ hbm
 dbb
 wUw
 pMc
+eWW
 eWW
 kVv
 qiH
@@ -39211,7 +39245,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 mDp
@@ -39222,6 +39255,7 @@ aUR
 cEL
 xCo
 pgO
+eWW
 eWW
 udr
 dlt
@@ -39405,7 +39439,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 lIp
 lIp
@@ -39416,6 +39449,7 @@ aHi
 qRu
 qRu
 fDP
+eWW
 lcH
 qRu
 qRu
@@ -39599,7 +39633,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 mDp
@@ -39610,6 +39643,7 @@ jtb
 act
 nhg
 pOm
+xjy
 hNl
 nhg
 olF
@@ -39793,7 +39827,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 mDp
@@ -39804,6 +39837,7 @@ mFx
 fSf
 fjC
 bNl
+mxS
 ezb
 kVv
 dbE
@@ -39987,7 +40021,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 mDp
@@ -39998,6 +40031,7 @@ nqb
 ekI
 xCo
 pMc
+eWW
 eWW
 udr
 oZt
@@ -40181,7 +40215,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 mDp
@@ -40192,6 +40225,7 @@ qRu
 qRu
 qRu
 hYh
+huY
 huY
 qRu
 qRu
@@ -40375,7 +40409,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 mDp
@@ -40386,6 +40419,7 @@ wcQ
 bsW
 rMY
 pnF
+xjy
 aVO
 qRu
 jGS
@@ -40569,7 +40603,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 lIp
 lIp
@@ -40580,6 +40613,7 @@ eWW
 eWW
 eAv
 pKi
+vzW
 wQy
 qRu
 iyI
@@ -40763,7 +40797,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 mDp
@@ -40774,6 +40807,7 @@ cjM
 sJj
 eWW
 bjg
+mxS
 ezb
 sQe
 iyI
@@ -40957,7 +40991,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 mDp
@@ -40968,6 +41001,7 @@ hgr
 hgr
 pyL
 dip
+eWW
 eWW
 sQe
 iyI
@@ -41151,7 +41185,6 @@ mDp
 mDp
 mDp
 mDp
-mDp
 aDe
 mDp
 ikZ
@@ -41162,6 +41195,7 @@ tPY
 ody
 eWW
 efz
+eWW
 miA
 cmc
 bDG
@@ -41345,9 +41379,8 @@ mDp
 mDp
 mDp
 mDp
-mDp
 lIp
-mDp
+lIp
 mDp
 sQe
 lVD
@@ -41356,6 +41389,7 @@ uDK
 ndm
 hui
 oqZ
+lYM
 wlm
 phf
 hpE
@@ -41542,7 +41576,7 @@ mDp
 mDp
 lIp
 mDp
-mDp
+dQf
 sQe
 acD
 uCN
@@ -42520,10 +42554,10 @@ hdc
 hia
 eQu
 oku
-blH
+wKj
 fxa
-iyI
-lui
+cEN
+dmG
 cIp
 qpQ
 qpQ
@@ -43105,7 +43139,7 @@ xdh
 cYX
 tij
 iyI
-lui
+wpj
 iWe
 lui
 wpj
@@ -43297,9 +43331,9 @@ hia
 eQu
 cQu
 rvs
-dQf
-poq
-eew
+tij
+aUY
+quN
 quN
 lDO
 wpj

--- a/maps/triumph/levels/deck3.dmm
+++ b/maps/triumph/levels/deck3.dmm
@@ -18386,16 +18386,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/rnd/research_foyer_auxiliary)
-"pmc" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/door/airlock/glass/research{
-	name = "Research Lobby";
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
 "pmG" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
@@ -48528,7 +48518,7 @@ cTS
 uWQ
 mAp
 oBJ
-pmc
+trm
 pWp
 hXs
 cbh

--- a/maps/triumph/levels/deck3.dmm
+++ b/maps/triumph/levels/deck3.dmm
@@ -87,11 +87,18 @@
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
 "ade" = (
-/obj/machinery/atmospherics/pipe/vent/high_volume{
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
-/area/space)
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "xenobiovs6";
+	name = "Divider Blast Doors";
+	pixel_y = -38;
+	req_one_access = list(29,47)
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology)
 "aee" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
@@ -643,6 +650,11 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/hydroponics{
+	name = "Xenobotanist's locker";
+	req_access = list();
+	req_one_access = list(30,35,47,77)
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "aDe" = (
@@ -821,9 +833,13 @@
 /turf/simulated/floor/wood,
 /area/medical/medbay4)
 "aHi" = (
-/obj/machinery/light,
-/obj/machinery/smartfridge/secure/extract,
-/turf/simulated/floor/tiled,
+/obj/machinery/door/blast/regular{
+	id = "xenobiovs4";
+	layer = 8;
+	name = "Divider Blast Door";
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "aHG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1129,7 +1145,13 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer_auxiliary)
 "aVO" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/vending/wallmed1{
+	name = "Emergency NanoMed";
+	pixel_y = -30
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "aWr" = (
@@ -1483,9 +1505,6 @@
 /turf/simulated/floor/tiled,
 /area/medical/surgery)
 "bpn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
@@ -1530,7 +1549,10 @@
 /area/rnd/xenobiology/xenoflora_storage)
 "bsW" = (
 /obj/structure/table/standard,
-/obj/item/melee/baton/slime/loaded,
+/obj/machinery/computer/atmoscontrol/laptop{
+	monitored_alarm_ids = list("xenopenvent");
+	req_one_access = list(47,24,11)
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "btU" = (
@@ -2514,12 +2536,13 @@
 /turf/simulated/floor/tiled,
 /area/medical/sleeper)
 "cjM" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/holopad,
-/turf/simulated/floor/tiled/dark,
-/area/assembly/robotics/surgery)
+/obj/structure/table/standard,
+/obj/item/weldingtool,
+/obj/item/weldingtool,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology)
 "ckU" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -2711,10 +2734,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "crw" = (
-/obj/structure/table/standard,
-/obj/item/gun/energy/taser/xeno,
-/obj/item/melee/baton/slime/loaded,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/manifold/hidden/purple{
+	dir = 1
+	},
+/turf/simulated/wall/prepainted/science,
 /area/rnd/xenobiology)
 "crH" = (
 /obj/machinery/door/airlock/maintenance/common,
@@ -2912,6 +2935,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
+/obj/fiftyspawner/cardboard,
 /turf/simulated/floor/tiled,
 /area/rnd/reception_desk)
 "cAb" = (
@@ -2997,6 +3021,9 @@
 	frequency = 1445;
 	id = "burn_in";
 	volume_rate = 700
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
@@ -3563,14 +3590,18 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "dbE" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "xenobiocoldroom"
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "xenobio10";
+	name = "Containment Blast Doors";
+	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
+/obj/machinery/door/window/brigdoor/southright{
+	name = "Containment Pen";
+	req_access = list(55)
 	},
-/turf/simulated/floor/bluegrid,
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "dci" = (
 /obj/effect/floor_decal/borderfloorwhite{
@@ -3725,9 +3756,16 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyisolation)
 "dip" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "djp" = (
@@ -3779,10 +3817,16 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
 "dlt" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 4
+/obj/spawner/window/low_wall/reinforced/full,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "xenobio9";
+	name = "Containment Blast Doors";
+	opacity = 0
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "dlw" = (
 /obj/machinery/door/firedoor{
@@ -4133,14 +4177,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyisolation)
 "dEc" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 5;
+	pixel_y = 32
 	},
-/obj/machinery/disposal,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "dEl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4759,6 +4801,7 @@
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper,
+/obj/item/hand_labeler,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "eaI" = (
@@ -5180,12 +5223,22 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyaccess)
 "ety" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "xenobiocoldroom"
+/obj/structure/closet/emcloset,
+/obj/machinery/camera/network/research{
+	dir = 4;
+	network = list("Xenobiology")
 	},
-/turf/simulated/floor/bluegrid,
-/area/rnd/xenobiology)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/research_foyer_auxiliary)
 "etB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5294,10 +5347,7 @@
 /turf/simulated/floor/tiled,
 /area/rnd/anomaly_lab/containment_two)
 "ezO" = (
-/obj/machinery/camera/network/research{
-	dir = 4;
-	network = list("Xenobiology")
-	},
+/obj/machinery/camera/network/research,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "eAh" = (
@@ -6514,18 +6564,15 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak/surgery)
 "fzt" = (
+/obj/spawner/window/low_wall/reinforced/full,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 8;
 	icon_state = "pdoor0";
-	id = "xenobio6";
+	id = "xenobio8";
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
-/obj/spawner/window/low_wall/reinforced/full,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "fzF" = (
@@ -6605,14 +6652,28 @@
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
 "fDP" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "xenobiocoldroom"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/bluegrid,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "xenobiovs4";
+	name = "Divider Blast Doors";
+	req_access = list(55);
+	pixel_y = 38
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/rnd/xenobiology)
 "fGD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
@@ -7005,9 +7066,6 @@
 /turf/simulated/floor/wood,
 /area/rnd/xenobiology)
 "fSg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/machinery/button/remote/blast_door{
 	dir = 4;
 	id = "xenobio7";
@@ -7021,6 +7079,9 @@
 	},
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/xenobiology)
@@ -7155,11 +7216,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "fXo" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "xenobiocoldroom";
-	name = "XenoBio Cold Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+/obj/machinery/door/blast/regular{
+	id = "xenobiovs6";
+	layer = 8;
+	name = "Divider Blast Door";
 	dir = 4
 	},
 /turf/simulated/floor/reinforced,
@@ -8402,19 +8462,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "hgr" = (
-/obj/machinery/camera/network/research{
-	dir = 4;
-	network = list("Xenobiology")
-	},
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 8
-	},
+/obj/structure/table/standard,
+/obj/item/melee/baton/slime/loaded,
+/obj/item/gun/energy/taser/xeno,
+/obj/item/slime_scanner,
 /turf/simulated/floor/tiled,
-/area/rnd/research_foyer_auxiliary)
+/area/rnd/xenobiology)
 "hhH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -8818,9 +8871,6 @@
 /turf/simulated/wall/prepainted/medical,
 /area/medical/virologyaccess)
 "huY" = (
-/obj/item/radio/intercom{
-	pixel_y = -24
-	},
 /obj/machinery/door/firedoor{
 	dir = 1
 	},
@@ -9324,18 +9374,30 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "hNe" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 10
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "xenobio8";
+	name = "Containment Blast Doors";
+	opacity = 0
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/door/window/brigdoor/southright{
+	name = "Containment Pen";
+	req_access = list(55)
+	},
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "hNl" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/light,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "xenobio10";
+	name = "Containment Blast Doors";
+	pixel_x = -24;
+	pixel_y = -24;
+	req_access = list(55)
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
@@ -9463,6 +9525,15 @@
 	dir = 8;
 	light_range = 12
 	},
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/component/binary/pump/high_power{
+	dir = 8;
+	id = "emg_pump";
+	name = "Emergency Pen Flood Manual Switch"
+	},
+/obj/structure/window/phoronreinforced,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "hRR" = (
@@ -9734,13 +9805,18 @@
 /turf/simulated/floor/tiled,
 /area/medical/psych_ward)
 "idK" = (
-/obj/machinery/vending/wallmed1{
-	name = "Emergency NanoMed";
-	pixel_y = -30
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/processor,
-/turf/simulated/floor/tiled,
-/area/rnd/xenobiology)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/assembly/robotics/surgery)
 "idX" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -9915,14 +9991,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "ilx" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/obj/machinery/camera/network/research{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/xenobiology)
+/obj/machinery/holopad,
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
 "ilA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -10656,10 +10727,15 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora/lab_atmos)
 "iNo" = (
-/obj/machinery/atmospherics/component/binary/pump/on{
-	dir = 8
+/obj/spawner/window/low_wall/reinforced/full,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "xenobio9";
+	name = "Containment Blast Doors";
+	opacity = 0
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "iNI" = (
 /obj/effect/floor_decal/techfloor,
@@ -11662,7 +11738,7 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
-/obj/machinery/vending/hydroseeds,
+/obj/machinery/seed_storage/xenobotany,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "jCw" = (
@@ -11827,12 +11903,12 @@
 /turf/simulated/floor/tiled,
 /area/medical/medbay_primary_storage)
 "jGS" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "xenobiocoldroom"
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 9
 	},
-/turf/simulated/floor/bluegrid,
-/area/rnd/xenobiology)
+/turf/simulated/floor/tiled,
+/area/rnd/research_foyer_auxiliary)
 "jHd" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/light{
@@ -12447,14 +12523,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/anomaly_lab/containment_one)
 "kmH" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "xenobiocoldroom"
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = -8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
-/turf/simulated/floor/bluegrid,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "kmO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -12512,14 +12586,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "kra" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
+/obj/structure/closet/hydrant,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "krA" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
+/obj/machinery/smartfridge/secure/extract,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "ktj" = (
 /obj/structure/window/reinforced,
@@ -12630,6 +12702,14 @@
 "kvb" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "xenobio8";
+	name = "Containment Blast Doors";
+	pixel_x = 24;
+	pixel_y = -24;
+	req_access = list(55)
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
@@ -12794,12 +12874,6 @@
 /area/medical/medbay_emt_bay)
 "kDK" = (
 /obj/machinery/button/remote/blast_door{
-	id = "xenobiovs";
-	name = "Divider Blast Doors";
-	pixel_x = -38;
-	req_access = list(55)
-	},
-/obj/machinery/button/remote/blast_door{
 	id = "xenobio2";
 	name = "Containment Blast Doors";
 	pixel_x = -25;
@@ -12821,6 +12895,13 @@
 	},
 /obj/machinery/camera/network/research{
 	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "xenobiovs2";
+	name = "Containment Blast Doors";
+	pixel_x = -38;
+	req_access = list(55)
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/xenobiology)
@@ -13006,6 +13087,8 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/glasses/welding,
 /turf/simulated/floor/tiled,
 /area/rnd/reception_desk)
 "kNr" = (
@@ -13163,11 +13246,11 @@
 /turf/simulated/floor/tiled,
 /area/medical/sleeper)
 "kVv" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Containment Pen";
+	req_access = list(55)
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "kVZ" = (
 /obj/structure/cable/green{
@@ -13364,9 +13447,20 @@
 /turf/simulated/floor/tiled,
 /area/triumph/station/stairs_three)
 "lcH" = (
-/obj/machinery/air_alarm{
+/obj/machinery/button/remote/blast_door{
 	dir = 1;
-	pixel_y = -25
+	id = "xenobiovs5";
+	name = "Divider Blast Doors";
+	pixel_y = -38;
+	req_one_access = list(29,47)
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "xenobio9";
+	name = "Containment Blast Doors";
+	pixel_x = -8;
+	pixel_y = -24;
+	req_access = list(55)
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
@@ -13583,14 +13677,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room/exam_2)
 "loK" = (
-/obj/machinery/atmospherics/component/binary/pump/high_power{
-	dir = 8;
-	id = "emg_pump";
-	name = "Emergency Pen Flood Manual Switch"
-	},
-/obj/structure/window/phoronreinforced,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall/prepainted/science,
 /area/rnd/xenobiology)
 "loL" = (
 /obj/effect/floor_decal/borderfloorwhite,
@@ -13613,15 +13704,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 5;
-	pixel_y = 32
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "xenobiovs3";
+	name = "Divider Blast Doors";
+	req_access = list(55);
+	pixel_y = 38
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/xenobiology)
@@ -13910,19 +14003,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics/surgery)
 "lCd" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+/obj/machinery/door/blast/regular{
+	id = "xenobiovs2";
+	layer = 8;
+	name = "Divider Blast Door"
 	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "xenobio3";
-	name = "Containment Blast Doors";
-	pixel_y = -28;
-	req_access = list(55)
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "lCA" = (
 /obj/machinery/camera/network/research{
@@ -14352,6 +14438,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/machinery/processor,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "lXq" = (
@@ -14732,9 +14819,6 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "moH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -15073,13 +15157,8 @@
 /turf/simulated/floor/wood,
 /area/rnd/xenobiology)
 "mFC" = (
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/bluegrid,
+/obj/random/slimecore,
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "mFI" = (
 /turf/simulated/floor/tiled/white,
@@ -15496,19 +15575,21 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "mWV" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "xenobiocoldroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
 	},
-/obj/machinery/camera/network/research{
-	dir = 4;
-	network = list("Xenobiology")
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/bluegrid,
-/area/rnd/xenobiology)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/xenoflora/lab_atmos)
 "mXg" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/meter,
@@ -16788,18 +16869,11 @@
 /area/medical/recoveryrestroom)
 "ody" = (
 /obj/structure/table/standard,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/glasses/welding,
-/obj/item/weldingtool,
-/obj/item/weldingtool,
-/obj/item/storage/bag/xenobio{
-	pixel_x = 7;
-	pixel_y = 5
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/obj/item/storage/bag/xenobio{
-	pixel_x = -7;
-	pixel_y = 5
-	},
+/obj/item/storage/box/syringes,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "oey" = (
@@ -16996,31 +17070,14 @@
 /turf/simulated/floor/tiled,
 /area/rnd/test_area)
 "olF" = (
+/obj/spawner/window/low_wall/reinforced/full,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
-	id = "xenobio6";
+	id = "xenobio10";
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
-/obj/machinery/door/window/brigdoor/northright{
-	dir = 8;
-	name = "Containment Pen";
-	req_access = list(55)
-	},
-/obj/machinery/door/window/brigdoor/northright{
-	dir = 4;
-	name = "Containment Pen";
-	req_access = list(55)
-	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "xenobiocoldroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/obj/structure/plasticflaps/mining,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "omH" = (
@@ -17446,11 +17503,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/testingrange)
 "oGQ" = (
-/obj/machinery/atmospherics/valve{
-	name = "VENT TO WASTE"
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/plating,
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "oHb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -17755,14 +17814,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/cmo)
 "oRR" = (
-/obj/machinery/atmospherics/component/unary/freezer{
-	dir = 1;
-	icon_state = "freezer_1";
-	power_setting = 20;
-	set_temperature = 73;
-	use_power = 1
+/obj/machinery/door/blast/regular{
+	id = "xenobiovs5";
+	layer = 8;
+	name = "Divider Blast Door";
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "oSi" = (
 /turf/simulated/floor/plating,
@@ -18018,18 +18076,16 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "oZt" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "xenobiocoldroom"
+/obj/spawner/window/low_wall/reinforced/full,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "xenobio10";
+	name = "Containment Blast Doors";
+	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/obj/machinery/air_alarm/monitor/isolation{
-	alarm_id = "xenopenvent";
-	pixel_y = 24
-	},
-/turf/simulated/floor/bluegrid,
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "oZA" = (
 /obj/machinery/light{
@@ -18201,19 +18257,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
 "phe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 8;
-	icon_state = "pdoor0";
-	id = "xenobio6";
-	name = "Containment Blast Doors";
-	opacity = 0
-	},
-/obj/spawner/window/low_wall/reinforced/full,
-/turf/simulated/floor/reinforced,
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/manifold/hidden/purple,
+/turf/simulated/wall/r_wall/prepainted/science,
 /area/rnd/xenobiology)
 "phf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18341,11 +18387,15 @@
 /turf/simulated/floor/grass,
 /area/rnd/research_foyer_auxiliary)
 "pmc" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+/obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
+/obj/machinery/door/airlock/glass/research{
+	name = "Research Lobby";
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled,
-/area/rnd/xenobiology)
+/area/hallway/primary/aft)
 "pmG" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
@@ -18634,14 +18684,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "pyL" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "xenobiocoldroom"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/bluegrid,
+/mob/living/bot/secbot/slime/slimesky,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "pyQ" = (
 /obj/structure/sign/warning/nosmoking_2,
@@ -19638,11 +19682,18 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer_auxiliary)
 "qiH" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "xenobio9";
+	name = "Containment Blast Doors";
+	opacity = 0
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/door/window/brigdoor/southright{
+	name = "Containment Pen";
+	req_access = list(55)
+	},
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "qiK" = (
 /obj/machinery/door/firedoor/glass,
@@ -20006,8 +20057,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/testingrange)
 "qys" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/obj/machinery/door/blast/regular{
+	id = "xenobiovs3";
+	layer = 8;
+	name = "Divider Blast Door";
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "qyX" = (
 /obj/machinery/camera/network/outside{
@@ -20107,8 +20163,8 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "qCZ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
@@ -20728,6 +20784,9 @@
 	id = "burn_in";
 	volume_rate = 700
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/rnd/xenobiology)
 "qYS" = (
@@ -20763,13 +20822,15 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/cockpit)
 "raK" = (
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 1
+/obj/spawner/window/low_wall/reinforced/full,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "xenobio8";
+	name = "Containment Blast Doors";
+	opacity = 0
 	},
-/obj/machinery/fire_alarm/south_mount{
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "rbc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -20952,9 +21013,6 @@
 /obj/machinery/air_alarm{
 	pixel_y = 22
 	},
-/obj/item/storage/box/botanydisk,
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "rfZ" = (
@@ -21610,6 +21668,9 @@
 	pixel_y = 24;
 	req_access = list()
 	},
+/obj/structure/table/glass,
+/obj/item/storage/box/botanydisk,
+/obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "rLU" = (
@@ -21894,8 +21955,9 @@
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
 "rXQ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
@@ -22105,7 +22167,6 @@
 /area/medical/surgeryprep)
 "slc" = (
 /obj/structure/table/standard,
-/obj/item/gun/energy/taser/xeno,
 /obj/item/multitool,
 /obj/machinery/camera/network/research{
 	dir = 4;
@@ -22326,17 +22387,9 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer_auxiliary)
 "svB" = (
-/obj/structure/table/standard,
-/obj/item/slime_scanner,
-/obj/item/slime_scanner,
-/obj/item/storage/box/monkeycubes{
-	starts_with = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped=10)
-	},
-/obj/item/storage/box/monkeycubes{
-	starts_with = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped=10)
-	},
+/obj/machinery/holopad,
 /turf/simulated/floor/tiled,
-/area/rnd/xenobiology)
+/area/rnd/test_area)
 "svR" = (
 /turf/simulated/wall/prepainted/science,
 /area/rnd/breakroom)
@@ -22731,6 +22784,18 @@
 /area/triumph/station/stairs_three)
 "sJj" = (
 /obj/structure/table/standard,
+/obj/item/storage/box/monkeycubes{
+	starts_with = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped=10)
+	},
+/obj/item/storage/box/monkeycubes{
+	starts_with = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped=10)
+	},
+/obj/item/storage/box/monkeycubes{
+	starts_with = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped=10)
+	},
+/obj/item/storage/box/monkeycubes{
+	starts_with = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped=10)
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "sJr" = (
@@ -22996,10 +23061,6 @@
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room/exam_2)
-"sYJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/floor/tiled,
-/area/rnd/xenobiology)
 "sYQ" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -23162,6 +23223,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 5
 	},
+/obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "tfh" = (
@@ -24105,8 +24167,14 @@
 /turf/simulated/wall/r_wall/prepainted/science,
 /area/rnd/anomaly_lab)
 "tPY" = (
-/obj/machinery/atmospherics/component/binary/pump/on{
-	dir = 4
+/obj/structure/table/standard,
+/obj/item/storage/bag/xenobio{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/storage/bag/xenobio{
+	pixel_x = 7;
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
@@ -24363,15 +24431,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "udr" = (
-/obj/structure/table/standard,
-/obj/machinery/computer/atmoscontrol/laptop{
-	monitored_alarm_ids = list("xenopenvent");
-	req_one_access = list(47,24,11)
-	},
-/obj/machinery/camera/network/research{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "ufe" = (
 /obj/structure/table/steel_reinforced,
@@ -24822,11 +24887,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "uwU" = (
-/obj/item/radio/intercom{
-	pixel_y = -24
-	},
-/obj/structure/closet/l3closet/scientist/double,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/manifold/hidden/purple,
+/turf/simulated/wall/r_wall/prepainted/science,
 /area/rnd/xenobiology)
 "uxu" = (
 /obj/structure/table/rack,
@@ -24955,7 +25017,6 @@
 	pixel_x = 25
 	},
 /obj/item/clothing/glasses/science,
-/obj/item/reagent_containers/syringe,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "uDx" = (
@@ -25631,11 +25692,7 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "vjC" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 4
-	},
-/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/machinery/holopad,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "vkz" = (
@@ -25743,6 +25800,7 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
+/obj/machinery/camera/network/research,
 /turf/simulated/floor/wood,
 /area/rnd/xenobiology)
 "vrg" = (
@@ -25833,12 +25891,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/psych_ward)
-"vti" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/xenobiology)
 "vtj" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light{
@@ -26137,9 +26189,9 @@
 /area/medical/medbay_emt_bay)
 "vFj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 4
+	dir = 9
 	},
-/turf/simulated/wall/prepainted/science,
+/turf/simulated/wall/r_wall/prepainted/science,
 /area/rnd/xenobiology)
 "vFG" = (
 /obj/machinery/computer/shuttle_control/explore/emt{
@@ -26316,15 +26368,11 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/research)
 "vMn" = (
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/borderfloor{
-	dir = 9
+/obj/machinery/camera/network/research{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/research_foyer_auxiliary)
+/turf/simulated/floor/reinforced,
+/area/rnd/xenobiology)
 "vMN" = (
 /obj/machinery/door/firedoor/glass{
 	dir = 4
@@ -26357,13 +26405,6 @@
 /obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled,
 /area/medical/sleeper)
-"vOc" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/atmospherics/valve{
-	name = "EMERGENCY VENT TO SPACE"
-	},
-/turf/simulated/floor/plating,
-/area/rnd/xenobiology)
 "vOA" = (
 /obj/machinery/sleep_console,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -26537,6 +26578,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 6
 	},
+/obj/item/hand_labeler,
 /turf/simulated/floor/tiled,
 /area/rnd/reception_desk)
 "vXG" = (
@@ -26731,14 +26773,8 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "wcQ" = (
-/obj/item/reagent_containers/food/snacks/monkeycube/wrapped,
 /obj/structure/table/standard,
-/obj/item/storage/box/monkeycubes{
-	starts_with = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped=10)
-	},
-/obj/item/storage/box/monkeycubes{
-	starts_with = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped=10)
-	},
+/obj/machinery/fire_alarm/alarms_hidden/west_mount,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "wdh" = (
@@ -27477,10 +27513,6 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -22
 	},
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -4
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -27489,6 +27521,20 @@
 	},
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "xenobio3";
+	name = "Containment Blast Doors";
+	req_access = list(55);
+	pixel_x = -25;
+	pixel_y = -5
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "xenobiovs2";
+	name = "Containment Blast Doors";
+	pixel_x = -38;
+	req_access = list(55)
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/xenobiology)
@@ -27502,12 +27548,6 @@
 /obj/machinery/fire_alarm/east_mount,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_d)
-"wLf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/xenobiology)
 "wLE" = (
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = null
@@ -27723,8 +27763,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
 "wTy" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/purple,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/purple{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "wTM" = (
@@ -27795,26 +27837,6 @@
 /obj/item/storage/box/firingpins,
 /turf/simulated/floor/tiled,
 /area/rnd/rdoffice)
-"wYE" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "xenobiocoldroom"
-	},
-/obj/machinery/atmospherics/component/unary/vent_pump{
-	dir = 8;
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
-	icon_state = "map_vent_in";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	on = 1;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0
-	},
-/turf/simulated/floor/bluegrid,
-/area/rnd/xenobiology)
 "wYX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/door/firedoor/glass,
@@ -28032,16 +28054,10 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "xjy" = (
-/obj/machinery/button/remote/blast_door{
-	id = "xenobio6";
-	name = "Containment Blast Doors";
-	pixel_y = 28;
-	req_access = list(55)
+/obj/machinery/camera/network/research{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "xjV" = (
 /obj/structure/noticeboard{
@@ -28466,10 +28482,12 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "xER" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/disposaloutlet{
+	dir = 8
 	},
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "xEU" = (
@@ -29195,15 +29213,13 @@
 /turf/simulated/floor/airless/ceiling,
 /area/rnd/research_foyer_auxiliary)
 "ymb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 4
+/obj/machinery/light,
+/obj/machinery/atmospherics/component/unary/outlet_injector{
+	frequency = 1445;
+	id = "burn_in";
+	volume_rate = 700
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance/rnd{
-	req_one_access = null
-	},
-/obj/map_helper/access_helper/airlock/station/science/department,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 
 (1,1,1) = {"
@@ -36456,7 +36472,7 @@ mbb
 caz
 iVG
 uHK
-qRu
+lCd
 caz
 iVG
 uHK
@@ -36650,7 +36666,7 @@ mbb
 hbm
 hbm
 kkS
-qRu
+lCd
 hbm
 hbm
 kkS
@@ -36844,7 +36860,7 @@ mbb
 hbm
 hbm
 kkS
-qRu
+lCd
 hbm
 hbm
 kkS
@@ -37429,7 +37445,7 @@ vAo
 wKj
 vAo
 vAo
-lCd
+vAo
 rOo
 tKG
 tKG
@@ -37617,15 +37633,15 @@ ljT
 taE
 mmM
 dSY
+xjy
+vjC
 eWW
-eWW
-eWW
-eWW
+kmH
 eWW
 rXQ
-vOc
-vjC
-ade
+eWW
+rOo
+tKG
 vyp
 mDp
 bBA
@@ -37813,13 +37829,13 @@ qRu
 qRu
 qRu
 bpn
-qys
-sYJ
-oGQ
-aVO
-idK
+eWW
+qRu
+qRu
+qRu
+qRu
+wTM
 rOo
-tKG
 tKG
 mDp
 suI
@@ -38002,18 +38018,18 @@ mDp
 ikZ
 rOo
 ezO
-caz
+hbm
 hbm
 wGo
-xER
+nhg
 moH
 eWW
-eWW
-eWW
-vti
-uwU
+nhg
+raK
+hbm
+hbm
+vMn
 rOo
-tKG
 lIp
 lIp
 suI
@@ -38202,12 +38218,12 @@ xiT
 wUw
 moH
 eWW
-eWW
-eWW
-qiH
-ilx
-rOo
-vnY
+kVv
+hNe
+hbm
+mFC
+ymb
+uwU
 vnY
 vnY
 suI
@@ -38396,12 +38412,12 @@ mow
 xCo
 fSg
 kvb
-svB
-eWW
-pmc
-xmL
+udr
+fzt
+aUR
+aUR
+oGQ
 rOo
-tKG
 tKG
 tKG
 suI
@@ -38583,21 +38599,21 @@ aDe
 mDp
 mDp
 rOo
-qRu
-qRu
-qRu
+qys
+qys
+qys
 qRu
 qRu
 lpx
-ezb
-crw
-dip
-kra
+ade
+qRu
+qRu
+oRR
+oRR
 oRR
 rOo
-gMc
 kMx
-tKG
+gMc
 suI
 bTp
 mxb
@@ -38778,18 +38794,18 @@ mDp
 mDp
 rOo
 ezO
-caz
+hbm
 hbm
 kIf
 nhg
 pMc
 eWW
-ody
+nhg
 iNo
-tPY
-aHi
+hbm
+hbm
+vMn
 rOo
-suI
 suI
 suI
 suI
@@ -38978,14 +38994,14 @@ dbb
 wUw
 pMc
 eWW
-eWW
-dlt
-wLf
-eWW
+kVv
+qiH
+hbm
+hbm
 ymb
+phe
 bTp
 tys
-bTp
 bTp
 bTp
 cpA
@@ -39174,13 +39190,13 @@ pgO
 eWW
 udr
 dlt
-kVv
-eWW
+aUR
+aUR
+xER
 rOo
-tji
 sXB
 oSV
-cpA
+tji
 bTp
 jgN
 ejI
@@ -39359,20 +39375,20 @@ aDe
 lIp
 lIp
 rOo
+aHi
+aHi
+aHi
 qRu
 qRu
-qRu
-qRu
-qRu
-pMc
+fDP
 lcH
 qRu
-xjy
+qRu
 fXo
-dEc
-wTM
+fXo
+fXo
+crw
 kMD
-xIf
 xIf
 xIf
 qNd
@@ -39554,17 +39570,17 @@ mDp
 mDp
 rOo
 vqV
-krA
+mFx
 jtb
 act
 nhg
 pOm
 hNl
-qRu
+nhg
 olF
-fzt
-phe
-qRu
+hbm
+hbm
+vMn
 loK
 hRL
 dJW
@@ -39753,14 +39769,14 @@ mFx
 fSf
 fjC
 bNl
-raK
-qRu
+ezb
+kVv
 dbE
-mWV
+hbm
 mFC
-qRu
+ymb
 vFj
-eWW
+qCZ
 cHx
 xIf
 bTp
@@ -39948,12 +39964,12 @@ ekI
 xCo
 pMc
 eWW
-qRu
+udr
 oZt
-kmH
-ety
+aUR
+aUR
+oGQ
 qRu
-hNe
 qCZ
 eWW
 xIf
@@ -40143,13 +40159,13 @@ qRu
 hYh
 huY
 qRu
-wYE
-fDP
-ety
 qRu
-spv
+qRu
+qRu
+qRu
+qRu
 wTy
-eWW
+xmL
 xIf
 bTp
 fMM
@@ -40335,12 +40351,12 @@ wcQ
 bsW
 rMY
 pnF
-kvb
+aVO
 qRu
 jGS
 ety
-ety
-qRu
+xoj
+mth
 spv
 soU
 tPb
@@ -40350,7 +40366,7 @@ rAp
 uEl
 tFQ
 ije
-wpd
+ilx
 ovX
 aDx
 ejy
@@ -40531,10 +40547,10 @@ eAv
 pKi
 wQy
 qRu
-jGS
-pyL
-ety
-qRu
+iyI
+wpj
+cIp
+mth
 dzg
 soU
 eWW
@@ -40717,18 +40733,18 @@ aDe
 mDp
 mDp
 sQe
+krA
 eWW
-eWW
-sJj
+cjM
 sJj
 eWW
 bjg
 ezb
-qRu
-qRu
-qRu
-qRu
-qRu
+sQe
+iyI
+wpj
+cIp
+mth
 ehf
 pdP
 eWW
@@ -40913,15 +40929,15 @@ mDp
 sQe
 pBY
 eWW
-sJj
-sJj
-eWW
-efz
+hgr
+hgr
+pyL
+dip
 eWW
 sQe
-vMn
-hgr
-xoj
+iyI
+wpj
+cIp
 qpQ
 ioE
 rWa
@@ -41105,10 +41121,10 @@ aDe
 mDp
 ikZ
 qRu
-pBY
+dEc
 eWW
-sJj
-sJj
+tPY
+ody
 eWW
 efz
 miA
@@ -41499,7 +41515,7 @@ vhU
 nzW
 nOY
 bmd
-bmd
+kra
 ntf
 iyI
 lui
@@ -42289,7 +42305,7 @@ bTp
 mxb
 uJh
 rsn
-cjM
+fiD
 vdw
 wiC
 dbo
@@ -42468,7 +42484,7 @@ ecE
 hdc
 hia
 eQu
-rFW
+oku
 blH
 fxa
 iyI
@@ -42484,7 +42500,7 @@ qpQ
 qpQ
 hSv
 fiD
-vdw
+idK
 yhE
 ikR
 qog
@@ -42856,7 +42872,7 @@ ecE
 hdc
 hia
 eQu
-oku
+rFW
 jBH
 vez
 bDG
@@ -44600,7 +44616,7 @@ uLo
 eEX
 wNs
 nCp
-pUl
+mWV
 oTA
 nbZ
 uLo
@@ -48512,7 +48528,7 @@ cTS
 uWQ
 mAp
 oBJ
-trm
+pmc
 pWp
 hXs
 cbh
@@ -50037,7 +50053,7 @@ pEE
 muS
 sLT
 sLT
-sLT
+svB
 clp
 cTl
 vws

--- a/maps/triumph/levels/deck3.dmm
+++ b/maps/triumph/levels/deck3.dmm
@@ -20163,8 +20163,8 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "qCZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)


### PR DESCRIPTION
## About The Pull Request

This is a bunch of changes to the Triumph to try to unshit parts of it at least. Here's a number of science QoL and mild mapping changes to correct small nitpicks or issues in it. This is part one of Probably Many, I'll do the changes department by department probably, until I get to general ones.

Here's a list of ALL the changes.
cardboard stack in r&d
labeler in r&d
another toolbelt & welding goggles in r&d
labeler in xenobotany
slimesky in xenobio by default
xenobio killbox removed, replaced with 3 more pens. (i dont think it was very useful, vs using a chem sprayer or cryogun. more pens also is More Logical.)
xenobio has a box of beakers & syringes.
xenobio has two sets of slime batons & taser guns instead of one.
xenobio welding tank removed.
all xenobio pens have dividers that are openable now.
2 random slime core spawns added in pens. (to match atlas)
2 xenobotany lockers in xenobotany (with plant bags and so on.)
bucket added to other water tank in xenobotany
correct xenobotany seed vendor to replace the seed vendor currently in xenobotany
holopads added to robotics morgue, xenobotany, toxins, and xenobiology


## Why It's Good For The Game

It adds parity across toolsets in the Triumph to the Atlas, including a few QoL things. They're small, but they're small things that add up to a general dissatisfaction with it.
It also makes more pen room for xenobiology replacing the kill room which I think was mostly not useful versus using the other tools to Murder slimes. As well as add a few holopads around for the AI / similar which was also needed.
The Slimesky thing could get removed, it's mostly there for QoL as well. Arguably, the recipe should get changed to a slime scanner instead of a helmet, but I think someone said they'll do that.

## Changelog

:cl:
add: Small pieces of equipment like a labeler, cardboard sheets were added to Triumph's R&D.
add: A slimesky now spawns in Xenobiology.
add: A few holopads were added around the Triumph's science department in Xenobio, Xenobotany, Toxins, and Robotics Morgue.
add: Xenobotany lockers now spawn in Triumph's Xenobotany.
tweak: Triumph's Xenobiology was shuffled around and changed to add more pens.
tweak: The Triumph's xenobotany plant vendor replaces the wrong one that is currently in place.
/:cl: