### PR TITLE
Exploration Mapping Tweaks

### DIFF
--- a/maps/rift/levels/rift-06-surface3.dmm
+++ b/maps/rift/levels/rift-06-surface3.dmm
@@ -2224,6 +2224,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-8"
 	},
+/obj/effect/floor_decal/borderfloorblack/corner2,
 /turf/simulated/floor/tiled/dark,
 /area/exploration/showers)
 "ahx" = (
@@ -2735,6 +2736,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/beige/bordercorner2,
 /turf/simulated/floor/tiled/steel,
 /area/exploration)
 "aiZ" = (
@@ -5608,8 +5611,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/beige/border,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -14191,7 +14192,6 @@
 /obj/item/clothing/accessory/permit/gun/planetside,
 /obj/item/roller,
 /obj/item/storage/backpack/parachute,
-/obj/item/binoculars,
 /obj/machinery/camera/network/exploration{
 	dir = 4
 	},
@@ -15684,7 +15684,6 @@
 /obj/item/clothing/accessory/permit/gun/planetside,
 /obj/item/roller,
 /obj/item/storage/backpack/parachute,
-/obj/item/binoculars,
 /turf/simulated/floor/tiled,
 /area/exploration/medic_prep)
 "aWW" = (
@@ -15900,10 +15899,12 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/camera/network/exploration{
 	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/showers)
@@ -15957,16 +15958,6 @@
 	},
 /turf/simulated/shuttle/wall/voidcraft/blue,
 /area/shuttle/courser/cockpit)
-"aXQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/exploration)
 "aXR" = (
 /obj/structure/closet/secure_closet/hop,
 /obj/item/megaphone,
@@ -17307,6 +17298,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 8
 	},
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/beige/bordercorner,
 /turf/simulated/floor/tiled/steel,
 /area/exploration/courser_dock)
 "ciC" = (
@@ -19043,6 +19036,18 @@
 "flP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/beige/bordercorner2{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/steel,
 /area/exploration/courser_dock)
@@ -21540,16 +21545,6 @@
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/exploration/meeting)
-"jFJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel,
-/area/exploration)
 "jFP" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -21722,6 +21717,12 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/beige/bordercorner2{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/steel,
 /area/exploration)
@@ -22263,12 +22264,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/exploration)
 "kQm" = (
@@ -23450,12 +23445,6 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 6
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/beige/bordercorner2{
-	dir = 6
-	},
 /turf/simulated/floor/tiled/steel,
 /area/exploration/courser_dock)
 "mZG" = (
@@ -23923,6 +23912,12 @@
 	dir = 8
 	},
 /obj/structure/table/bench/steel,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/beige/bordercorner2{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel,
 /area/exploration)
 "nPl" = (
@@ -24651,12 +24646,6 @@
 	dir = 1;
 	name = "Exploration";
 	sortType = "Exploration"
-	},
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/beige/bordercorner{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/exploration)
@@ -46654,9 +46643,9 @@ okY
 okY
 okY
 tSS
-jFJ
+okY
 kOx
-aXQ
+egu
 pis
 egu
 aKd

--- a/maps/rift/levels/rift-06-surface3.dmm
+++ b/maps/rift/levels/rift-06-surface3.dmm
@@ -6638,14 +6638,6 @@
 	pixel_x = 4;
 	pixel_y = -6
 	},
-/obj/item/binoculars{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/binoculars{
-	pixel_x = 2;
-	pixel_y = 2
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 4
 	},

--- a/maps/rift/levels/rift-06-surface3.dmm
+++ b/maps/rift/levels/rift-06-surface3.dmm
@@ -6658,6 +6658,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline,
 /obj/machinery/fire_alarm/north_mount,
+/obj/item/hand_labeler,
 /turf/simulated/floor/tiled/steel,
 /area/exploration/explorer_prep)
 "auU" = (
@@ -16364,7 +16365,7 @@
 	},
 /obj/item/robotanalyzer,
 /obj/item/storage/single_use/med_pouch/oxyloss,
-/obj/item/storage/single_use/med_pouch/toxin,
+/obj/item/hand_labeler,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/excursion/general)
 "aYY" = (

--- a/maps/triumph/levels/deck4.dmm
+++ b/maps/triumph/levels/deck4.dmm
@@ -26795,7 +26795,6 @@
 /obj/machinery/light,
 /obj/item/duct_tape_roll,
 /obj/item/duct_tape_roll,
-/obj/item/hand_labeler,
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "sLs" = (
@@ -31632,9 +31631,8 @@
 "wfu" = (
 /obj/machinery/camera/network/exploration,
 /obj/structure/table/standard,
-/obj/item/binoculars,
-/obj/item/binoculars,
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
+/obj/item/hand_labeler,
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "wfz" = (

--- a/maps/triumph/levels/deck4.dmm
+++ b/maps/triumph/levels/deck4.dmm
@@ -6431,6 +6431,7 @@
 	},
 /obj/structure/table/standard,
 /obj/item/duct_tape_roll,
+/obj/item/hand_labeler,
 /turf/simulated/floor/tiled/white,
 /area/exploration/medical)
 "ert" = (
@@ -26794,6 +26795,7 @@
 /obj/machinery/light,
 /obj/item/duct_tape_roll,
 /obj/item/duct_tape_roll,
+/obj/item/hand_labeler,
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "sLs" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Slight amounts of map housekeeping regarding the exploration department.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Things being wrong is bad.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Deleted mapped-in binoculars spawns for exploration, as they are now included in explo-related job lockers via code per #6796
del: Removed a toxin treatment pouch from Atlas Explo Shuttle.
add: Gave SAR & Explorers some Hand Labelers on both Atlas and Triumph.
tweak: Touched up some of the erroneous or incomplete floor markings in Atlas exploration.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
