### PR TITLE
Adds PKA capacity mods

### DIFF
--- a/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
@@ -72,6 +72,7 @@
 		new /datum/data/mining_equipment("KA Range Increase",			/obj/item/ka_modkit/range,								1000),
 		new /datum/data/mining_equipment("KA Damage Increase",			/obj/item/ka_modkit/damage,								1000),
 		new /datum/data/mining_equipment("KA Cooldown Decrease",		/obj/item/ka_modkit/cooldown,							1200),
+		new /datum/data/mining_equipment("KA Capacity Increase",		/obj/item/ka_modkit/capacity,							1500),
 		new /datum/data/mining_equipment("KA Holster",				/obj/item/clothing/accessory/holster/waist/kinetic_accelerator,			350),
 		new /datum/data/mining_equipment("Fine Excavation Kit - Chisels",/obj/item/storage/excavation,								500),
 		new /datum/data/mining_equipment("Fine Excavation Kit - Measuring Tape",/obj/item/measuring_tape,							125),

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -407,6 +407,20 @@
 	minebot_exclusive = TRUE
 
 
+//Capacity
+/obj/item/ka_modkit/capacity
+	name = "capacity increase"
+	desc = "A cutdown accelerator frame that increases mod capacity while reducing damage. Not compatible with minebots."
+	modifier = -6
+	cost = -15
+	maximum_of_type = 2
+	minebot_upgrade = FALSE
+	denied_type = /obj/item/ka_modkit/capacity
+
+/obj/item/ka_modkit/capacity/modify_projectile(obj/projectile/kinetic/K)
+	K.damage += modifier
+
+
 //AoE blasts
 /obj/item/ka_modkit/aoe
 	modifier = 0


### PR DESCRIPTION
adds PKA Capacity modes, that increase total capacity at the cost of damage

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a mod capacity mod for Proto Kinetic Accelerators, increasing capacity by 15 and decreasing damage by 6 each with a maximum of 2 installable mods.

## Why It's Good For The Game
This adds an option that fills the gap for the to be removed damage increase mod, exchanging damage for more customization, ultimately giving a small but useful increase in options. The 6:15 damage to mod capacity means it will not be viable to increase damage if damage mods end up being preserved

## Changelog

:cl:
add: PKA Capacity Mod 
:add: Mining vendor sells PKA Capacity Mod
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
