### PR TITLE
fix admin fax viewing

### DIFF
--- a/code/modules/paperwork/paper/paper.dm
+++ b/code/modules/paperwork/paper/paper.dm
@@ -95,12 +95,17 @@
 		. += "<span class='notice'>You have to go closer if you want to read it.</span>"
 	return
 
-/obj/item/paper/proc/show_content(var/mob/user, var/forceshow=0)
-	if(!user.client)
-		return
-	SSassets.send_asset_pack(user.client, /datum/asset_pack/simple/logos)
-	user.client.asset_cache_flush_browse_queue()
-	if(!(istype(user, /mob/living/carbon/human) || istype(user, /mob/observer/dead) || istype(user, /mob/living/silicon)) && !forceshow)
+/obj/item/paper/proc/show_content(mob/user, forceshow=0)
+	var/client/C
+	if (istype(user))
+		C = user.client
+	if (istype(user, /client))
+		C = user
+	if(C)
+		SSassets.send_asset_pack(C, /datum/asset_pack/simple/logos)
+		C.asset_cache_flush_browse_queue()
+
+	if(!(ishuman(user) || istype(user, /mob/observer/dead) || istype(user, /mob/living/silicon)) && !forceshow)
 		user << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[stars(info)][stamps]</BODY></HTML>", "window=[name]")
 		onclose(user, "[name]")
 	else


### PR DESCRIPTION
admin datum usr can be client

:cl:
fix: admins can see faxed paper again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
