### PR TITLE
racks construct costs 2 steel

### DIFF
--- a/code/modules/materials/definitions/metals/steel.dm
+++ b/code/modules/materials/definitions/metals/steel.dm
@@ -80,7 +80,7 @@
 	. += create_stack_recipe_datum(
 		name = "rack",
 		product = /obj/structure/table/rack,
-		cost = 1,
+		cost = 2,
 		time = 0.5 SECONDS,
 	)
 	. += create_stack_recipe_datum(


### PR DESCRIPTION
## About The Pull Request

if u deconstruct racks, they drop 2 steel. however, they only take 1 steel to make. hmm. now they cost 2 steel to make.

## Why It's Good For The Game

unduplicates ur matter

## Changelog

:cl:
tweak: Rack now costs 2 steel to make.
/:cl: