### PR TITLE
Fixes R&D related access, some Atlas Science access, and a button's access in Surt

### DIFF
--- a/code/modules/mapping/map_helpers/access_helper/airlock.dm
+++ b/code/modules/mapping/map_helpers/access_helper/airlock.dm
@@ -411,12 +411,12 @@
 /obj/map_helper/access_helper/airlock/station/science/research_lab
 	req_one_access = list(
 		ACCESS_GENERAL_PATHFINDER,
-		ACCESS_SCIENCE_MAIN,
+		ACCESS_SCIENCE_FABRICATION,
 	)
 
 /obj/map_helper/access_helper/airlock/station/science/shared_xenoflora
 	req_one_access = list(
-		ACCESS_SCIENCE_MAIN,
+		ACCESS_SCIENCE_XENOBOTANY,
 		ACCESS_GENERAL_BOTANY,
 	)
 

--- a/maps/rift/levels/rift-02-underground2.dmm
+++ b/maps/rift/levels/rift-02-underground2.dmm
@@ -6450,7 +6450,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance/cargo,
-/obj/map_helper/access_helper/airlock/station/supply/department,
+/obj/map_helper/access_helper/airlock/station/mining_operations,
 /turf/simulated/floor/plating,
 /area/quartermaster/miningdock)
 "wV" = (
@@ -8758,7 +8758,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/cargo,
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
+/obj/map_helper/access_helper/airlock/station/supply/department,
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningdock)
 "Gn" = (
@@ -8784,7 +8784,7 @@
 	name = "Mining Operations";
 	req_one_access = list()
 	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
+/obj/map_helper/access_helper/airlock/station/supply/mining,
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/miningdock)
 "Gs" = (
@@ -10020,7 +10020,6 @@
 	name = "Mining Operations";
 	req_one_access = list(47,48)
 	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningdock)
 "Lp" = (
@@ -10335,7 +10334,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/cargo,
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
+/obj/map_helper/access_helper/airlock/station/supply/department,
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/refinery)
 "MC" = (
@@ -10588,7 +10587,7 @@
 	name = "Mining Operations";
 	req_one_access = list()
 	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
+/obj/map_helper/access_helper/airlock/station/supply/mining,
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/miningdock)
 "Nt" = (
@@ -11841,7 +11840,7 @@
 	name = "Mining Operations";
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
+/obj/map_helper/access_helper/airlock/station/supply/department,
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/belterdock/refinery)
 "Ss" = (
@@ -12606,7 +12605,7 @@
 	name = "Mining Operations";
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
+/obj/map_helper/access_helper/airlock/station/supply/department,
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/belterdock/refinery)
 "Vd" = (
@@ -12724,7 +12723,7 @@
 "VC" = (
 /obj/machinery/door/airlock/maintenance/cargo,
 /obj/machinery/door/firedoor/glass,
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
+/obj/map_helper/access_helper/airlock/station/supply/mining,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
 "VD" = (

--- a/maps/rift/levels/rift-04-surface1.dmm
+++ b/maps/rift/levels/rift-04-surface1.dmm
@@ -36708,7 +36708,7 @@
 	name = "Cargo Airlock";
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
+/obj/map_helper/access_helper/airlock/station/supply/department,
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/office)
 "vYQ" = (

--- a/maps/rift/levels/rift-04-surface1.dmm
+++ b/maps/rift/levels/rift-04-surface1.dmm
@@ -4438,7 +4438,7 @@
 /obj/machinery/door/airlock/maintenance/rnd{
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/science/department,
+/obj/map_helper/access_helper/airlock/station/science/xenoarcheology,
 /turf/simulated/floor/plating,
 /area/rnd/xenoarch_storage)
 "dcG" = (
@@ -5422,8 +5422,7 @@
 	name = "Science First Aid";
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/medical/department,
-/obj/map_helper/access_helper/airlock/station/science/department,
+/obj/map_helper/access_helper/airlock/station/science/infirmary,
 /turf/simulated/floor/tiled/steel,
 /area/rnd/hallway)
 "dHp" = (
@@ -16981,8 +16980,7 @@
 /obj/machinery/door/airlock/maintenance/rnd{
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/service/botany,
-/obj/map_helper/access_helper/airlock/station/science/department,
+/obj/map_helper/access_helper/airlock/station/science/xenobotany,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
 "kJN" = (
@@ -30100,8 +30098,7 @@
 	name = "Xenoflora Research";
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/service/botany,
-/obj/map_helper/access_helper/airlock/station/science/department,
+/obj/map_helper/access_helper/airlock/station/science/xenobotany,
 /turf/simulated/floor/tiled/steel,
 /area/rnd/xenobiology/xenoflora/lab_atmos)
 "smJ" = (
@@ -35368,7 +35365,7 @@
 	name = "Chemical Research";
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/science/department,
+/obj/map_helper/access_helper/airlock/station/science/genetics,
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry_lab)
 "vdS" = (
@@ -36160,7 +36157,7 @@
 	id_tag = "researchdoor";
 	name = "Testing Room"
 	},
-/obj/map_helper/access_helper/airlock/station/science/department,
+/obj/map_helper/access_helper/airlock/station/science/genetics,
 /turf/simulated/floor/tiled/monowhite,
 /area/rnd/testingroom)
 "vIa" = (
@@ -36856,12 +36853,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/map_helper/access_helper/airlock/station/service/botany,
-/obj/map_helper/access_helper/airlock/station/science/department,
 /obj/machinery/door/airlock/glass/research{
 	name = "Xenoflora Research";
 	req_one_access = null
 	},
+/obj/map_helper/access_helper/airlock/station/science/xenobotany,
 /turf/simulated/floor/tiled/steel,
 /area/rnd/xenobiology/xenoflora)
 "wdf" = (
@@ -38188,7 +38184,7 @@
 /obj/machinery/door/airlock/maintenance/rnd{
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/science/department,
+/obj/map_helper/access_helper/airlock/station/science/xenoarcheology,
 /turf/simulated/floor/plating,
 /area/maintenance/research/lower)
 "wQk" = (

--- a/maps/rift/levels/rift-04-surface1.dmm
+++ b/maps/rift/levels/rift-04-surface1.dmm
@@ -11833,7 +11833,7 @@
 	name = "Mining Operations";
 	req_one_access = list()
 	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
+/obj/map_helper/access_helper/airlock/station/supply/department,
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/office)
 "hIo" = (
@@ -13856,7 +13856,7 @@
 /obj/machinery/door/airlock/maintenance/cargo{
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
+/obj/map_helper/access_helper/airlock/station/supply/department,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "iQn" = (

--- a/maps/sectors/lavaland_192/levels/lavaland_192.dmm
+++ b/maps/sectors/lavaland_192/levels/lavaland_192.dmm
@@ -2399,7 +2399,7 @@
 	name = "Staging Area Shutters";
 	pixel_x = 26;
 	pixel_y = 26;
-	req_one_access = s
+	req_one_access = list(1,5,31,38,47,48)
 	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)

--- a/maps/sectors/lavaland_192/levels/lavaland_192.dmm
+++ b/maps/sectors/lavaland_192/levels/lavaland_192.dmm
@@ -313,7 +313,7 @@
 	name = "Staging Area Shutters";
 	pixel_x = -28;
 	pixel_y = -28;
-	req_one_access = list(48)
+	req_one_access = list(1,5,31,38,47,48)
 	},
 /turf/simulated/floor/outdoors/lavaland,
 /area/lavaland/central/explored)
@@ -2399,7 +2399,7 @@
 	name = "Staging Area Shutters";
 	pixel_x = 26;
 	pixel_y = 26;
-	req_one_access = list(1,5,31,38,47,48)
+	req_one_access = s
 	},
 /turf/simulated/floor/tiled,
 /area/lavaland/central/base/common)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Explorers can no longer enter Research and Development. Explorers entering R&D is not intended to be the norm and got changed by mistake when access helpers came to pass a few months ago. Pathfinders can still enter it.
- Corrects Xenobotany's access on Atlas
- Corrects infirmary access on Atlas
- Chemistry lab changed to Xenobotany/Xenobiology ("genetics") access on Atlas ( sorry explorers. :^) )
- Everyone who can enter Surt can toggle the blast doors from the outside instead of just the inside now.

## Why It's Good For The Game

Fix gud.
I swear this isn't just some "explorers get no rights" PR.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: A few access corrections on Atlas and Surt/Lavaland.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
