### PR TITLE
makes distilling not require 1000 pressure for temp changes

### DIFF
--- a/code/modules/reagents/distilling/distilling.dm
+++ b/code/modules/reagents/distilling/distilling.dm
@@ -248,7 +248,7 @@
 	if(!powered())
 		on = FALSE
 
-	if(!on || (use_atmos && (!connected_port || avg_pressure < 1000)))
+	if(!on || (use_atmos && (!connected_port || avg_pressure < 15)))
 		current_temp = round((current_temp + T20C) / 2)
 
 	else if(on)
@@ -261,7 +261,7 @@
 					shift_mod = -1
 				current_temp = clamp(round((current_temp + 1 * shift_mod) + (rand(-5, 5) / 10)), min_temp, max_temp)
 				use_power(power_rating)
-		else if(connected_port && avg_pressure > 1000)
+		else if(connected_port && avg_pressure > 15)
 			current_temp = round((current_temp + avg_temp) / 2)
 		else if(!run_pump)
 			visible_message("<span class='notice'>\The [src]'s motors wind down.</span>")


### PR DESCRIPTION
## About The Pull Request

this makes the atmos setting not require 1000 kpa to do anything with temp

## Why It's Good For The Game

u do not want me putting enough gas to fill the triumph 3x over at 14 kelvin into a distillery.

## Changelog

:cl:
tweak: The distillery atmos setting will now adjust the temperature at fifteen kPA or greater pressure instead of 1000 kPA or higher.
/:cl: