### PR TITLE
fixes a cam dir in engineering of triumph

### DIFF
--- a/maps/triumph/levels/deck1.dmm
+++ b/maps/triumph/levels/deck1.dmm
@@ -15217,7 +15217,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/network/outside{
-	dir = 10
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

it floated off the wall, now it don't.

## Why It's Good For The Game

no more floating camera :D 

## Changelog

:cl:
fix: makes a camera not float in triumph's engineering.
/:cl: