### PR TITLE
blacklists Drinks That Kill You from flasks

### DIFF
--- a/code/modules/food/food/lunch.dm
+++ b/code/modules/food/food/lunch.dm
@@ -70,7 +70,8 @@ var/list/lunchables_drink_reagents_ = list(/datum/reagent/drink/nothing,
                                            /datum/reagent/drink/dry_ramen,
                                            /datum/reagent/drink/hell_ramen,
                                            /datum/reagent/drink/hot_ramen,
-                                           /datum/reagent/drink/soda/nuka_cola)
+                                           /datum/reagent/drink/soda/nuka_cola,
+                                           /datum/reagent/drink/nuclearwaste)
 
 
 // This default list is a bit different, it contains items we don't want
@@ -88,7 +89,8 @@ var/list/lunchables_ethanol_reagents_ = list(/datum/reagent/ethanol/acid_spit,
                                              /datum/reagent/ethanol/toxins_special,
 											 /datum/reagent/ethanol/voxdelight,
 											 /datum/reagent/ethanol/soemmerfire,
-											 /datum/reagent/ethanol/slimeshot)
+											 /datum/reagent/ethanol/slimeshot,
+                                             /datum/reagent/ethanol/desiretodie)
 
 /proc/lunchables_lunches()
 	if(!(lunchables_lunches_[lunchables_lunches_[1]]))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

as title

## Why It's Good For The Game

shouldn't be a roulette to take a basic loadout item and sometimes it just kills you

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Nuclear Waste and A Desire To Die are no longer options for loadout flasks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
