### PR TITLE
Adds Teshari Eyes Marking

### DIFF
--- a/code/modules/sprite_accessories/markings/tesh.dm
+++ b/code/modules/sprite_accessories/markings/tesh.dm
@@ -9,6 +9,15 @@
 	id = "marking_teshari_heterochromia"
 	icon_state = "teshi_heterochromia"
 	body_parts = list(BP_HEAD)
+<<<<<<< Updated upstream
+=======
+	
+/datum/sprite_accessory/marking/tesh/teshi_eyes
+	name = "Teshari Eyes"
+	id = "marking_teshari_eyes"
+	icon_state = "teshi_eyes"
+	body_parts = list(BP_HEAD)	
+>>>>>>> Stashed changes
 
 /datum/sprite_accessory/marking/tesh/tesh_feathers
 	name = "Teshari Feathers"


### PR DESCRIPTION
For those few people that play a robotesh but got upset that they cant color their eyes.

## About The Pull Request

Adds a singular Teshari marking that allows people who play roboteshes to have proper eyecolor

## Why It's Good For The Game

Actually having eyecolors other than monochromia and nanite grey is good.

## Changelog

:cl:
add: Teshari Eye Marking
/:cl:


