### PR TITLE
Power and Atmos Fixes

### DIFF
--- a/maps/endeavour/levels/deck1.dmm
+++ b/maps/endeavour/levels/deck1.dmm
@@ -41,12 +41,14 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d1fwdmaint)
 "abZ" = (
-/obj/machinery/power/apc/north_mount,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/civilian)
+/turf/simulated/floor/wood,
+/area/library)
 "acr" = (
 /obj/machinery/disperser/middle{
 	dir = 4
@@ -84,20 +86,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aej" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/library)
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d1starboardafthall)
 "aek" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 8
@@ -832,9 +828,6 @@
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/cargo)
 "aGG" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -1101,6 +1094,9 @@
 	dir = 4
 	},
 /obj/structure/table/bench/wooden,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aMl" = (
@@ -1343,6 +1339,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aXa" = (
@@ -1385,13 +1384,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/gateway)
 "aYc" = (
+/obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d1aftmaint)
 "aYh" = (
@@ -1409,11 +1403,8 @@
 	req_one_access = null
 	},
 /obj/structure/catwalk,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/structure/cable/orange{
-	icon_state = "5-10"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
@@ -1711,14 +1702,6 @@
 "blR" = (
 /turf/simulated/wall/prepainted/command,
 /area/bridge/hallway)
-"blT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/library)
 "bmD" = (
 /obj/machinery/air_alarm{
 	pixel_y = 22
@@ -1885,9 +1868,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
@@ -2271,11 +2251,11 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1fwdhall)
@@ -2423,6 +2403,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
 "bSl" = (
@@ -2478,12 +2461,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-10"
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
@@ -2561,10 +2538,10 @@
 /area/exploration/excursion_dock)
 "bYt" = (
 /obj/effect/floor_decal/chapel,
+/obj/effect/floor_decal/spline/fancy/wood/corner,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/spline/fancy/wood/corner,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "bYy" = (
@@ -2962,9 +2939,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/chapel/main)
 "ctt" = (
@@ -3342,6 +3316,9 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
 "cHj" = (
@@ -3588,6 +3565,9 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway)
 "cPY" = (
@@ -3728,9 +3708,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/chapel/main)
 "cUt" = (
@@ -3824,6 +3801,9 @@
 	},
 /obj/machinery/door/firedoor{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/library)
@@ -4227,6 +4207,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1afthall)
 "doZ" = (
@@ -4271,18 +4254,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
-"dqz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/endeavour/hallway/d1starboardamidhall)
 "dqY" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
@@ -4446,6 +4417,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1starboardamidhall)
 "dyH" = (
@@ -4553,6 +4527,9 @@
 	dir = 4
 	},
 /obj/structure/table/bench/wooden,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "dCX" = (
@@ -4752,6 +4729,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "dKl" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/chapel/main)
 "dKn" = (
@@ -5152,9 +5132,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
 "eaK" = (
@@ -5547,9 +5524,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/steel,
 /area/library)
 "ert" = (
@@ -5910,6 +5884,9 @@
 	name = "Chapel Morgue"
 	},
 /obj/map_helper/access_helper/airlock/station/service/chapel/cremator,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/chapel/main)
 "eDR" = (
@@ -6108,9 +6085,6 @@
 /area/endeavour/hallway/d1starboardafthall)
 "eNt" = (
 /obj/machinery/holopad,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/chapel/main)
 "eNv" = (
@@ -6349,6 +6323,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/glass,
 /obj/map_helper/access_helper/airlock/station/service/chapel/cremator,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/chapel/main)
 "eTR" = (
@@ -6652,9 +6629,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Chapel"
@@ -6886,9 +6860,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/exploration/explorer_prep)
 "fkZ" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -8095,14 +8066,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway2)
 "fYP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/chapel/main)
+/turf/simulated/floor/wood,
+/area/library)
 "fZu" = (
 /obj/machinery/camera/network/outside{
 	dir = 8
@@ -8169,6 +8137,9 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/camera/network/civilian{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
@@ -9150,11 +9121,23 @@
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/test_area)
 "gNs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/chapel/main)
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d1starboardafthall)
 "gNY" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -9594,6 +9577,9 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "hfp" = (
@@ -9785,21 +9771,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/civvie/general)
-"hlC" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/endeavour/hallway/d1starboardamidhall)
 "hlO" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 8
@@ -9826,6 +9797,9 @@
 /area/shuttle/excursion/general)
 "hnl" = (
 /obj/effect/floor_decal/steeldecal/steel_decals2,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1starboardafthall)
 "hnz" = (
@@ -10006,9 +9980,6 @@
 "htT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/camera/network/civilian{
 	dir = 9
 	},
@@ -10611,7 +10582,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1afthall)
@@ -10770,9 +10741,6 @@
 	},
 /obj/machinery/power/apc/north_mount,
 /obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/steel,
@@ -10843,6 +10811,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1starboardamidhall)
@@ -11993,9 +11964,6 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1afthall)
 "iUW" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central6,
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1starboardamidhall)
@@ -12218,6 +12186,9 @@
 	dir = 4
 	},
 /obj/landmark/spawnpoint/job/chaplain,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "jda" = (
@@ -12906,7 +12877,7 @@
 "jAq" = (
 /obj/machinery/power/apc/north_mount,
 /obj/structure/cable/green{
-	icon_state = "0-4"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
@@ -12950,9 +12921,6 @@
 "jDn" = (
 /obj/machinery/light/small{
 	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
@@ -13071,9 +13039,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -13245,9 +13210,6 @@
 "jNp" = (
 /obj/machinery/fire_alarm/south_mount{
 	pixel_y = -24
-	},
-/obj/structure/cable/green{
-	icon_state = "4-10"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet/bcarpet,
@@ -13523,11 +13485,20 @@
 /turf/simulated/wall/prepainted/civilian,
 /area/maintenance/substation/dock)
 "jWm" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/chapel/main)
+/obj/effect/floor_decal/corner/navgold/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d1starboardafthall)
 "jWo" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/recharger{
@@ -13608,9 +13579,6 @@
 "jXs" = (
 /obj/machinery/door/firedoor{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1starboardamidhall)
@@ -14525,11 +14493,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/docking_hallway2)
 "kIs" = (
+/obj/machinery/atmospherics/component/unary/vent_pump/on,
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/civilian)
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d1starboardamidhall)
 "kIy" = (
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 8
@@ -14597,6 +14566,9 @@
 	},
 /obj/effect/floor_decal/corner/navblue/border{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/exploration)
@@ -14769,9 +14741,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
 "kOG" = (
@@ -14831,10 +14800,10 @@
 /area/endeavour/hallway/d1aftmaint)
 "kPV" = (
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/steel,
-/area/endeavour/hallway/d1starboardamidhall)
+/turf/simulated/floor/plating,
+/area/maintenance/substation/civilian)
 "kQd" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -14862,8 +14831,8 @@
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
 "kQX" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/cable/orange{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardafthall)
@@ -14996,9 +14965,6 @@
 /turf/simulated/floor/water/deep/indoors,
 /area/hydroponics/garden)
 "kWt" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/map_helper/access_helper/airlock/station/maintenance,
 /obj/machinery/door/airlock/maintenance/engi{
 	req_one_access = null
@@ -15537,6 +15503,9 @@
 	},
 /obj/map_helper/access_helper/airlock/station/maintenance,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
 "lxY" = (
@@ -15633,10 +15602,10 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1starboardafthall)
 "lAI" = (
@@ -15708,11 +15677,11 @@
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_x = 32
 	},
-/obj/structure/cable/green{
-	icon_state = "2-5"
-	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
@@ -15897,9 +15866,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/steel,
@@ -16452,6 +16418,9 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1afthall)
 "mgA" = (
@@ -16496,6 +16465,9 @@
 /obj/effect/floor_decal/chapel,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -17260,12 +17232,9 @@
 /area/library)
 "mKR" = (
 /obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1starboardafthall)
 "mKU" = (
 /obj/effect/floor_decal/steeldecal/steel_decals9{
@@ -17538,12 +17507,12 @@
 /area/chapel/office)
 "mWe" = (
 /obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/north_mount,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
 "mWf" = (
@@ -17673,9 +17642,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1starboardamidhall)
@@ -18710,9 +18676,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/chapel/main)
 "nMY" = (
@@ -19574,12 +19537,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1afthall)
-"own" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/library)
 "owq" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -19997,9 +19954,6 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1fwdhall)
 "oPk" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
@@ -20108,15 +20062,12 @@
 /area/endeavour/hallway/d1starboardafthall)
 "oUi" = (
 /obj/landmark/spawnpoint/job/pilot,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
 /area/exploration/pilot_prep)
 "oUM" = (
@@ -20301,6 +20252,9 @@
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/mauve/bordercorner,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/exploration)
 "pbT" = (
@@ -20421,6 +20375,9 @@
 	dir = 6
 	},
 /obj/structure/table/bench/wooden,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "pfv" = (
@@ -20482,7 +20439,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/orange{
-	icon_state = "1-10"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1portforhall)
@@ -20773,9 +20730,6 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/surfacebase/sauna)
 "pql" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 8
 	},
@@ -21610,6 +21564,9 @@
 /area/shuttle/excursion/cockpit)
 "qfo" = (
 /obj/machinery/light,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
 "qfI" = (
@@ -21712,12 +21669,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration/courser_dock)
 "qke" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1starboardamidhall)
 "qko" = (
@@ -21828,6 +21779,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -22470,18 +22424,15 @@
 /obj/effect/floor_decal/corner/navgold/border{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/air_alarm/east_mount,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway)
@@ -22752,6 +22703,9 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "qXN" = (
@@ -22961,6 +22915,9 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/cable/green{
 	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
@@ -23388,15 +23345,18 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/exploration)
@@ -23423,6 +23383,15 @@
 "rzT" = (
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway2)
+"rAs" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/library)
 "rAx" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -23699,9 +23668,6 @@
 /turf/simulated/floor/wood,
 /area/library)
 "rMy" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -23709,6 +23675,12 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway)
 "rNe" = (
@@ -23928,7 +23900,10 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -24084,6 +24059,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/chapel/main)
 "sfl" = (
@@ -24213,6 +24191,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "skF" = (
@@ -24280,6 +24261,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
+"snc" = (
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/library)
 "sne" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -24545,9 +24535,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/teleporter)
 "sAT" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
@@ -25415,16 +25402,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "tjy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/wood,
 /area/library)
 "tjQ" = (
 /obj/structure/catwalk,
@@ -25738,9 +25719,6 @@
 "tux" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -25833,6 +25811,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
 "twp" = (
@@ -26404,6 +26385,9 @@
 "tQt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/chapel/main)
 "tQu" = (
@@ -26430,11 +26414,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -26770,10 +26754,7 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/chapel/main)
@@ -26833,9 +26814,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
@@ -26951,6 +26929,9 @@
 "ulc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "ulm" = (
@@ -27037,9 +27018,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/chapel/main)
@@ -27145,6 +27123,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "ush" = (
@@ -27203,6 +27184,9 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "utG" = (
@@ -27259,6 +27243,9 @@
 /obj/landmark{
 	name = "blobstart"
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/chapel/main)
 "uvD" = (
@@ -27280,9 +27267,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/bcarpet,
@@ -27700,7 +27684,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1starboardafthall)
@@ -27744,8 +27728,9 @@
 /area/crew_quarters/mimeoffice)
 "uQz" = (
 /obj/structure/cable/orange{
-	icon_state = "5-8"
+	icon_state = "1-8"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
 "uQL" = (
@@ -27853,9 +27838,6 @@
 "uUz" = (
 /obj/item/radio/intercom{
 	pixel_y = -24
-	},
-/obj/structure/cable/green{
-	icon_state = "5-8"
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
@@ -28044,9 +28026,6 @@
 "vaR" = (
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_y = -37
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
@@ -28521,9 +28500,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/holoposter{
 	pixel_y = 32
 	},
@@ -28851,9 +28827,6 @@
 /area/station/stairs_one)
 "vBM" = (
 /obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -28861,6 +28834,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1starboardafthall)
@@ -28915,11 +28891,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "vEe" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/library)
+/obj/effect/floor_decal/corner/navgold/border{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d1starboardamidhall)
 "vEi" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monofloor{
@@ -29072,7 +29060,10 @@
 /area/endeavour/hallway/d1starboardafthall)
 "vIH" = (
 /obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
@@ -29193,13 +29184,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/endeavour/hallway/d1fwdmaint)
-"vNz" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/substation/civilian)
 "vNY" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 8
@@ -29895,12 +29879,9 @@
 /turf/simulated/floor/tiled,
 /area/bridge/office)
 "wsZ" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/structure/catwalk,
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/structure/cable/orange{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
@@ -29973,9 +29954,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /obj/structure/bookcase{
 	name = "bookcase (Fiction)"
@@ -30179,6 +30157,9 @@
 "wAB" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
@@ -48395,10 +48376,10 @@ hWC
 vRj
 hVP
 aVW
-pPL
+kPV
 lxO
 hnl
-vEK
+aej
 iuy
 saW
 dsD
@@ -48975,24 +48956,24 @@ jMU
 cSr
 pPL
 pPL
-vNz
+sQy
 eUz
 sQy
 sQy
 tLz
-xgB
-iuy
-lPB
+jWm
+gNs
+mKR
 cWg
-mJP
-mJP
-mJP
+rAs
+esl
+esl
 vIH
-vEe
-mJP
-mJP
+esl
+esl
+esl
 wAB
-eOl
+tjy
 eOl
 fDI
 tsT
@@ -49148,7 +49129,7 @@ ayL
 ayL
 ayL
 gjG
-aYc
+sjt
 wim
 aLP
 wim
@@ -49166,12 +49147,12 @@ pKc
 iCH
 hJZ
 jMU
-abZ
-kIs
-kIs
+sQy
+sQy
+sQy
 wsZ
 uQz
-pPL
+sQy
 eGo
 jMU
 jkq
@@ -49186,7 +49167,7 @@ uvU
 jTs
 jTs
 rVX
-kzG
+abZ
 kzG
 fOe
 xoy
@@ -49342,7 +49323,7 @@ iPk
 iSA
 ayL
 wim
-gPV
+jLe
 wim
 wim
 wim
@@ -49380,7 +49361,7 @@ ugs
 aEK
 mJP
 iKm
-eOl
+fYP
 eOl
 eOl
 shJ
@@ -49536,7 +49517,7 @@ iPk
 hLu
 ayL
 wim
-gPV
+jLe
 wim
 wim
 wim
@@ -49566,11 +49547,11 @@ iZH
 nFp
 saW
 vLq
-iKm
+snc
 lLD
 rXg
 rxS
-own
+mJP
 rdf
 mJP
 mJP
@@ -49730,7 +49711,7 @@ iSA
 ebP
 ayL
 wim
-gPV
+jLe
 aFa
 aFa
 aFa
@@ -49751,7 +49732,7 @@ yfL
 mmk
 kiW
 kiW
-mKR
+rYG
 rYG
 rYG
 bIw
@@ -49764,7 +49745,7 @@ jAq
 gIW
 rXg
 qFN
-own
+mJP
 iKG
 mJP
 jNp
@@ -49924,7 +49905,7 @@ nqx
 ccR
 ayL
 wim
-gPV
+jLe
 aFa
 nBm
 aFa
@@ -49955,10 +49936,10 @@ voU
 lVS
 dsD
 jDn
-esl
-tjy
-blT
-aej
+mJP
+kOz
+jCV
+bVE
 mJP
 mJP
 vaR
@@ -50117,8 +50098,8 @@ ayL
 ayL
 ayL
 ayL
-ibx
-sjt
+wim
+jLe
 aFa
 gWe
 aFa
@@ -50311,8 +50292,8 @@ sti
 wim
 wim
 wim
-gPV
 wim
+jLe
 aFa
 lbL
 atV
@@ -50505,8 +50486,8 @@ sti
 wim
 wim
 wim
-gPV
 wim
+jLe
 aFa
 hUJ
 diJ
@@ -50699,8 +50680,8 @@ sti
 akq
 wim
 wim
-gPV
 wim
+jLe
 aFa
 jvV
 atV
@@ -50893,8 +50874,8 @@ sti
 wim
 wim
 aLP
-gPV
 wim
+jLe
 uJg
 lEw
 ghr
@@ -51087,8 +51068,8 @@ sti
 wim
 wim
 wim
-gPV
 wim
+jLe
 aFa
 aFa
 aFa
@@ -51281,9 +51262,9 @@ sti
 wim
 jLe
 jLe
-ehl
-kov
-uBR
+jLe
+jLe
+jLe
 jLe
 jLe
 jLe
@@ -51476,8 +51457,8 @@ wim
 jLe
 wim
 wim
+jLe
 wim
-gPV
 wim
 tDR
 wim
@@ -51503,22 +51484,22 @@ uze
 uze
 wUJ
 hYA
-dqz
-hlC
-kPV
+uZh
+rCE
+qke
 jXs
-kPV
-kPV
-kPV
-kPV
-kPV
+qke
+qke
+qke
+qke
+qke
 qke
 aGG
 pql
 jXs
-kPV
-kPV
-kPV
+qke
+qke
+qke
 aGG
 pql
 iUW
@@ -51670,10 +51651,10 @@ wim
 jLe
 wim
 wim
-aLP
-ehl
-kov
-uBR
+aYc
+jLe
+jLe
+jLe
 wim
 aFa
 gLA
@@ -51698,7 +51679,7 @@ fAe
 wUJ
 hvO
 fyb
-sCh
+rCE
 kKH
 dMq
 xUN
@@ -51867,7 +51848,7 @@ hub
 hub
 wim
 wim
-gPV
+jLe
 wim
 aFa
 gqq
@@ -52061,7 +52042,7 @@ obT
 hub
 wim
 wim
-gPV
+jLe
 wLB
 fZy
 cfv
@@ -52086,7 +52067,7 @@ iLD
 iLD
 txk
 gpc
-kCB
+xHM
 ptG
 sDi
 rWf
@@ -52255,7 +52236,7 @@ obT
 hub
 wim
 wim
-gPV
+jLe
 wim
 fZy
 mkq
@@ -52280,7 +52261,7 @@ iLD
 iLD
 txk
 hRp
-sCh
+rCE
 ycC
 sDi
 dRp
@@ -52449,7 +52430,7 @@ uwY
 hub
 wim
 wim
-gPV
+jLe
 wim
 fZy
 peY
@@ -52474,7 +52455,7 @@ iLD
 iLD
 jct
 jLq
-sCh
+rCE
 woM
 sDi
 mVP
@@ -52668,7 +52649,7 @@ iLD
 ojn
 txk
 vDK
-sCh
+rCE
 lSz
 sDi
 nBa
@@ -52874,13 +52855,13 @@ iRz
 gRB
 jcv
 bYy
-fYP
-gNs
+esm
+hWW
 eNt
 ctl
-gNs
-gNs
-jWm
+hWW
+hWW
+hWW
 hWW
 sDi
 uze
@@ -53054,9 +53035,9 @@ hfn
 gaE
 qXL
 qXL
-nAf
-jLq
-mho
+sSG
+vEe
+kIs
 fvL
 ulm
 urc

--- a/maps/endeavour/levels/deck2.dmm
+++ b/maps/endeavour/levels/deck2.dmm
@@ -13,21 +13,11 @@
 /turf/simulated/floor/airless/ceiling,
 /area/tether/station/public_meeting_room)
 "aaU" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = -10
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
+/area/medical/resleeving)
 "abm" = (
 /turf/simulated/wall/prepainted/medical,
 /area/medical/medbay3)
@@ -129,17 +119,14 @@
 	},
 /obj/machinery/fire_alarm/north_mount,
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "aee" = (
 /obj/machinery/door/firedoor{
 	dir = 1
 	},
 /obj/machinery/door/airlock/maintenance/common,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/cable/orange{
-	icon_state = "6-9"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2fwdmaint)
@@ -602,7 +589,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "aua" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -621,9 +608,6 @@
 "auq" = (
 /obj/machinery/door/firedoor/glass{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -723,9 +707,6 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -797,7 +778,7 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/cafeteria)
@@ -899,18 +880,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
-"aEn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "5-10"
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/hallway)
 "aEO" = (
 /obj/machinery/door/window/brigdoor/northright{
 	name = "Containment Pen";
@@ -1019,7 +988,7 @@
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/beige/border,
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "aHi" = (
 /obj/machinery/air_alarm{
 	pixel_y = 22
@@ -1102,6 +1071,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portforhall)
 "aJg" = (
@@ -1183,6 +1155,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2fwdhall)
@@ -1369,6 +1344,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portforhall)
 "aVr" = (
@@ -1405,9 +1383,6 @@
 /turf/simulated/floor/tiled,
 /area/medical/resleeving)
 "aYt" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/glass,
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/borderfloorblack,
@@ -1657,7 +1632,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
+/area/medical/surgeryprep)
 "bhr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1775,16 +1750,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/power/apc/west_mount{
 	pixel_x = 0;
 	pixel_y = 22;
 	dir = 2
 	},
 /obj/structure/cable/green{
-	icon_state = "0-8"
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/medbreak)
@@ -1900,7 +1875,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "bns" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -2185,9 +2160,6 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2afthall)
 "bBu" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/borderfloorwhite,
 /turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
@@ -2247,9 +2219,6 @@
 	req_one_access = null
 	},
 /obj/map_helper/access_helper/airlock/station/medical/department,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
 "bDe" = (
@@ -2408,20 +2377,17 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/station/docks)
 "bGi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryprep)
+/turf/simulated/floor/tiled,
+/area/rnd/hallway)
 "bGt" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/medical{
@@ -2460,21 +2426,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
-"bGM" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/mauve/border,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/research/researchdivision)
+/area/medical/medbay4)
 "bHs" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -2630,9 +2582,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/cafeteria)
 "bKV" = (
@@ -2726,11 +2675,17 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portafthall)
 "bNQ" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
+/area/medical/virology_fore_access)
 "bOa" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
@@ -2764,7 +2719,7 @@
 "bPx" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/dark,
-/area/medical/surgery2)
+/area/maintenance/medbay/aft)
 "bPE" = (
 /obj/structure/closet/hydrant{
 	pixel_y = 32
@@ -2967,6 +2922,9 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2afthall)
 "bWn" = (
@@ -3098,10 +3056,10 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2aftmaint)
 "bYH" = (
@@ -3150,14 +3108,14 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/glass,
-/obj/structure/cable/green{
-	icon_state = "4-10"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardamidhall)
@@ -3334,16 +3292,6 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
-"cfh" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/endeavour/hallway/d2fwdmaint)
 "cfl" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -3465,9 +3413,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -3545,6 +3490,9 @@
 /obj/effect/floor_decal/corner/navgold/border{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2fwdhall)
 "cmc" = (
@@ -3586,7 +3534,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardforhall)
@@ -3688,9 +3636,6 @@
 	dir = 9
 	},
 /obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -3746,7 +3691,7 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
@@ -4062,9 +4007,6 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/medical{
 	name = "Pre-Revival Processing";
 	req_one_access = null
@@ -4109,9 +4051,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "cDA" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -4380,9 +4319,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "cLW" = (
@@ -4480,7 +4416,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "cOM" = (
 /obj/machinery/camera/network/civilian{
 	dir = 8
@@ -4544,10 +4480,10 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/anomaly_lab)
@@ -4780,7 +4716,7 @@
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/beige/border,
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "dbo" = (
 /turf/simulated/wall/prepainted/science,
 /area/assembly/chargebay)
@@ -4886,9 +4822,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/station/stairs_two)
 "dgC" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -4904,8 +4837,11 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "dgF" = (
 /obj/effect/floor_decal/borderfloorwhite/corner,
 /obj/effect/floor_decal/corner/paleblue/bordercorner,
@@ -4986,12 +4922,13 @@
 /turf/simulated/wall/r_wall/prepainted/science,
 /area/rnd/storage)
 "dkb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
-	icon_state = "1-6"
+	icon_state = "1-2"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/endeavour/hallway/d2aftmaint)
+/turf/simulated/floor/tiled,
+/area/rnd/hallway)
 "dkr" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
@@ -5040,14 +4977,14 @@
 /turf/simulated/floor/wood,
 /area/endeavour/hallway/d2afthall)
 "dly" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/endeavour/hallway/d1starboardamidhall)
 "dlB" = (
@@ -5072,9 +5009,6 @@
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora/lab_atmos)
 "dni" = (
-/obj/structure/cable{
-	icon_state = "5-8"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -5083,6 +5017,9 @@
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/medical/virologymaint)
@@ -5196,9 +5133,6 @@
 /turf/simulated/floor/plating,
 /area/medical/surgery_storage)
 "drj" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -5340,6 +5274,15 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "dvL" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology_aft_access)
 "dwr" = (
@@ -5495,14 +5438,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_d)
 "dAa" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
+/turf/simulated/floor/plating,
+/area/endeavour/hallway/d2fwdmaint)
 "dAn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -5512,9 +5452,6 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5704,6 +5641,9 @@
 /area/medical/surgeryprep)
 "dHH" = (
 /obj/machinery/disposal,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
 "dIf" = (
@@ -5825,6 +5765,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
@@ -6017,6 +5960,9 @@
 /obj/effect/floor_decal/corner/navblue/border{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2fwdhall)
 "dSA" = (
@@ -6150,9 +6096,6 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "dWk" = (
@@ -6161,7 +6104,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
-/area/medical/surgery)
+/area/maintenance/medbay/aft)
 "dWP" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6434,10 +6377,10 @@
 /turf/simulated/wall/r_wall/prepainted/medical,
 /area/shuttle/emt/general)
 "ecV" = (
-/obj/structure/cable/orange{
-	icon_state = "6-9"
-	},
 /obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2fwdmaint)
 "ecY" = (
@@ -6453,9 +6396,6 @@
 "edn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
@@ -6738,9 +6678,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/assembly/robotics)
 "ejr" = (
-/obj/structure/catwalk,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2fwdmaint)
@@ -6781,13 +6720,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/assembly/robotics)
 "ejD" = (
-/obj/structure/cable/green{
+/obj/structure/catwalk,
+/obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2fwdmaint)
 "ejF" = (
@@ -6830,9 +6766,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
 "ekI" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -6842,9 +6775,6 @@
 /obj/map_helper/access_helper/airlock/station/medical/department,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/multi_tile/medical{
 	dir = 4;
@@ -6863,6 +6793,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardamidhall)
 "elT" = (
@@ -6972,9 +6905,6 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portamidhall)
 "eqL" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -7450,6 +7380,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardamidhall)
 "eKi" = (
@@ -7621,12 +7554,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "eRd" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/medbay/aft)
+/area/endeavour/hallway/d2fwdmaint)
 "eRt" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -7655,6 +7587,9 @@
 /area/rnd/xenobiology)
 "eRQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
 "eSf" = (
@@ -7762,7 +7697,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "eUQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -7940,10 +7875,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "eZz" = (
-/obj/structure/cable/green{
-	icon_state = "2-9"
-	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2aftmaint)
 "eZJ" = (
@@ -8099,6 +8034,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
 "feQ" = (
@@ -8254,9 +8192,6 @@
 /turf/simulated/floor/tiled,
 /area/medical/surgery2)
 "flF" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
@@ -8440,13 +8375,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
-"frz" = (
-/obj/machinery/power/sensor{
-	name = "Powernet Sensor - Deck 3 Subgrid";
-	name_tag = "Deck 3 Subgrid"
-	},
-/turf/simulated/wall/prepainted,
-/area/endeavour/hallway/d2aftmaint)
 "frJ" = (
 /obj/structure/table/bench/padded,
 /turf/simulated/floor/tiled,
@@ -8497,9 +8425,6 @@
 "fsS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
 "fsX" = (
@@ -8732,9 +8657,6 @@
 "fCE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -8742,17 +8664,17 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "fDp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 10
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/cable/orange{
+	icon_state = "1-4"
 	},
-/turf/simulated/wall/r_wall/prepainted/medical,
-/area/medical/virologymaint)
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d2portamidhall)
 "fDK" = (
 /obj/machinery/fire_alarm/south_mount,
 /obj/effect/floor_decal/borderfloorblack,
@@ -9038,9 +8960,6 @@
 /obj/machinery/camera/network/civilian{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navgold/border,
 /obj/structure/disposalpipe/segment{
@@ -9082,9 +9001,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/cafeteria)
 "fMC" = (
@@ -9108,7 +9024,7 @@
 "fNy" = (
 /obj/machinery/power/apc/north_mount,
 /obj/structure/cable/green{
-	icon_state = "0-4"
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2fwdmaint)
@@ -9844,9 +9760,6 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portamidhall)
 "gjp" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
@@ -9863,10 +9776,11 @@
 /turf/simulated/floor/wood,
 /area/medical/medbay4)
 "gkx" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/beige/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/endeavour/hallway/d2fwdmaint)
 "gkX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -9911,9 +9825,6 @@
 	dir = 8;
 	pixel_x = -28;
 	req_access = list()
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
@@ -10138,6 +10049,9 @@
 /obj/machinery/light{
 	dir = 8;
 	light_range = 12
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2fwdhall)
@@ -10379,7 +10293,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "gBH" = (
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/dark,
@@ -10654,17 +10568,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical_science)
 "gKL" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/medbreak)
@@ -11052,15 +10960,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portafthall)
-"gXq" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/cafeteria)
 "gXK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/disposal,
@@ -11089,9 +10988,6 @@
 /turf/simulated/floor/plating,
 /area/medical/virologymaint)
 "gYH" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -11165,9 +11061,6 @@
 "hbZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -11246,9 +11139,6 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardamidhall)
 "hff" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
@@ -11473,6 +11363,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portforhall)
 "hlu" = (
@@ -11684,33 +11577,28 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/station/docks)
 "hor" = (
-/obj/structure/cable{
-	icon_state = "5-10"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/endeavour/hallway/d2fwdmaint)
-"hoX" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/endeavour/hallway/d1starboardafthall)
-"hpi" = (
-/obj/structure/cable/green{
-	icon_state = "5-10"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/medbreak)
+"hoX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryprep)
+"hpi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
@@ -11727,6 +11615,9 @@
 /area/endeavour/hallway/d1starboardafthall)
 "hpB" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardamidhall)
 "hpE" = (
@@ -11866,9 +11757,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/anomaly_lab)
 "huo" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/glass,
@@ -11877,6 +11765,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology_fore_access)
 "huG" = (
@@ -11899,16 +11790,16 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardamidhall)
 "huR" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/cable/green{
 	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
@@ -12076,10 +11967,7 @@
 /area/medical/sleeper)
 "hBh" = (
 /obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
@@ -12477,6 +12365,9 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "hNe" = (
@@ -12655,9 +12546,6 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portamidhall)
 "hTw" = (
-/obj/structure/cable/green{
-	icon_state = "5-10"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
@@ -12681,18 +12569,6 @@
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
-"hUR" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
 "hVk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12834,6 +12710,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/endeavour/hallway/d1starboardamidhall)
 "icZ" = (
@@ -12858,9 +12737,6 @@
 "idn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
@@ -13223,24 +13099,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central7,
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardforhall)
-"ioE" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
 "ioN" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -13625,9 +13483,6 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -13638,6 +13493,9 @@
 /obj/effect/floor_decal/corner/paleblue/border,
 /obj/structure/disposalpipe/segment{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
@@ -13704,6 +13562,9 @@
 /obj/effect/floor_decal/corner/navblue/bordercorner{
 	dir = 8
 	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portamidhall)
 "iBK" = (
@@ -13756,15 +13617,12 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology_fore_access)
 "iFi" = (
@@ -13967,12 +13825,12 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora/lab_atmos)
 "iNn" = (
-/obj/structure/cable/orange{
-	icon_state = "2-9"
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/endeavour/hallway/d2fwdmaint)
+/turf/simulated/floor/carpet/blucarpet,
+/area/crew_quarters/medbreak)
 "iNo" = (
 /obj/spawner/window/low_wall/reinforced/full,
 /obj/machinery/door/blast/regular{
@@ -14157,9 +14015,6 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/rnd/breakroom)
 "iTB" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -14228,6 +14083,9 @@
 /obj/item/storage/box/donkpockets,
 /obj/item/storage/box/donkpockets{
 	pixel_y = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/medbreak)
@@ -14424,7 +14282,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "jdx" = (
 /obj/machinery/door/window/westleft{
 	req_one_access = list(5);
@@ -14928,6 +14786,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/rnd/hallway)
 "jvz" = (
@@ -14946,6 +14807,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardamidhall)
@@ -15214,10 +15078,10 @@
 "jER" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-10"
-	},
 /obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/endeavour/hallway/d2afthall)
 "jFD" = (
@@ -15238,12 +15102,12 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2fwdmaint)
 "jGe" = (
-/obj/structure/cable{
-	icon_state = "5-8"
-	},
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2fwdmaint)
@@ -15299,6 +15163,9 @@
 "jHd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
@@ -15366,6 +15233,8 @@
 /area/tether/station/public_meeting_room)
 "jKT" = (
 /obj/structure/bed/chair/comfy/brown,
+/obj/machinery/power/apc/east_mount,
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "jLg" = (
@@ -15403,7 +15272,7 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
-	icon_state = "4-10"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
@@ -15803,9 +15672,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/cafeteria)
@@ -15815,9 +15681,6 @@
 "kan" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
@@ -15952,17 +15815,12 @@
 /turf/simulated/wall/r_wall/prepainted/science,
 /area/rnd/research_foyer_auxiliary)
 "kfA" = (
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
-	},
-/obj/structure/cable/green{
+/obj/structure/catwalk,
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryprep)
+/turf/simulated/floor/plating,
+/area/endeavour/hallway/d2fwdmaint)
 "kfN" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -15990,6 +15848,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2afthall)
@@ -16179,13 +16040,13 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/anomaly_lab)
@@ -16287,7 +16148,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "kpO" = (
 /obj/machinery/camera/network/civilian,
 /obj/effect/floor_decal/borderfloorblack{
@@ -16508,16 +16369,10 @@
 /area/endeavour/hallway/d2afthall)
 "kyn" = (
 /obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
-/area/rnd/research/researchdivision)
+/area/rnd/hallway)
 "kyy" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -16596,11 +16451,11 @@
 /area/endeavour/hallway/d1starboardamidhall)
 "kBX" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central7,
-/obj/structure/cable/orange{
-	icon_state = "6-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portamidhall)
@@ -16778,7 +16633,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardforhall)
@@ -16815,13 +16670,19 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
 "kMg" = (
 /obj/effect/floor_decal/borderfloorwhite/corner,
 /obj/effect/floor_decal/corner/beige/bordercorner,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "kMm" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -16905,9 +16766,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "kOr" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/power/apc/west_mount{
 	pixel_x = 0;
 	pixel_y = 22;
@@ -17000,14 +16858,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/beige/bordercorner{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
@@ -17042,7 +16900,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "kTz" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/storage/belt/medical,
@@ -17108,9 +16966,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	icon_state = "6-9"
-	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portamidhall)
 "kUs" = (
@@ -17144,29 +16999,26 @@
 /turf/simulated/floor/tiled,
 /area/rnd/rdoffice)
 "kVh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/green/bordercorner{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology_aft_access)
 "kVo" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17176,6 +17028,9 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "kVv" = (
@@ -17200,6 +17055,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portforhall)
@@ -17439,6 +17297,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2fwdhall)
 "lcu" = (
@@ -17531,7 +17392,7 @@
 "lfu" = (
 /obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/tiled/dark,
-/area/medical/surgery)
+/area/maintenance/medbay/aft)
 "lfy" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/reagent_containers/spray/cleaner{
@@ -17665,11 +17526,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2afthall)
@@ -17862,7 +17723,7 @@
 	name = "Recovery Wing"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
+/area/medical/surgeryprep)
 "lsM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/radiocarbon_spectrometer,
@@ -18145,9 +18006,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics/surgery)
 "lBC" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -18317,9 +18175,6 @@
 /area/rnd/hallway)
 "lGE" = (
 /obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -18360,7 +18215,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "lJB" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -18550,14 +18405,14 @@
 /area/medical/virology)
 "lSb" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central7,
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portforhall)
@@ -18570,7 +18425,7 @@
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/wood,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "lSf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -18753,10 +18608,10 @@
 /turf/simulated/floor/wood/sif/indoors,
 /area/medical/reception)
 "lZR" = (
-/obj/structure/cable{
-	icon_state = "4-10"
-	},
 /obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2fwdmaint)
 "mai" = (
@@ -18803,9 +18658,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/cafeteria)
 "mcM" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -18818,14 +18670,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/effect/floor_decal/borderfloorwhite/corner2{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/beige/bordercorner2{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
@@ -19139,11 +18991,8 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
+/area/medical/surgeryprep)
 "mqr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -19197,11 +19046,11 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/endeavour/hallway/d1starboardafthall)
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/cafeteria)
 "mri" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -19212,9 +19061,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/black{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
@@ -19410,9 +19256,6 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/psych/psych_1)
 "mzd" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/endeavour/hallway/d1starboardafthall)
 "mzm" = (
@@ -19448,7 +19291,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "mzX" = (
 /obj/machinery/ai_status_display{
 	pixel_y = -32
@@ -19540,13 +19383,13 @@
 /turf/space,
 /area/space)
 "mDv" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2aftmaint)
 "mEn" = (
@@ -19723,9 +19566,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "mIK" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/structure/closet/firecloset/full,
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/machinery/light{
@@ -19996,6 +19836,9 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
 "mRr" = (
@@ -20030,6 +19873,9 @@
 /obj/machinery/camera/network/civilian{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2fwdhall)
 "mSd" = (
@@ -20038,9 +19884,6 @@
 "mSe" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20061,6 +19904,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portforhall)
@@ -20155,18 +20001,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/psych/psych_2)
-"mWa" = (
-/obj/machinery/light,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/navgold/border,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/hallway/d1starboardforhall)
 "mWk" = (
 /obj/machinery/holopad,
 /turf/simulated/floor/tiled/techfloor,
@@ -20203,6 +20037,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/endeavour/hallway/d1starboardamidhall)
 "mXR" = (
@@ -20218,10 +20055,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "mYG" = (
@@ -20271,6 +20108,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
@@ -20341,10 +20181,10 @@
 	dir = 9
 	},
 /obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/anomaly_lab)
@@ -20479,9 +20319,6 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 6
 	},
@@ -20560,12 +20397,12 @@
 "nho" = (
 /obj/structure/table/woodentable,
 /obj/item/book/manual/medical_diagnostics_manual,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/crew_quarters/medbreak)
 "nhq" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -20645,24 +20482,6 @@
 /obj/machinery/holopad,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"nlM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/green/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology_aft_access)
 "nmB" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -20702,12 +20521,12 @@
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
 "nnL" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardamidhall)
 "nok" = (
@@ -20776,6 +20595,9 @@
 /obj/effect/floor_decal/corner/navgold/bordercorner{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2fwdhall)
 "nrZ" = (
@@ -20813,9 +20635,6 @@
 /turf/simulated/floor/plating,
 /area/medical/virologymaint)
 "nuO" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -20970,9 +20789,6 @@
 "nyw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 8;
 	icon_state = "pipe-j2"
@@ -21080,11 +20896,8 @@
 /obj/machinery/door/airlock/glass/medical{
 	name = "Recovery Wing"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
+/area/medical/surgeryprep)
 "nBm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/orange{
@@ -21534,12 +21347,13 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2aftmaint)
 "nMK" = (
-/obj/structure/cable/orange{
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/effect/paint/babyblue,
+/obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/endeavour/hallway/d2fwdmaint)
+/turf/simulated/floor/tiled/white,
+/area/medical/psych_ward)
 "nMP" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -21640,7 +21454,7 @@
 	name = "Recovery Wing"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
+/area/medical/surgeryprep)
 "nPK" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 4
@@ -21676,9 +21490,6 @@
 "nRt" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 8
@@ -21987,9 +21798,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
 "oeP" = (
-/obj/structure/cable/green{
-	icon_state = "5-10"
-	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
 	},
@@ -21997,7 +21805,7 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "8-10"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2afthall)
@@ -22358,9 +22166,6 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "ors" = (
@@ -22503,9 +22308,6 @@
 /turf/simulated/floor/plating,
 /area/rnd/reception_desk)
 "owE" = (
-/obj/structure/cable/green{
-	icon_state = "5-8"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -22513,6 +22315,9 @@
 /obj/effect/floor_decal/corner/navgold/bordercorner,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardamidhall)
@@ -22556,9 +22361,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "ozA" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navgold/border,
 /obj/structure/disposalpipe/segment{
@@ -22625,13 +22427,8 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/navgold/border,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/hallway/d1starboardforhall)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/crew_quarters/cafeteria)
 "oBL" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
@@ -22641,6 +22438,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portamidhall)
@@ -22870,11 +22670,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
@@ -22936,9 +22736,6 @@
 /turf/simulated/floor/plating,
 /area/rnd/anomaly_lab/containment_two)
 "oJx" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -22951,13 +22748,16 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/machinery/power/apc/west_mount{
 	pixel_x = 0;
 	pixel_y = 22;
 	dir = 2
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -23064,6 +22864,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medical_restroom)
 "oNw" = (
@@ -23427,6 +23230,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portforhall)
 "oYo" = (
@@ -23471,14 +23277,14 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
@@ -23500,6 +23306,9 @@
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2fwdhall)
@@ -23571,18 +23380,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/anomaly_lab)
-"pay" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryprep)
 "pbh" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -23604,9 +23401,6 @@
 "pbk" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -23715,15 +23509,6 @@
 /obj/map_helper/access_helper/airlock/station/medical/department,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
-"peU" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/endeavour/hallway/d1starboardamidhall)
 "pfe" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -23785,9 +23570,6 @@
 	},
 /obj/effect/floor_decal/corner/green/border{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -23928,10 +23710,10 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
@@ -24003,15 +23785,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2afthall)
-"pkK" = (
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/beige/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
 "pkR" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -24025,7 +23798,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/tiled/dark,
-/area/medical/surgery)
+/area/maintenance/medbay/aft)
 "plL" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/door/firedoor,
@@ -24555,9 +24328,6 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry_lab)
 "pBU" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark,
@@ -24666,9 +24436,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
 "pDI" = (
@@ -24732,6 +24499,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardamidhall)
 "pFA" = (
@@ -25123,18 +24893,10 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical_science)
-"pQY" = (
-/obj/structure/cable/green{
-	icon_state = "5-10"
-	},
-/obj/effect/floor_decal/borderfloorblack/corner,
-/obj/effect/floor_decal/corner/navgold/bordercorner,
-/turf/simulated/floor/tiled,
-/area/endeavour/hallway/d2afthall)
 "pRH" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -25241,13 +25003,13 @@
 "pUB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass,
-/obj/structure/cable{
-	icon_state = "4-10"
-	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navgold/border,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardamidhall)
@@ -25295,9 +25057,6 @@
 /area/endeavour/hallway/d2portafthall)
 "pVI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/crew_quarters/medbreak)
@@ -25349,16 +25108,17 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/psych/psych_1)
 "pWE" = (
-/obj/structure/cable/green{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay/aft)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/cafeteria)
 "pWI" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
@@ -25730,7 +25490,7 @@
 "qhW" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/structure/cable/green{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
@@ -26124,6 +25884,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navblue/border,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portamidhall)
 "qvd" = (
@@ -26410,6 +26173,9 @@
 /obj/machinery/door/firedoor/glass{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
 "qBd" = (
@@ -26421,17 +26187,16 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2aftmaint)
 "qBq" = (
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/effect/paint/babyblue,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay4)
+/turf/simulated/floor/plating,
+/area/crew_quarters/medbreak)
 "qCG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorblack,
@@ -26475,7 +26240,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "qDX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -26511,7 +26276,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
+/area/medical/surgeryprep)
 "qED" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -26619,7 +26384,7 @@
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/beige/border,
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "qIm" = (
 /obj/machinery/fire_alarm/east_mount,
 /obj/effect/floor_decal/borderfloor{
@@ -26791,9 +26556,15 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora/lab_atmos)
 "qLC" = (
-/obj/machinery/holopad,
-/turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/endeavour/hallway/d2fwdmaint)
 "qLY" = (
 /obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/tiled/white,
@@ -27025,10 +26796,10 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2fwdmaint)
 "qVs" = (
+/obj/structure/curtain/medical,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/curtain/medical,
 /turf/simulated/floor/tiled,
 /area/medical/resleeving)
 "qWa" = (
@@ -27146,13 +26917,13 @@
 /turf/simulated/floor/wood,
 /area/medical/psych/psych_2)
 "qYt" = (
-/obj/structure/cable/green{
-	icon_state = "2-5"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "qYx" = (
@@ -27436,10 +27207,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/machinery/holopad,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
 "reX" = (
@@ -27525,6 +27296,9 @@
 /obj/effect/floor_decal/corner/navblue/border{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2fwdhall)
 "rig" = (
@@ -27552,17 +27326,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "rjD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/turf/simulated/wall/r_wall/prepainted/medical,
-/area/medical/virologymaint)
+/turf/simulated/floor/plating,
+/area/endeavour/hallway/d2aftmaint)
 "rjP" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/effect/paint/babyblue,
@@ -27644,6 +27412,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portforhall)
@@ -27838,14 +27609,14 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navblue/border,
-/obj/structure/cable/orange{
-	icon_state = "6-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portforhall)
@@ -28058,9 +27829,6 @@
 /turf/simulated/wall/prepainted,
 /area/endeavour/hallway/d2portamidhall)
 "rCE" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navblue/border,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -28068,6 +27836,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portforhall)
@@ -28093,9 +27864,6 @@
 	pixel_x = -26;
 	pixel_y = 32;
 	req_one_access = list(5)
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
@@ -28134,6 +27902,11 @@
 	dir = 8
 	},
 /obj/machinery/fire_alarm/west_mount,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology_aft_access)
 "rFd" = (
@@ -28387,7 +28160,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "rNS" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/effect/paint/babyblue,
@@ -28476,9 +28249,6 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/maintenance/common,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/map_helper/access_helper/airlock/station/science/robotics,
 /turf/simulated/floor/plating,
 /area/rnd/research/researchdivision)
@@ -28524,18 +28294,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
-"rRX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology_aft_access)
 "rTV" = (
 /obj/machinery/door/firedoor/glass{
 	dir = 4
@@ -28569,7 +28327,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/prepainted,
+/turf/space/basic,
 /area/endeavour/hallway/d2aftmaint)
 "rUx" = (
 /obj/effect/floor_decal/borderfloorwhite{
@@ -28668,9 +28426,6 @@
 "rXl" = (
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_y = -37
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navgold/border,
@@ -29031,9 +28786,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 6
 	},
@@ -29181,6 +28933,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portforhall)
 "sps" = (
@@ -29221,9 +28976,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/medical/patient_c)
 "sqh" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -29329,6 +29081,15 @@
 /obj/effect/floor_decal/corner/green/border{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology_aft_access)
 "svR" = (
@@ -29359,7 +29120,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "sxo" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/standard_operating_procedure,
@@ -29620,6 +29381,9 @@
 	dir = 8;
 	light_range = 12
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2fwdhall)
 "sGF" = (
@@ -29840,9 +29604,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room/exam_1)
 "sPx" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorwhite/corner{
@@ -29853,6 +29614,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
@@ -29961,7 +29725,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
@@ -29983,17 +29747,20 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/xenobiology/xenoflora_storage)
 "sUb" = (
-/obj/effect/floor_decal/borderfloor/corner{
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/mauve/bordercorner{
+/obj/effect/floor_decal/corner/navblue/border{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
 /obj/structure/cable/green{
-	icon_state = "5-10"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/rnd/hallway)
+/area/endeavour/hallway/d2portforhall)
 "sUg" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -30006,9 +29773,6 @@
 	req_one_access = null
 	},
 /obj/map_helper/access_helper/airlock/station/medical/department,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -30114,6 +29878,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2afthall)
 "sXx" = (
@@ -30207,9 +29974,6 @@
 /turf/simulated/floor/tiled,
 /area/medical/medbay_emt_bay)
 "taE" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 8
 	},
@@ -30244,11 +30008,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "tcW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
 	},
@@ -30641,16 +30400,12 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardafthall)
 "tpX" = (
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/power/apc/north_mount,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -30658,7 +30413,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "tpZ" = (
 /obj/structure/bed/chair/sofa/black/corner{
 	dir = 4
@@ -30674,18 +30429,15 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
@@ -31073,9 +30825,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "tCI" = (
-/obj/structure/bed/chair,
-/turf/simulated/floor/tiled/dark,
-/area/medical/surgery)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d2portforhall)
 "tDo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -31091,9 +30854,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
@@ -31229,6 +30989,9 @@
 /obj/item/storage/box/cups{
 	pixel_y = 5
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/crew_quarters/medbreak)
 "tIG" = (
@@ -31322,12 +31085,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer)
 "tMu" = (
@@ -31455,9 +31218,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "tQg" = (
@@ -31548,6 +31308,9 @@
 /obj/effect/floor_decal/corner/navblue/border,
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2fwdhall)
@@ -31745,6 +31508,9 @@
 /obj/effect/floor_decal/corner/navgold/border{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2fwdhall)
 "tZm" = (
@@ -31757,8 +31523,11 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "tZz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -31984,12 +31753,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 9
 	},
@@ -32133,9 +31896,6 @@
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
 "uor" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -32168,9 +31928,6 @@
 /turf/simulated/floor/tiled,
 /area/medical/resleeving)
 "upS" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/computer/timeclock/premade/south,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navgold/border,
@@ -32543,9 +32300,6 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "uDK" = (
@@ -32644,10 +32398,13 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
@@ -32780,7 +32537,7 @@
 /area/medical/surgery2)
 "uMl" = (
 /obj/structure/cable/orange{
-	icon_state = "6-9"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portamidhall)
@@ -32822,7 +32579,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "uNt" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -32901,9 +32658,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 4
 	},
@@ -32912,6 +32666,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
@@ -33656,9 +33413,6 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardforhall)
 "vqS" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/navgold/bordercorner,
 /obj/structure/disposalpipe/segment{
@@ -33794,9 +33548,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
 "vwx" = (
@@ -33853,9 +33604,6 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/psych/psych_2)
 "vAB" = (
-/obj/structure/cable/green{
-	icon_state = "4-9"
-	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 4
 	},
@@ -33864,6 +33612,12 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portamidhall)
@@ -33916,9 +33670,6 @@
 	pixel_x = -26;
 	pixel_y = 32;
 	req_one_access = list(5)
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
@@ -34072,6 +33823,9 @@
 "vHR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
 "vIj" = (
@@ -34159,6 +33913,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portforhall)
@@ -34407,11 +34164,11 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portamidhall)
@@ -34563,14 +34320,14 @@
 /obj/effect/floor_decal/corner/green/bordercorner{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology_aft_access)
@@ -35142,6 +34899,9 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/crew_quarters/medbreak)
 "wnk" = (
@@ -35286,9 +35046,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
 "wpO" = (
@@ -35317,9 +35074,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/assembly/robotics)
 "wqG" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/table/standard,
 /obj/item/reagent_containers/spray/cleaner,
@@ -35380,13 +35134,12 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/west_mount,
-/obj/structure/cable/green,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology_fore_access)
 "wtw" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -35771,7 +35524,7 @@
 	dir = 8
 	},
 /obj/structure/cable/orange{
-	icon_state = "4-9"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portamidhall)
@@ -36007,9 +35760,6 @@
 /turf/simulated/floor/wood,
 /area/rnd/breakroom)
 "wNb" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -36384,12 +36134,12 @@
 "wZf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 8;
 	icon_state = "pipe-j2"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardamidhall)
@@ -36403,7 +36153,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "xav" = (
 /obj/structure/table/standard,
 /obj/item/folder/blue{
@@ -36606,10 +36356,10 @@
 "xfb" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	icon_state = "2-4"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
@@ -36641,9 +36391,6 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2aftmaint)
 "xgi" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -36733,6 +36480,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portforhall)
@@ -36986,9 +36736,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "xrU" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -37014,7 +36761,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical_science)
@@ -37095,7 +36842,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "xvd" = (
 /obj/machinery/washing_machine,
 /obj/machinery/light{
@@ -37472,9 +37219,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "xHr" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -37529,6 +37273,9 @@
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2afthall)
 "xIp" = (
@@ -37549,10 +37296,7 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
@@ -37565,7 +37309,7 @@
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/beige/border,
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "xJb" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner,
@@ -37620,9 +37364,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora/lab_atmos)
 "xKb" = (
-/obj/structure/cable/green{
-	icon_state = "6-8"
-	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom (General)";
@@ -37730,11 +37471,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "2-5"
-	},
 /obj/machinery/door/airlock/multi_tile/glass/medical{
 	name = "Mental Health"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
@@ -37827,7 +37568,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
-/area/medical/surgery2)
+/area/maintenance/medbay/aft)
 "xQT" = (
 /obj/structure/flora/pottedplant/large,
 /obj/effect/floor_decal/borderfloorblack{
@@ -37896,6 +37637,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardamidhall)
 "xUq" = (
@@ -38051,9 +37795,6 @@
 /area/endeavour/hallway/d2afthall)
 "ybr" = (
 /obj/machinery/computer/timeclock/premade/south,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navgold/border,
 /obj/structure/disposalpipe/segment{
@@ -38205,7 +37946,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/psych_ward)
+/area/medical/medbay4)
 "yhx" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -38240,6 +37981,9 @@
 	},
 /obj/effect/floor_decal/corner/navgold/bordercorner{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2afthall)
@@ -43502,7 +43246,7 @@ gOV
 kBS
 vcY
 tOS
-ekU
+syi
 jdn
 kpp
 gBj
@@ -43696,9 +43440,9 @@ tyv
 aNu
 yde
 yde
-ekU
+syi
 bnr
-pkK
+iRW
 lJc
 rNh
 qIa
@@ -43890,11 +43634,11 @@ ebI
 kBS
 ptZ
 qkI
-ekU
-ekU
+syi
+syi
 xuu
-rjB
-vya
+cLl
+jPF
 dbh
 pTw
 hrZ
@@ -44085,10 +43829,10 @@ kBS
 vdS
 sun
 act
-ekU
+syi
 adj
-rjB
-qLC
+cLl
+yic
 swE
 eqt
 hrZ
@@ -44279,10 +44023,10 @@ kBS
 vcY
 fHi
 hZk
-ekU
+syi
 mzF
-rjB
-vya
+cLl
+jPF
 aHe
 oVx
 hrZ
@@ -44473,7 +44217,7 @@ kBS
 vcY
 hgb
 hgb
-ekU
+syi
 bGy
 atV
 yhw
@@ -44667,10 +44411,10 @@ aNu
 yde
 wAD
 yde
-ekU
-ekU
+syi
+syi
 tpX
-vya
+jPF
 qIa
 pTw
 huG
@@ -44862,11 +44606,11 @@ rbM
 hgb
 hgb
 gvn
-ekU
+syi
 dgC
 kMg
 tZm
-pTw
+nMK
 jKT
 sNF
 czv
@@ -45057,8 +44801,8 @@ lKI
 hgb
 hgb
 lSc
-ioE
-gkx
+gOV
+kBS
 aBt
 aBt
 aBt
@@ -45250,9 +44994,9 @@ rbM
 pFe
 hgb
 glw
-ekU
+syi
 eUy
-gkx
+kBS
 aBt
 xhw
 fjt
@@ -45444,9 +45188,9 @@ alY
 lKI
 hgb
 lkB
-aBt
+tQp
 uML
-gkx
+kBS
 aBt
 iJp
 hzN
@@ -45638,9 +45382,9 @@ qFw
 hgb
 aeS
 qnO
-aBt
+tQp
 cOG
-gkx
+kBS
 aBt
 gMS
 bOw
@@ -45832,8 +45576,8 @@ pff
 iXI
 mMo
 bYa
-aBt
-ioE
+tQp
+gOV
 wZJ
 aBt
 oHk
@@ -46028,14 +45772,14 @@ guA
 maq
 tQp
 mcM
-bNQ
+jPF
 bCS
 wpH
 glV
-qBq
-qBq
+dLx
+dLx
 rDO
-qBq
+dLx
 vCa
 dLx
 yde
@@ -46600,7 +46344,7 @@ jUZ
 gAf
 fTn
 eYj
-pQY
+tkO
 aHb
 iRW
 kGz
@@ -46992,7 +46736,7 @@ kxI
 mmI
 mmI
 mmI
-nAR
+mmI
 nAR
 rUX
 tWY
@@ -47777,12 +47521,12 @@ eEv
 eEv
 rfd
 oDK
-bGi
-kfA
-pay
+loU
+eVZ
+dbq
 nBj
-hUR
-aaU
+dbq
+fRq
 mqc
 bhg
 qEp
@@ -47975,11 +47719,11 @@ loU
 nWj
 pFA
 nPr
-dAa
-dAa
-dAa
-dAa
-dAa
+pFA
+pFA
+pFA
+pFA
+pFA
 nPr
 aIF
 nlx
@@ -48156,7 +47900,7 @@ nCR
 mmI
 nJM
 uhO
-tCI
+bPx
 sFu
 qMX
 fON
@@ -48350,7 +48094,7 @@ tJU
 mmI
 bAe
 uhO
-tCI
+bPx
 sFu
 eMi
 rcb
@@ -48518,7 +48262,7 @@ oCO
 nZC
 uUl
 kCt
-pWE
+iec
 itd
 xHD
 xHD
@@ -48712,7 +48456,7 @@ oCO
 xFT
 pVT
 kCt
-pTU
+iec
 iec
 xHD
 esy
@@ -48738,7 +48482,7 @@ pIE
 mmI
 mJc
 mmI
-eEv
+mmI
 eEv
 eEv
 eEv
@@ -48903,10 +48647,10 @@ nTZ
 nTZ
 cje
 oCO
-kyn
-bGM
+jVn
+bOa
 rRe
-eRd
+iec
 iec
 hqT
 qjz
@@ -49120,9 +48864,9 @@ xGm
 nzx
 nzx
 fvj
-hoX
+bHz
 mzd
-mqU
+tJU
 uor
 pWI
 mtG
@@ -50303,8 +50047,8 @@ jrk
 jrk
 reF
 kan
-jrk
-ssq
+hoX
+gjp
 gjp
 pDw
 tNZ
@@ -51247,7 +50991,7 @@ wJw
 xUb
 uam
 uam
-gXq
+fMy
 eFl
 vYV
 uam
@@ -51831,7 +51575,7 @@ lJH
 vZs
 ufJ
 bJZ
-ufJ
+oBJ
 vZs
 npm
 ioT
@@ -52025,7 +51769,7 @@ eRK
 eRK
 eRK
 slz
-aPo
+pWE
 aPo
 aPo
 aPo
@@ -52198,7 +51942,7 @@ aKR
 lDf
 ffI
 bqS
-nQX
+bGi
 qYt
 weW
 gkX
@@ -52219,7 +51963,7 @@ mOF
 mOF
 mOF
 lGE
-mOF
+mqU
 mOF
 mOF
 mOF
@@ -52392,7 +52136,7 @@ ffI
 ffI
 ffI
 bqS
-aEn
+nah
 xkU
 cvh
 xnC
@@ -52441,9 +52185,9 @@ dyE
 fwu
 jZP
 uHH
-rJd
+pHH
 qAp
-buE
+aaU
 jHd
 eRQ
 qhW
@@ -52585,7 +52329,7 @@ jQJ
 foJ
 sCm
 sCm
-sUb
+pqy
 nah
 mIF
 mIF
@@ -52777,9 +52521,9 @@ lLM
 mRv
 gKn
 bqS
-mIF
+kyn
 hpi
-qSn
+dkb
 jvv
 fFG
 fFG
@@ -53610,7 +53354,7 @@ sQb
 iRX
 tFQ
 cGc
-vAJ
+wpd
 etN
 etN
 sXW
@@ -53804,7 +53548,7 @@ uQD
 iRX
 tFQ
 wpd
-vAJ
+wpd
 wpd
 wpd
 wpd
@@ -53998,7 +53742,7 @@ awJ
 iRX
 tFQ
 wpd
-vAJ
+wpd
 wpd
 wpd
 ahH
@@ -54192,7 +53936,7 @@ uIx
 iRX
 tFQ
 wpd
-vAJ
+wpd
 wpd
 wpd
 wpd
@@ -54386,7 +54130,7 @@ sUY
 iRX
 tFQ
 wpd
-vAJ
+wpd
 wNh
 wNh
 wNh
@@ -55332,7 +55076,7 @@ uPR
 gij
 mdU
 jZY
-wvW
+hor
 vpm
 hRR
 hRR
@@ -55515,7 +55259,7 @@ jne
 oDd
 oDd
 oDd
-frz
+oDd
 lGG
 oDd
 oDd
@@ -55530,9 +55274,9 @@ bjp
 wng
 nho
 tIq
-sWG
+iNn
 iVW
-wRU
+qBq
 hMB
 lYU
 sPx
@@ -57269,7 +57013,7 @@ oDd
 oDd
 jRu
 icI
-peU
+eUd
 uQE
 rpe
 lEi
@@ -57474,7 +57218,7 @@ vYN
 vYN
 vYN
 tve
-nlM
+gaA
 fZo
 dvL
 hjX
@@ -57668,7 +57412,7 @@ aia
 ohv
 vYN
 vYN
-fDp
+vYN
 uHG
 dvL
 hjX
@@ -57862,7 +57606,7 @@ kzb
 kzb
 aia
 aia
-fDp
+vYN
 gGs
 dvL
 hjX
@@ -58056,9 +57800,9 @@ vYN
 kzb
 kzb
 aia
-rjD
+vYN
 tcW
-rRX
+dvL
 qgp
 uhe
 vUs
@@ -59974,7 +59718,7 @@ vUL
 jWn
 lbt
 mDv
-dkb
+qQK
 qQK
 cHC
 oDd
@@ -60167,8 +59911,8 @@ mYS
 gjd
 edP
 oDd
-cHC
-qQK
+rjD
+eZz
 eZz
 kEQ
 kEQ
@@ -61526,7 +61270,7 @@ oBL
 vAB
 uMl
 iBv
-wPE
+fDp
 bHC
 szh
 oDd
@@ -62123,9 +61867,9 @@ elh
 wZf
 nnL
 huo
-axp
 iET
-axp
+iET
+bNQ
 axp
 axp
 axp
@@ -63471,14 +63215,14 @@ tUb
 pkD
 pkD
 nMP
-hor
 nMP
+ecV
 pkD
 hlS
 tUb
 qUK
 ttn
-mWa
+xcG
 mbs
 oFh
 oku
@@ -63664,15 +63408,15 @@ rtj
 tUb
 iDd
 nMP
-hor
 nMP
-pkD
+nMP
+dAa
 pkD
 pkD
 tUb
 yah
 gaG
-oBJ
+oYE
 mbs
 oFh
 oku
@@ -63857,16 +63601,16 @@ wlW
 rtj
 tUb
 nMP
-hor
+nMP
 nMP
 pkD
-pkD
+dAa
 pkD
 pkD
 tUb
 sgw
 vWh
-oBJ
+oYE
 mbs
 oFh
 oku
@@ -64051,10 +63795,10 @@ sEs
 nvq
 tUb
 lZR
-nMP
-pkD
-pkD
-pkD
+kfA
+ejr
+ejr
+eRd
 pkD
 pkD
 tUb
@@ -64254,7 +63998,7 @@ rpj
 tUb
 vqH
 vWh
-oBJ
+oYE
 mbs
 gzk
 mzy
@@ -64448,7 +64192,7 @@ pUI
 tUb
 kpO
 oJk
-oBJ
+oYE
 mbs
 sgy
 oku
@@ -64642,7 +64386,7 @@ pUI
 tUb
 aua
 vWh
-oBJ
+oYE
 mbs
 hog
 bYo
@@ -64836,7 +64580,7 @@ cFB
 tUb
 aua
 ioD
-mWa
+xcG
 mbs
 hDD
 hDv
@@ -65603,9 +65347,9 @@ mFT
 ruu
 tUb
 fNy
-pkD
-pkD
-jyg
+gkx
+gkx
+qLC
 jGa
 pkD
 hlS
@@ -65792,15 +65536,15 @@ jRK
 jRK
 jRK
 mai
-eYA
+tCI
 lSb
 rCE
 aee
 ejD
-cTu
-cTu
-cfh
-ejr
+ejD
+ejD
+tVO
+ruN
 pkD
 pkD
 tUb
@@ -65990,11 +65734,11 @@ kVB
 gJm
 nDt
 tUb
-ecV
+nMP
 pkD
 pkD
 jyg
-ejr
+nMP
 nMP
 pkD
 tUb
@@ -66185,10 +65929,10 @@ qzR
 nDt
 tUb
 gAp
-iNn
-nMK
-tVO
-ruN
+nMP
+nMP
+jyg
+nMP
 nMP
 tUb
 tUb
@@ -66762,7 +66506,7 @@ gfA
 teE
 eYK
 eYK
-eYA
+sUb
 gJm
 tUN
 tUb

--- a/maps/endeavour/levels/deck3.dmm
+++ b/maps/endeavour/levels/deck3.dmm
@@ -179,20 +179,20 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
@@ -276,11 +276,17 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/hallway)
 "aoe" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/quartermaster/foyer)
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3portamidhall)
 "apl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -426,14 +432,25 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3starboardamidhall)
 "auM" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
+/obj/spawner/window/low_wall/borosillicate/reinforced/full,
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/hallway/d3fwdhall)
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/security/hallway)
 "auQ" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -474,9 +491,6 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "awm" = (
@@ -548,6 +562,9 @@
 /obj/effect/floor_decal/corner/navgold/border{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/endeavour/hallway/d3afthall)
 "ayd" = (
@@ -555,9 +572,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "ayg" = (
@@ -671,6 +685,10 @@
 "aBl" = (
 /obj/structure/closet/wardrobe,
 /obj/item/toy/plushie/black_cat,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/north_mount,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_9)
 "aCi" = (
@@ -711,6 +729,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/quartermaster/foyer)
 "aDw" = (
@@ -739,14 +760,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "aFF" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/hallway/d3starboardafthall)
+/turf/simulated/floor/wood,
+/area/crew_quarters/recreation_area)
 "aFS" = (
 /obj/machinery/light,
 /obj/structure/cable/green{
@@ -776,6 +799,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
+"aGu" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/navgold/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3fwdhall)
 "aGx" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32
@@ -845,6 +882,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -1188,9 +1228,6 @@
 /area/endeavour/hallway/d3afthall)
 "aWJ" = (
 /obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1201,6 +1238,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -1360,7 +1400,7 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
-	icon_state = "6-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
@@ -1442,6 +1482,10 @@
 	dir = 8
 	},
 /obj/spawner/window/low_wall/borosillicate/reinforced/full,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor,
 /area/security/hallway)
 "bee" = (
@@ -1832,14 +1876,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/navblue/border{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
@@ -1988,6 +2032,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
@@ -2269,9 +2316,6 @@
 /area/tether/surfacebase/entertainment)
 "bER" = (
 /obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/corner_oldtile/white/diagonal,
@@ -2336,6 +2380,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
@@ -2613,10 +2660,10 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
 "bUU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
-	icon_state = "1-4"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
@@ -2735,9 +2782,6 @@
 /area/endeavour/hallway/d3aftmaint)
 "bZs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -2930,6 +2974,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_9)
 "clL" = (
@@ -3013,9 +3060,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "cop" = (
@@ -3038,6 +3082,9 @@
 	id_tag = "dorm10";
 	name = "Dorm 10"
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_10)
 "cpz" = (
@@ -3048,6 +3095,27 @@
 /obj/effect/floor_decal/corner/navblue/border,
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
+"cpN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/hallway)
 "crj" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3148,6 +3216,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
@@ -3342,9 +3413,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 4
 	},
@@ -3417,9 +3485,6 @@
 /turf/simulated/floor/airless,
 /area/space)
 "cGF" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -3526,6 +3591,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3starboardafthall)
@@ -3816,7 +3884,10 @@
 "cVu" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/structure/cable/green{
-	icon_state = "1-4"
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/warden)
@@ -4151,6 +4222,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
 "deT" = (
@@ -4446,9 +4520,6 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3starboardafthall)
 "dns" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 4
@@ -4650,7 +4721,9 @@
 /area/security/interrogation)
 "dyR" = (
 /obj/machinery/power/apc/west_mount,
-/obj/structure/cable/green,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/wood,
 /area/quartermaster/foyer)
 "dyV" = (
@@ -4676,9 +4749,6 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
 "dzp" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -4687,6 +4757,9 @@
 	},
 /obj/effect/floor_decal/corner/navgold/border{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
@@ -4705,7 +4778,7 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -4740,6 +4813,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
@@ -4783,9 +4859,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar/lounge)
 "dBL" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -4832,9 +4905,6 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/endeavour/station/stairs_three)
 "dGe" = (
@@ -4867,11 +4937,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar/catwalk)
 "dHD" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
@@ -4979,9 +5052,6 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/crew_quarters/sleep/Dorm_12)
 "dLj" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
@@ -5238,11 +5308,28 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "dSy" = (
-/obj/structure/cable{
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass{
+	dir = 8
+	},
+/obj/spawner/window/low_wall/borosillicate/reinforced/full,
+/obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/endeavour/station/stairs_three)
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/security/hallway)
 "dSJ" = (
 /obj/structure/table/marble,
 /obj/item/storage/box/donkpockets,
@@ -5321,6 +5408,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_7)
 "dUN" = (
@@ -5369,6 +5459,9 @@
 /area/endeavour/hallway/d3fwdhall)
 "dVD" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_5)
 "dVI" = (
@@ -5483,7 +5576,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/power/sensor{
-	name = "Powernet Sensor - Deck 3 Subgrid";
+	name = "Powernet Sensor - Deck 3 Aft Subgrid";
 	name_tag = "Deck 3 Subgrid"
 	},
 /turf/simulated/floor/plating,
@@ -5825,7 +5918,10 @@
 /area/crew_quarters/sleep/Dorm_11)
 "emK" = (
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
@@ -5915,20 +6011,16 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
 "eoB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
+/obj/structure/table/steel,
+/obj/item/flashlight/lamp,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/hallway/d3starboardforhall)
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/old_cargo/red,
+/area/security/security_processing)
 "epb" = (
 /obj/structure/cable/green{
 	icon_state = "0-8"
@@ -6035,9 +6127,6 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -6069,9 +6158,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)
 "eth" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
@@ -6204,6 +6290,23 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3portforhall)
+"ewB" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass{
+	dir = 8
+	},
+/obj/spawner/window/low_wall/borosillicate/reinforced/full,
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/security/hallway)
 "ewW" = (
 /obj/machinery/camera/network/civilian{
 	dir = 1
@@ -6246,9 +6349,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
@@ -6257,6 +6357,9 @@
 	},
 /obj/machinery/status_display{
 	pixel_y = 32
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
@@ -6304,6 +6407,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
@@ -6720,9 +6826,6 @@
 /obj/map_helper/access_helper/airlock/station/security/department,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/security/hallway)
 "eLo" = (
@@ -6774,17 +6877,23 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/hallway)
 "eMM" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/door/firedoor/glass{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/hallway/d3starboardafthall)
+/obj/spawner/window/low_wall/borosillicate/reinforced/full,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor,
+/area/security/hallway)
 "eMX" = (
 /obj/structure/cable/green{
 	icon_state = "2-4"
@@ -6917,11 +7026,11 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
@@ -7316,10 +7425,10 @@
 /area/endeavour/hallway/d3portforhall)
 "fgJ" = (
 /obj/structure/cable/green{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/lobby)
@@ -7445,6 +7554,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
 "fjp" = (
@@ -7581,6 +7693,9 @@
 "fnh" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
@@ -7868,9 +7983,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "fCO" = (
@@ -8049,17 +8161,14 @@
 /turf/simulated/floor/wood,
 /area/endeavour/hallway/d3fwdhall)
 "fLu" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/hallway)
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3portamidhall)
 "fLD" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -8179,9 +8288,6 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
 "fMJ" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8210,15 +8316,12 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/prison/cell_block)
-"fMU" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/tiled/dark,
+/area/prison/cell_block)
+"fMU" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 8
 	},
@@ -8317,6 +8420,9 @@
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/structure/cable/green{
 	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/security/armoury)
@@ -8553,9 +8659,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
 "fUU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -8724,13 +8827,11 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "gbe" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/security/armoury)
 "gbs" = (
@@ -8895,14 +8996,14 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/vacant/vacant_shop)
 "gig" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
@@ -9196,6 +9297,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
+"grI" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/navgold/border,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3starboardforhall)
 "gtD" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/cable/orange{
@@ -9312,11 +9421,16 @@
 	alpha = 255
 	},
 /obj/effect/floor_decal/corner/navgold/bordercorner2,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "gxZ" = (
 /obj/structure/closet/wardrobe,
 /obj/item/toy/plushie/crab,
+/obj/structure/cable/green,
+/obj/machinery/power/apc/south_mount,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_8)
 "gyJ" = (
@@ -9434,6 +9548,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "gFi" = (
@@ -9484,11 +9601,11 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
@@ -9502,6 +9619,9 @@
 	req_one_access = null
 	},
 /obj/map_helper/access_helper/airlock/station/supply/maintenance,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/security)
 "gKi" = (
@@ -9555,7 +9675,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
@@ -9826,6 +9946,9 @@
 /obj/effect/floor_decal/corner/navgold/bordercorner{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
 "gUM" = (
@@ -9943,14 +10066,14 @@
 /area/security/hallway)
 "gZQ" = (
 /obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/glass/security{
 	name = "Cell Block";
 	req_one_access = null
 	},
 /obj/map_helper/access_helper/airlock/station/security/general,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/prison/cell_block)
 "gZV" = (
@@ -10275,6 +10398,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_10)
 "hmO" = (
@@ -10509,7 +10635,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/security)
@@ -10651,6 +10777,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_8)
@@ -10848,6 +10977,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/fitness)
+"hJb" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/navgold/border,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3starboardforhall)
 "hJm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -10878,9 +11015,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar/lounge)
 "hKI" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/fire_alarm/west_mount{
 	pixel_x = -24
@@ -11021,9 +11155,6 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/surfacebase/mining_main/refinery)
 "hOu" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/red/bordercorner,
 /obj/structure/cable/green{
@@ -11033,15 +11164,24 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "hOJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/spawner/window/reinforced/full,
-/turf/simulated/floor/plating,
-/area/maintenance/substation/security)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/recreation_area)
 "hOP" = (
 /obj/machinery/air_alarm{
 	dir = 4;
@@ -11115,6 +11255,8 @@
 "hTJ" = (
 /obj/structure/closet/wardrobe,
 /obj/item/toy/plushie/rat,
+/obj/structure/cable/green,
+/obj/machinery/power/apc/south_mount,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
 "hUg" = (
@@ -11142,9 +11284,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -11304,11 +11443,11 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navgold/border,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "iaP" = (
@@ -11343,6 +11482,9 @@
 	id_tag = "dorm9";
 	name = "Dorm 9"
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_9)
 "ibA" = (
@@ -11357,9 +11499,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_8)
 "ibW" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
@@ -11518,7 +11657,7 @@
 "ikx" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/structure/cable/green{
-	icon_state = "2-4"
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/warden)
@@ -11720,6 +11859,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)
 "isg" = (
@@ -11813,6 +11955,9 @@
 "ixU" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -11905,10 +12050,10 @@
 /area/crew_quarters/game_room)
 "iCt" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
 /obj/effect/paint/darkred,
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/security/security_processing)
 "iCL" = (
@@ -11959,12 +12104,9 @@
 /area/security/riot_control)
 "iFb" = (
 /obj/machinery/power/terminal,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/air_alarm/north_mount,
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/security)
@@ -12098,6 +12240,9 @@
 	dir = 9
 	},
 /obj/machinery/light,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "iJh" = (
@@ -12272,6 +12417,9 @@
 	dir = 4
 	},
 /obj/machinery/air_alarm/east_mount,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
 "iRB" = (
@@ -12475,6 +12623,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
@@ -12891,6 +13042,12 @@
 	},
 /turf/simulated/floor,
 /area/quartermaster/warehouse)
+"jpV" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3starboardforhall)
 "jpX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -12901,6 +13058,9 @@
 "jqq" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
@@ -13164,9 +13324,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "jCu" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -13282,10 +13439,10 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
+/obj/machinery/camera/network/security,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/security,
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "jGq" = (
@@ -13565,6 +13722,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "jSX" = (
@@ -13811,6 +13971,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "kcO" = (
@@ -14035,6 +14198,9 @@
 	opacity = 0
 	},
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor,
 /area/security/brig)
 "kkw" = (
@@ -14380,10 +14546,13 @@
 /area/security/riot_control)
 "kBT" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/security/warden)
 "kCb" = (
@@ -14467,9 +14636,6 @@
 "kDu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
@@ -14569,9 +14735,6 @@
 "kIo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/light_switch{
 	dir = 4;
 	pixel_x = -28
@@ -14647,9 +14810,6 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/cryo)
 "kKU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -14690,17 +14850,12 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/bar/lower)
 "kMk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /obj/structure/cable/green{
 	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/navblue/border{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
@@ -14862,14 +15017,14 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
 "kSN" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
@@ -14971,9 +15126,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
 /turf/simulated/floor/tiled/dark,
@@ -15283,20 +15435,11 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "liu" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/hallway)
+/turf/simulated/floor/plating,
+/area/maintenance/substation/security)
 "ljb" = (
 /obj/machinery/light{
 	dir = 4
@@ -15327,6 +15470,14 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/delivery)
+"lly" = (
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/effect/paint/darkred,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/security/breakroom)
 "llM" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable{
@@ -15477,9 +15628,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
@@ -15509,10 +15657,10 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -15580,22 +15728,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
 "lwh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/navgold/border,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/hallway/d3starboardafthall)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/recreation_area)
 "lwk" = (
 /obj/structure/bed/chair/sofa/left{
 	dir = 1
@@ -15778,20 +15921,14 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/surfacebase/mining_main/refinery)
 "lCJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/navblue/border{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel,
-/area/endeavour/hallway/d3portforhall)
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3starboardafthall)
 "lCU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -16034,9 +16171,6 @@
 "lKR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -16418,6 +16552,9 @@
 	id_tag = "dorm6";
 	name = "Dorm 6"
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
 "lYO" = (
@@ -16436,6 +16573,9 @@
 	},
 /obj/effect/floor_decal/corner/navgold/border{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/endeavour/hallway/d3afthall)
@@ -16460,6 +16600,10 @@
 "mbt" = (
 /obj/structure/closet/wardrobe,
 /obj/item/toy/plushie/carp/nebula,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/north_mount,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_5)
 "mbv" = (
@@ -16479,9 +16623,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
@@ -16619,6 +16760,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "miE" = (
@@ -16714,11 +16858,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
@@ -16926,6 +17070,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
@@ -17471,11 +17618,11 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
@@ -17483,14 +17630,14 @@
 /turf/simulated/wall/prepainted/cargo,
 /area/maintenance/bar/catwalk)
 "mVA" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/navgold/bordercorner{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
@@ -17846,7 +17993,10 @@
 /area/maintenance/cargo/mining)
 "nfG" = (
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/security)
@@ -17947,6 +18097,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "nkr" = (
@@ -18651,14 +18804,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
 "nLm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/recreation_area)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/security/warden)
 "nLT" = (
 /obj/machinery/atm{
 	pixel_y = 30
@@ -18772,9 +18926,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "nPo" = (
@@ -18801,26 +18952,26 @@
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/hanger)
 "nQm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/firedoor{
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/hallway/d3starboardforhall)
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d3portforhall)
 "nQv" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navgold/border,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
@@ -18831,6 +18982,18 @@
 /obj/machinery/camera/network/civilian,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
+"nQY" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/hallway)
 "nRf" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -19549,18 +19712,12 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "opq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -19694,6 +19851,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_5)
 "otU" = (
@@ -19760,6 +19920,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
@@ -19926,7 +20089,7 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
-	icon_state = "2-9"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
@@ -20055,9 +20218,6 @@
 "oFi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/camera/network/security{
 	dir = 4
 	},
@@ -20208,6 +20368,9 @@
 "oKt" = (
 /obj/structure/bed/chair{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/old_cargo/red,
 /area/security/security_processing)
@@ -20575,11 +20738,11 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
@@ -20851,9 +21014,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -21071,6 +21231,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "pnh" = (
@@ -21130,6 +21293,9 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "poW" = (
@@ -21140,6 +21306,9 @@
 	alpha = 255
 	},
 /obj/effect/floor_decal/corner/navgold/bordercorner2,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "pqk" = (
@@ -21200,6 +21369,9 @@
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
@@ -21517,6 +21689,15 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3starboardafthall)
+"pEO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3fwdhall)
 "pFD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -21569,6 +21750,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
@@ -21834,6 +22018,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/security/brig)
 "pRW" = (
@@ -21940,12 +22127,12 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/quartermaster/foyer)
@@ -21955,23 +22142,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
 "pWF" = (
-/obj/machinery/door/firedoor{
-	dir = 8
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/navblue/border{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/endeavour/hallway/d3portforhall)
+/turf/simulated/floor/tiled/dark,
+/area/security/hallway)
 "pXn" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
@@ -22098,12 +22279,6 @@
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/sleep/Dorm_12)
 "qca" = (
-/obj/machinery/power/apc/west_mount{
-	cell_type = /obj/item/cell/super
-	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -22130,7 +22305,7 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
@@ -22286,11 +22461,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
@@ -22354,8 +22529,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/endeavour/station/stairs_three)
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3portamidhall)
 "qlg" = (
 /turf/simulated/wall/prepainted/cargo,
 /area/quartermaster/foyer)
@@ -22496,6 +22671,9 @@
 	id_tag = "dorm7";
 	name = "Dorm 7"
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_7)
 "qoA" = (
@@ -22542,9 +22720,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -22727,6 +22902,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navgold/border,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "qvY" = (
@@ -23046,11 +23224,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
@@ -23147,6 +23325,9 @@
 /obj/effect/floor_decal/corner/navgold/border{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/endeavour/hallway/d3afthall)
 "qJB" = (
@@ -23183,6 +23364,10 @@
 /area/quartermaster/storage)
 "qLB" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/security/warden)
 "qLH" = (
@@ -23339,10 +23524,10 @@
 	},
 /obj/machinery/power/apc/north_mount,
 /obj/structure/cable/green{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
@@ -23536,6 +23721,9 @@
 	icon_state = "4-8"
 	},
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/security/brig)
 "rbG" = (
@@ -24216,6 +24404,9 @@
 /obj/spawner/window/low_wall/borosillicate/reinforced/full,
 /obj/structure/curtain/black,
 /obj/effect/paint_stripe/darkred,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor,
 /area/security/brig)
 "rzG" = (
@@ -24309,6 +24500,30 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
+"rDL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/hallway)
 "rDV" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 8
@@ -24337,6 +24552,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
@@ -24521,6 +24739,9 @@
 /obj/machinery/power/apc/south_mount,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navgold/border,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "rOz" = (
@@ -24550,13 +24771,13 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portamidhall)
 "rOR" = (
@@ -24867,6 +25088,9 @@
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/warden)
@@ -25294,6 +25518,9 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "soe" = (
@@ -25309,9 +25536,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "soV" = (
@@ -25372,7 +25596,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
-	icon_state = "5-8"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)
@@ -25988,6 +26212,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
 "sLk" = (
@@ -26031,6 +26258,9 @@
 /obj/machinery/door/airlock{
 	id_tag = "dorm8";
 	name = "Dorm 8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_8)
@@ -26188,6 +26418,18 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
+"sVD" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3portamidhall)
 "sWa" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -26290,18 +26532,22 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3portforhall)
 "sYp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass{
+	dir = 8
+	},
+/obj/spawner/window/low_wall/borosillicate/reinforced/full,
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable/green,
+/turf/simulated/floor,
 /area/security/hallway)
 "sYK" = (
 /obj/machinery/newscaster{
@@ -26442,6 +26688,8 @@
 "tcl" = (
 /obj/structure/closet/wardrobe,
 /obj/item/toy/plushie/borgplushie/pupdozer,
+/obj/structure/cable/green,
+/obj/machinery/power/apc/south_mount,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_10)
 "tdf" = (
@@ -26769,6 +27017,9 @@
 /obj/effect/floor_decal/corner/navgold/bordercorner2{
 	dir = 9
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "tpP" = (
@@ -26830,6 +27081,9 @@
 	},
 /obj/spawner/window/low_wall/borosillicate/reinforced/full,
 /obj/effect/paint_stripe/darkred,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor,
 /area/security/brig)
 "tsr" = (
@@ -27011,11 +27265,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
@@ -27094,9 +27348,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)
 "tDn" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27414,10 +27665,11 @@
 "tPf" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/structure/cable/green{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
+/obj/structure/cable/green,
 /obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/security/warden)
@@ -27487,6 +27739,9 @@
 	},
 /obj/effect/floor_decal/corner/navgold/border{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
@@ -27559,9 +27814,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "tVk" = (
@@ -27668,11 +27920,16 @@
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/belter)
 "tYX" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/endeavour/station/stairs_three)
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/old_cargo/gray,
+/area/security/security_processing)
 "tZq" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -27856,9 +28113,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
 "ugs" = (
@@ -28022,7 +28276,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/power/sensor{
-	name = "Powernet Sensor - Deck 3 Aft Subgrid";
+	name = "Powernet Sensor - Deck 3 Amidships Subgrid";
 	name_tag = "Deck 3 Aft Subgrid"
 	},
 /turf/simulated/floor/plating,
@@ -28077,14 +28331,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
 "ukf" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
@@ -28115,6 +28366,9 @@
 /obj/machinery/door/airlock{
 	id_tag = "dorm5";
 	name = "Dorm 5"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_5)
@@ -28178,9 +28432,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "unJ" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -28228,6 +28479,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
@@ -28289,19 +28543,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)
 "urW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/red/border,
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 1
+	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
@@ -28353,17 +28601,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/endeavour/station/stairs_three)
 "ute" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
 "utz" = (
@@ -28410,7 +28655,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
@@ -28567,13 +28812,13 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
 "uBN" = (
@@ -28661,6 +28906,9 @@
 "uGN" = (
 /obj/machinery/door/firedoor,
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/security/brig)
 "uHj" = (
@@ -28737,6 +28985,9 @@
 	},
 /obj/spawner/window/low_wall/borosillicate/reinforced/full,
 /obj/effect/paint_stripe/darkred,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor,
 /area/security/brig)
 "uJr" = (
@@ -28773,7 +29024,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
@@ -29406,13 +29657,13 @@
 /turf/simulated/floor/tiled,
 /area/security/hanger)
 "vhc" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
 "vhK" = (
@@ -29585,6 +29836,9 @@
 	icon_state = "4-8"
 	},
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/security/brig)
 "vlO" = (
@@ -29948,6 +30202,9 @@
 /area/security/range)
 "vxh" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_7)
 "vxy" = (
@@ -30142,6 +30399,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "vAZ" = (
@@ -30319,9 +30579,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /obj/machinery/camera/network/security,
 /obj/effect/floor_decal/borderfloorblack{
@@ -30552,7 +30809,7 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "4-10"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
@@ -30683,6 +30940,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
 "vQh" = (
@@ -30695,14 +30955,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/endeavour/hallway/d3afthall)
 "vQB" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/navgold/border{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
@@ -30961,6 +31221,10 @@
 "vYX" = (
 /obj/structure/closet/wardrobe,
 /obj/item/toy/plushie/blue_fox,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/north_mount,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_7)
 "vZR" = (
@@ -31061,9 +31325,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 1
 	},
@@ -31084,6 +31345,9 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
@@ -31336,13 +31600,13 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 2;
 	name = "Kitchen";
 	sortType = "Kitchen"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -31482,6 +31746,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
 "wvC" = (
@@ -31510,23 +31777,25 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_10)
 "wwk" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/structure/cable/green,
 /obj/structure/cable/green{
-	icon_state = "1-4"
+	icon_state = "1-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/security/brig)
+/turf/simulated/floor/plating,
+/area/security/warden)
 "wws" = (
 /obj/structure/table/steel,
 /obj/item/tape_recorder,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/old_cargo/red,
 /area/security/security_processing)
 "wwH" = (
@@ -31549,6 +31818,9 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
@@ -31623,9 +31895,6 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/fitness)
 "wBG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 4
 	},
@@ -31663,9 +31932,6 @@
 /turf/simulated/wall/r_wall/prepainted/security,
 /area/security/tactical)
 "wCQ" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 1
 	},
@@ -32252,14 +32518,14 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "xao" = (
+/obj/structure/cable/green,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/effect/paint/darkred,
 /obj/structure/cable/green{
-	icon_state = "1-4"
+	icon_state = "0-2"
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/turf/simulated/floor/plating,
+/area/security/security_processing)
 "xaH" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -32495,6 +32761,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
 "xlg" = (
@@ -32548,6 +32817,9 @@
 /area/crew_quarters/bar)
 "xmN" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_9)
 "xnb" = (
@@ -32673,9 +32945,6 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
@@ -32728,6 +32997,9 @@
 "xwz" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_8)
@@ -32843,9 +33115,6 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3starboardafthall)
 "xyJ" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
@@ -33205,6 +33474,9 @@
 /obj/effect/floor_decal/corner/navgold/border{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/endeavour/hallway/d3afthall)
 "xMC" = (
@@ -33300,9 +33572,6 @@
 "xPF" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
@@ -33484,6 +33753,9 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/old_cargo/red,
 /area/security/security_processing)
 "xXa" = (
@@ -33517,6 +33789,10 @@
 /obj/effect/floor_decal/corner/navgold/bordercorner2{
 	dir = 8
 	},
+/obj/machinery/power/apc/west_mount{
+	cell_type = /obj/item/cell/super
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
 "xXl" = (
@@ -33572,6 +33848,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
@@ -38919,7 +39198,7 @@ rcG
 pPp
 oyZ
 pSU
-xrk
+nQY
 qVJ
 fcE
 uGg
@@ -39104,7 +39383,7 @@ uTh
 qbm
 qbm
 udU
-bDw
+rJC
 tjK
 knW
 uGl
@@ -39113,10 +39392,10 @@ flS
 dPF
 vcO
 vBk
+dSy
 bed
 bed
-bed
-bed
+sYp
 evH
 pRW
 pRW
@@ -39304,13 +39583,13 @@ dMY
 oth
 oth
 pFD
-oth
+bUU
 dBm
-voq
-bed
+urW
+eMM
 cKR
 mxj
-bed
+auM
 pRW
 pRW
 pRW
@@ -39498,13 +39777,13 @@ bgj
 pSU
 uny
 mId
-uny
+pWF
 uny
 xrk
 puT
 pFW
 cKR
-bed
+ewB
 pRW
 pRW
 pRW
@@ -39688,11 +39967,11 @@ pUu
 qbm
 rbn
 dAT
-liu
-rKm
+bgj
+vBk
 cVu
 qLB
-qLB
+wwk
 jYQ
 jYQ
 jYQ
@@ -40070,7 +40349,7 @@ osg
 osg
 osg
 qQz
-wwk
+knk
 rcG
 tjK
 uGl
@@ -40657,7 +40936,7 @@ eYv
 eZg
 jkY
 jkY
-bUU
+jkY
 wwY
 qnW
 vxQ
@@ -40851,7 +41130,7 @@ rcG
 jip
 uny
 uny
-fLu
+uny
 cEz
 vBk
 ikx
@@ -41048,7 +41327,7 @@ pTu
 pTu
 cHK
 cZm
-sak
+nLm
 aId
 cUO
 xad
@@ -41240,8 +41519,8 @@ iXZ
 wbv
 xjK
 pTu
-lnD
-vBk
+rDL
+rKm
 tPf
 vAQ
 vFp
@@ -47005,10 +47284,10 @@ tUu
 rxD
 qcx
 jCu
-bhw
-bhw
-bhw
-xao
+qcx
+qcx
+qcx
+ejk
 leF
 wuh
 iXY
@@ -48213,7 +48492,7 @@ kSn
 kSn
 syH
 jRB
-qFk
+lCJ
 vUA
 vIs
 rFP
@@ -48407,7 +48686,7 @@ kSn
 kSn
 syH
 wQS
-qFk
+lCJ
 uwo
 hHh
 vIs
@@ -48817,7 +49096,7 @@ nSS
 hbK
 fMJ
 gZQ
-wUZ
+cpN
 oqU
 ylw
 sQY
@@ -49350,7 +49629,7 @@ cmw
 hrc
 izO
 bSQ
-aoe
+bSQ
 dyR
 bSQ
 tVX
@@ -49944,8 +50223,8 @@ qdW
 rBG
 rBG
 rBG
-pWF
-aCi
+nJu
+nQm
 wtj
 syH
 kSn
@@ -49981,7 +50260,7 @@ fxS
 rbG
 giv
 wsz
-wFj
+rCI
 lhi
 iyK
 lot
@@ -49991,7 +50270,7 @@ plV
 wZj
 cFR
 scb
-upG
+lly
 sJu
 pRW
 pRW
@@ -50138,8 +50417,8 @@ mIk
 fju
 fju
 rBG
+qxm
 kMk
-oxG
 kYx
 syH
 kSn
@@ -50332,7 +50611,7 @@ mIk
 fju
 fju
 rBG
-lCJ
+txu
 kSN
 prZ
 azB
@@ -50554,7 +50833,7 @@ kBH
 ibW
 jzh
 pnh
-pnh
+tYX
 tJB
 ktJ
 cgP
@@ -50745,7 +51024,7 @@ eyV
 dOf
 uih
 pwc
-cXt
+vBk
 qqU
 hzs
 xWQ
@@ -50939,10 +51218,10 @@ xkB
 aiW
 xyL
 rkC
-hvt
-pQC
+vBk
+xao
 wws
-kTd
+eoB
 txv
 wrN
 oxA
@@ -51123,7 +51402,7 @@ goa
 nnV
 cGV
 jmQ
-kRc
+qFk
 vUA
 qHe
 alB
@@ -51133,7 +51412,7 @@ jbP
 qHe
 dAT
 mWx
-cXt
+vBk
 qqU
 rza
 oKt
@@ -51317,7 +51596,7 @@ goa
 nnV
 cGV
 mXV
-kRc
+qFk
 uwo
 qHe
 qHe
@@ -51327,7 +51606,7 @@ qHe
 qHe
 dAT
 ksW
-cXt
+vBk
 qqU
 qqU
 iCt
@@ -51511,25 +51790,25 @@ tHm
 jlq
 cGV
 jRB
-eMM
+qFk
 cGF
 eLl
 tVi
 gaU
 lKR
 oFi
-sYp
+gaU
 wCQ
 kXs
 fMU
 opq
 kIo
-urW
-sYp
+gaU
+gaU
 dBL
-sYp
+gaU
 qoY
-sYp
+gaU
 bZs
 hVo
 phI
@@ -52086,15 +52365,15 @@ wXO
 wXO
 wXO
 hNe
-aFF
+hNe
 fUU
 kKU
 kKU
 kKU
 kKU
 wBG
-dbR
-lwh
+kRc
+vUA
 orP
 tOV
 tOV
@@ -52474,7 +52753,7 @@ bDG
 qHq
 pkQ
 qHq
-qkV
+qHq
 rQK
 pkQ
 qHq
@@ -52668,7 +52947,7 @@ bDG
 qHq
 qHq
 qHq
-qkV
+qHq
 rQK
 qHq
 qHq
@@ -52862,7 +53141,7 @@ xPB
 xPB
 eCk
 lfS
-qkV
+qHq
 rQK
 eCk
 xPB
@@ -53056,7 +53335,7 @@ mmq
 mmq
 qHq
 qHq
-qkV
+qHq
 rQK
 qHq
 mmq
@@ -53249,8 +53528,8 @@ eqa
 mmq
 mmq
 aec
-dSy
-tYX
+qHq
+qHq
 rQK
 aec
 mmq
@@ -53443,7 +53722,7 @@ mMr
 bWK
 bWK
 bWK
-qkV
+qHq
 iuv
 tIr
 bWK
@@ -53637,7 +53916,7 @@ mMr
 gKQ
 lTw
 mhY
-hOJ
+mhY
 mhY
 mhY
 mhY
@@ -54413,7 +54692,7 @@ mMr
 lTw
 lTw
 mhY
-ufX
+liu
 ufX
 mhY
 bCC
@@ -54607,7 +54886,7 @@ mMr
 lTw
 lTw
 mhY
-ufX
+liu
 mhY
 mhY
 soe
@@ -54995,7 +55274,7 @@ tZy
 tZy
 fek
 tEi
-gDD
+qkV
 opZ
 qca
 xPF
@@ -55189,7 +55468,7 @@ ddk
 ddk
 ddk
 ddk
-ddk
+fLu
 ddk
 bzp
 bzp
@@ -55383,8 +55662,8 @@ eWb
 eWb
 dhq
 eWb
-eWb
-eWb
+sVD
+aoe
 iRh
 tTS
 wex
@@ -59659,7 +59938,7 @@ mMr
 mMr
 mMr
 voc
-nQm
+adZ
 iaj
 gSN
 vYX
@@ -59854,7 +60133,7 @@ hQd
 llM
 tqq
 qck
-tGB
+grI
 gSN
 vjD
 vrD
@@ -60831,7 +61110,7 @@ dVD
 otS
 ulH
 nkn
-jSG
+aFF
 rVy
 coF
 aNV
@@ -61025,7 +61304,7 @@ avI
 usd
 hyv
 vIV
-ekX
+lwh
 rVy
 aNV
 aNV
@@ -61219,7 +61498,7 @@ hyv
 hyv
 hyv
 syZ
-ekX
+lwh
 rVy
 oez
 aNV
@@ -61413,7 +61692,7 @@ tHI
 vGJ
 hyv
 nwy
-vUM
+hOJ
 rVy
 rVy
 rVy
@@ -61796,11 +62075,11 @@ gFU
 ooS
 uJP
 ayd
-nLm
-nLm
+qMf
+qMf
 soz
 nPn
-nLm
+qMf
 mbJ
 aQa
 syZ
@@ -61987,7 +62266,7 @@ esO
 tOV
 orP
 gFU
-eoB
+adZ
 poW
 eVN
 eVN
@@ -62181,8 +62460,8 @@ orP
 orP
 orP
 lJp
-eoB
-tGB
+adZ
+hJb
 mMr
 lTw
 lTw
@@ -62569,8 +62848,8 @@ kDc
 nDp
 deT
 acN
-eoB
-tGB
+adZ
+hJb
 mMr
 fSP
 enJ
@@ -62763,8 +63042,8 @@ exf
 wGd
 wGd
 wGd
-eoB
-tGB
+adZ
+hJb
 bDg
 fSP
 alQ
@@ -62957,8 +63236,8 @@ wGd
 wGd
 wGd
 wGd
-eoB
-tGB
+adZ
+hJb
 mMr
 fSP
 gKQ
@@ -63346,7 +63625,7 @@ wGd
 wGd
 wGd
 com
-wGd
+jpV
 pku
 fSP
 lTw
@@ -64509,8 +64788,8 @@ vQB
 vQB
 vQB
 mVA
-auM
-ezM
+pEO
+aGu
 alQ
 lTw
 lTw

--- a/maps/endeavour/levels/deck4.dmm
+++ b/maps/endeavour/levels/deck4.dmm
@@ -82,9 +82,6 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4porthall)
 "agu" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
 	},
@@ -605,14 +602,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
@@ -744,7 +738,11 @@
 /turf/simulated/wall/r_wall/prepainted/engineering,
 /area/engineering/portnacelle)
 "aMT" = (
-/obj/machinery/atmospherics/component/quaternary/atmos_filter,
+/obj/machinery/atmospherics/component/quaternary/atmos_filter{
+	tag_south = 1;
+	tag_west = 2;
+	tag_north = 4
+	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -823,9 +821,6 @@
 	},
 /obj/machinery/door/firedoor{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "5-9"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
@@ -922,8 +917,11 @@
 /turf/simulated/floor/tiled/monowhite,
 /area/engineering/drone_fabrication)
 "aXZ" = (
-/obj/structure/cable{
-	icon_state = "1-6"
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
@@ -1013,9 +1011,6 @@
 	name = "Secondary PSU room"
 	},
 /obj/map_helper/access_helper/airlock/station/maintenance,
-/obj/structure/cable{
-	icon_state = "9-10"
-	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
 "bfx" = (
@@ -1485,14 +1480,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/starboardnacelle)
 "bJi" = (
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/lightorange/border,
-/obj/machinery/light,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/endeavour/hallway/d4portafthall)
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/effect/paint/sun,
+/turf/simulated/floor/plating,
+/area/endeavour/hallway/d4aftmaint)
 "bKR" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -1646,6 +1637,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
 "bSY" = (
@@ -1728,6 +1722,14 @@
 /obj/machinery/power/shield_generator,
 /turf/simulated/floor/tiled/monowhite,
 /area/engineering/shield_gen)
+"bWc" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lightorange/border,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/endeavour/hallway/d4portafthall)
 "bXA" = (
 /obj/machinery/camera/network/outside{
 	dir = 8
@@ -1741,9 +1743,6 @@
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "4-10"
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4portafthall)
 "bYQ" = (
@@ -1752,10 +1751,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portamidhall)
 "bYZ" = (
@@ -1805,15 +1804,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
-"cgn" = (
+"cfH" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	alpha = 255;
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightorange/bordercorner{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d4portamidhall)
+"cgn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/endeavour/command/turrets)
@@ -1877,7 +1889,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
-	icon_state = "1-4"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4starboardafthall)
@@ -2011,9 +2023,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
@@ -2165,9 +2174,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "5-6"
-	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4aftmaint)
 "cyR" = (
@@ -2191,17 +2197,14 @@
 /area/rnd/robotics/smallcraft)
 "cAe" = (
 /obj/machinery/holopad,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-10"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai/foyer)
@@ -2209,13 +2212,13 @@
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/endeavour/command/turrets)
 "cBS" = (
@@ -2288,8 +2291,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engineering_monitoring)
 "cGp" = (
-/obj/machinery/atmospherics/component/binary/pump{
-	dir = 4
+/obj/machinery/atmospherics/component/binary/pump/on{
+	dir = 4;
+	name = "Airmix to Portables"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/workshop)
@@ -2347,7 +2351,7 @@
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
@@ -2385,7 +2389,10 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-9"
+	icon_state = "1-2"
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4portafthall)
@@ -2553,7 +2560,7 @@
 "cYd" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/lightorange/border,
-/obj/structure/cable/orange{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
@@ -2714,18 +2721,11 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4portamidhall)
 "dlD" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/lightorange/border{
-	dir = 1
-	},
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/endeavour/hallway/d4portafthall)
+/turf/simulated/floor/plating,
+/area/endeavour/command/turrets)
 "dlI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2772,7 +2772,7 @@
 /area/tcommsat/chamber)
 "dpt" = (
 /obj/structure/cable/orange{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
@@ -2780,7 +2780,9 @@
 /turf/simulated/wall/r_wall/prepainted/engineering,
 /area/engineering/storage)
 "drD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/cap/visible{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "drH" = (
@@ -2930,17 +2932,16 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/portnacelle)
 "dCl" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
+/obj/machinery/door/airlock/highsecurity{
+	name = "Aux Bridge";
+	req_one_access = list()
 	},
-/obj/effect/floor_decal/corner/lightorange/border{
-	dir = 1
+/obj/map_helper/access_helper/airlock/station/command/bridge,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/endeavour/hallway/d4portafthall)
+/turf/simulated/floor/plating,
+/area/endeavour/command/turrets)
 "dCG" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3111,14 +3112,11 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4portamidhall)
 "dRg" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightorange/border{
-	dir = 1
-	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lightorange/border,
+/obj/machinery/light,
 /obj/structure/cable{
-	icon_state = "6-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4portafthall)
@@ -3270,6 +3268,9 @@
 /obj/effect/floor_decal/corner/lightorange/bordercorner2{
 	dir = 9
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4portafthall)
 "edS" = (
@@ -3333,10 +3334,10 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai_upload)
@@ -3476,6 +3477,9 @@
 "emb" = (
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
@@ -3715,9 +3719,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/network/engineering,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4portafthall)
 "eDQ" = (
@@ -4031,14 +4032,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "eUr" = (
-/obj/machinery/power/terminal{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/structure/cable/orange{
-	icon_state = "0-8"
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/cap/visible{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/endeavour/hallway/d4aftmaint)
+/area/engineering/atmos)
 "eWw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/window/reinforced{
@@ -4090,6 +4094,12 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4starboardforhall)
+"eYq" = (
+/obj/machinery/atmospherics/pipe/cap/visible{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "eYL" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -4261,14 +4271,14 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 10
 	},
-/obj/structure/cable{
-	icon_state = "5-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/endeavour/command/turrets)
@@ -4388,6 +4398,9 @@
 /obj/effect/floor_decal/corner/lightorange/bordercorner{
 	dir = 4
 	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
 "fow" = (
@@ -4433,7 +4446,13 @@
 /turf/simulated/floor/bluegrid,
 /area/ai)
 "ful" = (
-/obj/machinery/atmospherics/component/quaternary/atmos_filter,
+/obj/machinery/atmospherics/component/quaternary/mixer{
+	tag_east = 1;
+	tag_west = 1;
+	tag_north = 2;
+	tag_east_con = .79;
+	tag_west_con = .21
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "fuS" = (
@@ -5037,10 +5056,10 @@
 /area/crew_quarters/heads/chief)
 "gmL" = (
 /obj/structure/cable/orange{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /obj/structure/cable/orange{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4starboardhall)
@@ -5204,7 +5223,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engineering_monitoring)
 "gxk" = (
-/obj/machinery/atmospherics/component/quaternary/atmos_filter,
+/obj/machinery/atmospherics/component/quaternary/atmos_filter{
+	tag_west = 2;
+	tag_south = 6;
+	tag_north = 7;
+	tag_east = 1
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -6224,9 +6248,6 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -6235,6 +6256,9 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
@@ -6368,7 +6392,7 @@
 "hLB" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/lightorange/border,
-/obj/structure/cable/orange{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -6593,6 +6617,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4fwdmaint)
+"hUF" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/endeavour/hallway/d4aftmaint)
 "hVq" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -7021,6 +7057,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
+"iCl" = (
+/obj/machinery/atmospherics/component/binary/pump{
+	dir = 8;
+	name = "Mix to Nacelles"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "iCO" = (
 /obj/machinery/camera/network/engineering,
 /obj/machinery/atmospherics/valve/digital{
@@ -7381,6 +7424,8 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/item/storage/toolbox/electrical,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "jbO" = (
@@ -7492,14 +7537,14 @@
 /turf/simulated/floor/plating,
 /area/endeavour/command/turrets)
 "jiQ" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/endeavour/command/turrets)
@@ -7763,7 +7808,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
@@ -7808,6 +7853,15 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4starboardafthall)
+"jxY" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d4portafthall)
 "jyo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7986,9 +8040,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
@@ -8428,7 +8479,11 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4fwdhall)
 "klt" = (
-/obj/machinery/atmospherics/component/quaternary/atmos_filter,
+/obj/machinery/atmospherics/component/quaternary/atmos_filter{
+	tag_east = 1;
+	tag_north = 3;
+	tag_west = 2
+	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
@@ -8484,6 +8539,23 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/engineering/atmos/workshop)
+"kpG" = (
+/obj/machinery/power/smes/buildable/tcomms{
+	RCon_tag = "Secondary Supply";
+	name = "Secondary Supply PSU";
+	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. This is the one dedicated to the secondary power net.";
+	capacity = 8000;
+	charge = 19200;
+	output_level_max = 1500;
+	output_level = 1000;
+	cur_coils = 4;
+	input_attempt = 0
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/endeavour/hallway/d4aftmaint)
 "kqk" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -8517,6 +8589,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/portnacelle)
+"ksD" = (
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/effect/paint/sun,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/endeavour/hallway/d4aftmaint)
 "kts" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -8821,6 +8901,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
 "kMd" = (
@@ -8886,14 +8969,14 @@
 /area/engineering/portnacelle)
 "kRf" = (
 /obj/machinery/holopad,
-/obj/structure/cable{
-	icon_state = "1-10"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/endeavour/command/turrets)
@@ -9011,9 +9094,6 @@
 	},
 /obj/effect/floor_decal/corner/lightorange/bordercorner2{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4portafthall)
@@ -9518,9 +9598,6 @@
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/fire_alarm/north_mount,
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4portafthall)
@@ -9857,6 +9934,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
 "maG" = (
@@ -9976,6 +10056,9 @@
 	req_one_access = null
 	},
 /obj/map_helper/access_helper/airlock/station/external_airlock,
+/obj/machinery/atmospherics/pipe/cap/visible{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos/eva)
 "mgP" = (
@@ -10029,9 +10112,6 @@
 	},
 /obj/effect/floor_decal/corner/lightorange/bordercorner2{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4portafthall)
@@ -10400,7 +10480,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/orange{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel,
@@ -10660,6 +10740,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4starboardhall)
 "mSm" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
 "mTl" = (
@@ -10724,8 +10807,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/endeavour/command/turrets)
@@ -10737,10 +10820,10 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/endeavour/hallway/d4portforhall)
 "nat" = (
-/obj/machinery/atmospherics/pipe/simple/visible/aux{
-	dir = 1
+/obj/machinery/atmospherics/pipe/cap/visible{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "naO" = (
 /obj/effect/floor_decal/corner/navgold/full,
@@ -10917,12 +11000,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/tcommsat/computer)
 "nmO" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/structure/catwalk,
 /obj/structure/cable/green{
 	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
@@ -11200,12 +11283,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4starboardafthall)
 "nAl" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /obj/structure/catwalk,
 /obj/structure/cable/green{
 	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
@@ -11355,6 +11438,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4portafthall)
@@ -11546,6 +11632,9 @@
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/endeavour/command/turrets)
 "nRE" = (
@@ -11617,7 +11706,7 @@
 	dir = 1
 	},
 /obj/machinery/air_alarm/north_mount,
-/obj/structure/cable{
+/obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -11899,7 +11988,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -12011,9 +12100,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_airlock)
 "ovL" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -12141,12 +12227,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/buildable/main{
-	capacity = 8000;
-	charge = 21600;
-	output_level = 1500;
-	output_level_max = 1500;
-	cur_coils = 6;
-	max_coils = 8
+	charge = 9600
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_smes)
@@ -12976,12 +13057,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engineering_monitoring)
 "pSo" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portamidhall)
 "pSM" = (
@@ -13033,10 +13114,15 @@
 /turf/simulated/floor/tiled/monowhite,
 /area/engineering/drone_fabrication)
 "pTX" = (
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/lightorange/border,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/machinery/camera/network/engineering,
 /obj/structure/cable/orange{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4portafthall)
@@ -13194,9 +13280,6 @@
 	},
 /obj/machinery/camera/network/engineering,
 /obj/machinery/air_alarm/north_mount,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4portafthall)
 "qiC" = (
@@ -13226,6 +13309,9 @@
 	},
 /obj/effect/floor_decal/corner/lightorange/bordercorner2{
 	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4portafthall)
@@ -13297,8 +13383,9 @@
 /turf/simulated/wall/prepainted/engineering/atmos,
 /area/engineering/atmos/workshop)
 "qqA" = (
-/obj/machinery/atmospherics/component/binary/pump{
-	dir = 8
+/obj/machinery/atmospherics/component/binary/pump/on{
+	dir = 8;
+	name = "Airmix to Distro"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -13344,6 +13431,15 @@
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/engineering/atmos)
+"qtS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/endeavour/hallway/d4aftmaint)
 "quw" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	frequency = 2346;
@@ -13635,6 +13731,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai/foyer)
 "qPp" = (
@@ -13746,7 +13845,7 @@
 	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai/foyer)
@@ -14112,21 +14211,14 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
 "ryU" = (
-/obj/structure/cable/orange{
-	icon_state = "0-2"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
-/obj/machinery/power/smes/buildable/tcomms{
-	RCon_tag = "SECONDARY SUPPLY";
-	name = "Secondary Supply PSU";
-	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. This is the one dedicated to the secondary power net.";
-	capacity = 8000;
-	charge = 19200;
-	output_level_max = 1500;
-	output_level = 1000;
-	cur_coils = 4
+/obj/machinery/atmospherics/pipe/cap/visible{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/endeavour/hallway/d4aftmaint)
+/area/engineering/atmos)
 "ryY" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
@@ -14142,7 +14234,7 @@
 "rAa" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/power/apc/north_mount,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -14150,12 +14242,15 @@
 "rAt" = (
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/lightorange/bordercorner,
-/obj/structure/cable/orange{
-	icon_state = "2-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
@@ -14656,6 +14751,27 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4starboardafthall)
+"sox" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d4portafthall)
 "spe" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -14785,7 +14901,7 @@
 	charge = 21600;
 	capacity = 8000
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -15249,7 +15365,7 @@
 /area/engineering/atmos/workshop)
 "tfb" = (
 /obj/structure/cable{
-	icon_state = "4-10"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
@@ -15296,6 +15412,9 @@
 	alpha = 255
 	},
 /obj/effect/floor_decal/corner/lightorange/bordercorner2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4portafthall)
 "toe" = (
@@ -15359,6 +15478,13 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/tcommsat/chamber)
+"tqE" = (
+/obj/machinery/atmospherics/component/binary/pump{
+	dir = 1;
+	name = "Scrubbers to Filter"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "tqM" = (
 /obj/machinery/computer/med_data{
 	dir = 1
@@ -15373,9 +15499,6 @@
 /area/endeavour/command/turrets)
 "trF" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
 "tsN" = (
@@ -15463,6 +15586,13 @@
 /obj/effect/shuttle_landmark/endeavour/deck1/port,
 /turf/space,
 /area/space)
+"tBi" = (
+/obj/machinery/atmospherics/component/binary/pump/on{
+	dir = 1;
+	name = "Waste to Filter"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "tBv" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/spline/fancy{
@@ -15622,7 +15752,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "tLQ" = (
-/obj/machinery/atmospherics/component/quaternary/atmos_filter,
+/obj/machinery/atmospherics/component/quaternary/atmos_filter{
+	tag_east = 1;
+	tag_west = 2;
+	tag_north = 5
+	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
@@ -15795,14 +15929,17 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 10
 	},
-/obj/structure/cable{
-	icon_state = "5-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai/foyer)
@@ -15984,9 +16121,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	icon_state = "4-9"
-	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
 "ujN" = (
@@ -16021,6 +16155,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload_foyer)
@@ -16369,6 +16506,9 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4portafthall)
 "uLe" = (
@@ -16389,7 +16529,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4starboardafthall)
@@ -16655,9 +16795,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload_foyer)
 "vgB" = (
@@ -16723,9 +16860,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
 "vip" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
 	icon_state = "pipe-j2"
@@ -17115,16 +17249,10 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4portafthall)
 "vDs" = (
 /obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -17250,9 +17378,7 @@
 	pixel_y = -26
 	},
 /obj/machinery/power/apc/west_mount,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
+/obj/structure/cable,
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload_foyer)
 "vJG" = (
@@ -17323,8 +17449,8 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "vMK" = (
-/obj/machinery/power/breakerbox/activated{
-	RCon_tag = "POINT DEFENSE"
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/command/turrets)
@@ -17592,11 +17718,11 @@
 /obj/machinery/camera/network/command{
 	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/endeavour/command/turrets)
@@ -18405,6 +18531,12 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4portafthall)
 "xbR" = (
@@ -18443,25 +18575,16 @@
 /turf/simulated/wall/r_wall/prepainted/engineering/atmos,
 /area/engineering/atmos/eva)
 "xeb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lightorange/border,
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	alpha = 255
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
+/obj/effect/floor_decal/corner/lightorange/bordercorner2,
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4portafthall)
 "xeH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18602,8 +18725,8 @@
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 5
 	},
-/obj/structure/cable{
-	icon_state = "6-8"
+/obj/structure/cable/orange{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4portafthall)
@@ -19057,11 +19180,16 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/engi_wash)
 "xHf" = (
-/obj/structure/cable{
-	icon_state = "2-5"
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lightorange/border,
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/endeavour/hallway/d4aftmaint)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/endeavour/hallway/d4portafthall)
 "xHG" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -29031,7 +29159,7 @@ ikp
 jBO
 jBO
 jBO
-ikp
+bJi
 eNP
 gIB
 xnV
@@ -29227,8 +29355,8 @@ ren
 pLM
 uBe
 dpt
-xeb
-pTX
+xwJ
+mHH
 nqa
 eGc
 gaf
@@ -29422,7 +29550,7 @@ jhP
 cyd
 kLQ
 jzg
-bJi
+oSP
 nqa
 eGc
 szz
@@ -29613,10 +29741,10 @@ ikp
 dWT
 tFm
 tfb
-ikp
+ksD
 cLC
-xwJ
-cYd
+sox
+bWc
 nqa
 pNL
 jEy
@@ -30584,7 +30712,7 @@ jBO
 tFm
 sIE
 ikp
-eDC
+pTX
 agu
 mEZ
 jnW
@@ -31156,10 +31284,10 @@ nrt
 nrt
 ukW
 emb
-iCe
-aXZ
-ikp
-xHf
+qtS
+uEt
+ksD
+uEt
 uEt
 uEt
 uEt
@@ -31349,9 +31477,9 @@ jCb
 usH
 usH
 ukW
-wom
-eUr
-ren
+hUF
+iCe
+aXZ
 bfk
 pLM
 pLM
@@ -31360,7 +31488,7 @@ pLM
 coP
 jBO
 ikp
-cJh
+iAM
 hEI
 bSj
 vGs
@@ -31543,10 +31671,10 @@ usH
 myq
 kAf
 ukW
-jBO
-ryU
+kpG
+pLM
 coP
-ikp
+bJi
 jBO
 jBO
 jBO
@@ -31554,7 +31682,7 @@ jBO
 jBO
 jBO
 ikp
-dCl
+ihs
 pfR
 tmS
 ppa
@@ -31748,9 +31876,9 @@ gMW
 gMW
 gMW
 gMW
-cJh
+iAM
 kiI
-oSP
+dRg
 ppa
 qTY
 jZF
@@ -31942,9 +32070,9 @@ gMW
 gMW
 gMW
 gMW
-dCl
+ihs
 kiI
-mHH
+cYd
 ppa
 mMn
 jZF
@@ -32136,9 +32264,9 @@ uPE
 glO
 gMW
 gMW
-dlD
+uYJ
 eIN
-xnV
+xHf
 sHl
 vLD
 jZF
@@ -32332,7 +32460,7 @@ gMW
 gMW
 lHh
 kiI
-mHH
+cYd
 sHl
 hDC
 jZF
@@ -32526,7 +32654,7 @@ gMW
 gMW
 qip
 kiI
-kab
+hLB
 sHl
 okW
 jZF
@@ -32718,9 +32846,9 @@ uPE
 tTc
 gMW
 gMW
-dCl
+ihs
 kiI
-mHH
+cYd
 ppa
 vig
 jZF
@@ -32912,9 +33040,9 @@ uPE
 uPE
 gMW
 gMW
-cJh
+iAM
 kiI
-oSP
+dRg
 ppa
 dFF
 jZF
@@ -33300,7 +33428,7 @@ hZm
 irv
 gMW
 gMW
-cJh
+iAM
 kiI
 qjJ
 jQA
@@ -33494,7 +33622,7 @@ uPE
 xvh
 gMW
 gMW
-dCl
+ihs
 kiI
 mSm
 qyK
@@ -33690,7 +33818,7 @@ lcM
 lcM
 eDC
 jAX
-kLQ
+jxY
 ukI
 oxm
 iUe
@@ -34078,7 +34206,7 @@ tRe
 aFz
 trF
 qzY
-xnV
+xHf
 jQA
 dsn
 kBo
@@ -34272,7 +34400,7 @@ tcK
 eLG
 cry
 nwo
-mHH
+cYd
 gGK
 eaq
 kBo
@@ -34466,7 +34594,7 @@ iTa
 lcM
 kXh
 kiI
-kab
+hLB
 gGK
 fEN
 fSI
@@ -34658,9 +34786,9 @@ lcM
 lcM
 lcM
 lcM
-dCl
+ihs
 kiI
-mHH
+cYd
 gGK
 sBU
 kuh
@@ -34852,9 +34980,9 @@ hmF
 tDD
 vLC
 xwk
-cJh
+iAM
 kiI
-oSP
+dRg
 jQA
 dsn
 kuh
@@ -35046,7 +35174,7 @@ qUQ
 fWC
 fWC
 xwk
-dRg
+ihs
 kiI
 ecY
 jQA
@@ -35093,10 +35221,10 @@ mxs
 klt
 eMH
 eMH
-iLQ
-xKs
-xKs
-xKs
+eUr
+eYq
+eYq
+eYq
 xKs
 xKs
 gDj
@@ -35285,7 +35413,7 @@ kwy
 bBE
 jPA
 lEE
-qqA
+iCl
 qqA
 iLQ
 xKs
@@ -35630,7 +35758,7 @@ xwk
 xwk
 sYO
 jIm
-lgy
+xeb
 jQA
 ebp
 wMu
@@ -35868,7 +35996,7 @@ ful
 qRw
 pfc
 sgO
-jPA
+nat
 fVN
 xKs
 xKs
@@ -36018,7 +36146,7 @@ eLf
 dEd
 gFO
 vip
-iJa
+cfH
 gcn
 fgH
 gcn
@@ -36064,7 +36192,7 @@ jLt
 fBC
 vdE
 utR
-xKs
+drD
 xKs
 xKs
 xKs
@@ -36258,7 +36386,7 @@ eUp
 jPu
 eWw
 nmZ
-cWi
+ryU
 cWi
 cWi
 cWi
@@ -36450,8 +36578,8 @@ qwn
 qRw
 lEE
 sFd
+tqE
 gFL
-nat
 jse
 wrG
 tRp
@@ -36644,8 +36772,8 @@ wCy
 coT
 aMT
 ekS
+tBi
 gFL
-drD
 jOw
 njb
 rfg
@@ -37178,10 +37306,10 @@ dvY
 dvY
 wiw
 vMK
-jiL
-jiL
-jiL
-reV
+dlD
+dlD
+dlD
+dCl
 waS
 cBj
 btv

--- a/maps/endeavour/levels/deck4.dmm
+++ b/maps/endeavour/levels/deck4.dmm
@@ -4464,7 +4464,7 @@
 	tag_west = 1;
 	tag_north = 2;
 	tag_east_con = 0.79;
-	tag_west_con = .21
+	tag_west_con = 0.21
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)

--- a/maps/endeavour/levels/deck4.dmm
+++ b/maps/endeavour/levels/deck4.dmm
@@ -824,6 +824,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
+"aQR" = (
+/obj/machinery/atmospherics/pipe/cap/visible{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "aQW" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -1503,6 +1509,13 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
+"bLG" = (
+/obj/machinery/atmospherics/component/binary/pump{
+	dir = 1;
+	name = "Scrubbers to Filter"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "bMd" = (
 /obj/structure/sign/deck/fourth,
 /turf/simulated/wall/r_wall/prepainted/engineering,
@@ -2780,11 +2793,22 @@
 /turf/simulated/wall/r_wall/prepainted/engineering,
 /area/engineering/storage)
 "drD" = (
-/obj/machinery/atmospherics/pipe/cap/visible{
-	dir = 1
+/obj/machinery/power/smes/buildable/tcomms{
+	RCon_tag = "Secondary Supply";
+	name = "Secondary Supply PSU";
+	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. This is the one dedicated to the secondary power net.";
+	capacity = 8000;
+	charge = 19200;
+	output_level_max = 1500;
+	output_level = 1000;
+	cur_coils = 4;
+	input_attempt = 0
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/engineering/atmos)
+/area/endeavour/hallway/d4aftmaint)
 "drH" = (
 /obj/spawner/window/low_wall/borosillicate/reinforced/full/firelocks,
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
@@ -4032,14 +4056,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "eUr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/cap/visible{
-	dir = 8
+/obj/machinery/atmospherics/component/binary/pump/on{
+	dir = 1;
+	name = "Waste to Filter"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -4094,12 +4113,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4starboardforhall)
-"eYq" = (
-/obj/machinery/atmospherics/pipe/cap/visible{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
 "eYL" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -4450,7 +4463,7 @@
 	tag_east = 1;
 	tag_west = 1;
 	tag_north = 2;
-	tag_east_con = .79;
+	tag_east_con = 0.79;
 	tag_west_con = .21
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -6617,18 +6630,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4fwdmaint)
-"hUF" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/endeavour/hallway/d4aftmaint)
 "hVq" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -7057,13 +7058,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
-"iCl" = (
-/obj/machinery/atmospherics/component/binary/pump{
-	dir = 8;
-	name = "Mix to Nacelles"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
 "iCO" = (
 /obj/machinery/camera/network/engineering,
 /obj/machinery/atmospherics/valve/digital{
@@ -7615,6 +7609,13 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/engineering/engineering_monitoring)
+"jlT" = (
+/obj/machinery/atmospherics/component/binary/pump{
+	dir = 8;
+	name = "Mix to Nacelles"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "jmD" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -8539,23 +8540,6 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/engineering/atmos/workshop)
-"kpG" = (
-/obj/machinery/power/smes/buildable/tcomms{
-	RCon_tag = "Secondary Supply";
-	name = "Secondary Supply PSU";
-	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. This is the one dedicated to the secondary power net.";
-	capacity = 8000;
-	charge = 19200;
-	output_level_max = 1500;
-	output_level = 1000;
-	cur_coils = 4;
-	input_attempt = 0
-	},
-/obj/structure/cable/orange{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/endeavour/hallway/d4aftmaint)
 "kqk" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -10191,6 +10175,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d4fwdhall)
+"mpX" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/endeavour/hallway/d4aftmaint)
 "mqz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -10417,6 +10413,15 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4starboardamidhall)
+"mCV" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/cap/visible{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "mEi" = (
 /obj/machinery/atmospherics/component/binary/passive_gate{
 	dir = 8
@@ -10820,11 +10825,14 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/endeavour/hallway/d4portforhall)
 "nat" = (
-/obj/machinery/atmospherics/pipe/cap/visible{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/endeavour/hallway/d4aftmaint)
 "naO" = (
 /obj/effect/floor_decal/corner/navgold/full,
 /turf/simulated/floor/tiled/techfloor,
@@ -13431,15 +13439,6 @@
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/engineering/atmos)
-"qtS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/endeavour/hallway/d4aftmaint)
 "quw" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	frequency = 2346;
@@ -14211,11 +14210,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
 "ryU" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/cap/visible{
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -15378,6 +15374,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4porthall)
+"tkJ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/cap/visible{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "tkV" = (
 /obj/machinery/camera/network/command,
 /turf/simulated/floor/tiled/techfloor,
@@ -15478,13 +15486,6 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/tcommsat/chamber)
-"tqE" = (
-/obj/machinery/atmospherics/component/binary/pump{
-	dir = 1;
-	name = "Scrubbers to Filter"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
 "tqM" = (
 /obj/machinery/computer/med_data{
 	dir = 1
@@ -15586,13 +15587,6 @@
 /obj/effect/shuttle_landmark/endeavour/deck1/port,
 /turf/space,
 /area/space)
-"tBi" = (
-/obj/machinery/atmospherics/component/binary/pump/on{
-	dir = 1;
-	name = "Waste to Filter"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
 "tBv" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/spline/fancy{
@@ -18333,6 +18327,12 @@
 /obj/effect/floor_decal/corner/lightorange/border,
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4porthall)
+"wOD" = (
+/obj/machinery/atmospherics/pipe/cap/visible{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "wPg" = (
 /obj/structure/cable/green{
 	icon_state = "2-4"
@@ -31284,7 +31284,7 @@ nrt
 nrt
 ukW
 emb
-qtS
+nat
 uEt
 ksD
 uEt
@@ -31477,7 +31477,7 @@ jCb
 usH
 usH
 ukW
-hUF
+mpX
 iCe
 aXZ
 bfk
@@ -31671,7 +31671,7 @@ usH
 myq
 kAf
 ukW
-kpG
+drD
 pLM
 coP
 bJi
@@ -35221,10 +35221,10 @@ mxs
 klt
 eMH
 eMH
-eUr
-eYq
-eYq
-eYq
+tkJ
+ryU
+ryU
+ryU
 xKs
 xKs
 gDj
@@ -35413,7 +35413,7 @@ kwy
 bBE
 jPA
 lEE
-iCl
+jlT
 qqA
 iLQ
 xKs
@@ -35996,7 +35996,7 @@ ful
 qRw
 pfc
 sgO
-nat
+wOD
 fVN
 xKs
 xKs
@@ -36192,7 +36192,7 @@ jLt
 fBC
 vdE
 utR
-drD
+aQR
 xKs
 xKs
 xKs
@@ -36386,7 +36386,7 @@ eUp
 jPu
 eWw
 nmZ
-ryU
+mCV
 cWi
 cWi
 cWi
@@ -36578,7 +36578,7 @@ qwn
 qRw
 lEE
 sFd
-tqE
+bLG
 gFL
 jse
 wrG
@@ -36772,7 +36772,7 @@ wCy
 coT
 aMT
 ekS
-tBi
+eUr
 gFL
 jOw
 njb


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reworks a lot of the wiring on Endeavor. A lot of the work is just making it look nice and ensuring all wire junctions are oriented the right way (following any wire from an APC and going in the natural seeming direction will take you to the power source).  Some areas like starboard dorms didn't have power, I wired them up. A few breakers were moved/removed as needed for the ship to function right. The Main SMES was changed from something better than you can build to being a normal Main SMES but with half the starting charge since this ship is designed to use the Secondary Supply SMES for its starting power rather than Main. There was also some shifting of things from one grid to another, e.g. security was moved from the D3 midship grid to the D3 aft grid since it's in the aft of the ship. 

Also sets up the atmos machinery (filters, airmix to distro pump, etc.) to run at a basic level roundstart like on other maps.

## Why It's Good For The Game

Proper wiring makes troubleshooting power issues easier. Having power in all areas is good. Having air circulating is good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: Touches up the power systems on Endeavor
map: Sets up the atmos on Endeavor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
