### PR TITLE
atmosphere retention field touch message is now toucher only

### DIFF
--- a/code/game/machinery/atm_ret_field.dm
+++ b/code/game/machinery/atm_ret_field.dm
@@ -223,9 +223,9 @@
 
 /obj/structure/atmospheric_retention_field/attack_hand(mob/user, list/params)
 	if(density)
-		visible_message("You touch the retention field, and it crackles faintly. Tingly!")
+		to_chat(user, "You touch the retention field, and it crackles faintly. Tingly!")
 	else
-		visible_message("You try to touch the retention field, but pass through it like it isn't even there.")
+		to_chat(user, "You try to touch the retention field, but pass through it like it isn't even there.")
 
 /obj/structure/atmospheric_retention_field/legacy_ex_act()
 	return


### PR DESCRIPTION
## About The Pull Request

atmosphere retention field touch message is now toucher only

## Why It's Good For The Game

it was an aoe msg with first person structure

## Changelog

:cl:
fix: atmos field touching msg is now toucher only
/:cl: