### PR TITLE
Revert "Makes TEG Circulator bidirectional"

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -10,7 +10,7 @@ GLOBAL_LIST_EMPTY(all_turbines)
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 100 //Watts, I hope.  Just enough to do the computer and display things.
 
-	var/max_power = 5 MEGAWATTS
+	var/max_power = 500000
 	var/thermal_efficiency = 0.65
 
 	var/obj/machinery/atmospherics/component/binary/circulator/circ1


### PR DESCRIPTION
Reverts Citadel-Station-13/Citadel-Station-13-RP#6764

It literally does not work as advertised. It doesn't work at all. There's only one output side, it always puts into the output side. It can take from the output side, and then it puts it back into the output side. This is a non-functioning PR. Test your PRs properly.