### PR TITLE
Fixes crematoriums disintegrating

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -20,7 +20,7 @@
 	var/obj/structure/m_tray/connected = null
 	var/list/occupants = list()
 	anchored = 1
-	can_be_unanchored = 1
+	// can_be_unanchored = 1
 
 /obj/structure/morgue/Destroy()
 	if(connected)
@@ -83,6 +83,9 @@
 		attack_hand(user)
 
 /obj/structure/morgue/attack_hand(mob/user, datum/event_args/actor/clickchain/e_args)
+	if (!anchored)
+		user.show_message(SPAN_WARNING("You can't open [src] while it's unanchored."))
+		return
 	if (src.connected)
 		close()
 	else
@@ -132,6 +135,9 @@
 		else
 			src.name = "Morgue"
 	if(istype(W, /obj/item/tool/wrench))
+		if(connected)
+			user.show_message(SPAN_WARNING("You can't move [src] while it's open."))
+			return
 		if(anchored)
 			user.show_message(SPAN_NOTICE("[src] can now be moved."))
 			playsound(src, W.tool_sound, 50, 1)
@@ -251,8 +257,8 @@ GLOBAL_LIST_BOILERPLATE(all_crematoriums, /obj/structure/morgue/crematorium)
 				A.forceMove(src.connected.loc)
 			src.connected.icon_state = "cremat"
 		else
-			//src.connected = null
 			qdel(src.connected)
+			src.connected = null
 	src.add_fingerprint(user)
 	update()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a bug that caused crematoriums to permanently lose their trays if someone stood in front of the crematorium while opening it. Also prevents morgues from being open and unanchored simultaneously. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
An unusable crematorium is, well, unusable. 
The morgue unanchor mechanic is pretty obscure (I didn't even know it existed till now), but dragging an open morgue causes the tray to detatch and I'm not sure why someone would need to move a morgue before closing it.  
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: NanoTrasen has issued a mass recall on its Phoron War-era crematoriums and morgues amidst complaints about disappearing crematorium trays and unfounded reports of 'bluespace body snatching'. 

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
