### PR TITLE
Triumph + Rift Departure Shuttle renovations & fixes

### DIFF
--- a/code/modules/mapping/spawner/window.dm
+++ b/code/modules/mapping/spawner/window.dm
@@ -44,7 +44,7 @@
 		var/new_window = new window_full_path(loc)
 		if (spawn_low_wall)
 			new low_wall_path(loc)
-		if(id && istype(window_full_path, /obj/structure/window/reinforced/polarized))
+		if(id && istype(new_window, /obj/structure/window/reinforced/polarized))
 			var/obj/structure/window/reinforced/polarized/P = new_window
 			P.id = id
 	else

--- a/maps/rift/levels/rift-11-orbital.dmm
+++ b/maps/rift/levels/rift-11-orbital.dmm
@@ -312,6 +312,31 @@
 	},
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_emptycourt)
+"bg" = (
+/obj/structure/bed/chair/shuttle,
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 10
+	},
+/obj/structure/closet/hydrant{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/shuttle/escape)
+"bh" = (
+/obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks{
+	id = "emergency_medical"
+	},
+/turf/simulated/floor,
+/area/shuttle/escape)
 "bi" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2268,7 +2293,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/keycard_auth{
 	pixel_x = -24;
-	pixel_y = -8
+	pixel_y = 10
 	},
 /obj/item/storage/secure/briefcase,
 /obj/item/multitool,
@@ -2310,7 +2335,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/keycard_auth{
 	pixel_x = 24;
-	pixel_y = -8
+	pixel_y = 11
 	},
 /obj/item/folder/blue,
 /obj/item/radio{
@@ -2513,10 +2538,13 @@
 /obj/structure/bed/chair/bay/comfy/black{
 	dir = 8
 	},
+/obj/structure/closet/walllocker/autolok_wall{
+	pixel_y = 30;
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/shuttle/escape)
 "hY" = (
-/obj/structure/closet/walllocker/autolok_wall,
 /obj/structure/handrail{
 	dir = 1
 	},
@@ -2528,6 +2556,10 @@
 "ib" = (
 /obj/structure/bed/chair/bay/comfy/black{
 	dir = 4
+	},
+/obj/structure/closet/walllocker/autolok_wall{
+	pixel_y = 30;
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/shuttle/escape)
@@ -3306,6 +3338,7 @@
 "kw" = (
 /obj/structure/table/standard,
 /obj/item/material/ashtray/glass,
+/obj/random/action_figure,
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape)
 "kx" = (
@@ -3602,6 +3635,10 @@
 /obj/effect/floor_decal/corner/lightgrey/bordercorner2{
 	dir = 8
 	},
+/obj/structure/closet/hydrant{
+	dir = 4;
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/shuttle/escape)
 "lm" = (
@@ -3691,6 +3728,10 @@
 	},
 /obj/effect/floor_decal/corner/lightgrey/bordercorner2{
 	dir = 6
+	},
+/obj/structure/closet/hydrant{
+	dir = 4;
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/shuttle/escape)
@@ -3982,13 +4023,17 @@
 /area/shuttle/escape)
 "mp" = (
 /obj/structure/table/glass,
-/obj/random/action_figure,
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 8
 	},
+/obj/item/radio{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/radio,
 /turf/simulated/floor/tiled/steel_grid,
 /area/shuttle/escape)
 "mq" = (
@@ -4167,6 +4212,9 @@
 /obj/effect/floor_decal/corner/lightgrey/bordercorner2{
 	dir = 5
 	},
+/obj/machinery/vending/wallmed1/public{
+	pixel_x = 26
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/shuttle/escape)
 "mM" = (
@@ -4272,7 +4320,7 @@
 	name = "Shuttle Security";
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/security,
+/obj/map_helper/access_helper/airlock/station/security/department,
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape)
 "mZ" = (
@@ -4280,7 +4328,7 @@
 	name = "Shuttle Medical";
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/medical,
+/obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape)
 "na" = (
@@ -4306,7 +4354,9 @@
 	id = "emergency_shuttle_lockdown";
 	name = "Emergency Shuttle Blast Door"
 	},
-/obj/spawner/window/full/firelocks,
+/obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks{
+	id = "emergency_security"
+	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/escape)
 "nd" = (
@@ -4402,6 +4452,9 @@
 "nr" = (
 /obj/item/handcuffs,
 /obj/structure/table/standard,
+/obj/structure/closet/hydrant{
+	pixel_y = -26
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/shuttle/escape)
 "ns" = (
@@ -4531,7 +4584,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/shuttle/escape)
 "nM" = (
-/obj/spawner/window/full/firelocks,
+/obj/machinery/door/blast/regular/open{
+	id = "emergency_shuttle_lockdown";
+	name = "Emergency Shuttle Blast Door"
+	},
+/obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks{
+	id = "emergency_cockpit"
+	},
 /turf/simulated/floor,
 /area/shuttle/escape)
 "nN" = (
@@ -4656,6 +4715,9 @@
 	dir = 1
 	},
 /obj/structure/handrail,
+/obj/structure/closet/hydrant{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/shuttle/escape)
 "og" = (
@@ -6293,6 +6355,10 @@
 /obj/item/grenade/chem_grenade/metalfoam,
 /turf/unsimulated/floor/dark,
 /area/centcom/specops)
+"un" = (
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/turf/simulated/floor,
+/area/shuttle/escape)
 "ur" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6819,6 +6885,15 @@
 	icon_state = "lino"
 	},
 /area/tdome/tdomeobserve)
+"yJ" = (
+/obj/structure/bed/chair/shuttle{
+	dir = 4
+	},
+/obj/structure/closet/hydrant{
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/shuttle/escape)
 "yO" = (
 /obj/structure/table/standard,
 /obj/machinery/computer/skills{
@@ -7676,6 +7751,12 @@
 /obj/item/clothing/glasses/sunglasses/sechud/tactical,
 /turf/unsimulated/floor/dark,
 /area/centcom/specops)
+"BW" = (
+/obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks{
+	id = "emergency_cockpit"
+	},
+/turf/simulated/floor,
+/area/shuttle/escape)
 "Cb" = (
 /obj/machinery/lathe/autolathe{
 	desc = "Your typical Autolathe. It appears to have much more options than your regular one, however...";
@@ -7978,6 +8059,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/centcom/specops/dock)
+"Ey" = (
+/obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks{
+	id = "emergency_security"
+	},
+/turf/simulated/floor,
+/area/shuttle/escape)
 "EC" = (
 /obj/machinery/vending/tool,
 /turf/unsimulated/floor/dark,
@@ -8295,6 +8382,15 @@
 /obj/item/storage/belt/security/tactical,
 /turf/unsimulated/floor/dark,
 /area/centcom/specops)
+"Jr" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/machinery/door/blast/regular/open{
+	id = "emergency_shuttle_lockdown";
+	name = "Emergency Shuttle Blast Door"
+	},
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/turf/simulated/floor/reinforced,
+/area/shuttle/escape)
 "Jx" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/storage/firstaid/combat,
@@ -8425,6 +8521,25 @@
 /obj/effect/shuttle_landmark/shuttle_initializer/specops,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/specops/general)
+"Kv" = (
+/obj/structure/bed/chair/shuttle,
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 5
+	},
+/obj/structure/closet/hydrant{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/shuttle/escape)
 "Ky" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -9075,6 +9190,17 @@
 "Rn" = (
 /turf/unsimulated/wall,
 /area/centcom/specops/dock)
+"Ro" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/machinery/door/blast/regular/open{
+	id = "emergency_shuttle_lockdown";
+	name = "Emergency Shuttle Blast Door"
+	},
+/obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks{
+	id = "emergency_medical"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/escape)
 "Rs" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -11580,7 +11706,7 @@ gx
 ji
 jP
 kt
-nc
+Jr
 kt
 kt
 kt
@@ -11965,7 +12091,7 @@ gy
 gz
 nM
 gy
-jk
+bg
 jR
 rY
 ia
@@ -12352,7 +12478,7 @@ gz
 gz
 hi
 hX
-nM
+BW
 jm
 ia
 ku
@@ -12362,7 +12488,7 @@ lL
 gz
 gy
 mY
-nM
+Ey
 iE
 gz
 of
@@ -12546,7 +12672,7 @@ nM
 ha
 hj
 hY
-nM
+BW
 jn
 jT
 jT
@@ -12558,7 +12684,7 @@ mK
 ia
 nf
 ns
-nM
+un
 og
 oI
 px
@@ -12934,7 +13060,7 @@ nM
 hc
 hl
 hY
-nM
+BW
 jo
 jV
 jV
@@ -12946,7 +13072,7 @@ mL
 ia
 ng
 nu
-nM
+un
 oi
 oK
 gz
@@ -13128,7 +13254,7 @@ gz
 gz
 hm
 ib
-nM
+BW
 jp
 ia
 kx
@@ -13138,7 +13264,7 @@ lO
 gz
 gy
 mZ
-nM
+bh
 iE
 gz
 of
@@ -13333,7 +13459,7 @@ gy
 mM
 ia
 Cx
-Cx
+yJ
 gy
 oj
 oM
@@ -13517,7 +13643,7 @@ gy
 gz
 nM
 gy
-jF
+Kv
 jW
 rY
 ia
@@ -13908,7 +14034,7 @@ gx
 js
 jY
 kt
-nc
+Jr
 kt
 kt
 kt
@@ -14108,8 +14234,8 @@ lJ
 mr
 mP
 nb
-nc
-nc
+Ro
+Ro
 nb
 ok
 gx

--- a/maps/triumph/levels/flagship.dmm
+++ b/maps/triumph/levels/flagship.dmm
@@ -14,6 +14,15 @@
 	icon_state = "dark"
 	},
 /area/centcom/security)
+"ag" = (
+/obj/structure/bed/chair/shuttle{
+	dir = 1
+	},
+/obj/structure/closet/walllocker/emergsuit_wall{
+	pixel_y = -26
+	},
+/turf/simulated/shuttle/floor/black,
+/area/shuttle/escape)
 "ah" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/blue/border,
@@ -583,12 +592,12 @@
 /turf/unsimulated/floor/steel,
 /area/centcom/security)
 "bV" = (
-/obj/machinery/vending/cigarette,
 /obj/machinery/light{
 	dir = 8;
 	use_power = 0;
 	old_wall = 1
 	},
+/obj/structure/closet/emcloset,
 /turf/simulated/shuttle/floor/darkred,
 /area/shuttle/escape)
 "bX" = (
@@ -1154,8 +1163,8 @@
 	},
 /area/centcom/medical)
 "dx" = (
-/obj/item/bedsheet/medical,
-/obj/structure/bed/padded,
+/obj/structure/medical_stand/anesthetic,
+/obj/structure/bed/roller,
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
 "dy" = (
@@ -1964,6 +1973,13 @@
 "ga" = (
 /turf/unsimulated/wall,
 /area/centcom/living)
+"gb" = (
+/obj/structure/handrail,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/shuttle/escape)
 "gc" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -2001,6 +2017,13 @@
 	},
 /turf/unsimulated/floor/wood,
 /area/centcom/restaurant)
+"gg" = (
+/obj/structure/handrail,
+/obj/structure/closet/walllocker/emergsuit_wall{
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor/black,
+/area/shuttle/escape)
 "gh" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -2274,6 +2297,15 @@
 	icon_state = "white"
 	},
 /area/centcom/medical)
+"gS" = (
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/turf/simulated/shuttle/floor/black,
+/area/shuttle/escape)
 "gW" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/regular,
@@ -2288,6 +2320,15 @@
 	icon_state = "white"
 	},
 /area/centcom/medical)
+"gX" = (
+/obj/random/firstaid,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/bonemed,
+/obj/item/storage/firstaid/clotting,
+/obj/item/storage/firstaid/clotting,
+/obj/structure/table/reinforced,
+/turf/simulated/shuttle/floor,
+/area/shuttle/escape)
 "gY" = (
 /obj/structure/sign/nanotrasen,
 /turf/unsimulated/wall,
@@ -2645,11 +2686,19 @@
 	icon_state = "white"
 	},
 /area/centcom/control)
+"im" = (
+/obj/machinery/computer/communications{
+	dir = 4
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = -24;
+	pixel_y = -24
+	},
+/turf/simulated/shuttle/floor/white,
+/area/shuttle/escape)
 "in" = (
-/obj/machinery/light{
-	dir = 4;
-	use_power = 0;
-	old_wall = 1
+/obj/structure/handrail{
+	dir = 8
 	},
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/escape)
@@ -2700,6 +2749,19 @@
 	},
 /turf/unsimulated/floor/steel,
 /area/centcom/security)
+"iC" = (
+/obj/structure/fans/tiny,
+/obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks{
+	id = "emergency_medical"
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "emergency_shuttle_lockdown";
+	name = "Emergency Shuttle Blast Door"
+	},
+/turf/unsimulated/floor{
+	name = "plating"
+	},
+/area/shuttle/escape)
 "iE" = (
 /turf/unsimulated/floor/steel{
 	icon_state = "white"
@@ -3392,6 +3454,19 @@
 /obj/spawner/window/low_wall/borosillicate/full/firelocks,
 /turf/simulated/floor/plating,
 /area/shuttle/specops/engine)
+"kX" = (
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 8;
+	name = "holding cell"
+	},
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/shuttle/escape)
 "kY" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/borderfloor/corner2{
@@ -3455,6 +3530,13 @@
 	},
 /turf/unsimulated/floor/steel,
 /area/centcom/evac)
+"lo" = (
+/obj/structure/handrail,
+/obj/machinery/vending/wallmed1/public{
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor/black,
+/area/shuttle/escape)
 "lp" = (
 /obj/machinery/computer/card{
 	dir = 4
@@ -3756,6 +3838,12 @@
 	icon_state = "carpet"
 	},
 /area/centcom/command)
+"mb" = (
+/obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks{
+	id = "emergency_cockpit"
+	},
+/turf/simulated/floor,
+/area/shuttle/escape)
 "md" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3902,9 +3990,8 @@
 	},
 /area/centcom/security)
 "mA" = (
-/obj/machinery/optable,
-/obj/machinery/oxygen_pump/anesthetic{
-	pixel_y = 29
+/obj/machinery/sleep_console{
+	dir = 4
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
@@ -3986,8 +4073,10 @@
 	},
 /area/centcom/specops)
 "mE" = (
-/obj/spawner/window/low_wall/reinforced/full,
 /obj/structure/fans/tiny,
+/obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks{
+	id = "emergency_medical"
+	},
 /turf/unsimulated/floor{
 	name = "plating"
 	},
@@ -4005,6 +4094,15 @@
 /obj/map_helper/access_helper/airlock/station/command/vault,
 /turf/simulated/floor/reinforced,
 /area/centcom/command)
+"mG" = (
+/obj/structure/bed/chair/shuttle{
+	dir = 8
+	},
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/turf/simulated/shuttle/floor/white,
+/area/shuttle/escape)
 "mH" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -4101,6 +4199,18 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"mU" = (
+/obj/item/defib_kit,
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/surgery,
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/escape)
 "mV" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -4475,6 +4585,13 @@
 	icon_state = "white"
 	},
 /area/centcom/control)
+"nU" = (
+/obj/structure/bed/chair/shuttle,
+/obj/structure/closet/walllocker/emergsuit_wall{
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/shuttle/escape)
 "nV" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced,
@@ -4630,6 +4747,15 @@
 	icon_state = "white"
 	},
 /area/centcom/bathroom)
+"ov" = (
+/obj/structure/table/reinforced,
+/obj/item/radio{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/radio,
+/turf/simulated/shuttle/floor/darkred,
+/area/shuttle/escape)
 "ox" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/outdoors/grass/heavy/interior,
@@ -4646,6 +4772,13 @@
 	icon_state = "white"
 	},
 /area/centcom/medical)
+"oz" = (
+/obj/structure/bed/chair/shuttle,
+/obj/structure/closet/walllocker/emergsuit_wall{
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor/black,
+/area/shuttle/escape)
 "oA" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/borderfloor{
@@ -4703,7 +4836,11 @@
 /area/centcom/living)
 "oL" = (
 /obj/structure/fans/tiny,
-/obj/spawner/window/low_wall/reinforced/full,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/machinery/door/blast/regular/open{
+	id = "emergency_shuttle_lockdown";
+	name = "Emergency Shuttle Blast Door"
+	},
 /turf/simulated/floor,
 /area/shuttle/escape)
 "oN" = (
@@ -5147,6 +5284,24 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"qk" = (
+/obj/structure/closet/walllocker/autolok_wall{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 4;
+	use_power = 0
+	},
+/turf/simulated/shuttle/floor/white,
+/area/shuttle/escape)
+"qm" = (
+/obj/machinery/light{
+	dir = 4;
+	use_power = 0
+	},
+/obj/machinery/vending/fitness,
+/turf/simulated/shuttle/floor/darkred,
+/area/shuttle/escape)
 "qn" = (
 /obj/machinery/door/firedoor,
 /turf/unsimulated/floor/steel,
@@ -5263,6 +5418,13 @@
 	icon_state = "white"
 	},
 /area/centcom/medical)
+"qH" = (
+/obj/structure/handrail,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/escape)
 "qI" = (
 /obj/structure/table/rack,
 /obj/item/hardsuit_module/chem_dispenser/combat,
@@ -6655,6 +6817,13 @@
 /obj/item/clothing/glasses/welding,
 /turf/unsimulated/floor/steel,
 /area/centcom/control)
+"uV" = (
+/obj/structure/closet/hydrant{
+	dir = 4;
+	pixel_x = -32
+	},
+/turf/simulated/shuttle/floor/white,
+/area/shuttle/escape)
 "uW" = (
 /obj/item/storage/belt/security/tactical,
 /obj/item/storage/belt/security/tactical,
@@ -6898,6 +7067,10 @@
 /obj/machinery/light/flamp/noshade,
 /turf/unsimulated/floor/steel,
 /area/centcom/evac)
+"vR" = (
+/obj/machinery/vending/mre,
+/turf/simulated/shuttle/floor/darkred,
+/area/shuttle/escape)
 "vS" = (
 /obj/structure/sign/greencross,
 /turf/unsimulated/wall,
@@ -7402,6 +7575,17 @@
 	},
 /turf/unsimulated/floor/steel,
 /area/centcom/control)
+"xj" = (
+/obj/structure/fans/tiny,
+/obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks{
+	id = "emergency_security"
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "emergency_shuttle_lockdown";
+	name = "Emergency Shuttle Blast Door"
+	},
+/turf/simulated/floor,
+/area/shuttle/escape)
 "xk" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -8421,9 +8605,11 @@
 /turf/unsimulated/floor/steel,
 /area/centcom/control)
 "AA" = (
-/obj/structure/table/steel,
-/obj/item/defib_kit,
-/turf/simulated/shuttle/floor,
+/obj/structure/fans/tiny,
+/obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks{
+	id = "emergency_medical"
+	},
+/turf/simulated/floor,
 /area/shuttle/escape)
 "AB" = (
 /obj/structure/table/standard,
@@ -9233,6 +9419,14 @@
 	},
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/escape)
+"Dp" = (
+/obj/machinery/button/windowtint{
+	id = "emergency_medical";
+	pixel_x = 24;
+	pixel_y = -24
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/escape)
 "Dq" = (
 /obj/machinery/telecomms/processor/preset_cent,
 /turf/unsimulated/floor{
@@ -9430,6 +9624,12 @@
 	},
 /turf/unsimulated/floor/steel,
 /area/centcom/evac)
+"Ef" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1
+	},
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/escape)
 "Eg" = (
 /obj/structure/sign/securearea{
 	name = "\improper ARMORY";
@@ -9749,6 +9949,17 @@
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/shuttle,
 /turf/unsimulated/floor/steel,
 /area/centcom/evac)
+"Fl" = (
+/obj/structure/fans/tiny,
+/obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks{
+	id = "emergency_cockpit"
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "emergency_shuttle_lockdown";
+	name = "Emergency Shuttle Blast Door"
+	},
+/turf/simulated/floor,
+/area/shuttle/escape)
 "Fm" = (
 /obj/structure/window/reinforced,
 /turf/unsimulated/floor/steel,
@@ -9975,9 +10186,13 @@
 /turf/unsimulated/floor/steel,
 /area/centcom/main_hall)
 "FX" = (
-/obj/structure/bed/chair/shuttle{
-	dir = 1
+/obj/machinery/button/remote/blast_door{
+	id = "emergency_shuttle_lockdown";
+	name = "Emergency Blast Doors";
+	pixel_x = -24;
+	pixel_y = -7
 	},
+/obj/machinery/pointdefense_control,
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/escape)
 "FY" = (
@@ -10838,6 +11053,12 @@
 	icon_state = "lino"
 	},
 /area/centcom/command)
+"ID" = (
+/obj/structure/closet/walllocker/emergsuit_wall{
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor/black,
+/area/shuttle/escape)
 "IG" = (
 /obj/structure/table/reinforced,
 /obj/item/tool/crowbar,
@@ -11081,6 +11302,10 @@
 	icon_state = "white"
 	},
 /area/centcom/medical)
+"Jr" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/escape)
 "Js" = (
 /obj/machinery/r_n_d/protolathe,
 /turf/unsimulated/floor/steel,
@@ -12392,6 +12617,12 @@
 	icon_state = "white"
 	},
 /area/centcom/medical)
+"No" = (
+/obj/structure/closet/walllocker/emergsuit_wall{
+	pixel_y = -26
+	},
+/turf/simulated/shuttle/floor/black,
+/area/shuttle/escape)
 "Nq" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced{
@@ -12783,13 +13014,11 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
 "Oz" = (
-/obj/machinery/vending/fitness,
-/obj/machinery/light{
-	dir = 8;
-	use_power = 0;
-	old_wall = 1
+/obj/structure/fans/tiny,
+/obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks{
+	id = "emergency_security"
 	},
-/turf/simulated/shuttle/floor/darkred,
+/turf/simulated/floor,
 /area/shuttle/escape)
 "OA" = (
 /obj/machinery/tele_pad,
@@ -12885,13 +13114,10 @@
 	},
 /area/centcom/bathroom)
 "OZ" = (
-/obj/structure/table/steel,
-/obj/random/firstaid,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/bonemed,
-/obj/item/storage/firstaid/clotting,
-/obj/item/storage/firstaid/clotting,
-/turf/simulated/shuttle/floor,
+/obj/structure/handrail{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/darkred,
 /area/shuttle/escape)
 "Pa" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner,
@@ -12918,6 +13144,17 @@
 	},
 /turf/simulated/shuttle/wall/voidcraft,
 /area/shuttle/specops/engine)
+"Ph" = (
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/machinery/button/windowtint{
+	id = "emergency_security";
+	pixel_x = 8;
+	pixel_y = -24
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/shuttle/escape)
 "Pj" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -12946,11 +13183,10 @@
 /turf/simulated/floor/plating,
 /area/shuttle/specops/engine)
 "Pn" = (
-/obj/machinery/light{
-	dir = 4;
-	use_power = 0
+/obj/machinery/sleeper{
+	dir = 4
 	},
-/turf/simulated/shuttle/floor/white,
+/turf/simulated/shuttle/floor,
 /area/shuttle/escape)
 "Po" = (
 /obj/effect/floor_decal/derelict/d13,
@@ -13256,6 +13492,13 @@
 	icon_state = "white"
 	},
 /area/centcom/medical)
+"PY" = (
+/obj/structure/table/reinforced,
+/obj/machinery/holoplant{
+	pixel_y = 6
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/shuttle/escape)
 "Qa" = (
 /obj/structure/table/steel,
 /obj/item/storage/firstaid/regular,
@@ -13303,6 +13546,10 @@
 	icon_state = "dark"
 	},
 /area/centcom/security)
+"Qd" = (
+/obj/machinery/vending/blood,
+/turf/simulated/shuttle/floor,
+/area/shuttle/escape)
 "Qg" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -13564,6 +13811,17 @@
 	},
 /turf/unsimulated/floor/steel,
 /area/centcom/security)
+"QW" = (
+/obj/structure/closet/walllocker/autolok_wall{
+	pixel_y = -26
+	},
+/obj/machinery/light{
+	dir = 4;
+	use_power = 0;
+	old_wall = 1
+	},
+/turf/simulated/shuttle/floor/white,
+/area/shuttle/escape)
 "QX" = (
 /obj/machinery/shieldwallgen,
 /turf/unsimulated/floor{
@@ -13766,6 +14024,9 @@
 	old_wall = 1;
 	use_power = 0
 	},
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/escape)
 "Ry" = (
@@ -13945,6 +14206,9 @@
 "Sg" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 8
+	},
+/obj/structure/closet/walllocker/emergsuit_wall{
+	pixel_y = 32
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
@@ -14477,6 +14741,12 @@
 	icon_state = "white"
 	},
 /area/centcom/control)
+"TV" = (
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/white,
+/area/shuttle/escape)
 "TW" = (
 /obj/effect/floor_decal/steeldecal/steel_decals9,
 /obj/effect/floor_decal/steeldecal/steel_decals9{
@@ -14826,6 +15096,15 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"Vm" = (
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/structure/closet/walllocker/emergsuit_wall{
+	pixel_y = -26
+	},
+/turf/simulated/shuttle/floor/black,
+/area/shuttle/escape)
 "Vn" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/borderfloor{
@@ -15082,6 +15361,13 @@
 /obj/structure/closet/secure_closet/hop,
 /turf/unsimulated/floor/steel,
 /area/centcom/command)
+"Wj" = (
+/obj/structure/handrail,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor/black,
+/area/shuttle/escape)
 "Wk" = (
 /obj/structure/sign/warning/caution,
 /turf/unsimulated/wall,
@@ -15403,7 +15689,22 @@
 	},
 /area/centcom/security)
 "Xq" = (
-/obj/structure/bed/chair/shuttle,
+/obj/structure/table/reinforced,
+/obj/machinery/button/windowtint{
+	id = "emergency_cockpit";
+	pixel_x = -24;
+	pixel_y = 6
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = -24;
+	pixel_y = -8
+	},
+/obj/item/folder/blue,
+/obj/item/radio,
+/obj/item/radio{
+	pixel_x = 2;
+	pixel_y = 2
+	},
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/escape)
 "Xr" = (
@@ -16234,6 +16535,14 @@
 	icon_state = "white"
 	},
 /area/centcom/medical)
+"Zy" = (
+/obj/machinery/light{
+	dir = 4;
+	use_power = 0
+	},
+/obj/structure/closet/firecloset/full/double,
+/turf/simulated/shuttle/floor/darkred,
+/area/shuttle/escape)
 "ZA" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -16296,6 +16605,10 @@
 	icon_state = "steel"
 	},
 /area/centcom/bathroom)
+"ZM" = (
+/obj/machinery/power/pointdefense,
+/turf/simulated/floor/plating/eris/under,
+/area/shuttle/escape)
 "ZN" = (
 /obj/structure/sign/department/armory,
 /turf/unsimulated/wall,
@@ -29061,11 +29374,11 @@ AF
 AF
 AF
 jQ
-oL
-oL
-oL
-oL
-oL
+jQ
+Fl
+Fl
+Fl
+jQ
 jQ
 AF
 AF
@@ -29253,15 +29566,15 @@ AF
 AF
 AF
 AF
-AF
-jQ
+ZM
+Fl
 Xq
-yz
+TV
 PU
-yz
+im
 FX
-jQ
-AF
+Fl
+ZM
 AF
 AF
 AF
@@ -29446,17 +29759,17 @@ AF
 AF
 AF
 AF
-AF
-AF
+Ef
 jQ
-Xq
-yz
+wG
 QG
-yz
-FX
+QG
+QG
+QG
+mG
+wG
 jQ
-AF
-AF
+Jr
 AF
 AF
 AF
@@ -29643,11 +29956,11 @@ AF
 jQ
 jQ
 jQ
-wG
-Pn
+qk
+in
 yz
 in
-wG
+QW
 jQ
 jQ
 jQ
@@ -29836,14 +30149,14 @@ AF
 AF
 jQ
 bV
-al
 wG
-jQ
+mb
+mb
 Kg
-jQ
+mb
+mb
 wG
-va
-Oz
+bV
 jQ
 AF
 AF
@@ -30029,15 +30342,15 @@ AF
 AF
 AF
 jQ
-Gg
-yz
+Wj
+uV
 Ui
 pa
 yz
 pa
 Ui
-yz
-Jg
+uV
+gS
 jQ
 AF
 AF
@@ -30223,7 +30536,7 @@ AF
 AF
 AF
 jQ
-NW
+oz
 yz
 Ew
 NW
@@ -30231,7 +30544,7 @@ yz
 Ew
 NW
 yz
-Dm
+ag
 jQ
 AF
 AF
@@ -30999,7 +31312,7 @@ AF
 AF
 AF
 jQ
-NW
+oz
 yz
 Ew
 NW
@@ -31007,7 +31320,7 @@ yz
 Ew
 NW
 yz
-Dm
+ag
 jQ
 AF
 AF
@@ -31195,12 +31508,12 @@ AF
 jQ
 Gg
 yz
-Pn
 yz
 yz
 yz
 yz
-Pn
+yz
+yz
 Jg
 jQ
 AF
@@ -31387,15 +31700,15 @@ AF
 AF
 AF
 jQ
-jQ
-oL
-oL
-wG
-CG
-CG
-wG
-oL
-oL
+al
+vR
+Zy
+ov
+yz
+yz
+PY
+qm
+va
 jQ
 AF
 AF
@@ -31581,15 +31894,15 @@ AF
 AF
 AF
 jQ
-Ne
+jQ
 AA
-OZ
-jQ
-Gg
-Jg
-jQ
-ze
-lM
+AA
+wG
+gg
+Vm
+wG
+Oz
+Oz
 jQ
 AF
 AF
@@ -31775,15 +32088,15 @@ AF
 AF
 AF
 jQ
-Sp
-Sp
-Sp
+Ne
+mU
+gX
 mE
 CG
 CG
-oL
-nb
-lM
+Oz
+ze
+OZ
 jQ
 AF
 AF
@@ -31975,9 +32288,9 @@ dx
 mE
 CG
 CG
-oL
+Oz
 nb
-lM
+Ph
 jQ
 AF
 AF
@@ -32162,17 +32475,17 @@ AF
 AF
 AF
 AF
-jQ
+iC
 mA
 Sp
 dx
 jQ
-Gg
+lo
 Jg
 jQ
-nb
-lM
-jQ
+nU
+OZ
+xj
 AF
 AF
 AF
@@ -32356,8 +32669,8 @@ AF
 AF
 AF
 AF
-jQ
-Sp
+iC
+Pn
 Sp
 Sp
 Cw
@@ -32365,8 +32678,8 @@ CG
 CG
 uq
 lM
-lM
-jQ
+OZ
+xj
 AF
 AF
 AF
@@ -32551,15 +32864,15 @@ AF
 AF
 AF
 jQ
-Sp
-Sp
-Sp
+qH
+Dp
+Qd
 jQ
 Gg
 Jg
 jQ
-lM
-lM
+gb
+kX
 jQ
 AF
 AF
@@ -32749,8 +33062,8 @@ Sg
 Xs
 wG
 wG
-CG
-CG
+ID
+No
 jQ
 FB
 ya


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Non-map changes:
- Fixed electrochromatic window spawners not passing the given ID over to the windows they're spawning.

Both:
- Adds fire safety equipment
- Window spawners come with a low wall now.

Triumph:
- Moves the vendors back to the other wall
- Replaces the cigarette vendor with an MRE vendor (don't encourage smoking in a shuttle.)
- Changes up the bridge to be significantly less garbage
- Medbay's surgery table is replaced with a sleeper. Medbay's beds are now rolling beds, and IV drips with anesthetic tanks are set beside them. A blood vendor's been added.
- Lets people in the bridge see people outside in the passenger section.
- Adds point defense system
- Adds electrochromatic windows in the medbay, security, and command sections. Completely toggleable.
- Adds brig section in security area
- Adds safety equipment like softsuit closets & oxygen closets.

Rift:
- Fixes the tintable windows.
- Fixes access restrictions on security and medical sections.
- Adds additional blast doors.

## Why It's Good For The Game

Brings the departure shuttles which are designed to carry civillians and various crew members up to code in terms of safety and functionality. May eventually include its own built in air system later.

Fixes good.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Triumph's departure shuttle has been significantly improved in terms of equipment.
fix: Atlas and Triumph's departure shuttles have been given proper safety and functionality.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
