### PR TITLE
lints against turf overlaying

### DIFF
--- a/maps/away_missions/140x140/snow_outpost.dmm
+++ b/maps/away_missions/140x140/snow_outpost.dmm
@@ -853,7 +853,6 @@
 /turf/simulated/floor/snow/snow2,
 /area/awaymission/snow_outpost/outside/nospawn)
 "dN" = (
-/turf/simulated/floor/snow/snow2,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark6";
 	name = "Unknown Shuttle"
@@ -866,7 +865,6 @@
 	},
 /area/awaymission/snow_outpost/outside/nospawn)
 "dP" = (
-/turf/simulated/floor/snow/snow2,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark10";
 	name = "Unknown Shuttle"
@@ -972,7 +970,6 @@
 /turf/simulated/floor/tiled/white,
 /area/awaymission/snow_outpost/powered)
 "eb" = (
-/turf/simulated/floor/tiled/steel,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark5";
 	name = "Unknown Shuttle"
@@ -1030,14 +1027,12 @@
 /turf/simulated/floor/tiled/white,
 /area/awaymission/snow_outpost/powered)
 "em" = (
-/turf/simulated/floor/tiled/steel,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark9";
 	name = "Unknown Shuttle"
 	},
 /area/awaymission/snow_outpost/powered)
 "en" = (
-/turf/simulated/floor/tiled/steel,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark6";
 	name = "Unknown Shuttle"
@@ -1196,7 +1191,6 @@
 /turf/simulated/floor/tiled/white,
 /area/awaymission/snow_outpost/powered)
 "eL" = (
-/turf/simulated/floor/tiled/steel,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark10";
 	name = "Unknown Shuttle"
@@ -2350,14 +2344,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/awaymission/snow_outpost/powered)
 "iU" = (
-/turf/simulated/floor/snow/snow2,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark5";
 	name = "Unknown Shuttle"
 	},
 /area/awaymission/snow_outpost/outside/nospawn)
 "iV" = (
-/turf/simulated/floor/snow/snow2,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark9";
 	name = "Unknown Shuttle"
@@ -2531,7 +2523,6 @@
 /turf/simulated/floor/plating/outdoors,
 /area/awaymission/snow_outpost/dark)
 "DR" = (
-/turf/simulated/floor/tiled/steel,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark9";
 	name = "Unknown Shuttle"

--- a/maps/away_missions/archive/blackmarketpackers.dmm
+++ b/maps/away_missions/archive/blackmarketpackers.dmm
@@ -57,7 +57,6 @@
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship3)
 "an" = (
-/turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall,
 /area/awaymission/BMPship3)
 "ao" = (
@@ -591,7 +590,6 @@
 	},
 /area/awaymission/BMPship1)
 "cy" = (
-/turf/simulated/floor,
 /turf/simulated/shuttle/wall,
 /area/awaymission/BMPship3)
 "cA" = (

--- a/maps/away_missions/archive/jungle.dmm
+++ b/maps/away_missions/archive/jungle.dmm
@@ -661,7 +661,6 @@
 /turf/simulated/floor/outdoors/dirt,
 /area/jungle/crash_ship_source)
 "dA" = (
-/turf/simulated/floor/outdoors/dirt,
 /turf/simulated/shuttle/wall,
 /area/jungle/crash_ship_source)
 "dB" = (
@@ -689,7 +688,6 @@
 /turf/simulated/floor/tiled/white,
 /area/jungle/crash_ship_source)
 "dF" = (
-/turf/simulated/floor/tiled/white,
 /turf/simulated/shuttle/wall{
 	icon_state = "swall_c"
 	},

--- a/maps/away_missions/archive/spacebattle.dmm
+++ b/maps/away_missions/archive/spacebattle.dmm
@@ -5,7 +5,6 @@
 /turf/space,
 /area)
 "ac" = (
-/turf/simulated/shuttle/wall/dark,
 /turf/space,
 /area/awaymission/spacebattle/syndicate2)
 "ad" = (
@@ -73,7 +72,6 @@
 /turf/simulated/floor,
 /area/awaymission/spacebattle/syndicate2)
 "av" = (
-/turf/simulated/shuttle/wall/dark,
 /turf/space,
 /area/awaymission/spacebattle/syndicate3)
 "aw" = (
@@ -132,7 +130,6 @@
 /turf/simulated/floor,
 /area/awaymission/spacebattle/syndicate2)
 "aP" = (
-/turf/simulated/shuttle/wall/dark,
 /turf/space,
 /area/awaymission/spacebattle/syndicate1)
 "aQ" = (
@@ -307,7 +304,6 @@
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/syndicate1)
 "bJ" = (
-/turf/simulated/shuttle/wall/dark,
 /turf/space,
 /area/awaymission/spacebattle/cruiser)
 "bK" = (
@@ -812,7 +808,6 @@
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "et" = (
-/turf/simulated/shuttle/wall/dark,
 /turf/space,
 /area/awaymission/spacebattle/syndicate4)
 "eu" = (
@@ -1196,7 +1191,6 @@
 	},
 /area/awaymission/spacebattle/syndicate7)
 "gV" = (
-/turf/simulated/shuttle/wall/dark,
 /turf/space,
 /area/awaymission/spacebattle/syndicate7)
 "gW" = (
@@ -1561,7 +1555,6 @@
 /turf/simulated/shuttle/wall/dark,
 /area)
 "iE" = (
-/turf/simulated/shuttle/wall/dark,
 /turf/space,
 /area)
 "iF" = (
@@ -1594,7 +1587,6 @@
 	},
 /area)
 "iL" = (
-/turf/simulated/shuttle/wall/dark,
 /turf/space,
 /area/awaymission/spacebattle/syndicate5)
 "iM" = (
@@ -1644,7 +1636,6 @@
 /turf/space,
 /area/awaymission/spacebattle/syndicate5)
 "jc" = (
-/turf/simulated/shuttle/wall/dark,
 /turf/space,
 /area/awaymission/spacebattle/syndicate6)
 "jd" = (

--- a/maps/away_missions/archive/stationCollision.dmm
+++ b/maps/away_missions/archive/stationCollision.dmm
@@ -109,7 +109,6 @@
 /turf/simulated/shuttle/wall/dark,
 /area/awaymission/syndishuttle)
 "aD" = (
-/turf/simulated/shuttle/wall/dark,
 /turf/space,
 /area/awaymission/syndishuttle)
 "aH" = (
@@ -285,7 +284,6 @@
 /turf/simulated/shuttle/plating,
 /area/awaymission/syndishuttle)
 "bF" = (
-/turf/simulated/floor/airless,
 /turf/simulated/shuttle/wall{
 	dir = 4;
 	icon_state = "diagonalWall3"
@@ -1370,7 +1368,6 @@
 /turf/simulated/shuttle/plating,
 /area/awaymission/arrivalblock)
 "fT" = (
-/turf/space,
 /turf/simulated/shuttle/wall,
 /area/awaymission/arrivalblock)
 "fU" = (

--- a/maps/minitest/levels/minitest.dmm
+++ b/maps/minitest/levels/minitest.dmm
@@ -2898,12 +2898,10 @@
 /area/shuttle/webdemo)
 "hA" = (
 /obj/structure/shuttle/engine/heater,
-/turf/space,
 /turf/simulated/shuttle/plating/carry,
 /area/shuttle/webdemo)
 "hB" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
 /turf/simulated/shuttle/plating/carry,
 /area/shuttle/webdemo)
 "hC" = (
@@ -2914,7 +2912,6 @@
 /obj/machinery/ion_engine{
 	dir = 1
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/carry,
 /area/shuttle/overmapdemo)
 "hH" = (
@@ -3106,7 +3103,6 @@
 /area/space)
 "sA" = (
 /obj/structure/shuttle/engine/heater,
-/turf/space,
 /turf/simulated/shuttle/plating/carry,
 /area/shuttle/multidemo)
 "ts" = (
@@ -3621,7 +3617,6 @@
 /area/medical/medbay)
 "Pg" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
 /turf/simulated/shuttle/plating/carry,
 /area/shuttle/multidemo)
 "Ps" = (

--- a/maps/rift/engines/burn.dmm
+++ b/maps/rift/engines/burn.dmm
@@ -170,7 +170,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/turf/simulated/floor,
 /area/template_noop)
 "gK" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -291,7 +290,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
 /turf/simulated/floor,
 /area/template_noop)
 "nL" = (
@@ -534,13 +532,11 @@
 /area/engineering/engine_room)
 "Ab" = (
 /turf/simulated/floor,
-/turf/simulated/floor,
 /area/template_noop)
 "Ao" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
 /turf/simulated/floor,
 /area/template_noop)
 "AP" = (

--- a/maps/rift/engines/rust.dmm
+++ b/maps/rift/engines/rust.dmm
@@ -172,10 +172,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/turf/simulated/floor,
 /area/template_noop)
 "iJ" = (
-/turf/simulated/floor,
 /turf/simulated/floor,
 /area/template_noop)
 "iN" = (
@@ -962,7 +960,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/turf/simulated/floor,
 /area/template_noop)
 "Pm" = (
 /obj/machinery/light{
@@ -1026,7 +1023,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
 /turf/simulated/floor,
 /area/template_noop)
 "Ta" = (

--- a/maps/sectors/admin_planets_192/croatoan.dmm
+++ b/maps/sectors/admin_planets_192/croatoan.dmm
@@ -6931,7 +6931,6 @@
 /area/admin_planet/croatoan/sec_holding_cells)
 "yj" = (
 /obj/structure/reagent_dispensers/virusfood,
-/turf/simulated/floor/reinforced,
 /turf/simulated/wall/durasteel,
 /area/admin_planet/croatoan/high_sec_science_virology_lab)
 "yl" = (
@@ -14126,7 +14125,6 @@
 /turf/simulated/floor/cult,
 /area/admin_planet/croatoan/extreme_security_containment_facilities)
 "Xt" = (
-/turf/simulated/floor/reinforced,
 /turf/simulated/wall/durasteel,
 /area/admin_planet/croatoan/high_sec_science_virology_lab)
 "Xv" = (

--- a/maps/submaps/level_specific/debrisfield_vr/tinycarrier.dmm
+++ b/maps/submaps/level_specific/debrisfield_vr/tinycarrier.dmm
@@ -48,7 +48,6 @@
 /obj/machinery/atmospherics/component/unary/engine{
 	dir = 8
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/submap/debrisfield_vr/tinyshuttle/engine)
 "ai" = (
@@ -1055,7 +1054,6 @@
 /turf/simulated/floor/reinforced/airless,
 /area/submap/debrisfield_vr/tinyshuttle/hangar)
 "cb" = (
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/submap/debrisfield_vr/tinyshuttle/hangar)
 "cc" = (
@@ -1093,7 +1091,6 @@
 /area/submap/debrisfield_vr/tinyshuttle/engine)
 "cf" = (
 /obj/item/material/shard/phoron,
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/submap/debrisfield_vr/tinyshuttle/hangar)
 "cg" = (
@@ -1117,7 +1114,6 @@
 "ci" = (
 /obj/structure/lattice,
 /mob/living/simple_mob/mechanical/combat_drone/lesser,
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/submap/debrisfield_vr/tinyshuttle/hangar)
 "cj" = (
@@ -1139,7 +1135,6 @@
 /area/submap/debrisfield_vr/tinyshuttle/crew)
 "cl" = (
 /obj/effect/decal/mecha_wreckage/baron,
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/submap/debrisfield_vr/tinyshuttle/hangar)
 "cm" = (

--- a/maps/submaps/level_specific/virgo2/Blackshuttledown.dmm
+++ b/maps/submaps/level_specific/virgo2/Blackshuttledown.dmm
@@ -28,7 +28,6 @@
 /turf/simulated/mineral/floor/ignore_mapgen/virgo2,
 /area/submap/virgo2/Blackshuttledown)
 "ai" = (
-/turf/simulated/mineral/floor/ignore_mapgen/virgo2,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark6";
 	name = "Unknown Shuttle"
@@ -41,7 +40,6 @@
 	},
 /area/submap/virgo2/Blackshuttledown)
 "ak" = (
-/turf/simulated/mineral/floor/ignore_mapgen/virgo2,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark10";
 	name = "Unknown Shuttle"
@@ -114,7 +112,6 @@
 /turf/simulated/floor/tiled/steel,
 /area/submap/virgo2/Blackshuttledown)
 "au" = (
-/turf/simulated/mineral/floor/ignore_mapgen/virgo2,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark5";
 	name = "Unknown Shuttle"
@@ -141,7 +138,6 @@
 /turf/simulated/floor/tiled/steel,
 /area/submap/virgo2/Blackshuttledown)
 "az" = (
-/turf/simulated/mineral/floor/ignore_mapgen/virgo2,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark9";
 	name = "Unknown Shuttle"

--- a/maps/submaps/wilderness/Blackshuttledown.dmm
+++ b/maps/submaps/wilderness/Blackshuttledown.dmm
@@ -29,7 +29,6 @@
 /turf/template_noop,
 /area/submap/Blackshuttledown)
 "ai" = (
-/turf/template_noop,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark6";
 	name = "Unknown Shuttle"
@@ -42,7 +41,6 @@
 	},
 /area/submap/Blackshuttledown)
 "ak" = (
-/turf/template_noop,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark10";
 	name = "Unknown Shuttle"
@@ -144,7 +142,6 @@
 /turf/simulated/floor/tiled/white,
 /area/submap/Blackshuttledown)
 "av" = (
-/turf/simulated/floor/tiled/steel,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark5";
 	name = "Unknown Shuttle"
@@ -202,14 +199,12 @@
 /turf/simulated/floor/tiled/white,
 /area/submap/Blackshuttledown)
 "aG" = (
-/turf/simulated/floor/tiled/steel,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark9";
 	name = "Unknown Shuttle"
 	},
 /area/submap/Blackshuttledown)
 "aH" = (
-/turf/simulated/floor/tiled/steel,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark6";
 	name = "Unknown Shuttle"
@@ -368,7 +363,6 @@
 /turf/simulated/floor/tiled/white,
 /area/submap/Blackshuttledown)
 "bf" = (
-/turf/simulated/floor/tiled/steel,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark10";
 	name = "Unknown Shuttle"
@@ -756,14 +750,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/submap/Blackshuttledown)
 "cp" = (
-/turf/template_noop,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark5";
 	name = "Unknown Shuttle"
 	},
 /area/submap/Blackshuttledown)
 "cq" = (
-/turf/template_noop,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark9";
 	name = "Unknown Shuttle"

--- a/maps/submaps/wilderness/Blueshuttledown.dmm
+++ b/maps/submaps/wilderness/Blueshuttledown.dmm
@@ -29,7 +29,6 @@
 /turf/template_noop,
 /area/submap/Blackshuttledown)
 "ai" = (
-/turf/template_noop,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark6";
 	name = "Unknown Shuttle"
@@ -42,7 +41,6 @@
 	},
 /area/submap/Blackshuttledown)
 "ak" = (
-/turf/template_noop,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark10";
 	name = "Unknown Shuttle"
@@ -147,7 +145,6 @@
 /turf/simulated/floor/tiled/white,
 /area/submap/Blackshuttledown)
 "av" = (
-/turf/simulated/floor/tiled/steel,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark5";
 	name = "Unknown Shuttle"
@@ -205,14 +202,12 @@
 /turf/simulated/floor/tiled/white,
 /area/submap/Blackshuttledown)
 "aG" = (
-/turf/simulated/floor/tiled/steel,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark9";
 	name = "Unknown Shuttle"
 	},
 /area/submap/Blackshuttledown)
 "aH" = (
-/turf/simulated/floor/tiled/steel,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark6";
 	name = "Unknown Shuttle"
@@ -370,7 +365,6 @@
 /turf/simulated/floor/tiled/white,
 /area/submap/Blackshuttledown)
 "bf" = (
-/turf/simulated/floor/tiled/steel,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark10";
 	name = "Unknown Shuttle"
@@ -772,14 +766,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/submap/Blackshuttledown)
 "cp" = (
-/turf/template_noop,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark5";
 	name = "Unknown Shuttle"
 	},
 /area/submap/Blackshuttledown)
 "cq" = (
-/turf/template_noop,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark9";
 	name = "Unknown Shuttle"

--- a/maps/templates/admin/ert_base.dmm
+++ b/maps/templates/admin/ert_base.dmm
@@ -197,7 +197,6 @@
 	dir = 4;
 	icon_state = "propulsion_r"
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/specops/centcom)
 "ax" = (
@@ -255,7 +254,6 @@
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/specops/centcom)
 "aF" = (
@@ -552,7 +550,6 @@
 	dir = 4;
 	icon_state = "propulsion_l"
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/specops/centcom)
 "bh" = (

--- a/maps/templates/admin/mercbase.dmm
+++ b/maps/templates/admin/mercbase.dmm
@@ -3576,7 +3576,6 @@
 	dir = 8;
 	name = "pulse laser"
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/mercenary)
 "gl" = (
@@ -3753,7 +3752,6 @@
 	dir = 4;
 	icon_state = "propulsion_r"
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/mercenary)
 "gB" = (
@@ -4293,7 +4291,6 @@
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/mercenary)
 "hy" = (
@@ -4301,7 +4298,6 @@
 	dir = 4;
 	icon_state = "propulsion_l"
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/mercenary)
 "Xt" = (

--- a/maps/templates/admin/skipjack.dmm
+++ b/maps/templates/admin/skipjack.dmm
@@ -1497,7 +1497,6 @@
 /area/shuttle/skipjack)
 "dI" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/skipjack)
 "dJ" = (

--- a/maps/templates/archive/tradeship.dmm
+++ b/maps/templates/archive/tradeship.dmm
@@ -277,7 +277,6 @@
 	dir = 4;
 	icon_state = "propulsion_r"
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/trade)
 "aP" = (
@@ -346,7 +345,6 @@
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/trade)
 "ba" = (
@@ -600,7 +598,6 @@
 	dir = 4;
 	icon_state = "propulsion_l"
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/trade)
 "bE" = (

--- a/maps/templates/shuttles/overmaps/generic/curashuttle.dmm
+++ b/maps/templates/shuttles/overmaps/generic/curashuttle.dmm
@@ -1360,14 +1360,12 @@
 /obj/machinery/atmospherics/component/unary/engine{
 	dir = 1
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/curabitur/curashuttle/eng)
 "cP" = (
 /obj/machinery/ion_engine{
 	dir = 1
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/curabitur/curashuttle/eng)
 "dF" = (

--- a/maps/templates/shuttles/overmaps/generic/generic_shuttle.dmm
+++ b/maps/templates/shuttles/overmaps/generic/generic_shuttle.dmm
@@ -872,7 +872,6 @@
 /obj/machinery/atmospherics/component/unary/engine{
 	dir = 1
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/generic_shuttle/eng)
 "dV" = (

--- a/maps/tether/levels/misc.dmm
+++ b/maps/tether/levels/misc.dmm
@@ -280,7 +280,6 @@
 	},
 /area/space)
 "cC" = (
-/turf/space,
 /turf/space/transit/north,
 /area/space)
 "cK" = (
@@ -330,7 +329,6 @@
 	},
 /area/space)
 "dl" = (
-/turf/space,
 /turf/space/internal_edge/bottomright,
 /area/space)
 "dm" = (
@@ -1418,7 +1416,6 @@
 /turf/unsimulated/wall,
 /area/centcom/simulated/medical)
 "mJ" = (
-/turf/space,
 /turf/space/internal_edge/bottomleft,
 /area/space)
 "mK" = (
@@ -1506,7 +1503,6 @@
 /area/centcom/simulated/restaurant)
 "nq" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry{
 	dir = 1
 	},
@@ -2293,7 +2289,6 @@
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "burst_r"
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry{
 	dir = 1
 	},
@@ -2374,7 +2369,6 @@
 /turf/simulated/floor/tiled/steel,
 /area/centcom/simulated/terminal)
 "uA" = (
-/turf/space,
 /turf/space/internal_edge/topright,
 /area/space)
 "uD" = (
@@ -2749,7 +2743,6 @@
 	landmark_tag = "supply_cc";
 	name = "Centcom Supply Depot"
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry{
 	dir = 1
 	},
@@ -3927,7 +3920,6 @@
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_emptycourt)
 "FB" = (
-/turf/space,
 /turf/space/internal_edge/topleft,
 /area/space)
 "FC" = (
@@ -4299,7 +4291,6 @@
 	teleport_z = 4;
 	teleport_z_offset = 4
 	},
-/turf/space,
 /turf/space/transit/north,
 /area/space)
 "In" = (
@@ -5395,7 +5386,6 @@
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "burst_l"
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry{
 	dir = 1
 	},

--- a/maps/tether/levels/station2.dmm
+++ b/maps/tether/levels/station2.dmm
@@ -18010,7 +18010,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
 "KF" = (
-/turf/space,
 /turf/simulated/floor/wood,
 /area/tether/station/visitorhallway/office)
 "KG" = (

--- a/maps/tether/levels/surface3.dmm
+++ b/maps/tether/levels/surface3.dmm
@@ -3155,7 +3155,6 @@
 /area/tether/surfacebase/servicebackroom)
 "bGd" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
 /turf/simulated/shuttle/plating/carry,
 /area/shuttle/tether)
 "bGk" = (
@@ -37500,7 +37499,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/topairlock)
 "wix" = (
-/turf/space,
 /turf/simulated/wall/shull,
 /area/shuttle/tourbus/general)
 "wiD" = (

--- a/maps/triumph/levels/flagship.dmm
+++ b/maps/triumph/levels/flagship.dmm
@@ -16045,7 +16045,6 @@
 	},
 /area/centcom/control)
 "Yr" = (
-/turf/space/basic,
 /turf/unsimulated/wall,
 /area/space)
 "Yt" = (

--- a/maps/triumph/levels/misc.dmm
+++ b/maps/triumph/levels/misc.dmm
@@ -148,7 +148,6 @@
 /area/shuttle/supply)
 "cJ" = (
 /turf/space,
-/turf/space,
 /area/space)
 "cU" = (
 /obj/structure/holostool,
@@ -234,7 +233,6 @@
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "burst_r"
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry{
 	dir = 1
 	},
@@ -1129,7 +1127,6 @@
 	landmark_tag = "supply_cc";
 	name = "Centcom Supply Depot"
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry{
 	dir = 1
 	},
@@ -1439,7 +1436,6 @@
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "burst_l"
 	},
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry{
 	dir = 1
 	},
@@ -1498,7 +1494,6 @@
 /area/holodeck/source_boxingcourt)
 "Io" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
 /turf/simulated/shuttle/plating/airless/carry{
 	dir = 1
 	},

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -53,6 +53,10 @@ if grep -P '\W\/turf\s*[,\){]' maps/**/*.dmm; then
     echo "ERROR: base /turf path use detected in maps, please replace with proper paths."
     st=1
 fi;
+if grep -P '/turf[a-zA-Z0-9;\s\n_{}/]*,[\n]?/turf' maps/**/*.dmm; then
+    echo "ERROR: overlapping /turf's detected in maps, please fix it (do not have more than one /turf in a tile)."
+    st=1
+fi;
 # if grep -P '^/*var/' code/**/*.dm; then
 #     echo "ERROR: Unmanaged global var use detected in code, please use the helpers."
 #     st=1


### PR DESCRIPTION
byond lets you put two /turf's on one turf, which makes one turf look like the other

i don't know why it does this but this is never used in ss13 because it's absolutely horrible to deal with as you now have turfs using 1. underlays (ss13 doesn't) and 2. doing different things than it should

this removes all cases of it, and adds a lint.

this will not catch cases where there's more than two turfs but they're not adjacent but here's hoping people don't fuck up so royally hard that they somehow cause non-continuous turfs.