### PR TITLE
xenobotany requirement traits stop water / nutriment depletion.

### DIFF
--- a/code/modules/hydroponics/trays/tray_process.dm
+++ b/code/modules/hydroponics/trays/tray_process.dm
@@ -53,18 +53,18 @@
 			mutate((rand(100) < 15) ? 2 : 1)
 			mutation_level = 0
 
-	// Maintain tray nutrient and water levels.
-	if(seed.get_trait(TRAIT_NUTRIENT_CONSUMPTION) > 0 && nutrilevel > 0 && prob(25))
+	// Maintain tray nutrient and water levels, only if they don't have nutrient/water requirements.
+	if(seed.get_trait(TRAIT_REQUIRES_NUTRIENT) && seed.get_trait(TRAIT_NUTRIENT_CONSUMPTION) > 0 && nutrilevel > 0 && prob(25))
 		nutrilevel -= max(0,seed.get_trait(TRAIT_NUTRIENT_CONSUMPTION) * HYDRO_SPEED_MULTIPLIER)
-	if(seed.get_trait(TRAIT_WATER_CONSUMPTION) > 0 && waterlevel > 0 && prob(25))
+	if(seed.get_trait(TRAIT_REQUIRES_WATER) && seed.get_trait(TRAIT_WATER_CONSUMPTION) > 0 && waterlevel > 0 && prob(25))
 		waterlevel -= max(0,seed.get_trait(TRAIT_WATER_CONSUMPTION) * HYDRO_SPEED_MULTIPLIER)
 
 	// Make sure the plant is not starving or thirsty. Adequate
 	// water and nutrients will cause a plant to become healthier.
 	var/healthmod = rand(1,3) * HYDRO_SPEED_MULTIPLIER
-	if(seed.get_trait(TRAIT_REQUIRES_NUTRIENTS) && prob(35))
+	if(prob(35))
 		health += (nutrilevel < 2 ? -healthmod : healthmod)
-	if(seed.get_trait(TRAIT_REQUIRES_WATER) && prob(35))
+	if(prob(35))
 		health += (waterlevel < 10 ? -healthmod : healthmod)
 
 	// Check that pressure, heat and light are all within bounds.

--- a/code/modules/hydroponics/trays/tray_process.dm
+++ b/code/modules/hydroponics/trays/tray_process.dm
@@ -54,7 +54,7 @@
 			mutation_level = 0
 
 	// Maintain tray nutrient and water levels, only if they don't have nutrient/water requirements.
-	if(seed.get_trait(TRAIT_REQUIRES_NUTRIENT) && seed.get_trait(TRAIT_NUTRIENT_CONSUMPTION) > 0 && nutrilevel > 0 && prob(25))
+	if(seed.get_trait(TRAIT_REQUIRES_NUTRIENTS) && seed.get_trait(TRAIT_NUTRIENT_CONSUMPTION) > 0 && nutrilevel > 0 && prob(25))
 		nutrilevel -= max(0,seed.get_trait(TRAIT_NUTRIENT_CONSUMPTION) * HYDRO_SPEED_MULTIPLIER)
 	if(seed.get_trait(TRAIT_REQUIRES_WATER) && seed.get_trait(TRAIT_WATER_CONSUMPTION) > 0 && waterlevel > 0 && prob(25))
 		waterlevel -= max(0,seed.get_trait(TRAIT_WATER_CONSUMPTION) * HYDRO_SPEED_MULTIPLIER)


### PR DESCRIPTION
## About The Pull Request

for some reason trait_requires_nutrients / requires_water just stops the health. instead of like. just stopping nutrient/water intake. (which I would like it to do)
so farm bot would just go schizo
I also dont think it actually works as it should as it was before.
you also had no way of telling what the actual drain of both was, because the trait removes the visibility of intakes from the scanner.

This PR just basically makes the trait more obvious in what it does by making plants not drain their respective resource if they have that gene trait.

## Why It's Good For The Game

the trait was super obscured and actually just sort of made it impossible to restore your plants, making the trait sort of a negative one. now it's a lot more obvious as to what it's doing, and it correlates better to its actual name so the Farmbot doesn't also just go Schizo.

## Changelog

:cl:
tweak: Xenobotany's trait_requires_water & trait_requires_nutrient now stop the depletion of water/nutrient instead of health loss from a lack of either.
/:cl: