### PR TITLE
Triumph Engineering Tweaks

### DIFF
--- a/maps/triumph/levels/deck1.dmm
+++ b/maps/triumph/levels/deck1.dmm
@@ -581,11 +581,7 @@
 /turf/space/basic,
 /area/engineering/atmos/gas_storage)
 "bF" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/random/trash_pile,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
 /area/maintenance/engi_engine)
 "bH" = (
@@ -730,6 +726,10 @@
 	},
 /turf/simulated/floor/reinforced/airmix,
 /area/engineering/atmos/gas_storage)
+"ci" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor/plating,
+/area/maintenance/engi_engine)
 "cj" = (
 /obj/structure/catwalk,
 /obj/machinery/door/firedoor,
@@ -870,6 +870,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
+"cK" = (
+/obj/structure/catwalk,
+/obj/structure/catwalk,
+/turf/simulated/wall/r_wall/prepainted/engineering,
+/area/engineering/portnacelle)
 "cM" = (
 /obj/structure/atmos_tank_segment/n2o2{
 	icon_state = "0,3"
@@ -878,14 +883,14 @@
 /turf/space/basic,
 /area/engineering/atmos/gas_storage)
 "cN" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
 /obj/machinery/air_sensor{
 	frequency = 2345;
 	id_tag = "starboardnacelle_sensor"
 	},
-/turf/simulated/floor/airless/ceiling,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/starboardnacelle)
 "cO" = (
 /obj/structure/cable/green{
@@ -1479,9 +1484,9 @@
 /area/engineering/hallway/lower)
 "eS" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
+	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
 "eU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -2112,11 +2117,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_monitoring)
 "gN" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/simulated/floor/airless/ceiling,
-/area/engineering/starboardnacelle)
+/turf/space,
+/area/space)
 "gP" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -2160,13 +2166,9 @@
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
 "ha" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/table/rack,
-/obj/item/stack/cable_coil/yellow,
-/turf/simulated/floor/airless/ceiling,
-/area/maintenance/engi_engine)
+/obj/structure/catwalk,
+/turf/simulated/wall/r_wall/prepainted/engineering,
+/area/engineering/portnacelle)
 "hb" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/catwalk,
@@ -2279,9 +2281,9 @@
 /area/engineering/workshop)
 "hw" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5
+	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/starboardnacelle)
 "hx" = (
 /turf/simulated/floor/tiled/techmaint,
@@ -2342,6 +2344,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/portnacelle)
+"hD" = (
+/obj/random/trash_pile,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/engi_engine)
 "hG" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -2646,6 +2656,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
+"iF" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/portnacelle)
 "iG" = (
 /obj/machinery/power/thermoregulator,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -3002,6 +3019,12 @@
 /obj/item/stamp/ce,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
+"jU" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/starboardnacelle)
 "jV" = (
 /obj/machinery/pipedispenser/disposal,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -3110,8 +3133,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/spawner/window/low_wall/borosillicate/full,
-/obj/effect/paint_stripe/sun,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full{
+	icon_state = "phoronwindow0"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/starboardnacelle)
 "ki" = (
@@ -3377,13 +3402,10 @@
 /area/storage/tech)
 "lj" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
+	dir = 4
 	},
-/obj/machinery/sparker{
-	id = "portnacelle_igniter";
-	pixel_x = 24
-	},
-/turf/simulated/floor/airless/ceiling,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
 "lk" = (
 /obj/structure/cable{
@@ -3459,11 +3481,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "lC" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/simulated/floor/airless/ceiling,
-/area/engineering/starboardnacelle)
+/turf/simulated/floor/airless,
+/area/space)
 "lF" = (
 /turf/simulated/wall/prepainted/engineering/atmos,
 /area/engineering/break_room)
@@ -3478,9 +3501,12 @@
 	id = "portnacelle_blastdoor";
 	opacity = 0
 	},
-/obj/spawner/window/low_wall/borosillicate/full,
 /obj/effect/paint_stripe/sun,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/structure/window/phoronreinforced/full{
+	icon_state = "phoronwindow0"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
 "lK" = (
 /obj/structure/stairs/spawner/west,
@@ -3726,9 +3752,9 @@
 /area/engineering/atmos/storage)
 "mp" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
+	dir = 9
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/starboardnacelle)
 "mq" = (
 /obj/structure/cable/green{
@@ -4693,6 +4719,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
+"qc" = (
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/engi_engine)
 "qe" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/floor_decal/techfloor/orange,
@@ -4720,6 +4752,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
+"qi" = (
+/obj/structure/table/rack,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/stack/cable_coil/yellow,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/engi_engine)
 "qj" = (
 /obj/structure/lattice,
 /obj/structure/railing,
@@ -4760,14 +4801,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "qo" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
 /obj/machinery/air_sensor{
 	frequency = 2346;
 	id_tag = "portnacelle_sensor"
 	},
-/turf/simulated/floor/airless/ceiling,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
 "qp" = (
 /obj/machinery/air_alarm{
@@ -5838,10 +5879,10 @@
 /turf/simulated/floor/airless/ceiling,
 /area/engineering/atmos/gas_storage)
 "tA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 4
 	},
-/turf/simulated/wall/r_wall/prepainted/engineering,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/starboardnacelle)
 "tB" = (
 /obj/structure/disposalpipe/segment{
@@ -6944,9 +6985,12 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 4
 	},
-/obj/spawner/window/low_wall/borosillicate/full,
 /obj/effect/paint_stripe/sun,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/structure/window/phoronreinforced/full{
+	icon_state = "phoronwindow0"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
 "xj" = (
 /obj/machinery/power/apc/north_mount{
@@ -7646,14 +7690,11 @@
 /turf/simulated/floor/airless/ceiling,
 /area/engineering/atmos/gas_storage)
 "zM" = (
-/obj/structure/railing{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/portnacelle)
 "zO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /turf/simulated/floor/tiled,
@@ -7855,14 +7896,16 @@
 /turf/space/basic,
 /area/space)
 "Aw" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
 /obj/machinery/atmospherics/component/unary/outlet_injector{
 	dir = 8;
 	frequency = 2346;
 	id = "portnacelle_in";
 	power_rating = 5000
 	},
-/turf/simulated/floor/airless/ceiling,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
+	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
 "Ax" = (
 /obj/structure/disposalpipe/segment,
@@ -7963,7 +8006,7 @@
 /obj/machinery/door/airlock/maintenance/engi{
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/maintenance,
+/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/plating,
 /area/engineering/engine_monitoring)
 "AN" = (
@@ -8161,15 +8204,12 @@
 	},
 /area/tcommsat/chamber)
 "Bx" = (
-/obj/structure/lattice,
-/obj/structure/railing{
-	dir = 4
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full{
+	icon_state = "phoronwindow0"
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/portnacelle)
 "Bz" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -8252,9 +8292,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/spawner/window/low_wall/borosillicate/full,
 /obj/effect/paint_stripe/sun,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/structure/window/phoronreinforced/full{
+	icon_state = "phoronwindow0"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
 "BL" = (
 /obj/structure/atmos_tank_segment/co2{
@@ -8265,7 +8308,7 @@
 "BM" = (
 /obj/structure/railing,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/airless/ceiling,
 /area/maintenance/engi_engine)
@@ -8446,10 +8489,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/storage)
 "Cw" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
-	},
-/turf/simulated/floor/airless/ceiling,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
 "Cx" = (
 /obj/structure/table/rack{
@@ -8615,8 +8656,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/spawner/window/low_wall/borosillicate/full,
-/obj/effect/paint_stripe/sun,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full{
+	icon_state = "phoronwindow0"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/starboardnacelle)
 "Da" = (
@@ -9213,10 +9256,9 @@
 /area/engineering/engine_smes)
 "EY" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
 "EZ" = (
 /turf/simulated/wall/r_wall/prepainted/engineering,
@@ -9247,16 +9289,16 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/engineering/atmos/storage)
 "Fi" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 1
-	},
 /obj/machinery/atmospherics/component/unary/outlet_injector{
 	dir = 8;
 	frequency = 2345;
 	id = "starboardnacelle_in";
 	power_rating = 5000
 	},
-/turf/simulated/floor/airless/ceiling,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/starboardnacelle)
 "Fj" = (
 /turf/simulated/wall/r_wall/prepainted/engineering,
@@ -9449,10 +9491,14 @@
 /turf/simulated/wall/r_wall/prepainted/engineering,
 /area/engineering/starboardnacelle)
 "FN" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/obj/structure/window/phoronreinforced/full{
+	icon_state = "phoronwindow0"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
 "FO" = (
 /obj/structure/atmos_tank_segment/co2{
@@ -9695,6 +9741,16 @@
 /obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/lower)
+"GI" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/engi_engine)
 "GJ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 1
@@ -9762,7 +9818,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/starboardnacelle)
 "GZ" = (
 /obj/structure/window/reinforced{
@@ -10101,10 +10157,6 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/monitoring)
 "Ic" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access = null
-	},
-/obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "Id" = (
@@ -10532,14 +10584,11 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/hallway/lower)
 "Jx" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
+	dir = 4
 	},
-/obj/machinery/sparker{
-	id = "starboardnacelle_igniter";
-	pixel_x = 24
-	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/starboardnacelle)
 "Jy" = (
 /obj/structure/atmos_tank_segment/air{
@@ -10608,6 +10657,16 @@
 /obj/landmark/spawnpoint/job/atmospheric_technician,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/engineering/atmos/storage)
+"JJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full{
+	icon_state = "phoronwindow0"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/starboardnacelle)
 "JM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -10758,12 +10817,11 @@
 /turf/space,
 /area/space)
 "Ki" = (
-/obj/machinery/door/airlock/maintenance/engi{
-	req_one_access = null
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
 	},
-/obj/map_helper/access_helper/airlock/station/maintenance,
-/turf/simulated/floor/plating,
-/area/engineering/engine_room)
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/starboardnacelle)
 "Kl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 8
@@ -10987,6 +11045,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
+"Lb" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/portnacelle)
 "Lc" = (
 /obj/structure/atmos_tank_segment/n2{
 	icon_state = "1,2"
@@ -11193,10 +11257,7 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/monitoring)
 "LH" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing,
+/obj/structure/catwalk,
 /turf/space,
 /area/space)
 "LJ" = (
@@ -11740,11 +11801,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_airlock)
 "Nw" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/starboardnacelle)
 "Nx" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
@@ -11861,12 +11919,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
+"NW" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/portnacelle)
 "NY" = (
+/obj/machinery/sparker{
+	id = "starboardnacelle_igniter";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
-/area/engineering/portnacelle)
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/starboardnacelle)
 "Oa" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -12104,6 +12173,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/lower)
+"OE" = (
+/obj/machinery/sparker{
+	id = "starboardnacelle_igniter";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/starboardnacelle)
 "OF" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -12162,10 +12241,10 @@
 /area/engineering/hallway/lower)
 "ON" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5
+	dir = 6
 	},
-/turf/simulated/floor/airless/ceiling,
-/area/engineering/portnacelle)
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/starboardnacelle)
 "OO" = (
 /obj/machinery/camera/network/engineering{
 	dir = 4
@@ -12329,6 +12408,13 @@
 /obj/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos/storage)
+"Ps" = (
+/obj/landmark{
+	name = "carpspawn"
+	},
+/obj/structure/railing,
+/turf/space,
+/area/space)
 "Pt" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -12650,6 +12736,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/storage)
+"QB" = (
+/obj/machinery/sparker{
+	id = "portnacelle_igniter";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/portnacelle)
 "QC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning{
@@ -12800,7 +12897,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
 "Rg" = (
 /obj/structure/atmos_tank_segment/n2{
@@ -12993,8 +13090,10 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 4
 	},
-/obj/spawner/window/low_wall/borosillicate/full,
-/obj/effect/paint_stripe/sun,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full{
+	icon_state = "phoronwindow0"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/starboardnacelle)
 "RK" = (
@@ -13286,11 +13385,9 @@
 /turf/simulated/floor/tiled,
 /area/station/stairs_one)
 "SP" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
-	},
-/turf/simulated/floor/airless/ceiling,
-/area/engineering/starboardnacelle)
+/obj/structure/catwalk,
+/turf/space/basic,
+/area/space)
 "SQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -13396,10 +13493,10 @@
 /turf/simulated/floor/reinforced/phoron,
 /area/engineering/atmos/gas_storage)
 "Tf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 4
 	},
-/turf/simulated/wall/r_wall/prepainted/engineering,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
 "Tg" = (
 /obj/machinery/light/small/emergency{
@@ -13417,9 +13514,6 @@
 /area/engineering/atmos/storage)
 "Tl" = (
 /obj/structure/railing,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/structure/handrail{
 	dir = 4
 	},
@@ -13539,6 +13633,15 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/storage)
+"TF" = (
+/obj/structure/table/rack,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/rods,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/engi_engine)
 "TG" = (
 /obj/structure/atmos_tank_segment/co2{
 	icon_state = "3,3"
@@ -13615,14 +13718,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engi_engine)
 "TU" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/table/rack,
-/obj/fiftyspawner/rods,
-/obj/fiftyspawner/steel,
-/turf/simulated/floor/airless/ceiling,
-/area/maintenance/engi_engine)
+/turf/simulated/wall/r_wall/prepainted/engineering,
+/area/maintenance/dormitory)
 "TV" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/plushie/carp/nebula,
@@ -14796,14 +14893,10 @@
 	},
 /area/tcommsat/chamber)
 "XO" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/wall/prepainted,
 /area/maintenance/engi_engine)
 "XP" = (
 /obj/machinery/photocopier,
@@ -15277,13 +15370,12 @@
 /turf/space,
 /area/engineering/atmos/gas_storage)
 "Zm" = (
-/obj/structure/lattice,
-/obj/structure/railing{
-	dir = 4
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full{
+	icon_state = "phoronwindow0"
 	},
-/obj/structure/railing,
-/turf/space,
-/area/space)
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/starboardnacelle)
 "Zq" = (
 /obj/machinery/computer/telecomms/server,
 /turf/simulated/floor/tiled/techmaint,
@@ -27489,7 +27581,7 @@ TP
 TP
 TP
 TP
-TP
+sH
 LH
 oy
 EZ
@@ -27683,8 +27775,8 @@ TP
 TP
 TP
 TP
-TP
 sH
+LH
 oy
 HP
 BG
@@ -27693,8 +27785,8 @@ vz
 EZ
 ft
 Hg
-ME
-ME
+ci
+bF
 cD
 Bq
 Bq
@@ -27876,9 +27968,9 @@ TP
 TP
 TP
 TP
-TP
-TP
 sH
+gN
+SP
 oy
 qr
 DU
@@ -27889,7 +27981,6 @@ LX
 lS
 Uh
 ME
-Ki
 Bq
 Bq
 Bq
@@ -27907,7 +27998,8 @@ Bq
 Bq
 Bq
 Bq
-Ki
+Bq
+Bq
 FZ
 TS
 mL
@@ -28070,9 +28162,9 @@ TP
 TP
 TP
 TP
-TP
-TP
 sH
+LH
+SP
 oy
 qr
 us
@@ -28102,7 +28194,7 @@ Bq
 Bq
 Bq
 cD
-ME
+ci
 yE
 xd
 tc
@@ -28264,17 +28356,17 @@ TP
 TP
 TP
 TP
-TP
-TP
 sH
-oy
+LH
+EZ
+EZ
 qr
 VB
 Rz
 zH
 EZ
-TP
-Ze
+EZ
+EZ
 Wl
 pc
 cD
@@ -28298,15 +28390,15 @@ Ic
 Nf
 LZ
 yE
-Ze
-TP
+Hg
+Oq
 Oq
 Lt
 Lq
 FQ
 Wy
-oy
-Ap
+Oq
+Oq
 he
 he
 he
@@ -28458,17 +28550,17 @@ TP
 TP
 TP
 TP
-TP
-TP
 sH
-oy
-qr
+SP
+EZ
+Bx
+FN
 lI
 BJ
 xi
+Bx
+Bx
 EZ
-CT
-Ze
 QE
 ME
 cD
@@ -28492,15 +28584,15 @@ qU
 Nf
 kI
 yE
-Ze
-CT
-Oq
+Hg
+Zm
+Zm
 RJ
 CZ
 kh
-Wy
-oy
-Ap
+JJ
+Zm
+Oq
 TP
 TP
 TP
@@ -28652,17 +28744,17 @@ TP
 TP
 TP
 TP
-TP
-TP
 sH
-oy
+SP
+EZ
+Bx
 Tf
 Aw
 Rf
 qo
+zM
+Bx
 EZ
-TP
-Ze
 ul
 ME
 cD
@@ -28686,15 +28778,15 @@ YX
 Nf
 bF
 yE
-Ze
-TP
-Oq
+Hg
+Zm
+ON
 cN
 GS
 Fi
 tA
-oy
-aw
+Zm
+Oq
 he
 he
 he
@@ -28835,10 +28927,8 @@ TP
 TP
 TP
 TP
-TP
-TP
-TP
-TP
+he
+he
 TP
 TP
 TP
@@ -28849,14 +28939,16 @@ TP
 TP
 TP
 sH
-jt
+SP
 EZ
+Bx
+eS
 eS
 EY
 Cw
+Lb
+Bx
 EZ
-TP
-Ze
 Pe
 Ze
 cD
@@ -28878,17 +28970,17 @@ EX
 nj
 qU
 Nf
-ME
+hD
 yE
-Ze
-TP
-Oq
-gN
+Hg
+Zm
+Ki
 Nw
+mp
 hw
+hw
+Zm
 Oq
-oy
-aw
 he
 he
 he
@@ -29026,11 +29118,11 @@ TP
 TP
 TP
 TP
-TP
-TP
 er
 CT
 CT
+cd
+cd
 RY
 RY
 RY
@@ -29040,17 +29132,17 @@ eb
 RY
 RY
 er
-CT
-RY
-fL
-oy
+ga
+SP
 EZ
-lj
+Bx
 EY
-ON
+lj
+Cw
+Cw
+zM
+Bx
 EZ
-CT
-Ze
 Qd
 IV
 cD
@@ -29074,15 +29166,15 @@ Dz
 Nf
 ME
 yE
-Ze
-CT
-Oq
-SP
+Hg
+Zm
+ON
+Nw
 Nw
 Jx
+mp
+Zm
 Oq
-oy
-aw
 he
 he
 he
@@ -29220,9 +29312,9 @@ TP
 TP
 TP
 TP
-TP
-TP
 CT
+ab
+ab
 ab
 ab
 CT
@@ -29234,17 +29326,17 @@ Uq
 ab
 ab
 TP
-TP
-TP
 sH
-oy
+SP
 EZ
+Bx
+NW
+iF
+Cw
+Cw
+Lb
+Bx
 EZ
-NY
-NY
-EZ
-CT
-Ze
 Bf
 ME
 cD
@@ -29266,17 +29358,17 @@ WS
 xh
 Ha
 Nf
-Fl
+qc
 yE
-Ze
-CT
+Hg
+Zm
+Ki
+Nw
+Nw
+Jx
+jU
+Zm
 Oq
-mp
-mp
-Oq
-Oq
-oy
-aw
 he
 he
 he
@@ -29414,12 +29506,12 @@ TP
 TP
 TP
 TP
-TP
-TP
 CT
 ab
 TP
-TP
+he
+he
+ab
 ab
 CT
 CT
@@ -29427,18 +29519,18 @@ TP
 ab
 CT
 ab
-TP
-TP
 TP
 sH
-oy
-wL
+SP
 EZ
-FN
+Bx
+EY
+QB
 Cw
+Cw
+zM
+Bx
 EZ
-TP
-Ze
 Qd
 ME
 cD
@@ -29462,15 +29554,15 @@ kE
 Nf
 fj
 yE
-Ze
-CT
+Hg
+Zm
+ON
+Nw
+Nw
+NY
+mp
+Zm
 Oq
-gN
-lC
-Oq
-fL
-oy
-aw
 he
 he
 he
@@ -29608,11 +29700,11 @@ TP
 TP
 TP
 TP
-TP
-TP
 CT
 CT
 TP
+he
+he
 TP
 ab
 TP
@@ -29621,18 +29713,18 @@ TP
 ab
 CT
 ab
-TP
-CT
 TP
 sH
-oy
+SP
+EZ
+Bx
+Bx
+EY
+Cw
+Cw
+Lb
 Bx
 EZ
-EZ
-EZ
-EZ
-uy
-Ze
 Qd
 ME
 cD
@@ -29656,15 +29748,15 @@ kE
 Nf
 nq
 te
-Ze
-uy
-Oq
-Oq
-Oq
-Oq
+Hg
 Zm
-oy
-zM
+Ki
+Nw
+Nw
+OE
+Zm
+Zm
+Oq
 TP
 TP
 TP
@@ -29802,11 +29894,11 @@ TP
 TP
 TP
 TP
-TP
-TP
 CT
 TP
 TP
+he
+he
 TP
 ab
 ab
@@ -29816,17 +29908,17 @@ ab
 CT
 ab
 TP
-ab
-CT
-sH
-oy
-oy
-oy
-oy
-oy
-oy
-oy
-Ze
+Xx
+SP
+EZ
+ha
+Bx
+Bx
+Bx
+Bx
+Bx
+Bx
+EZ
 QE
 ME
 cD
@@ -29850,16 +29942,16 @@ fH
 Nf
 fj
 yE
-Ze
-oy
-oy
-oy
-oy
-oy
-oy
-oy
-oy
-aw
+Hg
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Oq
+Oq
+he
 he
 he
 he
@@ -29996,11 +30088,11 @@ TP
 TP
 TP
 TP
-TP
-TP
 RY
 TP
 TP
+he
+he
 TP
 ab
 ab
@@ -30010,17 +30102,17 @@ ab
 ab
 ab
 ab
-ab
-aj
-TP
-yS
-nq
-TU
-jn
+Ps
+SP
+LH
 ha
-nq
-oy
-Ze
+cK
+ha
+ha
+ha
+ha
+ha
+EZ
 Wl
 ME
 cD
@@ -30044,15 +30136,15 @@ Wu
 UE
 fj
 yE
-Ze
-oy
-st
-st
-st
-st
-st
-st
-oy
+Hg
+kw
+TU
+TU
+TU
+TU
+TU
+TU
+SP
 aw
 he
 he
@@ -30190,11 +30282,11 @@ TP
 TP
 TP
 TP
-TP
-TP
 RY
 TP
 TP
+he
+he
 ab
 ab
 CT
@@ -30205,13 +30297,13 @@ CT
 ab
 ab
 ab
-ab
-TP
-sH
+lC
+SP
+LH
 XO
-Mq
-aU
-aU
+TF
+jn
+qi
 Tl
 oy
 Ze
@@ -30384,11 +30476,11 @@ TP
 TP
 TP
 TP
-TP
-TP
 CT
 TP
 ab
+he
+he
 ab
 ab
 TP
@@ -30400,12 +30492,12 @@ ab
 CT
 ab
 CT
-ab
-sH
-re
-jn
-jn
-jn
+lC
+LH
+GI
+Mq
+aU
+aU
 BM
 oy
 Ze
@@ -30578,10 +30670,10 @@ TP
 TP
 TP
 TP
-TP
-TP
 CT
 Id
+Pf
+Pf
 Pf
 Pf
 Pf
@@ -30772,11 +30864,11 @@ TP
 TP
 TP
 TP
-TP
-TP
 CT
 TP
 TP
+he
+he
 ab
 ab
 CT
@@ -30966,11 +31058,11 @@ TP
 TP
 TP
 TP
-TP
-TP
 CT
 TP
 TP
+he
+he
 TP
 ab
 TP
@@ -31160,11 +31252,11 @@ TP
 TP
 TP
 TP
-TP
-TP
 RY
 TP
 TP
+he
+he
 TP
 ab
 TP
@@ -31354,11 +31446,11 @@ TP
 TP
 TP
 TP
-TP
-TP
 RY
 TP
 TP
+he
+he
 TP
 ab
 CT
@@ -31548,12 +31640,12 @@ TP
 TP
 TP
 TP
-TP
-TP
 RY
 TP
 TP
-TP
+he
+he
+CT
 ab
 CT
 TP
@@ -31742,18 +31834,18 @@ TP
 TP
 TP
 TP
-TP
-TP
 CT
 TP
 TP
-TP
+he
+he
+CT
 TP
 TP
 TP
 aj
 TP
-TP
+CT
 CT
 TP
 TP
@@ -31936,19 +32028,19 @@ TP
 TP
 TP
 TP
+CT
+TP
+TP
+he
+he
+cd
+TP
+TP
 TP
 TP
 CT
 TP
-TP
-TP
-TP
-TP
-TP
-TP
-TP
-TP
-TP
+CT
 TP
 TP
 TP
@@ -32130,11 +32222,11 @@ TP
 TP
 TP
 TP
-TP
-TP
 er
 CT
 CT
+he
+ab
 CT
 er
 CT
@@ -32324,12 +32416,12 @@ TP
 TP
 TP
 TP
-TP
-TP
 CT
 er
 ER
-ER
+ab
+ab
+ab
 CT
 TP
 TP
@@ -32518,11 +32610,11 @@ TP
 TP
 TP
 TP
-TP
-TP
 CT
 ER
 ER
+he
+cd
 ER
 CT
 TP
@@ -32712,11 +32804,11 @@ TP
 TP
 TP
 TP
-TP
-TP
 CT
 ER
 ER
+cd
+he
 ER
 CT
 CT
@@ -32906,11 +32998,11 @@ TP
 TP
 TP
 TP
-TP
-TP
 CT
 ER
 ER
+he
+cd
 ER
 CT
 TP
@@ -33100,11 +33192,11 @@ TP
 TP
 TP
 TP
-TP
-TP
 RY
 ER
 ER
+ab
+ab
 ER
 PD
 uy

--- a/maps/triumph/levels/deck1.dmm
+++ b/maps/triumph/levels/deck1.dmm
@@ -1488,11 +1488,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
-"eT" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/turf/space/basic,
-/area/space)
 "eU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -5392,14 +5387,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
-"sa" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/space/basic,
-/area/space)
 "sc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6061,11 +6048,6 @@
 /obj/effect/paint_stripe/sun,
 /turf/simulated/floor,
 /area/storage/tech)
-"ua" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/turf/space,
-/area/space)
 "ub" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -8743,6 +8725,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/workshop)
+"Dn" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/obj/machinery/sparker{
+	id = "portnacelle_igniter";
+	pixel_x = 24
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/portnacelle)
 "Do" = (
 /obj/structure/atmos_tank_segment/n2o2{
 	icon_state = "4,3"
@@ -11037,6 +11029,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_airlock)
+"KW" = (
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/space/basic,
+/area/space)
 "KX" = (
 /turf/simulated/wall/prepainted/engineering,
 /area/tcommsat/powercontrol)
@@ -11277,14 +11277,6 @@
 "LH" = (
 /obj/structure/catwalk,
 /turf/space,
-/area/space)
-"LI" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/space/basic,
 /area/space)
 "LJ" = (
 /obj/structure/atmos_tank_segment/air{
@@ -11952,16 +11944,10 @@
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
 "NY" = (
-/obj/machinery/sparker{
-	id = "starboardnacelle_igniter";
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/engineering/starboardnacelle)
+/obj/structure/catwalk,
+/obj/structure/railing,
+/turf/space/basic,
+/area/space)
 "Oa" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -12206,6 +12192,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
+	},
+/obj/machinery/sparker{
+	id = "starboardnacelle_igniter";
+	pixel_x = 24
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/starboardnacelle)
@@ -12763,16 +12753,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/storage)
 "QB" = (
-/obj/machinery/sparker{
-	id = "portnacelle_igniter";
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/engineering/portnacelle)
+/obj/structure/catwalk,
+/obj/structure/railing,
+/turf/space,
+/area/space)
 "QC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning{
@@ -12815,6 +12799,14 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/engineering/atmos)
+"QK" = (
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/space/basic,
+/area/space)
 "QM" = (
 /obj/machinery/fire_alarm/east_mount,
 /obj/machinery/light{
@@ -28231,7 +28223,7 @@ Bp
 Wy
 oy
 LH
-sa
+QK
 he
 he
 TP
@@ -28425,7 +28417,7 @@ FQ
 Wy
 Oq
 Oq
-eT
+NY
 he
 he
 TP
@@ -28619,7 +28611,7 @@ kh
 JJ
 Zm
 Oq
-ua
+QB
 TP
 TP
 TP
@@ -28813,7 +28805,7 @@ Fi
 tA
 Zm
 Oq
-eT
+NY
 he
 he
 he
@@ -29007,7 +28999,7 @@ hw
 hw
 Zm
 Oq
-eT
+NY
 he
 he
 he
@@ -29201,7 +29193,7 @@ Jx
 mp
 Zm
 Oq
-eT
+NY
 he
 he
 he
@@ -29395,7 +29387,7 @@ Jx
 jU
 Zm
 Oq
-eT
+NY
 he
 he
 he
@@ -29551,7 +29543,7 @@ SP
 EZ
 Bx
 EY
-QB
+iF
 Cw
 Cw
 zM
@@ -29585,11 +29577,11 @@ Zm
 ON
 Nw
 Nw
-NY
+Jx
 mp
 Zm
 Oq
-eT
+NY
 he
 he
 he
@@ -29745,7 +29737,7 @@ SP
 EZ
 Bx
 Bx
-EY
+Dn
 Cw
 Cw
 Lb
@@ -29783,7 +29775,7 @@ OE
 Zm
 Zm
 Oq
-ua
+QB
 TP
 TP
 TP
@@ -29977,7 +29969,7 @@ Zm
 Zm
 Oq
 Oq
-eT
+NY
 he
 he
 he
@@ -30171,7 +30163,7 @@ TU
 TU
 TU
 SP
-LI
+KW
 he
 he
 he

--- a/maps/triumph/levels/deck1.dmm
+++ b/maps/triumph/levels/deck1.dmm
@@ -1488,6 +1488,11 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
+"eT" = (
+/obj/structure/catwalk,
+/obj/structure/railing,
+/turf/space/basic,
+/area/space)
 "eU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -5387,6 +5392,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"sa" = (
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/space/basic,
+/area/space)
 "sc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6048,6 +6061,11 @@
 /obj/effect/paint_stripe/sun,
 /turf/simulated/floor,
 /area/storage/tech)
+"ua" = (
+/obj/structure/catwalk,
+/obj/structure/railing,
+/turf/space,
+/area/space)
 "ub" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -11259,6 +11277,14 @@
 "LH" = (
 /obj/structure/catwalk,
 /turf/space,
+/area/space)
+"LI" = (
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/space/basic,
 /area/space)
 "LJ" = (
 /obj/structure/atmos_tank_segment/air{
@@ -28010,8 +28036,8 @@ be
 fJ
 Wy
 oy
-Ap
-he
+gN
+aw
 he
 he
 TP
@@ -28204,8 +28230,8 @@ Az
 Bp
 Wy
 oy
-Ap
-he
+LH
+sa
 he
 he
 TP
@@ -28399,7 +28425,7 @@ FQ
 Wy
 Oq
 Oq
-he
+eT
 he
 he
 TP
@@ -28593,7 +28619,7 @@ kh
 JJ
 Zm
 Oq
-TP
+ua
 TP
 TP
 TP
@@ -28787,7 +28813,7 @@ Fi
 tA
 Zm
 Oq
-he
+eT
 he
 he
 he
@@ -28981,7 +29007,7 @@ hw
 hw
 Zm
 Oq
-he
+eT
 he
 he
 he
@@ -29175,7 +29201,7 @@ Jx
 mp
 Zm
 Oq
-he
+eT
 he
 he
 he
@@ -29369,7 +29395,7 @@ Jx
 jU
 Zm
 Oq
-he
+eT
 he
 he
 he
@@ -29563,7 +29589,7 @@ NY
 mp
 Zm
 Oq
-he
+eT
 he
 he
 he
@@ -29757,7 +29783,7 @@ OE
 Zm
 Zm
 Oq
-TP
+ua
 TP
 TP
 TP
@@ -29951,7 +29977,7 @@ Zm
 Zm
 Oq
 Oq
-he
+eT
 he
 he
 he
@@ -30145,7 +30171,7 @@ TU
 TU
 TU
 SP
-aw
+LI
 he
 he
 he


### PR DESCRIPTION
## About The Pull Request

The Nacelles were basically burn engines, but not actually like, burn engines?? For some reason they didn't have borosillicate against the edges to prevent the nacelles from blowing the fuck up 💀 . Also, this expands them a bit. They also now have floors inside with no air. An additional can of phoron / air was added next to them.

This also removes the excess doors on the Triumph engines; as engines all have their own doors (and would stack 2x doors).

## Why It's Good For The Game

this way, the nacelles dont blow out if you decide to get a little spicy, or refill them. the size increase is to fit the borosilicate. admittedly its a little larger still, but that's more of a space efficiency thing / making it look good (and it's only by like. 3-4 bonus tiles.)

## Changelog

:cl:
tweak: Triumph Nacelles now have borosillicate linings.
tweak: Triumph Nacelles are now a little bigger.
tweak: Triumph engine doors are no longer double stacked.
/:cl: