### PR TITLE
Resurrect Cargonia

### DIFF
--- a/maps/endeavour/levels/deck2.dmm
+++ b/maps/endeavour/levels/deck2.dmm
@@ -19856,21 +19856,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
-"mMY" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor{
-	dir = 1
-	},
-/turf/simulated/open,
-/area/rnd/research/researchdivision)
 "mNh" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fpmaint2)
@@ -21772,18 +21757,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/general)
-"nXl" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor{
-	dir = 1
-	},
-/turf/simulated/open,
-/area/rnd/research/researchdivision)
 "nXm" = (
 /turf/simulated/floor/tiled/dark,
 /area/rnd/anomaly_lab/containment_two)
@@ -52104,8 +52077,8 @@ kCt
 kCt
 cda
 lBS
-mMY
-nXl
+lBS
+lBS
 lBS
 ffI
 vWo

--- a/maps/endeavour/levels/deck3.dmm
+++ b/maps/endeavour/levels/deck3.dmm
@@ -32,9 +32,9 @@
 /area/endeavour/surfacebase/bar_backroom)
 "aaY" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 10
+	dir = 8
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "acd" = (
 /obj/machinery/light_switch{
@@ -55,6 +55,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
+"acL" = (
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/effect/paint_stripe/beastybrown,
+/turf/simulated/floor/plating,
+/area/endeavour/surfacebase/mining_main/break_room)
 "acN" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 1
@@ -121,17 +126,12 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aec" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
+/obj/machinery/air_alarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/effect/floor_decal/corner/navblue/border{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/endeavour/hallway/d3afthall)
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "agG" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
@@ -139,14 +139,14 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/crew_quarters/sleep/Dorm_12)
 "agT" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining_interior"
 	},
-/obj/machinery/sheet_silo{
-	obj_persist_static_id = "sheet-silo-mining"
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/machinery/mineral/output,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/belterdock/refinery)
 "agU" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 4
@@ -161,8 +161,9 @@
 /area/shuttle/belter)
 "agX" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/effect/paint_stripe/beastybrown,
 /turf/simulated/floor/plating,
-/area/maintenance/cargo)
+/area/quartermaster/foyer)
 "ahk" = (
 /obj/structure/closet/wardrobe,
 /turf/simulated/floor/wood,
@@ -244,6 +245,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"akP" = (
+/obj/machinery/atmospherics/component/unary/vent_pump/on,
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "alc" = (
 /obj/structure/table/woodentable,
 /obj/structure/cable/green{
@@ -307,10 +312,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
+"aps" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
+/obj/effect/floor_decal/corner/brown/bordercorner,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "apt" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/turf/simulated/wall/r_wall/prepainted/cargo,
+/area/maintenance/lower/trash_pit)
 "apI" = (
 /turf/simulated/wall/r_wall/prepainted/security,
 /area/security/security_equiptment_storage)
@@ -323,6 +335,11 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/kitchen)
+"apW" = (
+/obj/structure/closet,
+/obj/item/storage/backpack/dufflebag,
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "aqn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -407,23 +424,18 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
 "atw" = (
-/obj/random/trash_pile,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/cargo/mining)
-"atT" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
+"atT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/area/maintenance/bar/lower)
 "aup" = (
 /obj/machinery/computer/guestpass{
 	dir = 1;
@@ -596,18 +608,10 @@
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/evidence_storage)
 "ays" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 9
-	},
 /obj/structure/table/standard,
 /obj/item/hand_labeler,
 /obj/item/hand_labeler,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "ayC" = (
 /obj/structure/toilet{
@@ -686,9 +690,6 @@
 /area/crew_quarters/toilet)
 "aAV" = (
 /obj/structure/closet/l3closet/janitor,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
 "aBl" = (
@@ -735,31 +736,56 @@
 /obj/structure/grille,
 /turf/space,
 /area/space)
+"aDq" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/flora/pottedplant/large,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "aDs" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
-"aDw" = (
-/obj/machinery/mineral/output,
-/obj/effect/floor_decal/industrial/loading{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
+"aDw" = (
+/obj/effect/floor_decal/industrial/outline{
+	color = #D6DBDB
+	},
+/obj/structure/closet/crate/large,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/warehouse)
 "aDU" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 1;
+	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "aFg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -782,15 +808,24 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "aFS" = (
-/obj/machinery/light,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	dir = 8
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 1
+	},
+/obj/machinery/power/apc/north_mount,
+/obj/structure/cable/green{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/uxstorage)
+/area/endeavour/surfacebase/mining_main/break_room)
 "aGh" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -837,8 +872,21 @@
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aGE" = (
-/turf/simulated/wall/r_wall/prepainted/cargo,
-/area/maintenance/cargo/mining)
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
+"aGI" = (
+/obj/effect/floor_decal/industrial/outline{
+	color = #D6DBDB
+	},
+/obj/structure/closet/crate/engineering,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/warehouse)
 "aGV" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -881,6 +929,15 @@
 	},
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/security/range)
+"aHY" = (
+/obj/machinery/sheet_silo{
+	obj_persist_static_id = "sheet-silo-mining"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/belterdock/refinery)
 "aId" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -922,7 +979,7 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
 "aIZ" = (
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "aKg" = (
 /obj/machinery/washing_machine,
@@ -941,6 +998,10 @@
 	},
 /turf/simulated/floor/airless/ceiling,
 /area/endeavour/command/turrets)
+"aKx" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/wood,
+/area/quartermaster/office)
 "aKD" = (
 /obj/structure/catwalk,
 /obj/machinery/door/airlock/maintenance,
@@ -1064,14 +1125,15 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/game_room)
 "aOG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/warehouse)
+"aOQ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "aPr" = (
 /obj/structure/cable/orange{
 	icon_state = "1-8"
@@ -1117,6 +1179,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/endeavour/station/stairs_three)
+"aRN" = (
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "aTm" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -1136,6 +1204,12 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/bar/catwalk)
+"aUe" = (
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "aUp" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 8
@@ -1159,8 +1233,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
-/area/endeavour/station/stairs_three)
+/area/maintenance/bar/lower)
 "aVb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1271,6 +1348,27 @@
 /obj/map_helper/access_helper/airlock/station/security/department,
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
+"aXm" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining_interior";
+	name = "refining conveyor";
+	pixel_y = 2;
+	pixel_x = -11
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/belterdock/refinery)
+"aXu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "aXy" = (
 /obj/machinery/light{
 	dir = 1
@@ -1352,6 +1450,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"baY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "bbp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -1496,6 +1601,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/bedrooms)
+"beJ" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "bfd" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -1585,17 +1699,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "bgH" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "mining_interior"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/machinery/camera/network/cargo,
-/obj/machinery/mineral/output,
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/endeavour/surfacebase/mining_main/refinery)
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "bgM" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -1627,11 +1738,9 @@
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/evidence_storage)
 "bhw" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/carpet/bcarpet,
+/area/quartermaster/qm)
 "bhC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -1659,12 +1768,12 @@
 /turf/simulated/floor,
 /area/security/brig)
 "bhP" = (
-/obj/machinery/mineral/processing_unit_console{
-	density = 0;
-	pixel_y = 30
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/structure/flora/grass/event/generic_bush1,
+/turf/simulated/floor/grass,
+/area/quartermaster/warehouse)
 "bhQ" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -1702,6 +1811,23 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
+"bjC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3afthall)
 "bjQ" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -1747,21 +1873,11 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portamidhall)
 "blB" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/machinery/fire_alarm/south_mount{
-	pixel_y = -24
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
 	},
-/obj/machinery/camera/network/cargo{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/belterdock)
 "blM" = (
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
@@ -1791,6 +1907,14 @@
 "bmr" = (
 /turf/simulated/floor/carpet,
 /area/crew_quarters/sleep/Dorm_10)
+"bmR" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining_interior"
+	},
+/obj/machinery/mineral/input,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/belterdock/refinery)
 "bmY" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/starboardsolar)
@@ -1837,17 +1961,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "boI" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "boM" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -1904,16 +2028,17 @@
 /turf/simulated/floor/tiled/monotile,
 /area/endeavour/hallway/d3afthall)
 "bqs" = (
-/obj/machinery/computer/ship/navigation/telescreen{
-	pixel_y = -37
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/camera/network/cargo{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "brs" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -2064,12 +2189,13 @@
 /area/endeavour/hallway/d3afthall)
 "buX" = (
 /obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 1
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/bar/lower)
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "bvs" = (
 /obj/machinery/air_alarm{
 	dir = 4;
@@ -2078,14 +2204,8 @@
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/security_processing)
 "bvE" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining{
-	name = "Quartermaster";
-	req_one_access = list()
-	},
-/obj/map_helper/access_helper/airlock/station/head_office/quartermaster,
-/turf/simulated/floor/tiled,
-/area/quartermaster/qm)
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "bvI" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2117,17 +2237,14 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3portforhall)
 "bxW" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/railing{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
 "byF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -2373,12 +2490,27 @@
 /turf/simulated/floor/plating,
 /area/endeavour/command/turrets)
 "bHV" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "mining_interior"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/structure/bed/chair/sofa/black,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
+"bIf" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "bIs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2397,6 +2529,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
+"bIZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/bcarpet,
+/area/quartermaster/qm)
 "bJy" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/map_helper/access_helper/airlock/station/engineering/department,
@@ -2417,13 +2556,37 @@
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
-"bJS" = (
-/obj/machinery/air_alarm{
-	dir = 8;
-	pixel_x = 25
+"bJJ" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/foyer)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	use_power = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
+"bJS" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "belter_docking";
+	name = "Belting Dock Controller";
+	pixel_x = 1;
+	pixel_y = -24;
+	req_one_access = list(13,31)
+	},
+/obj/structure/table/reinforced,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "bKx" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
@@ -2474,16 +2637,16 @@
 /area/security/detectives_office)
 "bMN" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad2"
-	},
 /obj/machinery/shield_diffuser,
 /obj/map_helper/airlock/door/simple,
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/external_airlock,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad"
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/warehouse)
 "bNb" = (
@@ -2518,17 +2681,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "bOW" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/computer/roguezones,
 /turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/area/quartermaster/qm)
 "bPg" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/landmark/spawnpoint/job/cargo_technician,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "bPr" = (
 /turf/simulated/wall/r_wall/prepainted/security,
 /area/security/security_lockerroom)
@@ -2592,6 +2751,35 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/fitness)
+"bSl" = (
+/obj/item/storage/box/nifsofts_mining{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/item/suit_cooling_unit{
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/obj/item/suit_cooling_unit{
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/obj/item/duct_tape_roll{
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/item/stack/flag/green{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/stack/flag/green{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "bSQ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2603,16 +2791,10 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "bTA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "bUa" = (
 /obj/effect/floor_decal/borderfloor,
@@ -2752,6 +2934,18 @@
 "bWK" = (
 /turf/simulated/wall/prepainted,
 /area/endeavour/station/stairs_three)
+"bWZ" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "bXD" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/effect/paint/palebottlegreen,
@@ -2784,6 +2978,18 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/endeavour/hallway/d3afthall)
+"bYG" = (
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "bYP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -2823,6 +3029,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/lobby)
+"caf" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/grass/event/sunny_bush1,
+/turf/simulated/floor/grass/indoors,
+/area/quartermaster/foyer)
 "caA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2850,14 +3066,15 @@
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
 "ccA" = (
-/obj/structure/ore_box,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/power/apc/south_mount,
-/obj/structure/cable/green{
-	icon_state = "0-4"
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "cdy" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 4
@@ -2948,6 +3165,10 @@
 "chh" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/security/lobby)
+"cic" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
 "cih" = (
 /obj/machinery/camera/network/outside{
 	dir = 1
@@ -2998,31 +3219,49 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_9)
-"cmi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+"cln" = (
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/machinery/door/airlock/glass/mining{
+	name = "Mining Prep Room";
+	req_one_access = null
 	},
-/obj/spawner/window/low_wall/reinforced/full/firelocks,
-/turf/simulated/floor/plating,
-/area/maintenance/cargo/mining)
+/obj/map_helper/access_helper/airlock/station/supply/mining,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/refinery)
+"cmi" = (
+/obj/machinery/mineral/processing_unit_console{
+	density = 0;
+	pixel_y = -33;
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/belterdock/refinery)
 "cmw" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/effect/paint_stripe/beastybrown,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "cmE" = (
-/obj/machinery/camera/network/cargo,
-/obj/structure/table/standard,
-/obj/item/stamp/cargo,
-/obj/item/stamp/denied{
-	pixel_x = 7
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
-/obj/item/stamp/qm{
-	pixel_x = -6
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/obj/machinery/air_alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "cmR" = (
 /obj/structure/bed/chair/shuttle,
 /obj/structure/closet/walllocker/emerglocker/north,
@@ -3065,6 +3304,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
+"coj" = (
+/obj/machinery/light{
+	dir = 8;
+	light_range = 12
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "com" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3164,6 +3410,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/security/security_lockerroom)
+"csA" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "ctb" = (
 /obj/machinery/computer/shuttle_control/belter{
 	dir = 4
@@ -3254,6 +3513,10 @@
 "cuJ" = (
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
+"cuY" = (
+/obj/machinery/light,
+/turf/simulated/wall/prepainted,
+/area/endeavour/station/stairs_three)
 "cvA" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -3293,11 +3556,12 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "cyG" = (
-/obj/machinery/camera/network/cargo{
-	dir = 4
+/obj/machinery/status_display/supply_display{
+	pixel_x = -32;
+	pixel_y = 0
 	},
 /turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/area/quartermaster/qm)
 "czc" = (
 /turf/simulated/wall/r_wall/prepainted/security,
 /area/security/forensics)
@@ -3309,8 +3573,10 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
 "czr" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/obj/landmark/spawnpoint/job/cargo_technician,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "cAj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3425,12 +3691,21 @@
 /turf/simulated/floor/tiled,
 /area/security/hanger)
 "cDv" = (
-/obj/machinery/station_map{
-	dir = 4;
-	pixel_x = -32
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
+"cEj" = (
+/obj/machinery/vending/nifsoft_shop,
+/obj/machinery/camera/network/cargo{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "cEz" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3456,6 +3731,22 @@
 /obj/structure/railing,
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
+"cFA" = (
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "cFD" = (
 /obj/machinery/holopad,
 /turf/simulated/floor/tiled/monodark,
@@ -3600,17 +3891,17 @@
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/sleep/Dorm_1)
 "cJJ" = (
-/obj/machinery/air_alarm{
-	pixel_y = 22
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
 	},
-/obj/structure/ore_box,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 6
 	},
-/obj/machinery/camera/network/cargo,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/uxstorage)
+/obj/structure/bed/chair/sofa/black/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "cKe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3726,12 +4017,42 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "cNA" = (
-/obj/machinery/power/apc/north_mount,
-/obj/structure/cable/green{
-	icon_state = "0-2"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 20
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
+"cNV" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 4
+	},
+/obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/area/endeavour/surfacebase/mining_main/break_room)
 "cPE" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -3829,6 +4150,10 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/airless,
 /area/shuttle/mining_ship/general)
+"cRY" = (
+/obj/machinery/air_alarm/west_mount,
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "cSd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -3938,9 +4263,6 @@
 /turf/simulated/floor/plating,
 /area/security/warden)
 "cVy" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
@@ -3956,6 +4278,21 @@
 	},
 /turf/simulated/floor/grass,
 /area/security/brig)
+"cWN" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "cXt" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4096,14 +4433,29 @@
 /turf/simulated/floor/tiled/dark,
 /area/prison/cell_block)
 "daE" = (
-/obj/machinery/camera/network/cargo{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "daO" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/sleep/Dorm_4)
+"dbb" = (
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "dbt" = (
 /obj/structure/table/marble,
 /obj/item/flame/candle,
@@ -4159,14 +4511,15 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "dcu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/structure/bed/chair/comfy/black,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "dcx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4217,6 +4570,10 @@
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/interrogation)
+"dei" = (
+/obj/landmark/spawnpoint/job/shaft_miner,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "deo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -4227,14 +4584,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
 "des" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/mining{
-	name = "Cargo Bay";
-	req_one_access = null
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "deC" = (
 /obj/machinery/fire_alarm/south_mount{
 	pixel_y = -24
@@ -4348,10 +4708,10 @@
 /area/security/breakroom)
 "dgn" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 9
+	dir = 10
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/belterdock)
 "dgB" = (
 /obj/machinery/holopad,
 /obj/machinery/light{
@@ -4459,6 +4819,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
+"diM" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "diV" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 9
@@ -4466,11 +4834,9 @@
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/hanger)
 "djB" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/bcarpet,
+/area/quartermaster/qm)
 "dkj" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 8
@@ -4550,6 +4916,12 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/sleep/Dorm_9)
+"dmT" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/air_alarm/south_mount,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "dnk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4566,12 +4938,6 @@
 /area/endeavour/hallway/d3starboardafthall)
 "dns" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/navblue/bordercorner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -4778,11 +5144,17 @@
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/interrogation)
 "dyR" = (
-/obj/machinery/power/apc/west_mount,
-/obj/structure/cable/green{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "dyV" = (
 /turf/simulated/floor/tiled/white,
@@ -4864,6 +5236,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
+"dBd" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/endeavour/surfacebase/mining_main/break_room)
 "dBi" = (
 /turf/simulated/wall/prepainted/security,
 /area/security/security_lockerroom)
@@ -4930,6 +5311,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
+"dDu" = (
+/obj/structure/filingcabinet{
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/machinery/keycard_auth{
+	pixel_y = -28
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/quartermaster/qm)
 "dER" = (
 /obj/structure/flora/pottedplant/large,
 /obj/effect/floor_decal/borderfloorblack{
@@ -5019,9 +5410,12 @@
 /turf/simulated/floor/wood,
 /area/endeavour/hallway/d3fwdhall)
 "dHW" = (
-/obj/machinery/atmospherics/component/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
+	},
+/obj/structure/flora/grass/event/generic_bush1,
+/turf/simulated/floor/grass,
+/area/quartermaster/warehouse)
 "dHX" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -5069,7 +5463,8 @@
 /area/crew_quarters/kitchen)
 "dJV" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	pixel_y = 20
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5110,10 +5505,25 @@
 /area/crew_quarters/sleep/Dorm_12)
 "dLj" = (
 /obj/structure/cable/green{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
+"dLz" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "dMA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5289,14 +5699,11 @@
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/security_processing)
 "dPs" = (
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/fire_alarm/south_mount{
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "dPF" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 1
@@ -5306,6 +5713,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
+"dQv" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "dRK" = (
 /obj/structure/table/woodentable,
 /obj/machinery/microwave,
@@ -5359,10 +5776,16 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "QMLoad"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	id = "QMLoad2"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "dSy" = (
 /obj/machinery/door/blast/regular{
@@ -5421,12 +5844,21 @@
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/kitchen)
-"dTQ" = (
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	dir = 1
+"dTq" = (
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/grass/event/sparse_grass2,
+/turf/simulated/floor/grass/indoors,
+/area/quartermaster/foyer)
+"dTQ" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
+/obj/effect/floor_decal/corner/brown/bordercorner,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "dTT" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
@@ -5652,8 +6084,23 @@
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
+"dZI" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "eau" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorblack,
@@ -5751,8 +6198,16 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_13)
 "edk" = (
-/obj/machinery/mech_recharger,
-/turf/simulated/floor/tiled,
+/obj/landmark{
+	name = "blobstart"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "edp" = (
 /obj/structure/cable/green{
@@ -5842,16 +6297,17 @@
 /turf/simulated/floor/wood,
 /area/maintenance/dormitory)
 "egp" = (
-/obj/machinery/door/firedoor{
-	dir = 8
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Prep Room";
-	req_one_access = null
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
 	},
-/obj/map_helper/access_helper/airlock/station/supply/mining,
+/obj/machinery/camera/network/cargo,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled,
-/area/quartermaster/miningdock)
+/area/endeavour/surfacebase/mining_main/break_room)
 "egw" = (
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/sleep/Dorm_3)
@@ -5928,6 +6384,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
 "ejd" = (
@@ -5941,11 +6400,33 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
 "ejk" = (
+/obj/structure/dogbed,
+/mob/living/simple_mob/animal/sif/fluffy,
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/area/quartermaster/qm)
+"ejp" = (
+/obj/machinery/power/apc/north_mount,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/camera/network/cargo,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "ekc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -5956,19 +6437,9 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "ekD" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window{
-	dir = 8;
-	req_one_access = list(31)
-	},
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 4
-	},
-/obj/item/folder/white,
-/obj/item/pen,
-/turf/simulated/floor/tiled/monotile,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/effect/paint/beastybrown,
+/turf/simulated/floor/plating,
 /area/quartermaster/delivery)
 "ekH" = (
 /turf/simulated/wall/prepainted,
@@ -5992,6 +6463,10 @@
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/sleep/Dorm_11)
+"emx" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "emK" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6120,7 +6595,7 @@
 	req_one_access = null
 	},
 /obj/map_helper/access_helper/airlock/station/external_airlock,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/reinforced,
 /area/quartermaster/warehouse)
 "eqa" = (
 /obj/spawner/window/low_wall/full/firelocks,
@@ -6213,10 +6688,8 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "esB" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/uxstorage)
+/turf/simulated/wall/prepainted/cargo,
+/area/maintenance/lower/trash_pit)
 "esO" = (
 /obj/structure/bed/chair/comfy/teal,
 /obj/machinery/light_switch{
@@ -6259,10 +6732,9 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "etR" = (
-/obj/spawner/window/low_wall/reinforced/full/firelocks,
-/obj/effect/paint_stripe/beastybrown,
-/turf/simulated/floor/plating,
-/area/quartermaster/qm)
+/obj/machinery/vending/cola,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "etU" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -6283,16 +6755,11 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "etZ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central6{
-	dir = 4
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/item/duct_tape_roll,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "eum" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6309,12 +6776,11 @@
 /turf/simulated/floor/airless,
 /area/shuttle/mining_ship/general)
 "evc" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "evi" = (
 /obj/item/bedsheet/browndouble,
 /obj/structure/bed/double/padded,
@@ -6352,8 +6818,10 @@
 /turf/simulated/floor/wood,
 /area/security/breakroom)
 "ewr" = (
-/obj/machinery/light{
-	dir = 1
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
 	},
 /turf/simulated/floor/tiled/dark,
 /area/endeavour/hallway/d3afthall)
@@ -6413,6 +6881,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
+"exh" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/belterdock)
 "eyh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6531,13 +7003,23 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
 "eBl" = (
-/obj/structure/ore_box,
-/turf/simulated/floor/tiled/steel,
-/area/shuttle/belter)
+/obj/machinery/fire_alarm/east_mount,
+/turf/simulated/floor/tiled/dark,
+/area/endeavour/station/stairs_three)
 "eBs" = (
-/obj/machinery/mineral/unloading_machine,
-/turf/simulated/floor/tiled/steel_grid,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 9
+	},
+/obj/machinery/camera/network/cargo{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "eBO" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
@@ -6636,6 +7118,12 @@
 /obj/structure/sign/deck/third,
 /turf/simulated/wall/prepainted,
 /area/endeavour/station/stairs_three)
+"eCy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "eCE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6712,9 +7200,17 @@
 /turf/simulated/floor/wood,
 /area/endeavour/hallway/d3fwdhall)
 "eFf" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "eFA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6774,18 +7270,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "eHs" = (
-/obj/machinery/recharge_station,
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/window/reinforced/survival_pod,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "eHQ" = (
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_x = -32
@@ -6809,12 +7298,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/mining_ship/general)
 "eIB" = (
-/obj/structure/closet/hydrant{
-	pixel_x = 32
-	},
-/obj/machinery/vending/snack,
+/obj/structure/cable/green,
+/obj/machinery/power/apc/west_mount,
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/quartermaster/belterdock)
 "eIC" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -6864,17 +7351,40 @@
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3fwdmaint)
-"eKq" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate,
-/obj/machinery/power/apc/west_mount{
-	cell_type = /obj/item/cell/super
-	},
+"eJS" = (
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/machinery/holopad,
 /obj/structure/cable/green{
-	icon_state = "0-4"
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
+"eKq" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/office)
+"eKM" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 10
+	},
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/turf/simulated/floor/wood,
+/area/endeavour/surfacebase/mining_main/break_room)
 "eLl" = (
 /obj/machinery/door/airlock/maintenance/sec{
 	req_one_access = null
@@ -6939,6 +7449,22 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/hallway)
+"eMH" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3portforhall)
 "eMM" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -6983,9 +7509,10 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_2)
 "eNB" = (
-/obj/spawner/window/low_wall/full/nogrille/firelocks,
-/obj/effect/paint/beastybrown,
-/turf/simulated/floor/plating,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "eNE" = (
 /obj/structure/cable/green{
@@ -7008,14 +7535,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
 "ePB" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/computer/card{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/area/quartermaster/qm)
 "ePI" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 9
@@ -7134,16 +7658,25 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3portamidhall)
+"eVc" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "eVd" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Kitchen"
+	},
 /obj/map_helper/access_helper/airlock/station/service/kitchen,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner_oldtile/white/diagonal,
-/obj/machinery/door/airlock/civilian{
-	name = "Kitchen"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "eVt" = (
@@ -7188,15 +7721,12 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portamidhall)
 "eWe" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/effect/floor_decal/industrial/outline{
+	color = #D6DBDB
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/uxstorage)
+/obj/structure/closet/crate/medical,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/warehouse)
 "eWz" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -7299,18 +7829,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
 "eZz" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/map_helper/access_helper/airlock/station/supply/department,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Warehouse"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "eZW" = (
 /turf/simulated/wall/prepainted,
 /area/endeavour/hallway/d3portforhall)
@@ -7426,16 +7957,17 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portamidhall)
 "feq" = (
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/qm)
+/obj/machinery/mineral/mint,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "feE" = (
-/obj/machinery/camera/network/cargo{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "feQ" = (
 /obj/structure/cable{
@@ -7463,12 +7995,15 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "ffP" = (
-/obj/machinery/vending/cola,
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
-"ffW" = (
-/turf/simulated/wall/prepainted/cargo,
+/obj/machinery/computer/supplycomp/control{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
 /area/quartermaster/office)
+"ffW" = (
+/obj/machinery/atmospherics/component/unary/vent_pump/on,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "fgj" = (
 /obj/machinery/camera/network/civilian{
 	dir = 1
@@ -7530,7 +8065,11 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "fil" = (
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline{
+	color = #D6DBDB
+	},
+/obj/structure/closet/crate/plastic,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/warehouse)
 "fip" = (
 /obj/structure/cable/green{
@@ -7620,25 +8159,13 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
 "fjp" = (
-/obj/machinery/power/apc/north_mount,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/camera/network/cargo,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/structure/flora/pottedplant/small{
+	pixel_x = 0;
+	pixel_y = 11
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/belterdock)
 "fju" = (
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
@@ -7655,12 +8182,18 @@
 /turf/simulated/floor/wood,
 /area/endeavour/hallway/d3fwdhall)
 "fko" = (
-/obj/structure/table/reinforced,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/tank/jetpack/oxygen,
+/obj/machinery/air_alarm{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/reinforced,
 /area/quartermaster/miningdock)
 "fkv" = (
@@ -7713,6 +8246,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
+"fln" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "flr" = (
 /obj/structure/toilet{
 	dir = 1
@@ -7723,8 +8268,15 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
 "flt" = (
-/turf/simulated/floor/airless/ceiling,
-/area/maintenance/cargo)
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/structure/bed/chair/sofa/black,
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "flS" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -7736,10 +8288,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "fmj" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate/engineering,
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "fmB" = (
 /obj/machinery/air_alarm{
 	dir = 1;
@@ -7913,21 +8469,27 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "fvb" = (
-/obj/machinery/air_alarm{
-	pixel_y = 22
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/suit_storage_unit/mining,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "fvQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -7936,6 +8498,18 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
+"fwo" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 8
+	},
+/obj/map_helper/access_helper/airlock/station/supply/mining,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/quartermaster/belterdock/refinery)
 "fxn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8065,29 +8639,30 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
+"fDh" = (
+/obj/machinery/computer/supplycomp/control,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "fDt" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/machinery/mineral/processing_unit,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/belterdock/refinery)
 "fDw" = (
 /obj/structure/lattice,
 /turf/space/basic,
 /area/space)
+"fEf" = (
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/item/stool/padded,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/landmark/spawnpoint/job/shaft_miner,
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "fEj" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -8121,6 +8696,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
+"fFy" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "fFB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -8169,20 +8760,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/starboardsolar)
+"fJk" = (
+/obj/landmark/spawnpoint/job/quartermaster,
+/obj/machinery/light,
+/turf/simulated/floor/carpet/bcarpet,
+/area/quartermaster/qm)
 "fJl" = (
-/obj/structure/noticeboard{
-	pixel_y = 32
+/obj/structure/table/steel_reinforced,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 0;
+	pixel_y = 7
 	},
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/floor_decal/borderfloor{
-	dir = 9
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 0;
+	pixel_y = 3
 	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "fJn" = (
 /obj/machinery/light{
 	dir = 1
@@ -8200,6 +8794,14 @@
 "fJN" = (
 /turf/simulated/wall/r_wall/prepainted/security,
 /area/security/armoury)
+"fKc" = (
+/obj/machinery/hyperpad/centre{
+	map_pad_id = "lavaland_station";
+	map_pad_link_id = "lavaland_away";
+	newcolor = "#fcba03"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/belterdock)
 "fKI" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -8331,8 +8933,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "fLU" = (
-/turf/simulated/wall/prepainted/cargo,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/structure/lattice,
+/turf/space/basic,
+/area/endeavour/command/turrets)
 "fMA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -8630,6 +9233,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"fRy" = (
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/machinery/suit_cycler/mining,
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "fSo" = (
 /obj/machinery/door/airlock{
 	id_tag = "dorm2";
@@ -8694,7 +9302,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/belter)
 "fTU" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
 "fUc" = (
@@ -8876,13 +9488,14 @@
 /turf/simulated/floor/plating,
 /area/security/interrogation)
 "fYy" = (
-/obj/machinery/door/firedoor{
-	dir = 8
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/obj/spawner/window/low_wall/reinforced/full,
-/obj/effect/paint/beastybrown,
-/turf/simulated/floor/plating,
-/area/endeavour/surfacebase/mining_main/uxstorage)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "fYR" = (
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/evidence_storage)
@@ -8890,7 +9503,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence_storage)
 "gal" = (
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "gaU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8972,13 +9591,35 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
-"gdU" = (
-/obj/machinery/light_switch{
-	pixel_x = 25
+"gdM" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
 	},
-/obj/machinery/computer/card,
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2,
+/obj/effect/floor_decal/corner/brown/bordercorner2,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
+"gdU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/maintenance/bar/lower)
+"gdX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "gea" = (
 /obj/structure/table/marble,
 /obj/item/reagent_containers/food/condiment/spacespice{
@@ -9193,7 +9834,8 @@
 /area/endeavour/hallway/d3portforhall)
 "gmZ" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	pixel_y = 20
 	},
 /turf/simulated/floor/reinforced,
 /area/quartermaster/miningdock)
@@ -9207,16 +9849,10 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
 "gnO" = (
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Prep Room";
-	req_one_access = null
-	},
-/obj/map_helper/access_helper/airlock/station/supply/mining,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
 /turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/area/endeavour/surfacebase/mining_main/break_room)
 "goa" = (
 /obj/landmark/spawnpoint/latejoin/station/cyborg,
 /turf/simulated/floor/tiled/techfloor,
@@ -9306,35 +9942,30 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
 "gqw" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/status_display/supply_display{
+	mode = 99;
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "gqN" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
 "gqQ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Prep Room";
-	req_one_access = null
-	},
-/obj/map_helper/access_helper/airlock/station/supply/mining,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "gqT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9377,6 +10008,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
+"gsj" = (
+/obj/machinery/camera/network/cargo{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "gtD" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/cable/orange{
@@ -9416,10 +10053,11 @@
 /turf/space,
 /area/space)
 "gtZ" = (
-/obj/spawner/window/low_wall/reinforced/full/firelocks,
-/obj/effect/paint/beastybrown,
-/turf/simulated/floor/plating,
-/area/quartermaster/office)
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "gug" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9668,8 +10306,14 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "gGm" = (
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/delivery)
+/obj/machinery/light,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/ore_box,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "gHM" = (
 /turf/simulated/floor/tiled,
 /area/hydroponics)
@@ -9746,13 +10390,9 @@
 /turf/simulated/floor/tiled,
 /area/security/range)
 "gLK" = (
-/obj/item/storage/toolbox/mechanical,
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "gLQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9772,17 +10412,14 @@
 /turf/simulated/floor/wood,
 /area/endeavour/surfacebase/bar_backroom)
 "gLZ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "gMc" = (
 /obj/spawner/window/reinforced/full/firelocks,
@@ -9846,14 +10483,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/security)
 "gNj" = (
-/turf/simulated/wall/prepainted/cargo,
-/area/quartermaster/qm)
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/effect/paint_stripe/beastybrown,
+/turf/simulated/floor/plating,
+/area/quartermaster/belterdock)
 "gNV" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central6{
-	dir = 4
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "gNZ" = (
 /obj/machinery/door/airlock/civilian{
 	name = "Game Room"
@@ -9900,22 +10539,15 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "gQF" = (
-/obj/machinery/door/firedoor{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/cargo/mining)
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/brown/bordercorner,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "gRa" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -9947,6 +10579,18 @@
 /obj/item/material/ashtray/glass,
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/game_room)
+"gRl" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "gRy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9989,13 +10633,15 @@
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/security_processing)
 "gSF" = (
-/obj/structure/ore_box,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/uxstorage)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/machinery/air_alarm/north_mount,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "gSH" = (
 /obj/machinery/fire_alarm/south_mount{
 	pixel_y = -24
@@ -10049,6 +10695,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
+"gTv" = (
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "gUM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10115,13 +10768,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/bedrooms)
-"gXm" = (
+"gWf" = (
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/obj/landmark/spawnpoint/job/cargo_technician,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
+"gXm" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "gXN" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -10269,16 +10939,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)
 "hcH" = (
-/obj/machinery/requests_console/preset/cargo{
-	pixel_x = 30
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/air_alarm{
+	pixel_y = 22
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -1;
+	pixel_y = 2
 	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood,
 /area/quartermaster/office)
 "hdd" = (
 /obj/structure/cable/green{
@@ -10296,12 +10965,11 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
 "hdh" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/sign/directions/evac{
 	dir = 8
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/cargo/mining)
+/turf/simulated/wall/prepainted/civilian,
+/area/crew_quarters/kitchen)
 "hdY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10336,18 +11004,14 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
 "heJ" = (
-/obj/machinery/mineral/input,
-/obj/effect/floor_decal/industrial/loading,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "heO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/spawner/window/low_wall/reinforced/full/firelocks,
-/turf/simulated/floor/plating,
-/area/maintenance/cargo/mining)
+/turf/simulated/floor/carpet/bcarpet,
+/area/quartermaster/qm)
 "hgm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -10427,13 +11091,12 @@
 /area/security/hallway)
 "hkm" = (
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "hky" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -10468,11 +11131,13 @@
 /turf/simulated/wall/prepainted/civilian,
 /area/endeavour/hallway/d3aftmaint)
 "hlc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/mineral/output,
+/obj/effect/floor_decal/industrial/loading{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/qm)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "hlx" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -10501,9 +11166,13 @@
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "hmk" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/quartermaster/office)
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "hmF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -10613,21 +11282,27 @@
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/showers)
 "hrc" = (
-/obj/machinery/computer/supplycomp{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
-"hrS" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
-/obj/structure/catwalk,
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/map_helper/access_helper/airlock/station/supply/department,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Warehouse"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
+"hrS" = (
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/effect/paint/beastybrown,
 /turf/simulated/floor/plating,
-/area/maintenance/cargo/mining)
+/area/quartermaster/foyer)
 "hrV" = (
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
@@ -10638,6 +11313,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"hsc" = (
+/obj/map_helper/access_helper/airlock/station/supply/mining,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Refinery"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/monotile,
+/area/endeavour/surfacebase/mining_main/break_room)
 "hsr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10700,10 +11389,19 @@
 /area/endeavour/hallway/d3portforhall)
 "hus" = (
 /obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad2"
+	dir = 4;
+	id = "QMLoad"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "huy" = (
 /obj/structure/disposalpipe/segment{
@@ -10805,8 +11503,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "hwP" = (
-/turf/simulated/wall/prepainted/cargo,
-/area/maintenance/cargo/mining)
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/structure/bed/chair/sofa/black/left,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "hxO" = (
 /obj/machinery/door/airlock/glass_external{
 	frequency = 1379;
@@ -10849,12 +11558,9 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
 "hzi" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "hzs" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/light{
@@ -10923,30 +11629,21 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/sleep/Dorm_9)
 "hDl" = (
-/obj/machinery/camera/network/cargo,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
-"hDH" = (
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/disposalpipe/segment{
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/bar/lower)
+/obj/structure/flora/grass/event/bright_flowers1,
+/turf/simulated/floor/grass,
+/area/quartermaster/warehouse)
+"hDH" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance,
+/obj/map_helper/access_helper/airlock/station/supply/mining,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "hEc" = (
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/entertainment)
@@ -10998,6 +11695,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/endeavour/hallway/d3fwdmaint)
+"hGE" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "hHe" = (
 /obj/structure/bed/chair/sofa/black/right{
 	dir = 1
@@ -11063,20 +11768,11 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "hJm" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/glass/mining{
-	id_tag = "cargodoor";
-	name = "Cargo Office";
-	req_one_access = list()
-	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood,
 /area/quartermaster/office)
 "hJR" = (
 /obj/machinery/holopad,
@@ -11153,13 +11849,20 @@
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/entertainment)
 "hLw" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner_oldtile/white/diagonal,
-/obj/machinery/light,
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
-/area/crew_quarters/kitchen)
+/area/quartermaster/foyer)
 "hLN" = (
 /obj/machinery/camera/network/civilian{
 	dir = 1
@@ -11174,6 +11877,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
+"hLV" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/flora/pottedplant/minitree,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "hMc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11245,12 +11954,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/riot_control)
 "hOq" = (
-/obj/structure/stairs/spawner/south,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "hOu" = (
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/red/bordercorner,
@@ -11363,13 +12070,13 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portamidhall)
 "hUF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "hVe" = (
 /obj/machinery/camera/network/civilian{
@@ -11413,11 +12120,13 @@
 /turf/simulated/floor/wood,
 /area/endeavour/hallway/d3fwdhall)
 "hWB" = (
-/obj/machinery/light/small{
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/chemical_dispenser/catering/bar_coffee{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/cargo/mining)
+/turf/simulated/floor/wood,
+/area/endeavour/surfacebase/mining_main/break_room)
 "hWG" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -11436,13 +12145,19 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
-/area/endeavour/station/stairs_three)
+/area/maintenance/bar/lower)
 "hXO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "hXW" = (
 /obj/structure/table/steel,
@@ -11472,6 +12187,10 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
 "hYD" = (
+/obj/machinery/door/airlock{
+	name = "Kitchen";
+	req_one_access = list(28)
+	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11484,9 +12203,6 @@
 	},
 /obj/map_helper/access_helper/airlock/station/service/kitchen,
 /obj/effect/floor_decal/corner_oldtile/white/diagonal,
-/obj/machinery/door/airlock/civilian{
-	name = "Kitchen"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "hYL" = (
@@ -11560,9 +12276,12 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "iaP" = (
-/turf/simulated/wall/prepainted,
+/turf/simulated/wall/prepainted/civilian,
 /area/maintenance/bar/catwalk)
 "ibm" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -11657,15 +12376,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3starboardamidhall)
 "ifE" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/flora/grass/event/full_grass1,
+/turf/simulated/floor/grass,
+/area/quartermaster/warehouse)
 "ifT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11790,7 +12504,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/quartermaster/miningdock)
 "ili" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -11833,17 +12547,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
 "inw" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/cargo{
-	dir = 4
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = -28;
-	req_access = list()
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "inx" = (
 /turf/simulated/wall/prepainted,
 /area/endeavour/hallway/d3starboardafthall)
@@ -12003,10 +12715,13 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "itn" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "itv" = (
 /obj/machinery/door/firedoor,
@@ -12096,11 +12811,16 @@
 /turf/simulated/wall/prepainted/security,
 /area/security/breakroom)
 "izO" = (
-/obj/machinery/camera/network/cargo{
-	dir = 4
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "iAo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -12167,6 +12887,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/security_processing)
+"iCI" = (
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/camera/network/cargo{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "iCL" = (
 /obj/structure/bed/double,
 /obj/item/bedsheet/hosdouble,
@@ -12191,6 +12926,15 @@
 /obj/effect/paint/beastybrown,
 /turf/simulated/floor/plating,
 /area/quartermaster/delivery)
+"iDN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/quartermaster/qm)
 "iDZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -12288,14 +13032,18 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portamidhall)
 "iIq" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
 	},
-/obj/machinery/computer/supplycomp/control{
-	dir = 4
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 9
 	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/obj/structure/table/steel_reinforced,
+/obj/item/storage/box/lights/mixed,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "iIs" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 6
@@ -12333,8 +13081,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
 /area/maintenance/bar/lower)
 "iIU" = (
 /obj/machinery/camera/network/civilian{
@@ -12382,18 +13132,12 @@
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/evidence_storage)
 "iJR" = (
-/obj/structure/table/reinforced,
-/obj/item/hand_labeler,
-/obj/item/stamp/cargo,
-/obj/item/stamp/denied{
-	pixel_x = 7
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
 	},
-/obj/fiftyspawner/glass,
-/obj/fiftyspawner/steel,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled/steel_grid,
+/area/quartermaster/belterdock)
 "iKe" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -12525,6 +13269,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
+"iRl" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "iRB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12555,19 +13303,11 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
 "iSP" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor{
-	dir = 8
+/obj/machinery/computer/supplycomp/control{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/cargo/mining)
+/turf/simulated/floor/wood,
+/area/quartermaster/office)
 "iTp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12662,6 +13402,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/hanger)
+"iYp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "iYC" = (
 /obj/structure/table/marble,
 /obj/item/storage/box/wings,
@@ -12697,18 +13447,11 @@
 /turf/simulated/floor/crystal,
 /area/endeavour/hallway/d3fwdhall)
 "jag" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/conveyor{
-	tag = "mailroom";
-	id = "DLBelt"
-	},
-/obj/structure/plasticflaps/mining{
-	desc = "Heavy duty, airtight, plastic flaps."
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/delivery)
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/structure/closet/secure_closet/miner,
+/obj/item/binoculars,
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "jaT" = (
 /obj/machinery/holopad,
 /obj/structure/cable/green{
@@ -12765,6 +13508,18 @@
 /obj/item/pen,
 /turf/simulated/floor/tiled/monotile,
 /area/security/hallway)
+"jcV" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "jdI" = (
 /obj/machinery/camera/network/civilian{
 	dir = 8
@@ -12815,6 +13570,34 @@
 /obj/map_helper/access_helper/airlock/station/security/general,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/hallway)
+"jev" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
+"jex" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "jeT" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -12856,18 +13639,12 @@
 /turf/simulated/floor/wood,
 /area/security/lobby)
 "jhH" = (
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/conveyor{
+	dir = 5;
+	id = "mining_interior"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/belterdock/refinery)
 "jhI" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
@@ -12894,6 +13671,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/dormitory)
+"jhT" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/belterdock)
 "jhZ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/apc/south_mount,
@@ -13193,15 +13976,21 @@
 /turf/simulated/floor/crystal,
 /area/endeavour/hallway/d3fwdhall)
 "jrK" = (
-/obj/machinery/power/apc/west_mount,
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/structure/table/hardwoodtable,
+/obj/item/stamp/qm{
+	pixel_x = -7;
+	pixel_y = -1
 	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
+/obj/item/stamp/cargo{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = 9;
+	pixel_y = 11
 	},
 /turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/area/quartermaster/qm)
 "jrY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorblack{
@@ -13217,15 +14006,31 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "jtk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "jtn" = (
-/obj/machinery/vending/cigarette,
+/obj/structure/table/rack/steel,
+/obj/item/cartridge/quartermaster{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/cartridge/quartermaster{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/cartridge/quartermaster{
+	pixel_x = -3;
+	pixel_y = -5
+	},
+/obj/item/cartridge/quartermaster{
+	pixel_x = 6;
+	pixel_y = -5
+	},
 /turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/area/quartermaster/qm)
 "jtu" = (
 /obj/structure/window/basic{
 	dir = 1
@@ -13242,9 +14047,11 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/maintenance/dormitory)
 "juy" = (
-/obj/landmark/spawnpoint/job/quartermaster,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/qm)
+/obj/machinery/mineral/input,
+/obj/effect/floor_decal/industrial/loading,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "juB" = (
 /obj/structure/closet/toolcloset,
 /obj/item/storage/toolbox/mechanical,
@@ -13299,33 +14106,19 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portamidhall)
 "jwr" = (
-/obj/machinery/door/firedoor{
-	dir = 8
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/landmark/spawnpoint/job/shaft_miner,
+/obj/item/stool/padded{
+	pixel_x = 0;
+	pixel_y = 13
 	},
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Prep Room";
-	req_one_access = null
-	},
-/obj/map_helper/access_helper/airlock/station/supply/mining,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "jwQ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/glass{
-	name = "Cargo Lobby"
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "jxH" = (
 /turf/simulated/floor/tiled/dark,
@@ -13371,17 +14164,12 @@
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/security_processing)
 "jzp" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/machinery/air_alarm{
+	pixel_y = 22
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "jzG" = (
 /obj/machinery/vending/hydronutrients,
 /turf/simulated/floor/tiled/techfloor,
@@ -13394,27 +14182,23 @@
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/mining_ship/general)
 "jAe" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/carpet/bcarpet,
+/area/quartermaster/qm)
 "jAj" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "jAA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "jAH" = (
 /obj/structure/poster{
 	pixel_x = 32
@@ -13422,16 +14206,26 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar/lounge)
+"jAQ" = (
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/item/stack/flag/yellow{
+	pixel_x = 42;
+	pixel_y = 1
+	},
+/obj/item/stack/flag/yellow{
+	pixel_x = 42;
+	pixel_y = 2
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "jBe" = (
-/obj/machinery/suit_cycler/mining,
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/turf/simulated/wall/prepainted/cargo,
+/area/endeavour/surfacebase/mining_main/break_room)
 "jBD" = (
 /obj/structure/table/marble,
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
@@ -13441,11 +14235,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "jCu" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "jCV" = (
 /obj/structure/window/basic{
 	dir = 1
@@ -13497,14 +14296,15 @@
 /turf/simulated/wall/prepainted,
 /area/security/nuke_storage)
 "jEc" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/outline{
+	color = #D6DBDB
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/obj/structure/closet/crate,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/tank/oxygen,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/warehouse)
 "jEn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13512,15 +14312,9 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "jEN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/mining{
-	id_tag = "cargodoor";
-	name = "Cargo Office";
-	req_one_access = list()
-	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/obj/landmark/spawnpoint/job/cargo_technician,
+/turf/simulated/floor/wood,
+/area/quartermaster/office)
 "jFV" = (
 /obj/machinery/computer/guestpass{
 	dir = 1;
@@ -13598,6 +14392,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
+"jHB" = (
+/obj/machinery/door/airlock/glass/mining{
+	name = "Mining Prep Room";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/supply/mining,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "jIr" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -13683,13 +14489,10 @@
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/bar/lounge)
 "jLH" = (
-/obj/structure/table/bench/padded,
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/landmark/spawnpoint/job/shaft_miner,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/structure/table/hardwoodtable,
+/obj/item/flashlight/lamp/green,
+/turf/simulated/floor/carpet/bcarpet,
+/area/quartermaster/qm)
 "jLP" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13704,7 +14507,7 @@
 	req_one_access = null
 	},
 /obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "jMc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -13777,31 +14580,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/endeavour/hallway/d3fwdhall)
 "jON" = (
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "jPe" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/brown/border{
-	dir = 1
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/obj/item/packageWrap,
-/obj/item/packageWrap,
-/obj/item/packageWrap,
-/obj/item/destTagger,
+/obj/machinery/power/apc/east_mount,
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/steel,
-/area/quartermaster/delivery)
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "jQE" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
@@ -13856,17 +14652,14 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "jSX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "jTc" = (
 /obj/structure/cable/green{
 	icon_state = "0-8"
@@ -13878,6 +14671,12 @@
 /obj/effect/paint/darkred,
 /turf/simulated/floor/plating,
 /area/security/forensics)
+"jTn" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "jUf" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/donkpockets,
@@ -13999,16 +14798,18 @@
 /turf/simulated/wall/r_wall/prepainted/security,
 /area/security/warden)
 "jYU" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/obj/structure/closet/secure_closet/quartermaster,
+/obj/item/clothing/accessory/poncho/roles/cloak/qm,
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "jYY" = (
 /obj/machinery/gear_painter,
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
 "jZc" = (
+/obj/machinery/fire_alarm/south_mount{
+	pixel_y = -24
+	},
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navgold/border,
@@ -14022,11 +14823,8 @@
 /turf/simulated/wall/prepainted/civilian,
 /area/crew_quarters/game_room)
 "kad" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/turf/simulated/wall/r_wall/prepainted/cargo,
+/area/quartermaster/delivery)
 "kam" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
@@ -14118,7 +14916,13 @@
 	id_tag = "cargo_bay";
 	pixel_x = 28
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "kde" = (
 /obj/machinery/media/jukebox,
@@ -14415,6 +15219,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdmaint)
+"kpa" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "kpd" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector,
@@ -14430,11 +15241,8 @@
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/interrogation)
 "kpn" = (
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/turf/simulated/wall/r_wall/prepainted/cargo,
+/area/crew_quarters/bar/lounge)
 "kps" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -14483,8 +15291,13 @@
 /area/security/hallway)
 "ksT" = (
 /obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/effect/floor_decal/corner_oldtile/white/diagonal,
+/obj/item/barrier_tape_segment/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "ksW" = (
@@ -14508,14 +15321,9 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
 "kur" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/grass,
+/area/quartermaster/warehouse)
 "kuG" = (
 /obj/landmark/spawnpoint/latejoin/station/cryogenics,
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
@@ -14530,6 +15338,11 @@
 "kuM" = (
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
+"kve" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/machinery/light,
+/turf/simulated/floor/wood,
+/area/endeavour/surfacebase/mining_main/break_room)
 "kvG" = (
 /obj/machinery/fire_alarm/west_mount{
 	pixel_x = -26
@@ -14551,12 +15364,27 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "kwo" = (
-/obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
+/obj/machinery/door/window{
+	dir = 8;
+	req_one_access = list(31)
+	},
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/folder/white,
+/obj/item/pen,
+/obj/machinery/door/firedoor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "kwF" = (
 /obj/structure/stairs/spawner/north{
@@ -14566,16 +15394,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/endeavour/station/stairs_three)
 "kxv" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/floor_decal/industrial/hatch{
+	color = "#AF0000"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/warehouse)
 "kxI" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -14623,6 +15445,12 @@
 /obj/item/forensics/sample_kit/powder,
 /turf/simulated/floor/tiled/old_cargo/white,
 /area/security/forensics)
+"kzw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "kAe" = (
 /obj/item/radio/intercom{
 	pixel_y = -24
@@ -14767,14 +15595,12 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/fitness)
 "kDM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/structure/flora/grass/event/sparse_grass2,
+/turf/simulated/floor/grass,
+/area/quartermaster/warehouse)
 "kEf" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -14799,8 +15625,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
-/area/endeavour/station/stairs_three)
+/area/maintenance/bar/lower)
 "kEF" = (
 /obj/machinery/light{
 	dir = 1
@@ -14813,6 +15644,13 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3starboardafthall)
+"kFJ" = (
+/obj/machinery/light_switch{
+	pixel_x = -27;
+	pixel_y = 5
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/quartermaster/qm)
 "kGS" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navgold/border,
@@ -14889,15 +15727,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "kKO" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "kKQ" = (
 /obj/machinery/door/firedoor{
 	dir = 8
@@ -14975,6 +15811,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
+"kNz" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 6
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "kNT" = (
 /obj/vehicle/sealed/mecha/combat/fighter/cludge{
 	dir = 4;
@@ -14991,14 +15838,40 @@
 /turf/simulated/floor/wood,
 /area/maintenance/dormitory)
 "kOw" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/item/hand_labeler{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/item/hand_labeler{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/obj/item/hand_labeler{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/item/hand_labeler{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
+"kOE" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "kPK" = (
 /obj/machinery/door/blast/regular{
 	name = "Fighter Hanger Blast Door";
@@ -15020,14 +15893,12 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
 "kPT" = (
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/table/hardwoodtable,
+/obj/machinery/photocopier/faxmachine{
+	department = "Quartermaster-Office"
 	},
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/foyer)
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "kQn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -15065,17 +15936,10 @@
 /area/shuttle/mining_ship/general)
 "kRu" = (
 /obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad2"
+	dir = 4;
+	id = "QMLoad"
 	},
-/obj/machinery/status_display/supply_display{
-	mode = 99;
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "kRM" = (
 /obj/machinery/door/firedoor,
@@ -15158,13 +16022,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3starboardafthall)
 "kTN" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "kUz" = (
 /obj/machinery/door/firedoor/glass,
@@ -15177,6 +16038,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
+"kUA" = (
+/obj/machinery/door/airlock/glass/mining{
+	name = "Mining Prep Room";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/supply/mining,
+/obj/machinery/door/firedoor{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "kUM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15199,15 +16080,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "kWu" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/structure/closet/secure_closet/cargotech,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "kWJ" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/donkpockets,
@@ -15231,11 +16106,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "kXD" = (
-/obj/machinery/light/small{
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/cargo)
+/obj/structure/flora/grass/event/sparse_grass2,
+/turf/simulated/floor/grass,
+/area/quartermaster/foyer)
 "kXK" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -15252,19 +16131,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "kYu" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/item/radio/beacon/anchored,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance,
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/maintenance/bar/lower)
 "kYx" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -15293,9 +16166,14 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/game_room)
 "kZu" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "kZA" = (
 /obj/effect/floor_decal/corner/green/full{
 	dir = 1
@@ -15323,9 +16201,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3starboardafthall)
 "lag" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/machinery/camera/network/cargo{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "laD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15341,8 +16223,16 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
 "laQ" = (
-/obj/structure/sign/department/cargo_dock,
-/turf/simulated/wall/prepainted/cargo,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "lbQ" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
@@ -15391,20 +16281,27 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "ldm" = (
-/obj/machinery/fire_alarm/south_mount{
-	pixel_y = -24
-	},
-/obj/structure/closet/crate/bin{
-	anchored = 1
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/turf/simulated/wall/r_wall/prepainted/cargo,
+/area/quartermaster/office)
 "ldo" = (
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "ldK" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled,
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "len" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15421,9 +16318,13 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portamidhall)
 "leF" = (
-/obj/machinery/vending/weeb,
+/obj/machinery/air_alarm/east_mount,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/area/quartermaster/qm)
 "leL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -15431,6 +16332,18 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
+"leO" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/structure/bed/chair/sofa/black{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "lfc" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/evidence,
@@ -15451,11 +16364,9 @@
 /turf/simulated/floor/tiled/old_cargo/white,
 /area/security/forensics)
 "lfJ" = (
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/wood,
+/area/quartermaster/office)
 "lfS" = (
 /obj/machinery/light{
 	dir = 1
@@ -15488,16 +16399,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
 "lgM" = (
-/obj/machinery/door/firedoor{
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window{
+	dir = 4;
+	req_one_access = list(31)
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/door/airlock/maintenance/common,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/bar/lower)
+/turf/simulated/floor/tiled/monotechmaint,
+/area/quartermaster/belterdock/refinery)
 "lgT" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -15539,6 +16455,9 @@
 "lhR" = (
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/station_map{
+	pixel_y = 32
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -15590,9 +16509,11 @@
 /area/endeavour/hallway/d3portforhall)
 "lkP" = (
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "lly" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
@@ -15612,16 +16533,9 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3fwdmaint)
 "lmr" = (
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
-/obj/map_helper/access_helper/airlock/station/mining_operations,
-/obj/machinery/door/airlock/glass/mining{
-	name = "Magmatic Rift Leap Pad";
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "lmD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15639,13 +16553,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/security/lobby)
 "lnj" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/area/maintenance/bar/lower)
 "lnp" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -15720,6 +16632,16 @@
 /obj/effect/paint/darkred,
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/hos)
+"lqf" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/structure/bed/chair/comfy/brown,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "lqj" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -15733,8 +16655,15 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
 "lqE" = (
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "lqW" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
@@ -15897,15 +16826,15 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
 "lwA" = (
-/obj/machinery/power/apc/north_mount,
-/obj/structure/cable/green{
-	icon_state = "0-2"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 8
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/uxstorage)
+/obj/machinery/camera/network/cargo,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "lwL" = (
 /obj/machinery/door/window/brigdoor/southleft{
 	dir = 4;
@@ -15950,6 +16879,12 @@
 	},
 /turf/simulated/floor/tiled/old_cargo/white,
 /area/security/forensics)
+"lxo" = (
+/obj/machinery/air_alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "lxA" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -15971,9 +16906,23 @@
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/entertainment)
 "lye" = (
-/obj/machinery/atmospherics/component/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "lyz" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -16018,16 +16967,12 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/fitness)
 "lAm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorblack{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/navblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "lAo" = (
 /obj/effect/floor_decal/borderfloorblack,
@@ -16046,22 +16991,13 @@
 /turf/simulated/floor/wood,
 /area/security/breakroom)
 "lCC" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central6{
-	dir = 4
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/bed/chair/sofa/black{
+	dir = 1
 	},
-/obj/machinery/requests_console/preset/cargo{
-	pixel_x = 30
-	},
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	frequency = 1380;
-	id_tag = "belter_docking";
-	name = "Belting Dock Controller";
-	pixel_x = 24;
-	pixel_y = 30;
-	req_one_access = list(13,31)
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "lCJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -16178,13 +17114,9 @@
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/bar/lounge)
 "lEM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "lEY" = (
 /turf/simulated/wall/r_wall/prepainted/engineering,
@@ -16215,6 +17147,11 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space)
+"lIF" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/flora/grass/event/purple_flowers1,
+/turf/simulated/floor/grass,
+/area/quartermaster/warehouse)
 "lIO" = (
 /turf/simulated/floor/plating,
 /area/security/hanger)
@@ -16225,6 +17162,9 @@
 "lIR" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
 "lIV" = (
@@ -16246,6 +17186,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
+"lJo" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/microwave,
+/turf/simulated/floor/wood,
+/area/endeavour/surfacebase/mining_main/break_room)
 "lJp" = (
 /obj/machinery/light{
 	dir = 1
@@ -16272,31 +17220,29 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "lKt" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
-/obj/machinery/power/apc/north_mount,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "lKA" = (
 /turf/simulated/wall/r_wall/prepainted/engineering,
 /area/security/forensics)
 "lKH" = (
-/obj/machinery/mineral/input,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "mining_interior"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/structure/bed/chair/sofa/black/left,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "lKR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16330,27 +17276,23 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
+"lNd" = (
+/obj/structure/dispenser/oxygen,
+/obj/effect/floor_decal/industrial/warning/cee,
+/turf/simulated/floor/tiled/monotechmaint,
+/area/quartermaster/belterdock/refinery)
 "lNv" = (
 /obj/landmark/spawnpoint/job/entertainer,
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/surfacebase/entertainment)
 "lNT" = (
-/obj/machinery/door/firedoor{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/bar/catwalk)
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "lNU" = (
 /obj/structure/table/gamblingtable,
 /obj/item/deck/cards,
@@ -16407,11 +17349,12 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
 "lQq" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "lQs" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/glasses/meta,
@@ -16425,9 +17368,6 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
 "lRx" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
 /obj/structure/sign/warning/moving_parts{
 	pixel_y = 32
 	},
@@ -16435,7 +17375,10 @@
 	tag = "mailroom";
 	id = "DLBelt"
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "lRP" = (
 /obj/structure/cable/green{
@@ -16671,15 +17614,9 @@
 /turf/simulated/floor/plating,
 /area/security/lobby)
 "lXM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -4
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/bar/lower)
 "lYm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16695,7 +17632,6 @@
 /area/crew_quarters/sleep/Dorm_6)
 "lYO" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
-/obj/effect/paint/beastybrown,
 /turf/simulated/floor/tiled/steel/airless,
 /area/shuttle/belter)
 "lZO" = (
@@ -16744,12 +17680,34 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_5)
 "mbv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/landmark/spawnpoint/job/cargo_technician,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/obj/structure/table/steel_reinforced,
+/obj/item/duct_tape_roll{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/stamp/cargo{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/stamp/denied{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/obj/item/duct_tape_roll{
+	pixel_x = -8;
+	pixel_y = -4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/warehouse)
+"mbC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/bcarpet,
+/area/quartermaster/qm)
 "mbJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -16804,19 +17762,17 @@
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "mff" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor{
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
-/obj/machinery/door/airlock/glass/mining{
-	name = "Cargo Bay";
-	req_one_access = null
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
 	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "mfm" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
@@ -16831,6 +17787,15 @@
 "mfy" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/sleep/Dorm_12)
+"mfS" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/endeavour/surfacebase/mining_main/break_room)
 "mgD" = (
 /obj/effect/floor_decal/corner/black{
 	dir = 9
@@ -16870,15 +17835,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallwayaux)
 "mhO" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Cargo Lobby"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/endeavour/surfacebase/mining_main/break_room)
 "mhY" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/substation/security)
@@ -16890,11 +17848,24 @@
 /turf/simulated/floor/tiled/old_cargo/white,
 /area/security/forensics)
 "mii" = (
-/obj/effect/floor_decal/industrial/warning{
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
+"mil" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "miu" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner,
 /turf/simulated/floor/wood,
@@ -16956,10 +17927,14 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_11)
 "mjB" = (
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 4
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 5
+	},
+/obj/structure/flora/pottedplant/minitree,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "mkn" = (
 /obj/structure/cable/green{
@@ -17024,20 +17999,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "mlk" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass/mining{
-	name = "Cargo Airlock";
-	req_one_access = null
-	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "mll" = (
 /obj/machinery/light{
@@ -17150,34 +18120,43 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "moz" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "mining_interior"
-	},
-/obj/machinery/camera/network/cargo,
-/turf/simulated/floor/tiled/steel_grid,
-/area/endeavour/surfacebase/mining_main/refinery)
-"moE" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/brown/border{
-	dir = 8
+	dir = 1
 	},
+/obj/structure/bed/chair/sofa/black/right,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
+"moE" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/landmark/spawnpoint/job/shaft_miner,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/area/endeavour/surfacebase/mining_main/break_room)
 "mpt" = (
-/obj/landmark/spawnpoint/job/cargo_technician,
-/obj/machinery/camera/network/cargo{
-	dir = 4
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/power/apc/south_mount,
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "mpy" = (
 /obj/machinery/door/firedoor,
@@ -17233,6 +18212,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
+"mqI" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "mqK" = (
 /obj/structure/table/marble,
 /obj/machinery/reagentgrinder,
@@ -17278,6 +18269,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"mrC" = (
+/obj/structure/flora/pottedplant/thinbush{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "msf" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 4
@@ -17352,11 +18350,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/endeavour/hallway/d3afthall)
 "mwk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Foyer"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "mwA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -17431,9 +18433,12 @@
 /turf/simulated/floor/wood,
 /area/endeavour/surfacebase/bar_backroom)
 "mzJ" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/obj/machinery/power/apc/north_mount,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/delivery)
 "mAl" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -17520,10 +18525,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "mEb" = (
-/obj/spawner/window/low_wall/reinforced/full/firelocks,
-/obj/effect/paint_stripe/beastybrown,
-/turf/simulated/floor/plating,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/ore_box,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "mEG" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -17605,9 +18610,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
 "mIP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/qm)
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/item/stool/padded,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "mJs" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 1
@@ -17615,11 +18624,17 @@
 /turf/simulated/floor/wood,
 /area/endeavour/hallway/d3fwdhall)
 "mJv" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/obj/machinery/vending/fitness,
+/turf/simulated/floor/wood,
+/area/endeavour/surfacebase/mining_main/break_room)
 "mKJ" = (
-/turf/simulated/wall/prepainted/cargo,
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "mKK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17658,6 +18673,9 @@
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_4)
+"mLf" = (
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "mLk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17679,8 +18697,8 @@
 /turf/simulated/floor/reinforced,
 /area/quartermaster/miningdock)
 "mLm" = (
-/turf/simulated/floor/plating,
-/area/maintenance/cargo/mining)
+/turf/simulated/wall/r_wall/prepainted/cargo,
+/area/quartermaster/belterdock)
 "mLw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17695,6 +18713,27 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
+"mLC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
+"mMd" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 5
+	},
+/obj/structure/table/steel_reinforced,
+/obj/structure/flora/pottedplant/flower{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "mMk" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable/yellow,
@@ -17709,6 +18748,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
+"mNx" = (
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/machinery/camera/network/cargo{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "mNL" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -17800,8 +18846,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "mVn" = (
-/turf/simulated/wall/prepainted/cargo,
-/area/maintenance/bar/catwalk)
+/obj/structure/table/gamblingtable,
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "mVA" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 1
@@ -17984,19 +19031,28 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "mYS" = (
+/obj/map_helper/access_helper/airlock/station/head_office/quartermaster,
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Prep Room";
-	req_one_access = null
-	},
-/obj/map_helper/access_helper/airlock/station/supply/mining,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mining{
+	name = "Quartermaster";
+	req_one_access = list()
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "mZI" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/regular{
@@ -18038,7 +19094,13 @@
 /area/space)
 "nbW" = (
 /obj/structure/closet/emcloset,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "ncH" = (
 /obj/structure/table/steel,
@@ -18083,13 +19145,38 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "ncP" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/machinery/status_display/supply_display{
+	mode = 99;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "ncY" = (
 /obj/structure/sign/warning/secure_area,
 /turf/simulated/wall/r_wall/prepainted/command,
 /area/security/nuke_storage)
+"ndj" = (
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "ndp" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -18116,7 +19203,13 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "neq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18145,10 +19238,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
 "nfA" = (
-/obj/structure/closet/crate/trashcart,
-/obj/random/maintenance/engineering,
-/turf/simulated/floor/plating,
-/area/maintenance/cargo/mining)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "nfG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18280,18 +19381,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
 "nkT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/foyer)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "nkY" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -18302,12 +19405,41 @@
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portamidhall)
+"nlW" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/machinery/air_alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "nmv" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/reinforced,
 /area/quartermaster/miningdock)
+"nmD" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "nmQ" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -18337,11 +19469,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
 "noi" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /obj/machinery/door/firedoor,
-/obj/map_helper/access_helper/airlock/station/service/kitchen,
-/obj/machinery/door/airlock/civilian{
+/obj/machinery/door/airlock{
 	name = "Kitchen"
 	},
+/obj/map_helper/access_helper/airlock/station/service/kitchen,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "noB" = (
@@ -18370,8 +19505,20 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "noW" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/office)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "noY" = (
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/starboardsolar)
@@ -18412,15 +19559,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "npS" = (
-/obj/machinery/fire_alarm/west_mount{
-	pixel_x = -26
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine{
-	department = "Quartermaster-Office"
-	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "nqm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -18448,22 +19591,29 @@
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
 "nrZ" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
-"nsH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
+"nsH" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "nta" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18485,6 +19635,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
+"ntW" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4;
+	use_power = 0
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "nue" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -18523,6 +19692,29 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/fitness)
+"nvP" = (
+/obj/item/folder/white,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window{
+	dir = 8;
+	req_one_access = list(31)
+	},
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/pen,
+/obj/machinery/door/firedoor{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/delivery)
 "nws" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -18550,6 +19742,18 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
+"nxl" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/status_display/supply_display{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/bed/chair/sofa/black{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "nxo" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -18566,9 +19770,12 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
 "nxz" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "nxT" = (
 /obj/machinery/camera/network/civilian{
 	dir = 4
@@ -18576,8 +19783,14 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "nyi" = (
-/turf/simulated/wall/prepainted/cargo,
-/area/quartermaster/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "nyw" = (
 /obj/machinery/light_switch{
 	pixel_y = -23
@@ -18605,17 +19818,8 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
 "nzA" = (
-/obj/machinery/air_alarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate/large,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/turf/simulated/floor/wood,
+/area/quartermaster/office)
 "nAJ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -18623,10 +19827,9 @@
 /turf/simulated/floor/water/deep/indoors,
 /area/crew_quarters/sleep/bedrooms)
 "nAS" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plating,
-/area/vacant/vacant_shop)
+/obj/machinery/atmospherics/component/unary/vent_pump/on,
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "nBf" = (
 /obj/structure/closet/wardrobe,
 /turf/simulated/floor/wood,
@@ -18639,6 +19842,18 @@
 /obj/effect/paint/darkred,
 /turf/simulated/floor/plating,
 /area/security/lobby)
+"nBB" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "nBM" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -18722,20 +19937,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3starboardamidhall)
 "nDz" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/storage/firstaid{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "nEe" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -18756,12 +19961,23 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3portforhall)
 "nFa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/navblue/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d3portforhall)
 "nFD" = (
 /obj/structure/closet/wardrobe,
 /obj/machinery/newscaster{
@@ -18869,6 +20085,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/navblue/bordercorner2{
+	dir = 4
+	},
+/obj/machinery/fire_alarm/north_mount,
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3portforhall)
 "nJE" = (
@@ -18891,13 +20114,18 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
 "nKd" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/dogbed,
-/obj/machinery/fire_alarm/south_mount{
-	pixel_y = -24
+/obj/machinery/computer/supplycomp,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "nKw" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
@@ -19157,11 +20385,17 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/external_airlock,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
 /area/quartermaster/warehouse)
 "nRt" = (
 /obj/effect/floor_decal/corner_steel_grid/diagonal,
@@ -19232,6 +20466,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/security_lockerroom)
+"nTg" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/stamp/cargo{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/stamp/denied{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/pen{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/office)
 "nTi" = (
 /obj/structure/disposalpipe/tagger/partial{
 	name = "partial tagger - Sorting Office";
@@ -19341,21 +20595,13 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
 "nVC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/effect/floor_decal/borderfloorblack/corner,
+/obj/effect/floor_decal/corner/brown/bordercorner,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "nVP" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -19364,11 +20610,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/recreation_area)
 "nWj" = (
-/obj/machinery/computer/security/mining{
-	dir = 4
+/obj/machinery/computer/roguezones{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/obj/effect/floor_decal/industrial/warning/cee,
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "nWz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -19401,11 +20648,15 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/sleep/Dorm_9)
 "nYH" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/mineral/unloading_machine,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/cargo/mining)
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/belterdock/refinery)
 "nYR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -19514,6 +20765,13 @@
 /obj/machinery/holopad,
 /turf/simulated/floor/tiled,
 /area/security/lobby)
+"ocq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/landmark/spawnpoint/job/shaft_miner,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "ocx" = (
 /obj/effect/floor_decal/corner_steel_grid/diagonal,
 /obj/structure/fitness/weightlifter,
@@ -19756,6 +21014,15 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
+"okQ" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "okS" = (
 /obj/structure/table/woodentable,
 /obj/machinery/door/window/westright{
@@ -19820,15 +21087,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
 "omy" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate,
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = -28;
-	req_access = list()
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/structure/bed/chair/sofa/black,
+/obj/machinery/light_switch{
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/endeavour/surfacebase/mining_main/break_room)
 "onm" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
@@ -19838,10 +21108,19 @@
 /area/hydroponics)
 "onr" = (
 /obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "onZ" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
@@ -19921,9 +21200,6 @@
 /obj/item/packageWrap,
 /obj/machinery/camera/network/civilian,
 /obj/effect/floor_decal/corner_oldtile/white/diagonal,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "opZ" = (
@@ -19967,14 +21243,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "orm" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 6
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/office)
 "orr" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lime/border,
@@ -19998,11 +21277,14 @@
 /turf/simulated/wall/prepainted/security,
 /area/security/brig)
 "osx" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "osL" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -20023,6 +21305,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
+"otC" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/bed/chair/sofa/black{
+	dir = 1
+	},
+/obj/machinery/air_alarm/south_mount,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
+"otE" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "otM" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/floor_decal/spline/plain,
@@ -20069,11 +21375,12 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "ouS" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "QMLoad"
+/obj/machinery/conveyor_switch/oneway{
+	id = "QMLoad2";
+	pixel_x = 11;
+	pixel_y = 21
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "ova" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -20189,6 +21496,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
+"oxR" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/belterdock)
 "oxV" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -20239,9 +21552,8 @@
 /area/maintenance/dormitory)
 "oyU" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate,
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "oyZ" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
@@ -20291,6 +21603,18 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3portamidhall)
+"oBi" = (
+/obj/machinery/sheet_silo_loader{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/belterdock/refinery)
 "oBE" = (
 /obj/structure/flora/pottedplant/aquatic,
 /turf/simulated/floor/carpet/tealcarpet,
@@ -20443,8 +21767,7 @@
 "oFO" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/effect/paint_stripe/beastybrown,
-/obj/effect/mine/dnascramble,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless/ceiling,
 /area/quartermaster/warehouse)
 "oGe" = (
 /obj/machinery/air_alarm{
@@ -20574,17 +21897,27 @@
 /obj/effect/floor_decal/corner_oldtile/white/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
+"oLy" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/machinery/status_display/supply_display{
+	mode = 99;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "oMi" = (
 /obj/item/bedsheet/reddouble,
 /obj/structure/bed/double/padded,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/sleep/Dorm_10)
 "oMq" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/turf/simulated/floor/carpet/bcarpet,
+/area/quartermaster/qm)
 "oNp" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -20607,17 +21940,17 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portamidhall)
 "oNw" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "oNx" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 1
@@ -20688,9 +22021,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
 "oOy" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/bar/lower)
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "oOG" = (
 /obj/machinery/power/apc/west_mount,
 /obj/structure/cable/green{
@@ -20699,16 +22037,26 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/game_room)
 "oOI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/mining{
-	req_one_access = null
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
 	},
-/obj/map_helper/access_helper/airlock/station/head_office/quartermaster,
-/turf/simulated/floor/plating,
-/area/quartermaster/qm)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "oOV" = (
-/turf/simulated/wall/prepainted/cargo,
-/area/endeavour/surfacebase/mining_main/uxstorage)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "oPq" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -20737,6 +22085,21 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
+"oSc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "oSn" = (
 /obj/machinery/light,
 /obj/machinery/computer/arcade,
@@ -20822,19 +22185,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "oWf" = (
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Prep Room";
-	req_one_access = null
-	},
-/obj/map_helper/access_helper/airlock/station/supply/mining,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/break_room)
+/area/maintenance/bar/lower)
 "oWG" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Crew Quarters"
@@ -20849,19 +22201,7 @@
 /turf/simulated/floor/tiled,
 /area/security/hanger)
 "oXi" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/navblue/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/navblue/bordercorner2{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/wall/r_wall/prepainted/cargo,
 /area/quartermaster/foyer)
 "oXu" = (
 /obj/structure/cable/orange{
@@ -20871,14 +22211,19 @@
 /area/crew_quarters/sleep/bedrooms)
 "oXV" = (
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/blue/border,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
 /area/quartermaster/office)
 "oYh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -20892,15 +22237,9 @@
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/evidence_storage)
 "oYC" = (
-/obj/machinery/camera/network/cargo{
-	dir = 4
-	},
-/obj/structure/closet/hydrant{
-	pixel_x = -32
-	},
-/obj/structure/closet/crate,
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/area/endeavour/surfacebase/mining_main/break_room)
 "oYK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -21014,12 +22353,6 @@
 /obj/structure/sign/department/mail{
 	pixel_x = -32
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 10
-	},
 /obj/structure/table/standard,
 /obj/item/packageWrap,
 /obj/item/packageWrap,
@@ -21029,40 +22362,19 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 8
-	},
 /obj/machinery/camera/network/cargo{
 	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "pdT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 26
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "ped" = (
 /obj/landmark/observer_spawn,
 /obj/effect/floor_decal/spline/fancy/wood,
@@ -21092,19 +22404,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "pfu" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Prep Room";
-	req_one_access = null
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/map_helper/access_helper/airlock/station/supply/mining,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
 "pfH" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/cell_charger,
@@ -21255,11 +22563,7 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "pjE" = (
-/obj/machinery/air_alarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/reinforced,
 /area/quartermaster/warehouse)
 "pjF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -21385,8 +22689,26 @@
 /turf/simulated/floor/wood,
 /area/security/breakroom)
 "pmy" = (
-/turf/simulated/wall/prepainted,
-/area/crew_quarters/kitchen)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/structure/bed/chair/sofa/black/left,
+/obj/machinery/status_display/supply_display{
+	mode = 99;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
+"pmG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "pmM" = (
 /obj/item/bedsheet/bluedouble,
 /obj/structure/bed/double/padded,
@@ -21446,11 +22768,12 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
 "poa" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/wood,
+/area/endeavour/surfacebase/mining_main/break_room)
 "poe" = (
 /obj/effect/shuttle_landmark{
 	base_area = /area/space;
@@ -21494,16 +22817,9 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "pqk" = (
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Prep Room";
-	req_one_access = null
-	},
-/obj/map_helper/access_helper/airlock/station/supply/mining,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "pqE" = (
 /obj/machinery/vending/hydroseeds,
 /obj/effect/floor_decal/corner/green{
@@ -21596,20 +22912,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/endeavour/hallway/d3afthall)
 "ptR" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "puw" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 4
@@ -21624,12 +22934,22 @@
 /turf/simulated/floor/carpet/tealcarpet,
 /area/crew_quarters/sleep/Dorm_8)
 "puP" = (
-/obj/structure/plasticflaps/mining,
-/obj/machinery/conveyor{
-	id = "mining_interior"
+/obj/structure/table/hardwoodtable,
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 7
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/item/pen{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/machinery/button/windowtint{
+	id = "qm_office";
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "puT" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass/security{
@@ -21643,6 +22963,12 @@
 /obj/structure/flora/pottedplant/mysterious,
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/sleep/Dorm_5)
+"pvt" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "pvA" = (
 /obj/structure/table/steel,
 /obj/item/reagent_containers/food/drinks/drinkingglass/soda,
@@ -21684,6 +23010,12 @@
 	},
 /turf/simulated/floor/tiled/monodark,
 /area/prison/cell_block)
+"pwG" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/belterdock)
 "pxt" = (
 /obj/structure/table/rack/steel,
 /obj/item/instrument/violin,
@@ -21703,25 +23035,13 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/heads/hos)
 "pyb" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/mining{
-	name = "Quartermaster";
-	req_one_access = list()
-	},
-/obj/map_helper/access_helper/airlock/station/head_office/quartermaster,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "pyZ" = (
 /obj/structure/cable/green{
 	icon_state = "2-4"
@@ -21747,13 +23067,9 @@
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
 "pzs" = (
-/obj/machinery/hyperpad/centre{
-	map_pad_id = "lavaland_station";
-	map_pad_link_id = "lavaland_away";
-	newcolor = "#fcba03"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/office)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "pAC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21781,30 +23097,42 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/hanger)
+"pCG" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/brown/bordercorner,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "pCQ" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/dormitory)
 "pDb" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window{
-	dir = 1;
-	req_one_access = list(31)
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "pDe" = (
 /turf/simulated/wall/r_wall/prepainted/security,
 /area/security/riot_control)
 "pDn" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/simulated/floor/airless/ceiling,
+/area/space)
 "pDN" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/security{
@@ -21911,9 +23239,6 @@
 	pixel_y = 16
 	},
 /obj/effect/floor_decal/corner_oldtile/white/diagonal,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "pFW" = (
@@ -21949,24 +23274,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
-"pHB" = (
-/obj/machinery/air_alarm{
-	pixel_y = 22
+"pHm" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 20
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/endeavour/hallway/d3portforhall)
+"pHB" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "pIT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22003,10 +23330,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
 "pJe" = (
-/obj/structure/table/bench/padded,
-/obj/landmark/spawnpoint/job/shaft_miner,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "pJi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22021,13 +23355,24 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
 "pJR" = (
-/obj/machinery/computer/supplycomp/control{
-	dir = 4
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "pKe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -22120,10 +23465,16 @@
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/security_processing)
 "pOK" = (
-/obj/machinery/mineral/input,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/structure/table/woodentable,
+/obj/structure/flora/pottedplant/smallcactus{
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/turf/simulated/floor/wood,
+/area/endeavour/surfacebase/mining_main/break_room)
 "pON" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -22156,10 +23507,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "pQh" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate/plastic,
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/machinery/atmospherics/component/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "pQv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -22312,13 +23662,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "pWD" = (
 /obj/structure/table/rack,
@@ -22347,12 +23693,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "pXt" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/structure/catwalk,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
 /area/maintenance/bar/lower)
 "pXE" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -22402,18 +23750,16 @@
 "pZg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/navblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
+"pZF" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/dispenser/oxygen,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "qaT" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -22437,6 +23783,15 @@
 "qbm" = (
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"qbu" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance,
+/obj/map_helper/access_helper/airlock/station/maintenance,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/maintenance/bar/lower)
 "qbv" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood,
@@ -22596,17 +23951,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
 "qek" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/obj/structure/closet/crate/trashcart,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/bar/lower)
 "qeD" = (
 /obj/machinery/power/port_gen/pacman/mrs{
 	anchored = 1
@@ -22717,8 +24065,25 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portamidhall)
 "qlg" = (
-/turf/simulated/wall/prepainted/cargo,
-/area/quartermaster/foyer)
+/obj/structure/table/wooden_reinforced,
+/obj/item/stamp/cargo{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/stamp/denied{
+	pixel_x = -6;
+	pixel_y = -1
+	},
+/obj/item/paper_bin{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/pen{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/office)
 "qlP" = (
 /obj/machinery/fitness/heavy/lifter,
 /obj/effect/floor_decal/corner_steel_grid{
@@ -22752,8 +24117,10 @@
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/security/range)
 "qmQ" = (
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/qm)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "qmV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22763,19 +24130,18 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
 "qmY" = (
-/obj/machinery/status_display/supply_display{
-	pixel_y = 32
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/camera/network/cargo,
-/obj/machinery/suit_storage_unit/mining,
 /turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/area/endeavour/surfacebase/mining_main/break_room)
 "qmZ" = (
 /obj/item/stool/padded,
 /obj/landmark/spawnpoint/job/entertainer,
@@ -22876,22 +24242,10 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/bedrooms)
 "qoU" = (
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/obj/machinery/door/airlock/maintenance,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/effect/paint_stripe/beastybrown,
 /turf/simulated/floor/plating,
-/area/maintenance/bar/lower)
+/area/quartermaster/belterdock/refinery)
 "qoW" = (
 /obj/structure/table/woodentable,
 /obj/machinery/microwave,
@@ -22933,6 +24287,14 @@
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/crew_quarters/recreation_area)
+"qpD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "qpE" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/cell_charger,
@@ -22996,6 +24358,7 @@
 /obj/machinery/camera/network/civilian{
 	dir = 1
 	},
+/obj/machinery/computer/timeclock/premade/south,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navgold/border,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -23029,12 +24392,29 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/entertainment)
+"quo" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "qup" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/item/barrier_tape_segment/engineering,
-/obj/map_helper/network_builder/power_cable/green/auto,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/bar/catwalk)
+"quL" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/belterdock)
 "quZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -23042,22 +24422,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
 "qvo" = (
-/obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass/mining{
-	name = "Cargo Airlock";
-	req_one_access = null
-	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "qvz" = (
 /obj/item/stool/padded,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -23120,13 +24491,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3portforhall)
 "qwK" = (
-/obj/machinery/holopad,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "qwY" = (
 /obj/structure/table/woodentable,
@@ -23193,45 +24564,50 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/entertainment)
-"qzI" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+"qyK" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
-	},
-/obj/machinery/camera/network/cargo,
-/obj/item/clothing/accessory/permit/gun/planetside,
-/obj/item/clothing/accessory/permit/gun/planetside,
-/obj/item/clothing/accessory/permit/gun/planetside,
-/obj/item/clothing/accessory/permit/gun/planetside,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/southright{
-	req_one_access = list(48)
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/gun/energy/kinetic_accelerator,
-/obj/item/gun/energy/kinetic_accelerator,
-/obj/item/gun/energy/kinetic_accelerator,
-/obj/item/gun/energy/kinetic_accelerator,
 /turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/area/endeavour/surfacebase/mining_main/break_room)
+"qzI" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad"
+	},
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "qzO" = (
 /obj/structure/table/woodentable,
 /obj/machinery/microwave,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_5)
 "qAh" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "qAl" = (
 /obj/machinery/conveyor{
@@ -23312,8 +24688,8 @@
 /turf/simulated/floor/wood,
 /area/endeavour/hallway/d3fwdhall)
 "qCs" = (
-/turf/simulated/wall/prepainted,
-/area/maintenance/bar/lower)
+/turf/simulated/wall/prepainted/civilian,
+/area/crew_quarters/barrestroom)
 "qCM" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/machinery/camera/network/security,
@@ -23327,34 +24703,19 @@
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "qDe" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/structure/table/steel_reinforced,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 0;
+	pixel_y = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "qDH" = (
 /turf/simulated/wall/r_wall,
 /area/space)
 "qDS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/turf/simulated/wall/r_wall/prepainted/cargo,
+/area/quartermaster/belterdock/refinery)
 "qEf" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/sleep/Dorm_2)
@@ -23443,17 +24804,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "qIo" = (
-/obj/machinery/vending/cola,
-/turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
-"qIr" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Foyer"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
+"qIr" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "qIx" = (
 /obj/structure/cable/yellow{
@@ -23492,6 +24855,9 @@
 "qJx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -23505,10 +24871,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/endeavour/hallway/d3afthall)
 "qJB" = (
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/warehouse)
 "qJM" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -23520,22 +24884,23 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "qKQ" = (
-/turf/simulated/wall/r_wall/prepainted/cargo,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks,
+/obj/effect/paint_stripe/beastybrown,
+/obj/map_helper/electrochromatic_linker{
+	id = "qm_office"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/qm)
 "qLx" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/status_display/supply_display{
+	mode = 99;
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/glass/mining{
-	name = "Cargo Storage";
-	req_one_access = null
-	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/atmospherics/component/unary/vent_pump/on,
+/obj/fiftyspawner/steel,
+/turf/simulated/floor/wood,
+/area/quartermaster/office)
 "qLB" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/structure/cable/green{
@@ -23580,13 +24945,18 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "qMz" = (
-/obj/structure/closet/secure_closet/quartermaster,
-/obj/item/clothing/accessory/poncho/roles/cloak/qm,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/obj/machinery/status_display/supply_display{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "qMN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -23607,21 +24977,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/prison/cell_block)
 "qMP" = (
-/obj/machinery/fire_alarm/south_mount{
-	pixel_y = -24
-	},
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
-"qNE" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/warehouse)
+"qNE" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/air_alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d3portforhall)
 "qNM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -23659,10 +25032,19 @@
 /area/crew_quarters/recreation_area)
 "qPi" = (
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "qPw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -23743,13 +25125,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
 "qSv" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate/science,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "qSx" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4
@@ -23761,6 +25150,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/entertainment)
+"qUa" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "qVm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23815,10 +25213,9 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "qXh" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -23975,10 +25372,34 @@
 /turf/simulated/floor/tiled,
 /area/security/range)
 "rdb" = (
-/obj/structure/dogbed,
-/mob/living/simple_mob/animal/sif/fluffy,
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/brown/bordercorner2,
+/obj/structure/flora/pottedplant/minitree,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
+"rdF" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d3portforhall)
 "rdY" = (
 /obj/structure/window/basic{
 	dir = 1
@@ -24071,6 +25492,29 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
+"rhw" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Refinery";
+	dir = 8
+	},
+/obj/map_helper/access_helper/airlock/station/supply/mining,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "rhE" = (
 /obj/machinery/door/window/brigdoor/southleft{
 	dir = 4;
@@ -24099,15 +25543,13 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_7)
 "rjY" = (
-/obj/machinery/status_display/supply_display{
-	mode = 99;
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/disposalpipe/segment{
+/obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "rks" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -24138,6 +25580,35 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
+"rkY" = (
+/obj/map_helper/airlock/door/simple,
+/obj/machinery/door/firedoor{
+	dir = 8
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/warehouse)
+"rkZ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 9
+	},
+/obj/structure/bed/chair/sofa/black/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "rlf" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -24160,28 +25631,27 @@
 /turf/simulated/floor/crystal,
 /area/endeavour/hallway/d3fwdhall)
 "rmb" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 5
-	},
-/obj/item/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 26
-	},
+/obj/machinery/mineral/output,
 /obj/machinery/light{
-	dir = 1
+	dir = 4;
+	use_power = 0
 	},
-/obj/machinery/suit_storage_unit/mining,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/machinery/conveyor{
+	id = "mining_interior"
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/belterdock/refinery)
 "rme" = (
 /obj/structure/table/woodentable,
-/obj/item/material/ashtray/glass,
+/obj/machinery/recharger,
 /turf/simulated/floor/carpet/turcarpet,
 /area/crew_quarters/recreation_area)
+"rmA" = (
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "rmU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -24230,6 +25700,13 @@
 "rpK" = (
 /turf/simulated/floor/wood,
 /area/maintenance/dormitory)
+"rqC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "rqI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -24280,15 +25757,26 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/security/range)
+"rrz" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "rrZ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/conveyor{
+	id = "QMLoad2"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "rsb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -24384,6 +25872,10 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
+"rsV" = (
+/obj/effect/floor_decal/corner/brown/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "rtp" = (
 /obj/structure/undies_wardrobe,
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
@@ -24445,20 +25937,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3starboardamidhall)
 "rvC" = (
-/obj/structure/table/standard,
-/obj/item/coin/silver,
-/obj/item/coin/silver,
-/obj/item/cartridge/quartermaster{
-	pixel_x = 6;
-	pixel_y = 5
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/item/cartridge/quartermaster{
-	pixel_x = -4;
-	pixel_y = 7
-	},
-/obj/item/cartridge/quartermaster,
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "rvT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24485,11 +25969,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
 "rwh" = (
-/obj/structure/bed/chair{
-	dir = 8
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/chemical_dispenser/catering/bar_soft{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/foyer)
+/obj/item/storage/box/glasses/square{
+	pixel_x = -25;
+	pixel_y = 6
+	},
+/turf/simulated/floor/wood,
+/area/endeavour/surfacebase/mining_main/break_room)
 "rwx" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -24528,13 +26018,14 @@
 /turf/simulated/wall/r_wall/prepainted/cargo,
 /area/space)
 "rxO" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate/medical,
-/obj/machinery/camera/network/cargo{
-	dir = 4
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window{
+	dir = 1;
+	req_one_access = list(31)
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/quartermaster/office)
 "ryu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -24762,6 +26253,14 @@
 "rEk" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/bar/catwalk)
+"rEu" = (
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/item/stool/padded{
+	pixel_x = 0;
+	pixel_y = 13
+	},
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "rEv" = (
 /obj/structure/cable/green{
 	icon_state = "0-8"
@@ -24788,11 +26287,11 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
 "rER" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "rEX" = (
 /obj/machinery/holopad,
 /turf/simulated/floor/wood,
@@ -24823,6 +26322,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
+"rGS" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "rHk" = (
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -24932,6 +26439,21 @@
 /obj/machinery/holopad,
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/entertainment)
+"rMT" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "rNH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -25002,12 +26524,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/starboardsolar)
 "rOW" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar/catwalk)
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/monotile,
+/area/endeavour/surfacebase/mining_main/break_room)
 "rPa" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navblue/border,
@@ -25021,8 +26551,10 @@
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/security/security_processing)
 "rPE" = (
-/turf/simulated/wall/r_wall/prepainted/cargo,
-/area/maintenance/bar/catwalk)
+/obj/machinery/mineral/equipment_vendor,
+/obj/effect/floor_decal/corner/brown/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "rPF" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -25048,14 +26580,17 @@
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/entertainment)
 "rQs" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/fire_alarm/south_mount{
-	pixel_y = -24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/uxstorage)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "rQE" = (
 /obj/structure/table/woodentable,
 /obj/item/tape_recorder{
@@ -25099,6 +26634,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
+"rRz" = (
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "rSp" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -25229,14 +26770,15 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portamidhall)
 "rXa" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "rXe" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/substation/cargo)
@@ -25247,23 +26789,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
 "rYo" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/navblue/border{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/station_map{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/hallway/d3afthall)
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "rYq" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/quartermaster/miningdock)
@@ -25302,15 +26839,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "rZY" = (
-/obj/machinery/mineral/equipment_vendor,
-/obj/effect/floor_decal/borderfloor{
-	dir = 9
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "sak" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/structure/cable/green{
@@ -25382,18 +26915,17 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "sbx" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/structure/table/steel_reinforced,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "scb" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
@@ -25421,6 +26953,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"scP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/quartermaster/qm)
 "scV" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navblue/border,
@@ -25432,8 +26976,19 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
 "scZ" = (
-/turf/simulated/wall/prepainted/cargo,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
+"sde" = (
+/obj/machinery/atmospherics/component/unary/vent_pump/on,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "see" = (
 /obj/machinery/computer/timeclock/premade/south,
 /obj/structure/cable{
@@ -25506,18 +27061,17 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/lobby)
 "shF" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "shG" = (
 /obj/machinery/holopad,
 /obj/structure/cable/green{
@@ -25535,8 +27089,21 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/crew_quarters/sleep/Dorm_12)
 "shT" = (
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "shW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -25590,6 +27157,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/endeavour/hallway/d3fwdhall)
+"sjp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "sjq" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -25769,6 +27349,7 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/map_helper/access_helper/airlock/station/supply/maintenance,
 /turf/simulated/floor/plating,
 /area/crew_quarters/recreation_area)
 "soV" = (
@@ -25904,6 +27485,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
+"stN" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "stW" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -25940,6 +27532,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
+"suJ" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "svs" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -26111,12 +27708,31 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardamidhall)
 "sxc" = (
-/obj/machinery/conveyor{
-	dir = 9;
-	id = "mining_interior"
+/obj/machinery/door/firedoor{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/map_helper/access_helper/airlock/station/mining_operations,
+/obj/machinery/door/airlock/glass/mining{
+	name = "Magmatic Rift Leap Pad";
+	req_one_access = null
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "sxq" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -26176,14 +27792,23 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portamidhall)
 "szw" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
 	},
-/obj/structure/bed/chair{
-	dir = 8
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 6
 	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/foyer)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "sAp" = (
 /obj/machinery/power/apc/north_mount,
 /obj/structure/cable/green{
@@ -26231,57 +27856,41 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portamidhall)
 "sBr" = (
-/obj/machinery/air_alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/computer/roguezones{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/steel_grid,
+/area/quartermaster/belterdock)
 "sCx" = (
 /turf/space/basic,
 /area/security/range)
 "sDb" = (
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "sDc" = (
-/obj/machinery/light_switch{
-	pixel_x = 25;
-	pixel_y = 7
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/obj/item/storage/box/lights/mixed{
+	pixel_x = 2;
+	pixel_y = 3
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
+/obj/item/storage/box/lights/mixed{
+	pixel_x = -4;
+	pixel_y = 3
 	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood,
 /area/quartermaster/office)
 "sDq" = (
 /obj/structure/stairs/spawner/east,
 /turf/simulated/floor/plating,
 /area/maintenance/bar/lower)
 "sDX" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/air_alarm{
-	pixel_y = 22
+/obj/machinery/mineral/input,
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/belterdock/refinery)
 "sEi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -26289,14 +27898,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/interrogation)
 "sEz" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "sEE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26355,23 +27961,31 @@
 /turf/simulated/floor/water/deep/indoors,
 /area/crew_quarters/sleep/bedrooms)
 "sFW" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/table/rack/shelf,
+/obj/item/radio{
+	pixel_x = 0;
+	pixel_y = 7
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/kitchen)
-"sFX" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
+/obj/item/radio{
+	pixel_x = 6;
+	pixel_y = 7
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/item/radio{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/random/toolbox{
+	pixel_x = 0;
+	pixel_y = -5
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/area/quartermaster/belterdock)
+"sFX" = (
+/obj/map_helper/access_helper/airlock/station/supply/maintenance,
+/obj/structure/catwalk,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
 "sFZ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/cutout,
@@ -26408,14 +28022,17 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "sGH" = (
-/obj/structure/ore_box,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/status_display/supply_display{
-	mode = 99;
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "sHr" = (
 /obj/machinery/light{
 	dir = 1
@@ -26464,7 +28081,6 @@
 /area/endeavour/hallway/d3starboardafthall)
 "sKL" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
-/obj/effect/paint/beastybrown,
 /turf/simulated/floor/tiled/steel/airless,
 /area/shuttle/mining_ship/general)
 "sKV" = (
@@ -26510,12 +28126,21 @@
 /obj/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/starboardsolar)
+"sLZ" = (
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/office)
 "sMN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "sNh" = (
 /obj/structure/disposalpipe/segment,
@@ -26601,24 +28226,15 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/kitchen)
 "sSl" = (
-/obj/machinery/status_display/supply_display{
-	mode = 99;
-	pixel_y = 32
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/machinery/fire_alarm/east_mount,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "sSx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26648,21 +28264,27 @@
 /turf/space,
 /area/space)
 "sTs" = (
-/obj/machinery/holopad,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
-"sUL" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "QMLoad2"
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
+"sUL" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/simulated/floor/airless/ceiling,
+/area/space)
 "sUQ" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -26687,6 +28309,16 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
+"sVv" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/fire_alarm/east_mount,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "sVD" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -26720,25 +28352,17 @@
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/security/range)
 "sWe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
+/obj/effect/floor_decal/industrial/outline{
+	color = #D6DBDB
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Prep Room";
-	req_one_access = null
-	},
-/obj/map_helper/access_helper/airlock/station/supply/mining,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/structure/closet/crate/large,
+/obj/structure/closet/crate/large,
+/obj/item/pickaxe,
+/obj/item/shovel,
+/obj/item/shovel,
+/obj/item/pickaxe,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/warehouse)
 "sWg" = (
 /obj/effect/floor_decal/corner_oldtile/white/diagonal,
 /obj/machinery/light_switch{
@@ -26773,11 +28397,10 @@
 /turf/simulated/floor/tiled/monodark,
 /area/prison/cell_block)
 "sXC" = (
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/structure/cable/green,
+/obj/machinery/power/apc/south_mount,
+/turf/simulated/floor/wood,
+/area/quartermaster/office)
 "sXK" = (
 /obj/machinery/light{
 	dir = 1
@@ -26861,14 +28484,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
 "sZQ" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/navblue/bordercorner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/bordercorner2{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
@@ -26917,37 +28546,44 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
 "tbF" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 10
+	},
+/obj/machinery/fire_alarm/west_mount,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
+"tbK" = (
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
+"tbT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
-"tbK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
-"tbT" = (
-/obj/machinery/holopad,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "tcb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/qm)
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/disposalpipe/junction,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "tcl" = (
 /obj/structure/closet/wardrobe,
 /obj/item/toy/plushie/borgplushie/pupdozer,
@@ -26956,32 +28592,44 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_10)
 "tdf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/structure/flora/grass/event/yellow_flowers1,
+/turf/simulated/floor/grass,
+/area/quartermaster/foyer)
 "tdk" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "tdr" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate,
-/obj/machinery/camera/network/cargo,
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/machinery/door/airlock/glass/mining{
+	name = "Mining Prep Room";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/supply/department,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/wood,
+/area/quartermaster/office)
 "tdG" = (
 /turf/simulated/wall/r_wall/prepainted/cargo,
 /area/shuttle/mining_ship/general)
+"tdM" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
+/obj/effect/floor_decal/corner/brown/bordercorner,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "teq" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -27021,9 +28669,11 @@
 /turf/simulated/floor/tiled,
 /area/security/hanger)
 "tgP" = (
-/obj/structure/dispenser/oxygen,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/uxstorage)
+/obj/effect/floor_decal/industrial/outline{
+	color = #D6DBDB
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/warehouse)
 "thy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27151,15 +28801,10 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/crew_quarters/recreation_area)
 "tkT" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/structure/closet,
-/obj/item/storage/backpack/dufflebag,
-/obj/machinery/power/apc/south_mount,
-/obj/structure/cable/green,
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/obj/machinery/suit_storage_unit/mining,
+/obj/effect/floor_decal/corner/brown/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "tle" = (
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/structure/table/woodentable,
@@ -27211,8 +28856,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
 /area/maintenance/bar/lower)
 "tos" = (
 /obj/machinery/ai_status_display{
@@ -27308,10 +28955,11 @@
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/belter)
 "tqv" = (
-/obj/spawner/window/low_wall/reinforced/full/firelocks,
-/obj/effect/paint_stripe/beastybrown,
+/obj/structure/lattice,
+/obj/structure/lattice,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/endeavour/surfacebase/mining_main/refinery)
+/area/space)
 "tqX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -27373,6 +29021,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/endeavour/hallway/d3fwdhall)
+"ttw" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "tuT" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
@@ -27398,26 +29055,27 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "tvT" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/effect/floor_decal/industrial/outline{
+	color = #D6DBDB
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/closet/crate/science,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/warehouse)
+"twi" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "twA" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 9
-	},
 /obj/structure/table/standard,
 /obj/item/paper_bin,
-/obj/machinery/power/apc/north_mount,
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 10
 	},
@@ -27427,34 +29085,20 @@
 /obj/machinery/camera/network/cargo{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "twR" = (
 /turf/simulated/wall/r_wall/prepainted/cargo,
 /area/quartermaster/qm)
 "txc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
-/obj/machinery/door/airlock/glass/mining{
-	name = "Cargo Bay";
-	req_one_access = null
-	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/structure/catwalk,
+/obj/machinery/door/airlock/maintenance,
+/obj/map_helper/access_helper/airlock/station/supply/maintenance,
+/turf/simulated/floor/plating,
+/area/quartermaster/foyer)
 "txu" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -27490,6 +29134,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
+"tzi" = (
+/obj/item/radio/intercom{
+	pixel_x = 0;
+	req_access = list();
+	pixel_y = -26
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "tzm" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -27524,7 +29182,13 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
 "tBn" = (
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "tBs" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
@@ -27532,13 +29196,15 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/game_room)
 "tBN" = (
-/obj/item/radio/beacon,
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/structure/closet/secure_closet/miner,
+/obj/item/binoculars,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 20
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/foyer)
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "tBY" = (
 /obj/structure/sign/directions/cargo{
 	dir = 1;
@@ -27605,6 +29271,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
+"tDY" = (
+/obj/machinery/atmospherics/component/unary/vent_pump/on,
+/turf/simulated/floor/carpet/bcarpet,
+/area/quartermaster/qm)
 "tEi" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -27628,15 +29298,16 @@
 /turf/simulated/floor/tiled/old_cargo/white,
 /area/security/forensics)
 "tES" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -37
+	},
+/obj/machinery/camera/network/cargo{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
-	},
-/obj/machinery/suit_storage_unit/mining,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "tGi" = (
 /obj/structure/table/woodentable,
 /obj/item/handcuffs/legcuffs/fuzzy,
@@ -27650,9 +29321,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "tGp" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor/wood,
-/area/endeavour/surfacebase/mining_main/break_room)
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/quartermaster/qm)
 "tGr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -27682,11 +29355,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
 "tHq" = (
-/obj/machinery/lathe/autolathe,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/landmark/spawnpoint/job/cargo_technician,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "tHC" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -27740,8 +29411,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/bar/lower)
+/area/crew_quarters/barrestroom)
 "tIr" = (
 /obj/machinery/light{
 	dir = 4
@@ -27858,13 +29530,25 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/map_helper/access_helper/airlock/station/service/kitchen,
-/obj/effect/floor_decal/corner_oldtile/white/diagonal,
-/obj/machinery/door/airlock/civilian{
+/obj/machinery/door/airlock/freezer{
 	name = "Kitchen Cold Room"
 	},
+/obj/map_helper/access_helper/airlock/station/service/kitchen,
+/obj/effect/floor_decal/corner_oldtile/white/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
+"tMZ" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "tNF" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 4
@@ -28093,13 +29777,16 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "tVX" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/machinery/camera/network/cargo{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "tWm" = (
 /obj/structure/closet/l3closet/security,
@@ -28136,10 +29823,13 @@
 /area/endeavour/hallway/d3afthall)
 "tXt" = (
 /obj/machinery/fire_alarm/north_mount,
-/obj/landmark{
-	name = "blobstart"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "tXY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -28256,17 +29946,16 @@
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/mining_ship/general)
 "ubA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/camera/network/cargo{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "ubN" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -28277,6 +29966,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/entertainment)
+"uca" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/belterdock)
 "udg" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -28426,15 +30121,11 @@
 /turf/simulated/floor/reinforced/overhang,
 /area/maintenance/bar/catwalk)
 "uhv" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/floor_decal/borderfloor{
-	dir = 6
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "uhA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28454,11 +30145,8 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "uhE" = (
-/obj/effect/floor_decal/steeldecal/steel_decals5{
-	dir = 8
-	},
 /obj/landmark/spawnpoint/job/cargo_technician,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "uhW" = (
 /obj/item/bedsheet/purpledouble,
@@ -28501,20 +30189,12 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
 "uiJ" = (
-/obj/machinery/door/firedoor,
-/obj/item/folder/white,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window{
-	dir = 8;
-	req_one_access = list(31)
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 4
-	},
-/obj/item/pen,
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/delivery)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3portforhall)
 "uiN" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -28648,36 +30328,41 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "umx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor{
+/obj/machinery/lathe/autolathe,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
+"umX" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/item/clothing/accessory/permit/gun/planetside,
+/obj/item/clothing/accessory/permit/gun/planetside,
+/obj/item/clothing/accessory/permit/gun/planetside,
+/obj/item/clothing/accessory/permit/gun/planetside,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southright{
+	req_one_access = list(48)
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/map_helper/access_helper/airlock/station/supply/mining,
-/obj/machinery/door/airlock/glass/mining{
-	name = "Magmatic Rift Leap Pad";
-	req_one_access = null
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
-"umX" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/effect/floor_decal/corner/brown/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "uny" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -28762,11 +30447,29 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "uqr" = (
-/obj/structure/bed/chair/office/dark,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "url" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor{
@@ -29049,6 +30752,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/security_lockerroom)
+"uAD" = (
+/obj/machinery/computer/security/mining,
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "uAQ" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 1
@@ -29059,12 +30766,12 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "uAU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/bar/lower)
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "uBK" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -29081,6 +30788,13 @@
 "uBN" = (
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
+"uDd" = (
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 1
+	},
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/monotechmaint,
+/area/quartermaster/belterdock/refinery)
 "uEp" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -29128,15 +30842,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "uGC" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/navblue/border{
-	dir = 1
-	},
-/obj/machinery/air_alarm{
-	pixel_y = 22
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -29263,11 +30968,9 @@
 /turf/simulated/floor,
 /area/security/brig)
 "uJr" = (
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/qm)
+/obj/machinery/fire_alarm/west_mount,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "uJv" = (
 /obj/machinery/holopad,
 /turf/simulated/floor/tiled,
@@ -29285,7 +30988,6 @@
 /obj/effect/floor_decal/corner/navgold/bordercorner2{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
 "uJP" = (
@@ -29302,29 +31004,33 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "uKk" = (
-/obj/structure/table/reinforced,
-/obj/item/pen{
-	pixel_x = -6;
-	pixel_y = 7
+/obj/machinery/door/airlock/glass/mining{
+	name = "Mining Prep Room";
+	req_one_access = null
 	},
-/obj/item/paper_bin{
-	pixel_x = 5;
-	pixel_y = 12
-	},
-/obj/item/stamp/cargo,
-/obj/item/stamp/denied{
-	pixel_x = 7
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
-"uKF" = (
+/obj/map_helper/access_helper/airlock/station/supply/department,
+/obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/office)
+"uKF" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/quartermaster/belterdock)
 "uKP" = (
 /obj/machinery/door/firedoor{
 	dir = 8
@@ -29398,16 +31104,18 @@
 /area/endeavour/hallway/d3aftmaint)
 "uMs" = (
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 4
+	dir = 6
 	},
-/obj/effect/floor_decal/corner/navgold/border{
-	dir = 4
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 6
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/effect/floor_decal/borderfloorblack/corner2,
+/obj/effect/floor_decal/corner/brown/bordercorner2,
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/endeavour/hallway/d3afthall)
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "uMD" = (
 /obj/structure/table/bench/steel,
 /obj/effect/floor_decal/borderfloorblack{
@@ -29473,9 +31181,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3portamidhall)
 "uOU" = (
-/obj/structure/lattice,
-/turf/simulated/floor/airless/ceiling,
-/area/maintenance/cargo)
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "uPx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29526,6 +31234,15 @@
 /obj/map_helper/access_helper/airlock/station/engineering/department,
 /turf/simulated/floor/tiled/dark,
 /area/endeavour/hallway/d3aftmaint)
+"uQN" = (
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "uSv" = (
 /obj/structure/table/woodentable,
 /obj/machinery/microwave,
@@ -29539,9 +31256,7 @@
 /obj/effect/floor_decal/corner/navblue/border,
 /obj/effect/floor_decal/borderfloorblack/corner2,
 /obj/effect/floor_decal/corner/navblue/bordercorner2,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3portforhall)
 "uSC" = (
@@ -29570,19 +31285,18 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "uUl" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/glass/mining{
-	name = "Mining Stroage";
-	req_one_access = null
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/map_helper/access_helper/airlock/station/supply/mining,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/uxstorage)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/grass/event/generic_bush1,
+/turf/simulated/floor/grass,
+/area/quartermaster/foyer)
 "uUx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -29651,15 +31365,23 @@
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/mining_ship/general)
 "uWL" = (
-/obj/machinery/light_switch{
-	pixel_x = 25
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/sheet_silo_loader{
-	dir = 8
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d3portforhall)
 "uXI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -29788,12 +31510,15 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/recreation_area)
 "vaA" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Cargo Lobby"
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "vaR" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -29848,14 +31573,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "veW" = (
-/obj/structure/bed/chair{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "vfa" = (
 /turf/simulated/floor/carpet/purcarpet,
@@ -29996,14 +31723,15 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_12)
 "viU" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/effect/floor_decal/corner_oldtile/white/diagonal,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "vjb" = (
@@ -30027,15 +31755,29 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
 "vjg" = (
-/obj/structure/bed/chair/comfy/beige{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/qm)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/bar/catwalk)
 "vjD" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_7)
+"vkd" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 20
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d3portforhall)
 "vkh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -30115,21 +31857,17 @@
 /turf/simulated/floor/plating,
 /area/security/brig)
 "vlO" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/table/steel_reinforced,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "vmT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -30393,12 +32131,13 @@
 /turf/simulated/open,
 /area/endeavour/hallway/d3aftmaint)
 "vsY" = (
-/obj/machinery/computer/roguezones,
-/obj/effect/floor_decal/industrial/warning/cee{
-	dir = 1
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/turf/simulated/floor/plating,
+/area/maintenance/bar/catwalk)
 "vtP" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood,
@@ -30481,11 +32220,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
 "vxE" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/area/quartermaster/belterdock)
 "vxL" = (
 /obj/structure/closet/crate/secure,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -30502,6 +32238,24 @@
 /obj/map_helper/access_helper/airlock/station/security/armory,
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
+"vyj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
+"vyx" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9
+	},
+/obj/machinery/vending/wallmed1{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 2
+	},
+/turf/simulated/floor/wood,
+/area/endeavour/surfacebase/mining_main/break_room)
 "vyR" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 8
@@ -30741,19 +32495,24 @@
 /turf/simulated/floor/water/deep/indoors,
 /area/crew_quarters/sleep/bedrooms)
 "vCC" = (
-/obj/machinery/mineral/output,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "mining_interior"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/structure/bed/chair/sofa/black/right,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "vCG" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
@@ -30765,14 +32524,12 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
 "vDo" = (
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 1
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "vDN" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
@@ -30964,6 +32721,16 @@
 /obj/machinery/camera/network/civilian,
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
+"vIK" = (
+/obj/structure/plasticflaps,
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
 "vIV" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -31025,11 +32792,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "vKr" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/cargo)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "vKG" = (
 /obj/spawner/window/low_wall/reinforced/electrochromic/full/firelocks,
 /obj/map_helper/electrochromatic_linker{
@@ -31108,24 +32873,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
 "vMr" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/item/binoculars,
-/obj/item/stack/flag/red,
-/obj/item/binoculars{
-	pixel_y = 6
+/obj/machinery/door/firedoor{
+	dir = 8
 	},
-/obj/item/binoculars{
-	pixel_y = 6
-	},
-/obj/item/binoculars{
-	pixel_y = 6
-	},
-/obj/item/stack/flag/yellow,
-/obj/item/stack/flag/green,
-/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/area/endeavour/surfacebase/mining_main/break_room)
 "vNb" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -31274,11 +33026,24 @@
 /turf/simulated/wall/r_wall/prepainted/command,
 /area/security/nuke_storage)
 "vRv" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 8
+	},
+/obj/machinery/air_alarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "vRH" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet"
@@ -31292,8 +33057,11 @@
 	sortType = "Trash";
 	dir = 8
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/obj/machinery/light,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
 /area/maintenance/bar/lower)
 "vSl" = (
 /turf/simulated/wall/r_wall/prepainted/cargo,
@@ -31399,8 +33167,9 @@
 /turf/simulated/floor/wood,
 /area/security/lobby)
 "vVA" = (
-/turf/simulated/wall/r_wall/prepainted/cargo,
-/area/endeavour/surfacebase/mining_main/uxstorage)
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "vVH" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -31522,8 +33291,13 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_7)
 "vZR" = (
-/turf/simulated/wall/r_wall/prepainted/cargo,
-/area/quartermaster/storage)
+/obj/effect/floor_decal/steeldecal/steel_decals_central6{
+	dir = 4
+	},
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/effect/paint_stripe/beastybrown,
+/turf/simulated/floor/airless/ceiling,
+/area/quartermaster/warehouse)
 "wau" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
@@ -31538,12 +33312,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
 "waA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/component/unary/vent_pump/on{
-	dir = 8
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/structure/bed/chair/comfy/brown,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "wbb" = (
 /obj/machinery/air_alarm{
 	dir = 8;
@@ -31552,6 +33329,19 @@
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3fwdmaint)
+"wbf" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "wbj" = (
 /obj/machinery/light{
 	dir = 1
@@ -31653,15 +33443,19 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/security_lockerroom)
 "wfZ" = (
+/obj/machinery/door/firedoor/glass,
+/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
+/obj/machinery/door/airlock/glass/mining{
+	name = "Cargo Airlock";
+	req_one_access = null
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/cargo/mining)
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "wgN" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/conveyor{
@@ -31715,6 +33509,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/showers)
+"wjO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "wjT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -31728,13 +33526,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
 "wki" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction/yjunction,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "wku" = (
 /obj/machinery/light/small{
@@ -31751,22 +33550,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/vacant/vacant_shop)
 "wkI" = (
-/obj/item/storage/box/nifsofts_mining,
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
-	},
-/obj/machinery/camera/network/cargo{
-	dir = 4
-	},
-/obj/item/suit_cooling_unit,
-/obj/item/suit_cooling_unit,
-/obj/item/duct_tape_roll,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/turf/simulated/wall/r_wall/prepainted/cargo,
+/area/quartermaster/belterdock/gear)
 "wkY" = (
 /obj/machinery/door/airlock/maintenance/sec{
 	req_one_access = null
@@ -31828,15 +33613,12 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "wmU" = (
-/obj/machinery/fire_alarm/north_mount,
-/obj/machinery/light{
-	dir = 1
+/obj/effect/floor_decal/spline/plain{
+	dir = 5
 	},
-/obj/machinery/air_alarm{
-	pixel_y = 27
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/structure/flora/grass/event/purple_flowers1,
+/turf/simulated/floor/grass,
+/area/quartermaster/warehouse)
 "wns" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
@@ -31845,9 +33627,13 @@
 /turf/simulated/floor/wood,
 /area/endeavour/hallway/d3fwdhall)
 "wnA" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/quartermaster/foyer)
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/machinery/power/apc/east_mount,
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "woj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -32145,9 +33931,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "wxp" = (
-/obj/machinery/mineral/mint,
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "wxK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32177,28 +33975,32 @@
 /area/security/tactical)
 "wzB" = (
 /turf/simulated/wall/r_wall/prepainted/cargo,
-/area/maintenance/cargo)
+/area/vacant/vacant_shop)
 "wzV" = (
-/obj/machinery/keycard_auth{
-	pixel_y = -28
+/obj/machinery/conveyor{
+	dir = 6;
+	id = "mining_interior"
 	},
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/obj/structure/plasticflaps/mining,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/belterdock/refinery)
 "wAe" = (
-/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/glass/mining{
-	name = "Cargo Bay";
-	req_one_access = null
+/obj/machinery/camera/network/cargo{
+	dir = 1
 	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "wAQ" = (
 /obj/machinery/camera/network/civilian{
 	dir = 4
@@ -32239,8 +34041,15 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "wCE" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/reinforced,
 /area/quartermaster/miningdock)
 "wCJ" = (
@@ -32282,13 +34091,11 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/kitchen)
 "wEw" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "mining_interior";
-	name = "refining conveyor";
-	pixel_y = 14
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/turf/simulated/floor/grass,
+/area/quartermaster/warehouse)
 "wEW" = (
 /obj/structure/bed/double,
 /obj/item/bedsheet/hosdouble,
@@ -32375,6 +34182,12 @@
 /obj/item/reagent_containers/glass/cooler_bottle,
 /turf/simulated/floor/tiled/monotile,
 /area/security/hallway)
+"wHt" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "wHz" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /turf/simulated/floor/tiled,
@@ -32391,30 +34204,30 @@
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
 "wHG" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/computer/ship/navigation/telescreen{
-	pixel_y = -37
-	},
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
-	dir = 1
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "wIy" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad2"
-	},
 /obj/map_helper/airlock/door/simple,
 /obj/machinery/door/firedoor{
+	dir = 8
+	},
+/obj/map_helper/access_helper/airlock/station/external_airlock,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
 	dir = 8
 	},
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/plating,
 /area/quartermaster/warehouse)
 "wIA" = (
@@ -32434,6 +34247,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_11)
+"wJM" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 6
+	},
+/obj/machinery/vending/snack,
+/turf/simulated/floor/wood,
+/area/endeavour/surfacebase/mining_main/break_room)
 "wJO" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/donkpockets,
@@ -32567,10 +34387,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
 "wQu" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "QMLoad"
-	},
 /obj/map_helper/airlock/door/simple,
 /obj/machinery/door/firedoor{
 	dir = 8
@@ -32579,6 +34395,16 @@
 	req_one_access = null
 	},
 /obj/map_helper/access_helper/airlock/station/external_airlock,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/warehouse)
 "wQI" = (
@@ -32620,6 +34446,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardafthall)
+"wRx" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "QMLoad";
+	pixel_x = 11;
+	pixel_y = 21
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "wRM" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 10
@@ -32631,9 +34465,15 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/fitness)
 "wRS" = (
-/obj/machinery/holopad,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/window/reinforced/survival_pod,
+/obj/machinery/light{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "wTk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -32703,7 +34543,6 @@
 /area/security/lobby)
 "wWK" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
-/obj/effect/paint/palebottlegreen,
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "wWQ" = (
@@ -32781,8 +34620,26 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "wYU" = (
-/turf/simulated/floor/tiled/steel_grid,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 10
+	},
+/obj/machinery/status_display/supply_display{
+	mode = 99;
+	pixel_y = 0;
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "wYW" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -32794,16 +34651,16 @@
 /area/tether/surfacebase/entertainment)
 "wZh" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "QMLoad"
-	},
 /obj/machinery/shield_diffuser,
 /obj/map_helper/airlock/door/simple,
+/obj/map_helper/access_helper/airlock/station/external_airlock,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad2"
+	},
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/floor/plating,
 /area/quartermaster/warehouse)
 "wZj" = (
@@ -32851,6 +34708,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_12)
+"wZQ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 10
+	},
+/obj/machinery/requests_console/preset/cargo{
+	pixel_x = -31;
+	pixel_y = -1
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "xad" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -32858,14 +34728,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "xai" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/computer/ship/navigation/telescreen{
-	pixel_y = -37
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/air_alarm/south_mount,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "xao" = (
 /obj/structure/cable/green,
@@ -32888,6 +34758,11 @@
 "xbA" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
+"xbG" = (
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/machinery/atmospherics/component/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "xbH" = (
 /turf/simulated/wall/prepainted/civilian,
 /area/maintenance/bar/lower)
@@ -32921,12 +34796,26 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "xeo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "xet" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 4
@@ -33065,20 +34954,27 @@
 /turf/simulated/floor/tiled,
 /area/security/hanger)
 "xkg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/mining{
-	name = "Cargo Storage";
-	req_one_access = null
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 1
 	},
-/obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
 "xkB" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/hallway)
+"xkG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "xkN" = (
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
@@ -33099,11 +34995,8 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
 "xlg" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/office)
+/turf/simulated/wall/prepainted/cargo,
+/area/quartermaster/belterdock/refinery)
 "xlq" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -33124,19 +35017,25 @@
 	pixel_x = -24;
 	pixel_y = -10
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/effect/floor_decal/corner_oldtile/white/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "xlC" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/machinery/status_display/supply_display{
+	mode = 99;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "xlR" = (
 /obj/machinery/power/apc/south_mount,
 /obj/structure/cable/green{
@@ -33238,20 +35137,28 @@
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/entertainment)
 "xtI" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d3portforhall)
+"xtY" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/navblue/border{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
-/area/endeavour/hallway/d3portforhall)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "xus" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -33285,6 +35192,15 @@
 /obj/effect/paint/darkred,
 /turf/simulated/floor/plating,
 /area/security/range)
+"xvW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "xvZ" = (
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_y = -37
@@ -33365,6 +35281,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portamidhall)
+"xxs" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 20
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d3portforhall)
 "xxF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -33433,6 +35362,9 @@
 /obj/machinery/air_alarm{
 	pixel_y = 22
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 8
+	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
@@ -33442,17 +35374,19 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3starboardafthall)
 "xyJ" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "xyL" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /obj/effect/floor_decal/borderfloorblack{
@@ -33464,23 +35398,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
 "xzc" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/effect/floor_decal/industrial/outline{
+	color = #D6DBDB
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/structure/ore_box,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/warehouse)
 "xzh" = (
 /obj/machinery/door/airlock/maintenance/engi{
 	req_one_access = null
@@ -33534,26 +35457,18 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/security_lockerroom)
 "xCO" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 8
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "xCV" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/storage)
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/quartermaster/belterdock/gear)
 "xDe" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/fire_alarm/west_mount{
@@ -33583,17 +35498,27 @@
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/kitchen)
 "xDr" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
 "xDs" = (
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/area/quartermaster/belterdock)
 "xDS" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -33609,11 +35534,10 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar/lounge)
 "xEJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/space)
 "xEP" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -33641,6 +35565,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/bedrooms)
+"xGR" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/structure/bed/chair/comfy/brown,
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "xGU" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -33698,12 +35632,11 @@
 /turf/simulated/floor/crystal,
 /area/endeavour/hallway/d3fwdhall)
 "xJv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar/lower)
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/belterdock/refinery)
 "xJx" = (
 /obj/structure/closet/hydrant{
 	pixel_y = 30
@@ -33738,8 +35671,13 @@
 /area/security/brig)
 "xKi" = (
 /obj/machinery/camera/network/cargo,
-/obj/machinery/mech_recharger,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/warehouse)
 "xLd" = (
 /obj/structure/closet/wardrobe/red,
@@ -33756,9 +35694,13 @@
 /turf/simulated/floor/tiled,
 /area/security/security_lockerroom)
 "xLm" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/cargo/mining)
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/quartermaster/foyer)
 "xLD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -33779,9 +35721,19 @@
 /turf/simulated/floor/reinforced,
 /area/quartermaster/miningdock)
 "xMc" = (
-/obj/machinery/mineral/processing_unit,
-/turf/simulated/floor/tiled/steel_grid,
-/area/endeavour/surfacebase/mining_main/refinery)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "xMu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -33813,6 +35765,13 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/kitchen)
+"xMP" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/effect/floor_decal/borderfloorblack/corner2,
+/obj/effect/floor_decal/corner/brown/bordercorner2,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/foyer)
 "xMQ" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -33857,11 +35816,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
+"xOT" = (
+/obj/effect/paint_stripe/beastybrown,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/turf/simulated/floor/plating,
+/area/quartermaster/office)
 "xPj" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate/freezer,
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/warehouse)
 "xPq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -33875,23 +35843,10 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
 "xPu" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/effect/floor_decal/industrial/outline/red{
+	color = "#AF0000"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/warehouse)
 "xPB" = (
 /obj/spawner/window/low_wall/full/firelocks,
@@ -33912,6 +35867,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/vending/fitness,
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "xQu" = (
@@ -33993,12 +35949,13 @@
 /area/security/brig)
 "xTf" = (
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/office)
 "xTl" = (
 /obj/structure/cable/green{
 	icon_state = "0-8"
@@ -34022,6 +35979,13 @@
 /obj/effect/paint/darkred,
 /turf/simulated/floor/plating,
 /area/security/security_lockerroom)
+"xVq" = (
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/north_mount,
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "xVA" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -34183,8 +36147,17 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
 "xYM" = (
-/turf/simulated/floor/tiled/steel,
-/area/quartermaster/delivery)
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/surfacebase/mining_main/break_room)
 "xZp" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -34341,6 +36314,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
+"ygD" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/warehouse)
 "ygO" = (
 /obj/machinery/light{
 	dir = 4
@@ -34362,12 +36348,18 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/mining_ship/general)
+"yhb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced,
+/area/quartermaster/miningdock)
 "yhp" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/item/stool,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled/monodark,
 /area/quartermaster/delivery)
 "yhH" = (
 /obj/structure/cable/green{
@@ -34436,7 +36428,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/lobby)
 "ykp" = (
-/obj/machinery/vending/fitness,
+/obj/structure/closet/wardrobe/green,
 /turf/simulated/floor/carpet/turcarpet,
 /area/crew_quarters/recreation_area)
 "ykx" = (
@@ -34530,14 +36522,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
 "ymc" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/surfacebase/mining_main/refinery)
+/turf/simulated/floor/grass,
+/area/quartermaster/warehouse)
 "ymh" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -41219,8 +43208,8 @@ pRW
 pRW
 pRW
 tUu
-eAp
-bzE
+rxD
+kpn
 kbt
 uzm
 iaP
@@ -41229,13 +43218,13 @@ qLS
 qLS
 tXh
 gDZ
-aMQ
-aMQ
-aMQ
+qCs
+qCs
+qCs
 dFB
 eLv
 eLv
-aMQ
+qCs
 uGk
 uPC
 fgL
@@ -41413,8 +43402,8 @@ pRW
 pRW
 pRW
 pRW
-eAp
-eAp
+rxD
+rxD
 ddU
 piG
 iaP
@@ -41423,7 +43412,7 @@ dmA
 dmA
 dGV
 gDZ
-aMQ
+qCs
 nUf
 kjU
 qHr
@@ -41617,9 +43606,9 @@ rEk
 rEk
 aTX
 iaP
-aMQ
-aMQ
-aMQ
+qCs
+qCs
+qCs
 lTT
 lTY
 aUp
@@ -41809,9 +43798,9 @@ rra
 bta
 bta
 rEk
+vjg
 qLS
-qLS
-aMQ
+qCs
 bje
 rTq
 rkO
@@ -42003,12 +43992,12 @@ bta
 bta
 bta
 rEk
-qLS
-qLS
-aMQ
-aMQ
-aMQ
-aMQ
+vjg
+vjg
+qCs
+qCs
+qCs
+qCs
 qCs
 qCs
 tIj
@@ -42198,12 +44187,12 @@ bta
 bta
 qup
 qLS
-qLS
-mVn
+vjg
+esB
 xLD
 lif
 lif
-kgM
+apt
 xZH
 leL
 pir
@@ -42392,12 +44381,12 @@ bta
 bta
 rEk
 qLS
-qLS
-mVn
+vjg
+esB
 lif
 lif
 lif
-kgM
+apt
 xZH
 leL
 pir
@@ -42408,7 +44397,7 @@ mup
 mup
 mup
 mup
-hLw
+hCa
 pir
 piX
 tJl
@@ -42586,12 +44575,12 @@ bta
 bta
 rEk
 qLS
-qLS
-mVn
+vjg
+esB
 lif
 lif
 lif
-kgM
+apt
 xZH
 leL
 pir
@@ -42779,13 +44768,13 @@ bta
 bta
 uhj
 rEk
-qLS
-qLS
-mVn
-xLD
-lif
-lif
-kgM
+wku
+vjg
+esB
+pfu
+vIK
+bxW
+apt
 fSt
 leL
 pir
@@ -42973,13 +44962,13 @@ bta
 bta
 bta
 rEk
-rOW
-mVn
-mVn
-lif
+qLS
+vsY
+sFX
+xkg
 xCO
-lif
-kgM
+cic
+apt
 xZH
 leL
 pir
@@ -43145,9 +45134,9 @@ pRW
 pRW
 pRW
 pRW
-pRW
-pRW
-rxD
+fDw
+fDw
+wuh
 ilf
 ilf
 ilf
@@ -43159,21 +45148,21 @@ ilf
 ilf
 ilf
 ilf
-qDH
-qDH
-qDH
-qDH
-rEk
-rEk
-rEk
-rEk
-qLS
-qLS
-kgM
-lif
+wuh
+wuh
+wuh
+wuh
+wkI
+wkI
+wkI
+wkI
 qDS
-aDU
-kgM
+fwo
+qDS
+qDS
+qDS
+qDS
+qDS
 xZH
 leL
 pir
@@ -43339,7 +45328,7 @@ pRW
 pRW
 pRW
 pRW
-pRW
+xEJ
 pRW
 wuh
 iXY
@@ -43356,19 +45345,19 @@ iXY
 iXY
 iXY
 iXY
-rxD
-rPE
-qLS
-qLS
-qLS
-qLS
-qLS
-kgM
-kgM
-kgM
+wuh
+tkT
+tkT
+tkT
+tkT
+xlg
+fln
+jcV
+uDd
+lNd
 lgM
-kgM
-xZH
+qDS
+lXM
 leL
 pir
 nhj
@@ -43533,8 +45522,8 @@ pRW
 pRW
 pRW
 pRW
-pRW
-pRW
+tqv
+fDw
 wuh
 iXY
 tdG
@@ -43550,19 +45539,19 @@ iXY
 iXY
 iXY
 ehr
-rxD
-rPE
-qLS
-qLS
-qLS
-qLS
-qLS
-kgM
-xZH
-xZH
-uAU
-kgM
-xZH
+wuh
+jzp
+xbG
+vDo
+rsV
+qoU
+mqI
+fmj
+gXm
+gXm
+tzi
+qDS
+qek
 leL
 uvj
 mup
@@ -43727,7 +45716,7 @@ pRW
 pRW
 pRW
 pRW
-pRW
+xEJ
 tUu
 wuh
 gmZ
@@ -43744,20 +45733,20 @@ iXY
 iXY
 iXY
 iXY
-rxD
-rPE
-qLS
-qLS
-qLS
-qLS
-qLS
-kgM
-xZH
-xZH
+wuh
+tBN
+jwr
+mIP
+jag
+qoU
+mqI
+aRN
+mEb
+mLf
 uAU
+qDS
 kgM
-xZH
-leL
+kYu
 pir
 pir
 tMP
@@ -43921,7 +45910,7 @@ pRW
 pRW
 pRW
 pRW
-pRW
+xEJ
 pRW
 wuh
 iXY
@@ -43931,27 +45920,27 @@ lwX
 gpG
 tdG
 iXY
+eCy
+rZY
 iXY
 iXY
 iXY
 iXY
 iXY
-iXY
-iXY
-rxD
-rPE
-qLS
-qLS
-qLS
-qLS
-mVn
-kgM
-xZH
-xZH
-uAU
-kgM
-fSt
-leL
+wuh
+jag
+rEu
+fEf
+jag
+qoU
+mqI
+ocq
+mEb
+xJv
+iIq
+qoU
+oWf
+lnj
 pir
 cUi
 apJ
@@ -43960,7 +45949,7 @@ dgB
 hOP
 aVW
 aVW
-sFW
+aVW
 pir
 fbH
 uhA
@@ -44115,33 +46104,33 @@ pRW
 pRW
 pRW
 pRW
-pRW
+fDw
 pRW
 wuh
-iXY
+lxo
 tdG
 ygR
 muW
 jhZ
 tdG
 iXY
-iXY
+gdX
 iXY
 iXY
 iXY
 iXY
 iXY
 mcn
-rxD
-rPE
-qLS
-qLS
-qLS
-qLS
-mVn
-fSt
-xZH
-xZH
+wuh
+fRy
+xCV
+ccA
+gTv
+xlg
+aDU
+sjp
+iYp
+twi
 buX
 hDH
 iIN
@@ -44309,7 +46298,7 @@ pRW
 pRW
 pRW
 pRW
-pRW
+fDw
 pRW
 wuh
 mLl
@@ -44319,27 +46308,27 @@ tpp
 kxI
 tdG
 iXY
+xkG
+dbb
 iXY
 iXY
 iXY
 iXY
 iXY
-iXY
-iXY
-rxD
+wuh
 rPE
-wku
-qLS
-qLS
-qLS
+rsV
+eJS
+jAQ
+cln
 lNT
-xZH
-xZH
-xZH
-xZH
-kgM
-xZH
-leL
+pCG
+rrz
+rrz
+rdb
+qoU
+oWf
+atT
 pir
 sRJ
 xMC
@@ -44503,7 +46492,7 @@ pRW
 pRW
 pRW
 pRW
-jGe
+fLU
 jYr
 wuh
 ufN
@@ -44513,25 +46502,25 @@ iRB
 jeT
 tdG
 iXY
-iXY
+rYo
 iXY
 iXY
 iXY
 iXY
 iXY
 ehr
-rxD
-rPE
-qLS
-qLS
-qLS
-qLS
-mVn
-xZH
-xZH
-xZH
-xZH
-kgM
+wuh
+umX
+mNx
+wnA
+bSl
+xlg
+ejp
+nmD
+aHY
+oBi
+wzV
+qDS
 xZH
 tol
 pir
@@ -44539,9 +46528,9 @@ sRJ
 aHs
 kyF
 jfy
-aVW
 aHs
-aVW
+aHs
+aHs
 dhd
 pir
 lhR
@@ -44707,25 +46696,25 @@ ifT
 eIe
 tdG
 iXY
+rYo
 iXY
 iXY
 iXY
 iXY
 iXY
 iXY
-iXY
-rxD
-rPE
-qLS
-qLS
-qLS
-qLS
-mVn
-xZH
-xZH
-xZH
-xZH
-kgM
+wuh
+jBe
+jBe
+jBe
+jBe
+jBe
+quo
+xyJ
+aXm
+qoU
+agT
+qDS
 sDq
 tol
 pir
@@ -44737,8 +46726,8 @@ pir
 pir
 pir
 pir
-pir
-rYo
+hdh
+iSj
 rfb
 kGS
 glG
@@ -44891,7 +46880,7 @@ pRW
 pRW
 pRW
 pRW
-jGe
+fLU
 jYr
 wuh
 ufN
@@ -44901,37 +46890,37 @@ ifT
 eIe
 tdG
 iXY
-iXY
+rYo
 vSl
 lYO
 lYO
 lYO
 vSl
-iXY
-rxD
-mVn
-qLS
-qLS
-qLS
-qLS
-mVn
+aec
+wuh
+rkZ
+leO
+xYM
+wZQ
+jBe
+nlW
+xyJ
+cmi
+qDS
+fDt
+qDS
 kgM
-kgM
-xZH
-xZH
-kgM
+gdU
 xbH
-buX
-oOy
-oOy
+xZH
 qXh
-xJv
 xZH
 xZH
-pmy
-pmy
-pmy
-pmy
+xZH
+bWK
+bWK
+bWK
+bWK
 ooh
 jVt
 buM
@@ -45082,10 +47071,10 @@ pRW
 pRW
 pRW
 pRW
-mDp
 pRW
 pRW
 pRW
+fDw
 pRW
 wuh
 ufN
@@ -45095,31 +47084,31 @@ eum
 ofW
 tdG
 iXY
-iXY
+rYo
 vSl
 oaN
 ctb
 wGx
 vSl
 iXY
-rxD
+wuh
+omy
 mVn
-mVn
-qLS
-qLS
-mVn
-mVn
-mLm
-kgM
+mhO
+okQ
+hsc
+qUa
+xyJ
+sDX
 qoU
+bmR
+qDS
 kgM
-kgM
-xbH
 pXt
+qbu
 fTU
 fTU
 fTU
-buX
 lIR
 hXA
 bWK
@@ -45276,10 +47265,10 @@ pRW
 pRW
 pRW
 pRW
-mDp
 pRW
 pRW
 pRW
+xEJ
 pRW
 wuh
 dJV
@@ -45289,26 +47278,26 @@ bgM
 tMa
 tdG
 iXY
-iXY
+rYo
 vSl
 tYv
 dym
 qmc
 vSl
 iXY
-rxD
-hwP
-hwP
-hwP
+wuh
+flt
+mVn
+bYG
 gQF
-hwP
-mLm
-mLm
+rOW
+otE
+szw
 nYH
-mLm
-mLm
-xbH
-xbH
+rmb
+jhH
+qDS
+kgM
 pYt
 pYt
 vRH
@@ -45470,10 +47459,10 @@ pRW
 pRW
 pRW
 pRW
-mDp
 pRW
 pRW
 pRW
+xEJ
 tUu
 wuh
 ufN
@@ -45483,26 +47472,26 @@ xJx
 cRB
 tdG
 iXY
-iXY
+rYo
 vSl
 aKj
-eBl
+qIH
 qIH
 vSl
 iXY
-rxD
+wuh
 hwP
-mLm
-mLm
-mLm
-hwP
-mLm
-mLm
-mLm
-mLm
-mLm
-mLm
-mLm
+mhO
+nBB
+jTn
+jBe
+acL
+acL
+jBe
+qDS
+qDS
+qDS
+kgM
 pYt
 wHF
 muK
@@ -45664,10 +47653,10 @@ pRW
 pRW
 pRW
 pRW
-mDp
 pRW
 pRW
 pRW
+xEJ
 pRW
 wuh
 ufN
@@ -45676,23 +47665,23 @@ buL
 qSx
 drT
 tdG
-iXY
-iXY
+nAS
+rqC
 vSl
 hRx
 qIH
 hpq
 vSl
 iXY
-rxD
-aGE
-mLm
-mLm
-mLm
-hwP
-hwP
-mLm
-mLm
+wuh
+egp
+emx
+moE
+gnO
+vyx
+lJo
+eKM
+jBe
 lMH
 lMH
 lMH
@@ -45858,10 +47847,10 @@ pRW
 pRW
 pRW
 pRW
-mDp
 pRW
 pRW
 pRW
+fDw
 pRW
 wuh
 ufN
@@ -45871,22 +47860,22 @@ rAq
 rAq
 iXY
 iXY
-iXY
+rYo
 xXl
 fTI
 qIH
 iVL
 vSl
 mcn
-rxD
-aGE
-mLm
-mLm
-mLm
-mLm
-hwP
-mLm
-mLm
+wuh
+cmE
+oYC
+qmY
+gnO
+mfS
+qcx
+rwh
+jBe
 lMH
 gic
 qBI
@@ -45901,11 +47890,11 @@ aUT
 bWK
 mmq
 mmq
-qHq
+eBl
 tXo
 tXY
 hjP
-qHq
+eBl
 mmq
 mmq
 bWK
@@ -46052,11 +48041,11 @@ pRW
 pRW
 pRW
 pRW
+pRW
 mDp
 mDp
-mDp
-mDp
-mDp
+xEJ
+lIp
 wuh
 fip
 nmv
@@ -46064,23 +48053,23 @@ nmv
 nmv
 nmv
 xMb
-nmv
 rOn
+rYo
 vSl
 aKK
 qIH
 agW
 vSl
 iXY
-rxD
-aGE
-mLm
-mLm
-mLm
-mLm
-hwP
+wuh
+aFS
+mhO
+qyK
+gnO
+pOK
+qcx
 hWB
-mLm
+jBe
 lMH
 hMP
 evn
@@ -46092,7 +48081,7 @@ pYt
 pYt
 pYt
 kEi
-bWK
+cuY
 xPB
 xPB
 bWK
@@ -46246,35 +48235,35 @@ pRW
 pRW
 pRW
 pRW
+pRW
 mDp
 mDp
+xEJ
 mDp
-mDp
-mDp
-rxD
-wuh
-wuh
-wuh
-wuh
-wuh
-wuh
-gmZ
-ufN
+twR
+twR
+twR
+twR
+twR
+twR
+twR
+vaA
+rYo
 vSl
 ufL
 qIH
 agW
 vSl
-iXY
-rxD
+mLl
+jHB
 aGE
-mLm
-mLm
-mLm
-mLm
-hwP
-mLm
-mLm
+sde
+fFy
+gnO
+dBd
+qcx
+kve
+jBe
 lMH
 lMH
 lCU
@@ -46289,7 +48278,7 @@ boM
 mLk
 mLk
 mLk
-mLk
+bjC
 wTk
 prg
 cua
@@ -46438,37 +48427,37 @@ pRW
 pRW
 mDp
 mDp
+pRW
+pRW
+pRW
 mDp
 mDp
+xEJ
 mDp
-mDp
-mDp
-mDp
-mDp
-rxD
+twR
 bOW
 cyG
-qcx
+puP
 jrK
 ePB
-oWf
-nmv
+twR
+nxz
 rYq
 vSl
 vSl
 vSl
 vSl
 vSl
-iXY
-rxD
-hwP
-hWB
-mLm
-mLm
-mLm
-hwP
-mLm
-mLm
+ufN
+wuh
+cNV
+mhO
+qyK
+ntW
+poa
+mJv
+wJM
+jBe
 lMH
 vIC
 vmT
@@ -46632,38 +48621,38 @@ mDp
 mDp
 mDp
 mDp
+pRW
+pRW
+pRW
 mDp
 mDp
+lIp
 mDp
-mDp
-mDp
-mDp
-mDp
-rxD
-qcx
-qcx
-qcx
-ejk
-qcx
-vkn
-wuh
-fSr
+twR
+fDh
+oMq
+kFJ
+heO
+fJk
+twR
+ufN
+rYo
 iXY
 tqt
 kLg
 tqt
 iXY
-iXY
-rxD
-hwP
-mLm
-mLm
-mLm
-mLm
-hwP
-mLm
-mLm
-nAS
+ufN
+wuh
+vkn
+vMr
+rhw
+vkn
+vkn
+vkn
+vkn
+vkn
+lMH
 cgt
 fCZ
 qVm
@@ -46674,7 +48663,7 @@ vEC
 eIC
 fub
 hHQ
-aec
+bYm
 pSd
 bYm
 ecr
@@ -46684,7 +48673,7 @@ bfD
 bfD
 srX
 mvQ
-uMs
+bfD
 uPx
 gFf
 kGS
@@ -46831,31 +48820,31 @@ pRW
 pRW
 pRW
 pRW
-jGe
+fLU
 jYr
-rxD
+twR
+uAD
 oMq
 oMq
-oMq
-ejk
-qcx
-kZu
+iDN
+dDu
+twR
+fip
+tMZ
+boI
+iXY
+iXY
+iXY
+iXY
+ufN
 wuh
-wuh
-iXY
-iXY
-iXY
-iXY
-iXY
-iXY
-rxD
-hwP
-mLm
-mLm
-mLm
-mLm
-hwP
-mLm
+sBr
+vxE
+xtY
+eIB
+coj
+cRY
+mrC
 mLm
 lMH
 ukb
@@ -47027,29 +49016,29 @@ pRW
 pRW
 jYr
 aKn
-rxD
-tGp
-tGp
-tGp
+twR
+kPT
+oMq
+jLH
 jAe
 bhw
-pDn
-apt
+twR
+twR
+twR
+oSc
+mLC
+beJ
+uQN
+nmv
+gGm
 wuh
-iXY
-iXY
-iXY
-iXY
-iXY
-mcn
-rxD
-hwP
-mLm
-mLm
-mLm
-mLm
-hwP
-mLm
+uKF
+vVA
+wbf
+blB
+quL
+dgn
+iRl
 mLm
 lMH
 vxy
@@ -47219,31 +49208,31 @@ pRW
 pRW
 pRW
 pRW
-jGe
+fLU
 jYr
-rxD
+twR
+xVq
 tGp
 tGp
+scP
 tGp
-qcx
-qcx
 ejk
 jtn
-wuh
+twR
 fko
 iXY
+rER
+ufN
 iXY
-iXY
-iXY
-iXY
-rxD
-hwP
-mLm
-mLm
-mLm
-mLm
-hwP
-mLm
+lag
+wuh
+sFW
+vxE
+nkT
+jhT
+fKc
+exh
+gsj
 mLm
 lMH
 iON
@@ -47253,7 +49242,7 @@ oms
 ukb
 lUi
 lMH
-cVy
+xxs
 rqN
 cpz
 syH
@@ -47413,31 +49402,31 @@ pRW
 pRW
 pRW
 pRW
+fDw
 pRW
-pRW
-rxD
+twR
+apW
+tDY
 djB
-djB
-djB
-qcx
-qcx
-ejk
-qIo
-wuh
+bIZ
+mbC
+sGH
+nNn
+twR
 wCE
+wjO
+yhb
+ufN
 iXY
-ehr
+bJS
 wuh
-twR
-twR
-twR
-gNj
-gNj
-gNj
-mLm
-mLm
-hwP
-mLm
+iJR
+akP
+xDs
+pwG
+uca
+oxR
+vxE
 mLm
 lMH
 new
@@ -47607,32 +49596,32 @@ pRW
 pRW
 pRW
 pRW
-pRW
+pDn
 tUu
-rxD
-qcx
-jCu
-qcx
-qcx
-qcx
-ejk
+twR
+jYU
+nNn
+nNn
+nNn
+aOQ
+fvb
 leF
-wuh
+twR
+bWZ
 iXY
+tbK
+fSr
 iXY
-iXY
-wuh
-rvC
 nWj
-iIq
+wuh
 sBr
 npS
-gNj
+cFA
+dLz
+ndj
+bIf
+fjp
 mLm
-mLm
-hwP
-hwP
-hwP
 lMH
 evB
 ukb
@@ -47801,31 +49790,31 @@ pRW
 pRW
 pRW
 pRW
-pRW
-pRW
+sUL
+fDw
+twR
+twR
 qKQ
 qKQ
 qKQ
-qKQ
-qKQ
-pqk
+twR
 mYS
-qKQ
-qKQ
-qKQ
-egp
+twR
+twR
+kUA
 wuh
 wuh
-cmE
-qmQ
-vjg
-qmQ
-wzV
+wuh
+wuh
+wuh
+wuh
+mLm
+mLm
 gNj
-mLm
-mLm
-mLm
-mLm
+gNj
+sxc
+gNj
+gNj
 mLm
 lMH
 skT
@@ -47995,32 +49984,32 @@ pRW
 pRW
 pRW
 pRW
+pDn
 pRW
-pRW
-qKQ
+mSw
 eBs
-pOK
 inw
-ldo
+inw
+inw
 wYU
 onr
 vRv
 tbF
-oYC
-ldo
+pJe
+mil
 gLK
 etR
-nNn
+cEj
 uJr
 juy
 feq
-nNn
+mSw
 oOI
-xLm
-xLm
-xLm
-xLm
-mLm
+bgH
+xeo
+bgH
+eVc
+oXi
 lMH
 nqP
 ukb
@@ -48189,32 +50178,32 @@ pRW
 pRW
 pRW
 pRW
+pDn
 pRW
-pRW
-qKQ
-bgH
-tqv
-dgn
+mSw
+oOV
+heJ
+heJ
 bPg
-ldo
-ldo
-ldo
+feE
+gWf
 hkm
-ldo
-ldo
-ldo
+hkm
+jCu
+suJ
 bvE
-nNn
-tcb
-mIP
+bvE
+dei
+bvE
+bvE
 hlc
-rdb
-gNj
-hWB
-mLm
-mLm
+jon
+xGR
+mii
+jev
+mii
 xLm
-mLm
+oXi
 lMH
 cBD
 ukb
@@ -48383,41 +50372,41 @@ pRW
 pRW
 pRW
 pRW
+fDw
 pRW
-pRW
-qKQ
+mSw
 moz
-tqv
-ldo
-ldo
-ldo
-vsY
-lCC
-hkm
+heJ
+heJ
+heJ
+xvW
+gqQ
+heJ
+heJ
 ldo
 lQq
 hOq
-gNj
-gdU
+hOq
+hOq
 jSX
-rER
-qMz
-tkT
-gNj
+bvE
+bvE
+jon
+lKt
 atw
 nfA
-mLm
-xLm
-hwP
-lMH
-lMH
-lMH
-lMH
-lMH
-lMH
-lMH
-lMH
-xtI
+hzi
+qMz
+oXi
+wzB
+wzB
+wzB
+wzB
+wzB
+wzB
+wzB
+wzB
+vkd
 rZg
 swv
 syH
@@ -48577,38 +50566,38 @@ pRW
 pRW
 pRW
 pRW
+pDn
 pRW
-pRW
-tqv
+jon
 bHV
-tqv
+heJ
 dHW
 kDM
 dPs
-scZ
-scZ
+gqQ
+jEc
 sWe
-mEb
-mEb
-scZ
-ffW
-ffW
+pJe
+wRS
+kpa
+pqk
+ygD
 pyb
 gtZ
-ffW
-ffW
-ffW
-ffW
-ffW
-ffW
+pHB
+jon
+dcu
+mii
+cWN
+mii
 hmk
-cmi
+oXi
 nCY
 che
 dOT
 hvh
 dOT
-jag
+che
 wgN
 eyn
 mXi
@@ -48771,40 +50760,40 @@ pRW
 pRW
 pRW
 pRW
-pRW
-pRW
-tqv
+sUL
+fDw
+jon
 lKH
-tqv
+heJ
 wEw
-kur
-sGH
-scZ
-rZY
-moE
-wkI
+lIF
+dPs
+gqQ
+tgP
+tgP
+pJe
 eHs
-jBe
-ffW
+kWu
+bvE
 fJl
 vlO
-blB
-ffW
-eFf
-noW
-xlg
-noW
-ffW
-hmk
-heO
+bvE
+pHB
+mSw
+oLy
+jON
+daE
+jON
+aDq
+oXi
 pwn
 pwn
 lRx
 yhp
 aaY
-aaY
 pwn
 pwn
+kad
 rcz
 kXK
 avK
@@ -48965,40 +50954,40 @@ pRW
 pRW
 pRW
 pRW
+pDn
 pRW
-pRW
-qKQ
+mSw
 xMc
-tqv
+heJ
 hDl
 kur
-ccA
-scZ
-qzI
+dPs
+gqQ
 xzc
-lnj
-lnj
+xzc
+pJe
+eHs
 kWu
-pfu
+bvE
 qDe
 sbx
-xeo
+bvE
 umx
-xlC
-noW
+mSw
+cNA
 pzs
 noW
-ffW
-hmk
-hdh
-pwn
+mii
+wHt
+oXi
+mzJ
 twA
-xYM
+aIZ
 uhE
-xYM
-xYM
+aIZ
+aIZ
 pdF
-pwn
+kad
 uZv
 esx
 qBG
@@ -49159,38 +51148,38 @@ pRW
 pRW
 pRW
 pRW
+pDn
 pRW
-pRW
-tqv
+jon
 vCC
-fLU
+heJ
 bhP
 ifE
-uKF
-scZ
-lKt
-umX
+dPs
+gqQ
+fil
+tgP
 pJe
-shT
-vMr
+eHs
+kWu
 ffW
 pdT
-nrZ
+mbv
 etZ
-ffW
-sDX
-noW
-noW
+uOU
+jon
+waA
+jON
 daE
-ffW
-ffW
-hdh
+jON
+stN
+hrS
 eNB
-jPe
-gGm
+aIZ
+aIZ
 qWd
-gGm
-gGm
+aIZ
+aIZ
 ays
 iDE
 tBY
@@ -49353,35 +51342,35 @@ pRW
 pRW
 pRW
 pRW
+fDw
 pRW
-pRW
-tqv
+jon
 bHV
-fLU
+heJ
 wmU
 ymc
-atT
+dPs
 gqQ
-xCV
+tgP
 tvT
 pJe
 wRS
 evc
-ffW
+bvE
 pHB
 kOw
-iJR
-gtZ
-bxW
+bvE
+bvE
+jon
 rXa
 mii
-mii
+lye
 kKO
 qvo
 wfZ
 mlk
 lkP
-gGm
+lkP
 nsH
 sMN
 sMN
@@ -49547,33 +51536,33 @@ pRW
 pRW
 pRW
 pRW
-jGe
+fLU
 jYr
-qKQ
-moz
-tqv
-agT
-dcu
+mSw
+pmy
+heJ
+heJ
+heJ
 wHG
-scZ
-tES
-tdf
+gqQ
+heJ
+heJ
 pJe
-shT
-tdk
-ffW
-fjp
+eHs
+lmr
+bvE
+bvE
 ptR
 tHq
-gtZ
-nDz
+bvE
+jon
 waA
 jON
-nxz
-bqs
-ffW
+daE
+jON
+xMP
 hrS
-eNB
+aIZ
 aIZ
 aIZ
 dZb
@@ -49743,39 +51732,39 @@ pRW
 pRW
 jYr
 aKn
-qKQ
-sxc
-puP
-uWL
-boI
-vDo
-scZ
-fvb
-jAA
-jLH
-shT
-tdk
-cmw
-nVC
+mSw
+oOV
+heJ
+heJ
+heJ
+heJ
+gqQ
+heJ
+heJ
+pJe
+eHs
+pZF
+pvt
+pvt
 nrZ
 qMP
-ffW
-ffW
-gtZ
-lmr
-gtZ
-ffW
-ffW
-iSP
-pwn
-eNB
+dQv
+mSw
+xlC
+mii
+cWN
+mii
+dmT
+oXi
+kad
+kad
 ekD
 kwo
-uiJ
-eNB
-eNB
-pwn
-rub
+ekD
+nvP
+ekD
+kad
+pHm
 xiG
 avK
 syH
@@ -49935,39 +51924,39 @@ pRW
 pRW
 pRW
 pRW
-jGe
+fLU
 jYr
-vVA
+mSw
 fYy
-fYy
-oOV
-txc
-mff
+heJ
+heJ
+heJ
+heJ
 scZ
-qmY
 sDb
-shT
+sDb
+csA
 shT
 tdk
-cmw
-nVC
+tdk
+tdk
 sTs
 pJR
-cmw
+tdk
 hrc
 izO
-gal
-gal
+pZg
+tcb
 dyR
 cDv
 tVX
-vaA
 gal
 gal
 gal
 gal
+mff
 gal
-gal
+qSv
 oXi
 sZQ
 xiG
@@ -50129,40 +52118,40 @@ pRW
 pRW
 pRW
 pRW
+fDw
 pRW
-pRW
-vVA
+mSw
 gSF
 eWe
-uUl
-oNw
-vxE
-scZ
-rmb
-jzp
+tgP
+tgP
+heJ
+kRu
+heJ
+heJ
 sEz
 shF
 uhv
-cmw
+oOy
 nVC
 qPi
 uqr
 pDb
+jex
 qAh
-qAh
-gal
+jwQ
 dLj
 aDs
-jhH
+jwQ
 pVz
 jwQ
 fva
-fva
-fva
-fva
-fva
-fva
-fva
+jwQ
+jwQ
+ttw
+jwQ
+jwQ
+mwk
 ukf
 emK
 bAI
@@ -50323,40 +52312,40 @@ pRW
 pRW
 pRW
 pRW
-pRW
+pDn
 tUu
-vVA
-cJJ
-aFS
+mSw
 oOV
-fil
-fil
-scZ
-scZ
-jwr
-gnO
-scZ
-scZ
-ffW
+tgP
+tgP
+aGI
+heJ
+kRu
+heJ
+heJ
+heJ
+hXO
+heJ
+aps
 sSl
-qPi
+ldm
 uKk
-cmw
-gal
+ldm
+ldm
 mjB
 hUF
 qwK
 wki
 bTA
 xDr
-mhO
-lAm
-lAm
-pZg
-lAm
-lAm
+bTA
+qpD
 pZg
 pZg
+lAm
+pZg
+pZg
+vyj
 dns
 xlf
 swv
@@ -50517,40 +52506,40 @@ pRW
 pRW
 pRW
 pRW
+pDn
 pRW
-pRW
-vVA
+mSw
 lwA
-rQs
-oOV
-fil
-fil
-feE
-pjE
-ubA
-mbv
+heJ
+heJ
+heJ
+rmA
+kRu
+heJ
+xPu
+xPu
 hXO
 xPu
 wAe
-fDt
-xyJ
+ldm
+ldm
 oXV
 hJm
-jEc
-kYu
-eZz
-tBN
+ldm
+cmw
+cmw
+nKd
 veW
-kPT
+mii
 jtk
-rBG
-rBG
-rBG
-rBG
-qdW
-rBG
-rBG
-rBG
+dTQ
+hUF
+dZI
+oNw
+hUF
+hLw
+gdM
+oXi
 nJu
 nQm
 wtj
@@ -50711,41 +52700,41 @@ pRW
 pRW
 pRW
 pRW
-pRW
-pRW
-vVA
-esB
+sUL
+fDw
+mSw
+fYy
 tgP
-oOV
-cNA
-gXm
-poa
-poa
-gqw
-poa
-poa
+tgP
+tgP
+dPs
+kRu
+heJ
+kxv
+kxv
+hXO
 kxv
 des
-hcH
+ldm
 sDc
 orm
 jEN
-jYU
+nzA
 lfJ
-gal
+rxO
 tBn
-wnA
-wnA
+veW
+mii
 jtk
-rBG
-fju
+hLV
+uUl
 kXD
-fju
-mIk
-fju
-fju
-rBG
-qxm
+tdf
+dTq
+caf
+tdf
+oXi
+eMH
 kMk
 kYx
 syH
@@ -50905,41 +52894,41 @@ pRW
 pRW
 pRW
 pRW
+pDn
 pRW
-pRW
-vVA
+mSw
 oOV
-oOV
-oOV
-qNE
-czr
-czr
+aDw
+tgP
+tgP
+aXu
+kOE
 czr
 lEM
-ldK
+lEM
 ldK
 kTN
 laQ
-mKJ
-nyi
-nyi
-nyi
+ldm
+aKx
+eKq
+nzA
 qlg
 ffP
-eIB
-bJS
-rwh
-szw
-nkT
-rBG
-vKr
-fju
-fju
-mIk
-fju
-fju
-rBG
-txu
+cmw
+tBn
+veW
+mii
+jtk
+cDv
+gal
+mff
+gal
+gal
+mff
+qSv
+oXi
+uWL
 kSN
 prZ
 azB
@@ -51099,42 +53088,42 @@ pRW
 pRW
 pRW
 pRW
-pRW
+pDn
 pRW
 mSw
 ncP
 heJ
-wxp
-fil
+heJ
+heJ
 tbT
-fil
-xDs
-hzi
+kRu
+heJ
 qJB
-fil
-kTN
+qJB
+dPs
+qJB
 mpt
 ldm
-nyi
+hcH
 eKq
 nzA
-nyi
-nyi
-nyi
-nyi
-nyi
-rBG
-rBG
-rBG
-fju
-fju
-fju
-mIk
-fju
-fju
-rBG
+nTg
+iSP
+cmw
+tBn
+rQs
+qmQ
+diM
+qmQ
+baY
+qmQ
+qmQ
+pmG
+qmQ
+qmQ
+qIo
 xtI
-bBc
+uiJ
 uSz
 syH
 vPk
@@ -51293,40 +53282,40 @@ pRW
 pRW
 pRW
 pRW
-pRW
+fDw
 pRW
 jon
-mJv
+fYy
 fil
 aDw
-fil
-czr
-czr
-czr
-tbK
-xEJ
-xEJ
-sFX
+tgP
+tbT
+kRu
+heJ
+qJB
+qJB
+dPs
+qJB
 qIr
-qek
+ldm
 qLx
 xTf
-nFa
-lXM
-omy
+jEN
+nzA
+lfJ
 rxO
-oyU
+tBn
 nyi
-fju
-fju
-mIk
-mIk
-mIk
-mIk
-mIk
-fju
-fju
-rBG
+mii
+jtk
+mii
+aUe
+mii
+mii
+gNV
+mii
+mii
+vKr
 uGC
 viu
 ras
@@ -51487,41 +53476,41 @@ pRW
 pRW
 pRW
 pRW
-pRW
+fDw
 pRW
 jon
 edk
+tgP
+tgP
 fil
-fil
-fil
-fil
-fil
-lye
+tbT
+kRu
+heJ
 aOG
-dTQ
-fil
-fil
-fil
-mwk
-xkg
-lqE
+aOG
+dPs
+aOG
+tES
+ldm
+ldm
+sLZ
 sXC
-kpn
-fmj
-oyU
+ldm
+cmw
+xOT
 nKd
 nyi
-vKr
-fju
-mIk
-fju
-rBG
-rBG
-rBG
-rBG
-rBG
-rBG
-sTd
+mii
+jtk
+dTQ
+hUF
+rMT
+iCI
+lqf
+wxp
+uMs
+oXi
+nFa
 bBc
 fgj
 cGV
@@ -51681,41 +53670,41 @@ pRW
 pRW
 pRW
 pRW
-pRW
-pRW
+sUL
+lIp
 jon
 xKi
-fil
-fil
-mzJ
+heJ
+heJ
+heJ
 mKJ
 kRu
-fil
-fil
-fil
-ouS
-fil
-ldK
+heJ
+heJ
+heJ
+kzw
+rRz
+rjY
 xai
-nyi
+ldm
 tdr
-lag
-lqE
-lqE
-lqE
+ldm
+ldm
+oOI
+gal
 osx
 nyi
-fju
-fju
-mIk
-rBG
-rBG
-fju
-fju
-fju
-fju
-rBG
-sTd
+mii
+jtk
+rGS
+oXi
+oXi
+oXi
+oXi
+oXi
+oXi
+oXi
+qNE
 bBc
 bxI
 cGV
@@ -51875,41 +53864,41 @@ pRW
 pRW
 pRW
 pRW
-pRW
+pDn
 pRW
 mSw
 tXt
-gNV
-fil
-fil
-fil
-hus
-fil
-gNV
-fil
+heJ
+heJ
+tdM
+ubA
+qzI
+wRx
+heJ
+heJ
 ouS
-fil
-ldK
+heJ
+heJ
 rjY
-nyi
-pQh
+gRl
 xPj
-lqE
-oyU
-oyU
+xPj
+eZz
+osx
+mii
 pQh
-nyi
-fju
-fju
-mIk
-rBG
+kZu
+mii
+rvC
+otC
+oXi
 rMi
 rMi
 rMi
 rMi
 rMi
 rMi
-txu
+rdF
 eTr
 ras
 cGV
@@ -52069,34 +54058,34 @@ pRW
 pRW
 pRW
 pRW
-pRW
+pDn
 tUu
 mSw
 neg
+bJJ
 nbW
-nbW
-nbW
-sUL
+kNz
+mSw
 hus
-kad
+itn
 kcR
 itn
-ouS
-dSm
-fil
 rrZ
-nyi
-oyU
-xPj
+dSm
+rrZ
+rrZ
+rrZ
+rrZ
+itn
 lqE
+qwK
 oyU
-qSv
 oyU
-nyi
-fju
-fju
-mIk
-rBG
+jAA
+mii
+rvC
+lCC
+oXi
 rMi
 ovN
 qVv
@@ -52263,34 +54252,34 @@ pRW
 pRW
 pRW
 pRW
+pDn
 pRW
-pRW
 mSw
 mSw
 mSw
 jon
 jon
-jon
+mSw
 wIy
-nRo
+rkY
 jon
 nRo
 wQu
-jon
-jon
+oFO
+oFO
+oFO
+oFO
+vZR
+oFO
 mSw
-vZR
-vZR
-vZR
-vZR
-nyi
-nyi
-nyi
-nyi
-fju
-fju
-mIk
-rBG
+gqw
+nDz
+nDz
+hGE
+mii
+rvC
+nxl
+oXi
 rMi
 nBf
 vfa
@@ -52457,7 +54446,7 @@ pRW
 pRW
 pRW
 pRW
-pRW
+pDn
 mDp
 csb
 aaK
@@ -52465,26 +54454,26 @@ csb
 aaK
 csb
 jon
-jpo
-fil
-jon
-fil
 qAl
+pjE
+jon
+pjE
+jpo
 oFO
 csb
-flt
-flt
+aaK
 csb
+aaK
 csb
-wzB
-fju
-mIk
-mIk
-mIk
-mIk
-mIk
-mIk
-rBG
+mSw
+mMd
+eFf
+bqs
+sVv
+hUF
+jPe
+cJJ
+oXi
 rMi
 edb
 adB
@@ -52651,8 +54640,8 @@ pRW
 pRW
 pRW
 pRW
-pRW
-pRW
+fDw
+fDw
 aaK
 aaK
 aaK
@@ -52666,19 +54655,19 @@ epe
 wZh
 vaR
 aaK
-uOU
-uOU
 aaK
 aaK
-wzB
+aaK
+aaK
+mSw
 agX
-yab
-fju
-fju
-mIk
-fju
-fju
-rBG
+oXi
+oXi
+oXi
+txc
+oXi
+oXi
+oXi
 rMi
 kke
 qsL

--- a/maps/endeavour/levels/misc.dmm
+++ b/maps/endeavour/levels/misc.dmm
@@ -146,9 +146,6 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/supply)
-"cJ" = (
-/turf/space,
-/area/space)
 "cU" = (
 /obj/structure/holostool,
 /obj/effect/floor_decal/carpet,
@@ -626,9 +623,10 @@
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_emptycourt)
 "qb" = (
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /obj/machinery/conveyor{
-	dir = 4;
-	id = "QMLoad"
+	dir = 8;
+	id = "QMLoad2"
 	},
 /obj/machinery/door/airlock/glass_external{
 	frequency = 1380;
@@ -638,7 +636,6 @@
 	name = "Shuttle Hatch";
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "qd" = (
@@ -2032,9 +2029,10 @@
 /turf/simulated/floor/holofloor/grass,
 /area/holodeck/holodorm/source_garden)
 "We" = (
+/obj/map_helper/access_helper/airlock/station/external_airlock,
 /obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad2"
+	dir = 4;
+	id = "QMLoad"
 	},
 /obj/machinery/door/airlock/glass_external{
 	frequency = 1380;
@@ -2044,7 +2042,6 @@
 	name = "Shuttle Hatch";
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/external_airlock,
 /turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "Ws" = (
@@ -22966,11 +22963,11 @@ oi
 RS
 pQ
 cI
-Us
+Ys
 pQ
 sZ
 pQ
-Ys
+Us
 cI
 RS
 RS
@@ -23160,11 +23157,11 @@ oi
 RS
 pQ
 pQ
-Us
-pQ
-pQ
-pQ
 Ys
+pQ
+pQ
+pQ
+Us
 pQ
 pQ
 HY
@@ -23354,11 +23351,11 @@ oi
 RS
 pQ
 pQ
-Us
-pQ
-pQ
-pQ
 Ys
+pQ
+pQ
+pQ
+Us
 pQ
 pQ
 HY
@@ -38720,9 +38717,9 @@ oi
 oi
 oi
 oi
-cJ
-cJ
-cJ
+oi
+oi
+oi
 oi
 oi
 oi
@@ -39101,10 +39098,10 @@ Uk
 oi
 oi
 oi
-cJ
-cJ
-cJ
-cJ
+oi
+oi
+oi
+oi
 oi
 oi
 oi


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cargo rebuilt from the ground up.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Endeavour's cargo is one of the things I originally wanted to avoid in making the map. This rectifies it, returning some dignity to the important department.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
Tears down and completely replaces cargo. This also removes the **RIDICULOUS** stairs from science into the refinery. If you really need it with no cargo, break in like everyone else.
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: stairs into refinery
del: floating buttons
tweak: tweaked cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
