### PR TITLE
Stop Dying Glacicorns

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/farm animals/lythios.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/farm animals/lythios.dm
@@ -25,7 +25,7 @@
 	iff_factions = MOB_IFF_FACTION_FARM_ANIMAL
 
 	minbodytemp = 180
-	maxbodytemp = 275
+	maxbodytemp = 280 //Temp Stablization means that Glacicorns overheat when Lythios is warmest.
 
 	health = 40
 	maxHealth = 40


### PR DESCRIPTION
This will stop Glacicorns from randomly dying from heatstroke.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## CURSE YOU TEMP STABILIZATION
Apparently when Lythios is at its warmest temperature stabilization warms up Glacicorns just enough to die of heatstroke. As simple mob temp stabilization will eventually be removed according to Silicons I am simply upping Glacicorn heat tolerance slightly.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Glacicorns should no longer die when Lythios gets a bit warm.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
