### PR TITLE
Add a requirement of one player ready for the round to start

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -135,6 +135,10 @@ SUBSYSTEM_DEF(ticker)
 	fire()
 
 /datum/controller/subsystem/ticker/proc/process_pregame()
+	var/citest = FALSE
+#ifdef CITESTING
+	citest = TRUE
+#endif
 	if(isnull(timeLeft))
 		timeLeft = max(0,start_at - world.time)
 	if(start_immediately)
@@ -143,7 +147,7 @@ SUBSYSTEM_DEF(ticker)
 		return
 	timeLeft -= wait
 	if(timeLeft <= 0)
-		if(how_many_players_have_readied_up() > 0)
+		if((how_many_players_have_readied_up() > 0) && (!citest))
 			current_state = GAME_STATE_SETTING_UP
 			Master.SetRunLevel(RUNLEVEL_SETUP)
 			if(start_immediately)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -147,7 +147,7 @@ SUBSYSTEM_DEF(ticker)
 		return
 	timeLeft -= wait
 	if(timeLeft <= 0)
-		if((how_many_players_have_readied_up() > 0) || (citest))
+		if((how_many_players_have_readied_up() > 0) || citest || start_immediately)
 			current_state = GAME_STATE_SETTING_UP
 			Master.SetRunLevel(RUNLEVEL_SETUP)
 			if(start_immediately)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -147,7 +147,7 @@ SUBSYSTEM_DEF(ticker)
 		return
 	timeLeft -= wait
 	if(timeLeft <= 0)
-		if((how_many_players_have_readied_up() > 0) && (!citest))
+		if((how_many_players_have_readied_up() > 0) || (citest))
 			current_state = GAME_STATE_SETTING_UP
 			Master.SetRunLevel(RUNLEVEL_SETUP)
 			if(start_immediately)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -143,10 +143,27 @@ SUBSYSTEM_DEF(ticker)
 		return
 	timeLeft -= wait
 	if(timeLeft <= 0)
-		current_state = GAME_STATE_SETTING_UP
-		Master.SetRunLevel(RUNLEVEL_SETUP)
-		if(start_immediately)
-			fire()
+		if(how_many_players_have_readied_up() > 0)
+			current_state = GAME_STATE_SETTING_UP
+			Master.SetRunLevel(RUNLEVEL_SETUP)
+			if(start_immediately)
+				fire()
+		else
+			handle_no_players_ready()
+			return
+
+/datum/controller/subsystem/ticker/proc/how_many_players_have_readied_up()
+	var/ready = FALSE
+	for(var/client/C in GLOB.clients)
+		if(istype(C.mob, /mob/new_player))
+			var/mob/new_player/p = C.mob
+			ready += p.ready
+	return ready
+
+/datum/controller/subsystem/ticker/proc/handle_no_players_ready()
+	to_chat(world, SPAN_ANNOUNCE("No Players are ready to play, delaying round start."))
+	start_at = world.time + 1 MINUTE
+	timeLeft = max(0,start_at - world.time)
 
 /datum/controller/subsystem/ticker/proc/Reboot(reason, end_string, delay)
 	set waitfor = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Unless more than 0 Players have stated their intention of playing the round, the round will delay by 1 minute, then check again.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hopefully reduces the amount of dead dead rounds during low population hours
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Add a requirement of one player ready for the round to start
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
