### PR TITLE
Lowers the recoil on the JSDF Rifle because it makes JSDF rifle users motion sick

### DIFF
--- a/code/modules/projectiles/guns/legacy_vr_guns/custom_guns.dm
+++ b/code/modules/projectiles/guns/legacy_vr_guns/custom_guns.dm
@@ -7,7 +7,7 @@
 	item_state = "battlerifle_i"
 	item_icons = null
 	w_class = WEIGHT_CLASS_BULKY
-	recoil = 2 // The battlerifle was known for its nasty recoil.
+	recoil = 1.5 // The battlerifle was known for its nasty recoil.
 	max_shells = 36
 	caliber = /datum/ammo_caliber/a9_5mm
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 2)


### PR DESCRIPTION
## About The Pull Request

The screenshake RN is extremely heavy handed. Its nausea inducing. The gun itself is more of a meme on itself (you cannot print its ammo). Mostly used for CDDA or Milsim larpers anyhow. 


## Why It's Good For The Game

It still has considerable screenshake but hopefully not so much that it makes the JSDF rifle fan puke. It is really *that* bad. Don't believe me? Give it a try, try using it with lots of stuff on the screen, it is quite nauseating. And its a thing waiting to happen till John Explorer goes looc: "brb puking due to JSDF screenshake".

## Alternatives?

Rename it to "Metaphysical Sickshot Battlerifle" because it manages to affect the "It" every character has.

## Changelog

:cl:
balance: JSDF rifle shouldnt induce motion sickness IRL anymore when firing it.
/:cl:

