### PR TITLE
giga cd on examiner

### DIFF
--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -366,6 +366,7 @@
 	spawn_flags = IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3, TECH_BIO = 4)
 	power_draw_per_use = 80
+	cooldown_per_use = 50
 
 /obj/item/integrated_circuit/input/examiner/do_work(ord)
 	if(ord == 1)


### PR DESCRIPTION
## About The Pull Request

raises cd on examiner circuit; because examining is expensive. it probably shouldnt be able to spam every 0.1 seconds. its now 5 seconds. realistically i'd ideally make examine less expensive but uh.

## Why It's Good For The Game

lol

## Changelog

:cl:
tweak: examiner circuit cd is now 5 seconds
/:cl: