### PR TITLE
Rust adjustment (H2 energy level to ACTUALLY obtainable power reqs)

### DIFF
--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -152,7 +152,7 @@ var/list/fusion_reactions
 /singleton/fusion_reaction/hydrogen_hydrogen
 	p_react = "hydrogen"
 	s_react = "hydrogen"
-	minimum_energy_level = FUSION_HEAT_CAP * 0.75
+	minimum_energy_level = FUSION_HEAT_CAP * 0.745
 	energy_consumption = 0
 	energy_production = 20
 	radiation = 5

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -143,7 +143,7 @@ var/list/fusion_reactions
 /singleton/fusion_reaction/boron_hydrogen
 	p_react = "boron"
 	s_react = "hydrogen"
-	minimum_energy_level = FUSION_HEAT_CAP * 0.5
+	minimum_energy_level = 78500 //Was unobtainable or rather unsustainable before
 	energy_consumption = 3
 	energy_production = 15
 	radiation = 3
@@ -152,7 +152,7 @@ var/list/fusion_reactions
 /singleton/fusion_reaction/hydrogen_hydrogen
 	p_react = "hydrogen"
 	s_react = "hydrogen"
-	minimum_energy_level = FUSION_HEAT_CAP * 0.745
+	minimum_energy_level = 117000 //So its actually unobtainable even with the new values I swear if engineering makes me add cold fusion I am going to not touch engineering for at least a month
 	energy_consumption = 0
 	energy_production = 20
 	radiation = 5


### PR DESCRIPTION
Engineering asked for it. I trust our engineering players know what they are talking about.

## About The Pull Request

Lowers energy req to run H2-H2 fusion reaction so its actually more sustainable. (Its not runable without the change unless you are a masochist...)

Same for boron-h2

Also obligatory "Irkalla when do u code real shit?"

When I am done with job obligations and have holidays.


## Why It's Good For The Game

Engineering asked for it.

## Changelog

:cl:
tweak: 117000  for new energy reqs for H2-H2. Boron-H2 lowered to 78500. I trust engineering players enough to know what they are talking about. Its actually unrunable apparently without the change. The rust apparently runs on abstracted real world parameters yet temperatures cannot be reached ingame proper. Amazing.
/:cl:


