### PR TITLE
Stops xenoarcheology talking objects from annoying ghosts

### DIFF
--- a/code/modules/xenoarcheaology/finds/talking.dm
+++ b/code/modules/xenoarcheaology/finds/talking.dm
@@ -114,8 +114,6 @@
 			continue //skip monkeys and leavers
 		if (istype(M, /mob/new_player))
 			continue
-		if(M.stat == DEAD && M.get_preference_toggle(/datum/game_preference_toggle/observer/ghost_ears))
-			listening|=M
 
 	for(var/mob/M in listening)
 		to_chat(M, "[icon2html(thing = holder_atom, target = M)] <b>[holder_atom]</b> reverberates, \"<font color=#4F49AF>[msg]</font>\"")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title

## Why It's Good For The Game

If normal objects don't annoy ghosts who have Ghost Ears enabled, I don't see why these things should either.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Xenoarcheology's parroting objects will no longer annoy ghosts who have Ghost Ears enabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
