### PR TITLE
Fixes Ranged Roach Attack Speed

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/roach/roach.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/roach/roach.dm
@@ -347,7 +347,7 @@
 
 	armor_type = /datum/armor/physiology/roach/atomar
 
-	base_attack_cooldown = 4
+	base_attack_cooldown = 2 SECONDS
 	projectiletype = /obj/projectile/energy/blob/toxic
 	projectilesound = 'sound/effects/slime_squish.ogg'
 
@@ -426,7 +426,7 @@
 	taser_kill = 0
 	armor_type = /datum/armor/physiology/roach/strahland
 
-	base_attack_cooldown = 4
+	base_attack_cooldown = 2 SECONDS
 	projectiletype = /obj/projectile/energy/dart
 
 	ai_holder_type = /datum/ai_holder/polaris/simple_mob/ranged/kiting


### PR DESCRIPTION
Decreases ranged attack speed of roaches by 80%. No more MG roaches

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Machinegun Roaches are not fun
Due to a coding bug that for some reason was never squashed. Ranged roach subtypes were able fire faster then most mercenaries with machine guns. As one type used a primarily agony damage attack this resulted in a roach that could chain stun you, the other spammed a poison projectile capable of rapidly killing an unarmored target faster than most gun armed opponents. Both of these are oversights and this PR corrects them.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Ranged Roaches attack 80% slower.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
