### PR TITLE
Optimize circuit examiner and revert CD

### DIFF
--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -366,7 +366,6 @@
 	spawn_flags = IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3, TECH_BIO = 4)
 	power_draw_per_use = 80
-	cooldown_per_use = 50
 
 /obj/item/integrated_circuit/input/examiner/do_work(ord)
 	if(ord == 1)
@@ -378,12 +377,6 @@
 		else
 			set_pin_data(IC_OUTPUT, 1, H.name)
 			set_pin_data(IC_OUTPUT, 2, H.desc)
-
-			if(istype(H, /mob/living))
-				var/msg = H.examine(H)
-				if(msg)
-					set_pin_data(IC_OUTPUT, 2, msg)
-
 			set_pin_data(IC_OUTPUT, 3, H.x-T.x)
 			set_pin_data(IC_OUTPUT, 4, H.y-T.y)
 			set_pin_data(IC_OUTPUT, 5, sqrt((H.x-T.x)*(H.x-T.x)+ (H.y-T.y)*(H.y-T.y)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Revert #6684 while also addressing the performance concern.
Turns out that the proc examine was called for nothing since it never worked in the first place.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The examiner is not only used for desc. Many circuit concept rely on a very fast and responsive x and y relative cordinate and or distance feedback so having the cooldown on 5 severly crippled many designs.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

