### PR TITLE
Ticking reactions will now proper begin & distillery QoL

### DIFF
--- a/code/modules/reagents/chemistry/reagent_holder-reactions.dm
+++ b/code/modules/reagents/chemistry/reagent_holder-reactions.dm
@@ -99,7 +99,7 @@
  */
 /datum/reagent_holder/proc/start_ticked_reaction(datum/chemical_reaction/reaction)
 	SHOULD_NOT_OVERRIDE(TRUE)
-	if(LAZYFIND(active_reactions, reaction))
+	if(active_reactions?[reaction])
 		return
 	log_chemical_reaction_ticked_start(src, reaction)
 	LAZYSET(active_reactions, reaction, list())

--- a/code/modules/reagents/chemistry/reagent_holder-reactions.dm
+++ b/code/modules/reagents/chemistry/reagent_holder-reactions.dm
@@ -99,7 +99,7 @@
  */
 /datum/reagent_holder/proc/start_ticked_reaction(datum/chemical_reaction/reaction)
 	SHOULD_NOT_OVERRIDE(TRUE)
-	if(active_reactions[reaction])
+	if(LAZYFIND(active_reactions, reaction))
 		return
 	log_chemical_reaction_ticked_start(src, reaction)
 	LAZYSET(active_reactions, reaction, list())

--- a/code/modules/reagents/distilling/Distilling-Recipes.dm
+++ b/code/modules/reagents/distilling/Distilling-Recipes.dm
@@ -12,12 +12,19 @@
 
 	var/temp_shift = 0 // How much the temperature changes when the reaction occurs.
 
+/datum/chemical_reaction/on_reaction_start(datum/reagent_holder/holder)
+	. = ..()
+	holder.my_atom.visible_message("<span class='notice'>\The [holder.my_atom] rumbles to life!</span>")
+
 /datum/chemical_reaction/distilling/on_reaction_tick(datum/reagent_holder/holder, delta_time, multiplier)
 	. = ..()
-	if(istype(holder.my_atom, /obj/item/reagent_containers/glass/distilling))
-		var/obj/item/reagent_containers/glass/distilling/D = holder.my_atom
-		var/obj/machinery/portable_atmospherics/powered/reagent_distillery/RD = D.Master
-		RD.current_temp += temp_shift
+	if(prob(10))
+		holder.my_atom.visible_message("<span class='notice'>\The [holder.my_atom] rumbles faintly...</span>")
+	holder.temperature += temp_shift
+
+/datum/chemical_reaction/distilling/on_reaction_finish(datum/reagent_holder/holder)
+	. = ..()
+	holder.my_atom.visible_message("<span class='notice'>\The [holder.my_atom]'s rumbling dies down...</span>")
 
 // Subtypes //
 

--- a/code/modules/reagents/distilling/distilling.dm
+++ b/code/modules/reagents/distilling/distilling.dm
@@ -21,11 +21,8 @@
 	var/max_temp = T20C + 300
 	var/min_temp = T0C - 10
 
-	var/current_temp = T20C
-
 	var/use_atmos = FALSE	// If true, this machine will be connectable to ports, and use gas mixtures as the source of heat, rather than its internal controls.
 
-	var/static/radial_examine = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_examine")
 	var/static/radial_use = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_use")
 
 	var/static/radial_pump = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_pump")
@@ -39,8 +36,6 @@
 	var/static/radial_install_output = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_add")
 
 	var/static/radial_inspectgauges = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_lookat")
-
-	var/static/radial_mix = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_mix")
 
 // Overlay holders so we don't have to constantly remake them.
 	var/image/overlay_output_beaker
@@ -109,10 +104,8 @@
 
 /obj/machinery/portable_atmospherics/powered/reagent_distillery/attack_hand(mob/user, datum/event_args/actor/clickchain/e_args)
 	var/list/options = list()
-	options["examine"] = radial_examine
 	options["use"] = radial_use
 	options["inspect gauges"] = radial_inspectgauges
-	options["pulse agitator"] = radial_mix
 
 	if(InputBeaker)
 		options["eject input"] = radial_eject_input
@@ -133,9 +126,6 @@
 		choice = show_radial_menu(user, src, options, require_near = !issilicon(user))
 
 	switch(choice)
-		if("examine")
-			examine(user)
-
 		if("use")
 			if(powered())
 				on = !on
@@ -145,15 +135,7 @@
 			to_chat(user, "<span class='notice'>\The [src]'s gauges read:</span>")
 			if(!use_atmos)
 				to_chat(user, "<span class='notice'>- Target Temperature:</span> <span class='warning'>[target_temp]</span>")
-			to_chat(user, "<span class='notice'>- Temperature:</span> <span class='warning'>[current_temp]</span>")
-
-		if("pulse agitator")
-			to_chat(user, "<span class='notice'>You press \the [src]'s chamber agitator button.</span>")
-			if(on)
-				visible_message("<span class='notice'>\The [src] rattles to life.</span>")
-			else
-				spawn(1 SECOND)
-					to_chat(user, "<span class='notice'>Nothing happens..</span>")
+			to_chat(user, "<span class='notice'>- Temperature:</span> <span class='warning'>[Reservoir.reagents.temperature]</span>")
 
 		if("eject input")
 			if(InputBeaker)
@@ -248,20 +230,20 @@
 		on = FALSE
 
 	if(!on || (use_atmos && (!connected_port || avg_pressure < 15)))
-		current_temp = round((current_temp + T20C) / 2)
+		Reservoir.reagents.temperature = round((Reservoir.reagents.temperature + T20C) / 2)
 
 	else if(on)
 		if(!use_atmos)
-			if(current_temp != round(target_temp))
+			if(Reservoir.reagents.temperature != round(target_temp))
 				var/shift_mod = 0
-				if(current_temp < target_temp)
+				if(Reservoir.reagents.temperature < target_temp)
 					shift_mod = 1
-				else if(current_temp > target_temp)
+				else if(Reservoir.reagents.temperature > target_temp)
 					shift_mod = -1
-				current_temp = clamp(round((current_temp + 1 * shift_mod) + (rand(-5, 5) / 10)), min_temp, max_temp)
+				Reservoir.reagents.temperature = clamp(round((Reservoir.reagents.temperature + 1 * shift_mod) + (rand(-5, 5) / 10)), min_temp, max_temp)
 				use_power(power_rating)
 		else if(connected_port && avg_pressure > 15)
-			current_temp = round((current_temp + avg_temp) / 2)
+			Reservoir.reagents.temperature = round((Reservoir.reagents.temperature + avg_temp) / 2)
 		else if(!run_pump)
 			visible_message("<span class='notice'>\The [src]'s motors wind down.</span>")
 			on = FALSE
@@ -288,9 +270,9 @@
 	if(on)
 		if(OutputBeaker && OutputBeaker.reagents.total_volume < OutputBeaker.reagents.maximum_volume)
 			add_overlay(overlay_dumping)
-		else if(current_temp == round(target_temp))
+		else if(Reservoir.reagents.temperature == round(target_temp))
 			add_overlay(overlay_ready)
-		else if(current_temp < target_temp)
+		else if(Reservoir.reagents.temperature < target_temp)
 			add_overlay(overlay_heating)
 		else
 			add_overlay(overlay_cooling)


### PR DESCRIPTION
## About The Pull Request

This adds feedback messages for the distillery reactions.
The examine radial was removed because it didn't work and gave no relevant info.
It also fixes start_ticked_reaction with an if statement that won't runtime.
It also makes the distillery adjust the reagent_holder's temperature instead of having a current_temp var.

## Why It's Good For The Game

makes distillery work and not be hell.

## Changelog

:cl:
tweak: Distilleries now adjust their reagent_holder's temperature instead.
fix: Ticked reactions will now properly start up.
qol: Distillery reactions will now give feedback of starting up, still running, and stopping.
/:cl: