### PR TITLE
lets mechs open blast doors

### DIFF
--- a/code/modules/vehicles/sealed/mecha/mecha.dm
+++ b/code/modules/vehicles/sealed/mecha/mecha.dm
@@ -624,7 +624,7 @@
 	return
 
 /obj/vehicle/sealed/mecha/proc/interface_action(obj/machinery/target)
-	if(istype(target, /obj/machinery/access_button))
+	if(istype(target, /obj/machinery/access_button) || istype(target, /obj/machinery/button/remote/blast_door))
 		src.occupant_message("<span class='notice'>Interfacing with [target].</span>")
 		src.log_message("Interfaced with [target].")
 		target.attack_hand(src.occupant_legacy)


### PR DESCRIPTION
## About The Pull Request

it lets mechs interact with blast door buttons

## Why It's Good For The Game

they can already interact with airlocks and stuff. its kind of stupid you have to eject like four times and get back in four times to get a mech out properly.

🥺 

## Changelog

:cl:
qol: mechs can now operate blast door controls
/:cl: