### PR TITLE
Z-Mimic: Speculative fixes for glass turfs

### DIFF
--- a/code/controllers/subsystem/zcopy.dm
+++ b/code/controllers/subsystem/zcopy.dm
@@ -373,7 +373,7 @@ SUBSYSTEM_DEF(zcopy)
 			var/atom/movable/openspace/turf_mimic/DC = T.below.mimic_above_copy
 			DC.appearance = T.below
 			DC.mouse_opacity = initial(DC.mouse_opacity)
-			DC.plane = OPENTURF_MAX_PLANE - turf_depth - 1
+			DC.plane = OPENTURF_MAX_PLANE
 
 		else if (T.below.mimic_above_copy)
 			QDEL_NULL(T.below.mimic_above_copy)
@@ -555,7 +555,8 @@ SUBSYSTEM_DEF(zcopy)
 		if (/atom/movable/openspace/turf_proxy, /atom/movable/openspace/turf_mimic)
 			OO.depth += 1
 		if (/atom/movable/openspace/multiplier)
-			OO.depth += 1
+			// Ignore override depth for these.
+			OO.depth = min(zlev_maximums[OO.z] - original_z + 1, OPENTURF_MAX_DEPTH)
 
 	OO.mimiced_type = original_type
 	OO.override_depth = override_depth
@@ -803,7 +804,7 @@ var/list/zmimic_fixed_planes = list(
 	for (var/atom/movable/openspace/O in T)
 		found_oo += O
 
-	if (T.shadower.overlays.len)
+	if (T.shadower?.overlays.len)
 		for (var/overlay in T.shadower.overlays)
 			var/atom/movable/openspace/debug/D = new
 			D.appearance = overlay
@@ -863,7 +864,7 @@ var/list/zmimic_fixed_planes = list(
 /datum/controller/subsystem/zcopy/proc/debug_fmt_thing(atom/A, list/out, turf/original)
 	if (istype(A, /atom/movable/openspace/mimic))
 		var/atom/movable/openspace/mimic/OO = A
-		var/base = "<li>[fmt_label("Mimic", A)] plane [A.plane], layer [A.layer], depth [FMT_DEPTH(OO.depth)]"
+		var/base = "<li>[fmt_label("Mimic", A)] plane [A.plane], layer [A.layer], depth [FMT_DEPTH(OO.depth)], override depth [FMT_DEPTH(OO.override_depth)]"
 		if (QDELETED(OO.associated_atom))	// This shouldn't happen, but can if the deletion hook is not working.
 			return "[base] - [OO.type] copying <unknown> ([OO.mimiced_type]) - <font color='red'>ORPHANED</font></em></li>"
 

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -153,6 +153,7 @@
 	SHOULD_CALL_PARENT(FALSE)
 	atom_flags |= ATOM_INITIALIZED
 	SSzcopy.openspace_overlays += 1
+	loc?.Entered(src, null)
 
 /atom/movable/openspace/mimic/Destroy()
 	SSzcopy.openspace_overlays -= 1


### PR DESCRIPTION
There's still some update ordering issues that seem connected to lighting, but I'm not sure if this is actually an issue with ZM/O7L itself or seeker having a moment.
Also fixes some issues with new atom notifications in ZM not working with recursive mimic properly.