### PR TITLE
add minHealth which controls when carbons die so we can set it in species

### DIFF
--- a/code/__DEFINES/mobs/life.dm
+++ b/code/__DEFINES/mobs/life.dm
@@ -55,3 +55,7 @@
 #define ORGAN_DECAY_PER_SECOND_BRAIN			(60 / (60 * 10))				// brain decays entirely over 10 minutes, or to lethal degrees in 5
 
 
+//? Health - General
+/** Store the default minimum health carbons die at
+*/
+#define CARBON_MINIMUM_HEALTH	-100

--- a/code/__DEFINES/mobs/life.dm
+++ b/code/__DEFINES/mobs/life.dm
@@ -56,6 +56,7 @@
 
 
 //? Health - General
-/** Store the default minimum health carbons die at
+/** Store the default minimum health mobs die at
+ * This is currently only respected by carbons
 */
-#define CARBON_MINIMUM_HEALTH	-100
+#define MOB_MINIMUM_HEALTH		-100

--- a/code/__DEFINES/mobs/life.dm
+++ b/code/__DEFINES/mobs/life.dm
@@ -56,7 +56,9 @@
 
 
 //? Health - General
-/** Store the default minimum health mobs die at
- * This is currently only respected by carbons
+/** Store the default minimum health, crit health, soft crit health
+ * These are currently only respected by carbons
 */
-#define MOB_MINIMUM_HEALTH		-100
+#define MOB_MINIMUM_HEALTH			-100
+#define MOB_CRITICAL_HEALTH			-50
+#define MOB_SOFT_CRITICAL_HEALTH 	0

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -377,7 +377,7 @@
 			occupantData["isViableSubject"] = 0
 		occupantData["health"] = connected.occupant.health
 		occupantData["maxHealth"] = connected.occupant.maxHealth
-		occupantData["minHealth"] = connected_occupant.getMinHealth()
+		occupantData["minHealth"] = connected.occupant.getMinHealth()
 		occupantData["uniqueEnzymes"] = connected.occupant.dna.unique_enzymes
 		occupantData["uniqueIdentity"] = connected.occupant.dna.uni_identity
 		occupantData["structuralEnzymes"] = connected.occupant.dna.struc_enzymes

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -377,7 +377,7 @@
 			occupantData["isViableSubject"] = 0
 		occupantData["health"] = connected.occupant.health
 		occupantData["maxHealth"] = connected.occupant.maxHealth
-		occupantData["minHealth"] = config_legacy.health_threshold_dead
+		occupantData["minHealth"] = connected_occupant.getMinHealth()
 		occupantData["uniqueEnzymes"] = connected.occupant.dna.unique_enzymes
 		occupantData["uniqueIdentity"] = connected.occupant.dna.uni_identity
 		occupantData["structuralEnzymes"] = connected.occupant.dna.struc_enzymes

--- a/code/game/gamemodes/cult/soulstone.dm
+++ b/code/game/gamemodes/cult/soulstone.dm
@@ -108,7 +108,7 @@
 	if(src.imprinted != "empty")
 		to_chat(U, "<span class='danger'>Capture failed!</span>: The soul stone has already been imprinted with [src.imprinted]'s mind!")
 		return
-	if ((T.health + T.halloss) > config_legacy.health_threshold_crit && T.stat != DEAD)
+	if ((T.health + T.halloss) > T.getCritHealth() && T.stat != DEAD)
 		to_chat(U, "<span class='danger'>Capture failed!</span>: Kill or maim the victim first!")
 		return
 	if(T.client == null)

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -73,7 +73,7 @@
 		occupantData["stat"] = occupant.stat
 		occupantData["health"] = occupant.health
 		occupantData["maxHealth"] = occupant.maxHealth
-		occupantData["minHealth"] = config_legacy.health_threshold_dead
+		occupantData["minHealth"] = occupant.getMinHealth()
 		occupantData["bruteLoss"] = occupant.getBruteLoss()
 		occupantData["oxyLoss"] = occupant.getOxyLoss()
 		occupantData["toxLoss"] = occupant.getToxLoss()

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -112,7 +112,7 @@
 		occupantData["stat"] = occupant.stat
 		occupantData["health"] = occupant.health
 		occupantData["maxHealth"] = occupant.getMaxHealth()
-		occupantData["minHealth"] = config_legacy.health_threshold_dead
+		occupantData["minHealth"] = occupant.getMinHealth()
 		occupantData["bruteLoss"] = occupant.getBruteLoss()
 		occupantData["oxyLoss"] = occupant.getOxyLoss()
 		occupantData["toxLoss"] = occupant.getToxLoss()

--- a/code/game/objects/items/defib/shockpaddles.dm
+++ b/code/game/objects/items/defib/shockpaddles.dm
@@ -223,7 +223,7 @@
 	H.apply_damage(burn_damage_amt, DAMAGE_TYPE_BURN, BP_TORSO)
 
 	//set oxyloss so that the patient is just barely in crit, if possible
-	var/barely_in_crit = config_legacy.health_threshold_crit - 1
+	var/barely_in_crit = getCritHealth() - 1
 	var/adjust_health = barely_in_crit - H.health //need to increase health by this much
 	H.adjustOxyLoss(-adjust_health)
 

--- a/code/game/objects/items/defib/shockpaddles.dm
+++ b/code/game/objects/items/defib/shockpaddles.dm
@@ -223,7 +223,7 @@
 	H.apply_damage(burn_damage_amt, DAMAGE_TYPE_BURN, BP_TORSO)
 
 	//set oxyloss so that the patient is just barely in crit, if possible
-	var/barely_in_crit = getCritHealth() - 1
+	var/barely_in_crit = H.getCritHealth() - 1
 	var/adjust_health = barely_in_crit - H.health //need to increase health by this much
 	H.adjustOxyLoss(-adjust_health)
 

--- a/code/game/objects/items/defib/shockpaddles.dm
+++ b/code/game/objects/items/defib/shockpaddles.dm
@@ -85,10 +85,10 @@
 	H.update_health()
 
 	if(H.isSynthetic())
-		if(H.health + H.getOxyLoss() + H.getToxLoss() <= config_legacy.health_threshold_dead)
+		if(H.health + H.getOxyLoss() + H.getToxLoss() <= H.getMinHealth())
 			return "buzzes, \"Resuscitation failed - Severe damage detected. Begin manual repair.\""
 
-	else if(H.health + H.getOxyLoss() <= config_legacy.health_threshold_dead || (MUTATION_HUSK in H.mutations) || !H.can_defib)
+	else if(H.health + H.getOxyLoss() <= H.getMinHealth() || (MUTATION_HUSK in H.mutations) || !H.can_defib)
 		// TODO: REFACTOR DEFIBS AND HEALTH
 		return "buzzes, \"Resuscitation failed - Severe tissue damage makes recovery of patient impossible via defibrillator.\""
 

--- a/code/game/rendering/atom_huds/atom_hud_provider.dm
+++ b/code/game/rendering/atom_huds/atom_hud_provider.dm
@@ -242,7 +242,7 @@ GLOBAL_LIST_INIT(atom_hud_providers, initialize_atom_hud_providers())
 	if(M.stat == DEAD)
 		I.icon_state = "-100"
 	else
-		I.icon_state = RoundHealth((M.health-config_legacy.health_threshold_crit)/(M.getMaxHealth()-config_legacy.health_threshold_crit)*100)
+		I.icon_state = RoundHealth((M.health-M.getCritHealth())/(M.getMaxHealth()-M.getCritHealth())*100)
 
 /datum/atom_hud_provider/security_implant
 	icon = 'icons/screen/atom_hud/implant.dmi'

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -64,9 +64,9 @@
 		to_chat(user, "<span class='notice'>\The [I] does <b>[DPS]</b> damage per second.</span>")
 		if(DPS > 0)
 			to_chat(user, "<span class='notice'>At your maximum health ([user.getMaxHealth()]), it would take approximately;</span>")
-			to_chat(user, "<span class='notice'>[(user.getMaxHealth() - config_legacy.health_threshold_softcrit) / DPS] seconds to softcrit you. ([config_legacy.health_threshold_softcrit] health)</span>")
-			to_chat(user, "<span class='notice'>[(user.getMaxHealth() - config_legacy.health_threshold_crit) / DPS] seconds to hardcrit you. ([config_legacy.health_threshold_crit] health)</span>")
-			to_chat(user, "<span class='notice'>[(user.getMaxHealth() - config_legacy.health_threshold_dead) / DPS] seconds to kill you. ([config_legacy.health_threshold_dead] health)</span>")
+			to_chat(user, "<span class='notice'>[(user.getMaxHealth() - user.getCritHealth()) / DPS] seconds to softcrit you. ([user.getSoftCritHealth()] health)</span>")
+			to_chat(user, "<span class='notice'>[(user.getMaxHealth() - user.getCritHealth()) / DPS] seconds to hardcrit you. ([user.getCritHealth()] health)</span>")
+			to_chat(user, "<span class='notice'>[(user.getMaxHealth() - user.getMinHealth()) / DPS] seconds to kill you. ([user.getMinHealth()] health)</span>")
 
 	else
 		to_chat(user, "<span class='warning'>You need to be a living mob, with hands, and for an object to be in your active hand, to use this verb.</span>")

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -96,7 +96,7 @@
 		src.apply_status_effect(/datum/status_effect/sight/blindness, 5 SECONDS)//60 seconds is just a randomly picked number, the modifier does not expire as long as the holder is dead
 		silent = 0
 	else				//ALIVE. LIGHTS ARE ON
-		if( !container && (health < config_legacy.health_threshold_dead || ((world.time - timeofhostdeath) > config_legacy.revival_brain_life)) )
+		if( !container && (health < getMinHealth() || ((world.time - timeofhostdeath) > config_legacy.revival_brain_life)) )
 			death()
 			src.apply_status_effect(/datum/status_effect/sight/blindness, 5 SECONDS)
 			silent = 0

--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -2,7 +2,7 @@
 
 //Start of a breath chain, calls breathe()
 /mob/living/carbon/handle_breathing()
-	if(SSair.current_cycle%4==2 || failed_last_breath || (health < config_legacy.health_threshold_crit)) 	//First, resolve location and get a breath
+	if(SSair.current_cycle%4==2 || failed_last_breath || (health < getCritHealth())) 	//First, resolve location and get a breath
 		breathe()
 
 /mob/living/carbon/proc/breathe()
@@ -16,7 +16,7 @@
 
 	//First, check if we can breathe at all
 	// cpr completely nullifies brainstem requirement
-	if(health < config_legacy.health_threshold_crit && !(CE_STABLE in chem_effects) && !stabilization) //crit aka circulatory shock
+	if(health < getCritHealth() && !(CE_STABLE in chem_effects) && !stabilization) //crit aka circulatory shock
 		AdjustLosebreath(1)
 
 	if(losebreath>0) //Suffocating so do not take a breath

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -61,7 +61,7 @@
 	return ..()
 
 /mob/living/carbon/proc/help_shake_act(mob/living/carbon/M)
-	if(src.health >= config_legacy.health_threshold_crit)
+	if(src.health >= getCritHealth())
 		if(src == M && istype(src, /mob/living/carbon/human))
 
 			var/mob/living/carbon/human/H = src

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -55,3 +55,5 @@
 	//the second is the message in question.
 	var/last_taste_time = 0
 	var/last_taste_text = ""
+
+	var/min_health = CARBON_MINIMUM_HEALTH

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -55,5 +55,3 @@
 	//the second is the message in question.
 	var/last_taste_time = 0
 	var/last_taste_text = ""
-
-	var/min_health = CARBON_MINIMUM_HEALTH

--- a/code/modules/mob/living/carbon/health.dm
+++ b/code/modules/mob/living/carbon/health.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/is_in_critical()
-	return !IS_DEAD(src) && (health < config_legacy.health_threshold_crit)
+	return !IS_DEAD(src) && (health < getCritHealth())
 
 /mob/living/carbon/rejuvenate(fix_missing, reset_to_slot)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human-damage-legacy.dm
+++ b/code/modules/mob/living/carbon/human/human-damage-legacy.dm
@@ -23,7 +23,7 @@
 	health = getMaxHealth() - getOxyLoss() - getToxLoss() - getCloneLoss() - total_burn - total_brute
 
 	//TODO: fix husking
-	if( ((getMaxHealth() - total_burn) < config_legacy.health_threshold_dead) && stat == DEAD)
+	if( ((getMaxHealth() - total_burn) < getMinHealth()) && stat == DEAD)
 		ChangeToHusk()
 
 	if(old != health)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1130,7 +1130,7 @@
 			return 1
 
 		//UNCONSCIOUS. NO-ONE IS HOME
-		if((getOxyLoss() > (species.total_health/2)) || (health <= config_legacy.health_threshold_crit))
+		if((getOxyLoss() > (species.total_health/2)) || (health <= getCritHealth()))
 			afflict_unconscious(20 * 3)
 
 		if(hallucination)
@@ -1696,12 +1696,12 @@
 	if(!can_feel_pain())
 		return
 
-	if(health < config_legacy.health_threshold_softcrit)// health 0 makes you immediately collapse
+	if(health < getSoftCritHealth())// health 0 makes you immediately collapse
 		shock_stage = max(shock_stage, 61)
 
 	if(traumatic_shock >= 80)
 		shock_stage += 1
-	else if(health < config_legacy.health_threshold_softcrit)
+	else if(health < getSoftCritHealth())
 		shock_stage = max(shock_stage, 61)
 	else
 		shock_stage = min(shock_stage, 160)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1123,7 +1123,7 @@
 	else				//ALIVE. LIGHTS ARE ON
 		update_health()	//TODO
 
-		if(health <= config_legacy.health_threshold_dead || (should_have_organ("brain") && !has_brain()))
+		if(health <= getMinHealth() || (should_have_organ("brain") && !has_brain()))
 			death()
 			apply_status_effect(/datum/status_effect/sight/blindness, 5 SECOND)
 			silent = 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -335,6 +335,12 @@ default behaviour is:
 /mob/living/proc/getMinHealth()
 	return minHealth
 
+/mob/living/proc/getCritHealth()
+	return critHealth
+
+/mob/living/proc/getSoftCritHealth()
+	return softCritHealth
+
 /mob/living/Confuse(amount)
 	for(var/datum/modifier/M in modifiers)
 		if(!isnull(M.disable_duration_percent))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -331,6 +331,9 @@ default behaviour is:
 	health = (health/maxHealth) * (newMaxHealth) // Adjust existing health
 	maxHealth = newMaxHealth
 
+// Use this to get a mob's min health whenever possible. (modifiers for minHealth don't exist currently!)
+/mob/living/proc/getMinHealth()
+	return minHealth
 
 /mob/living/Confuse(amount)
 	for(var/datum/modifier/M in modifiers)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -169,3 +169,5 @@
 	var/datum/immune_system/immune_system
 
 	var/minHealth = MOB_MINIMUM_HEALTH
+	var/softCritHealth = MOB_SOFT_CRITICAL_HEALTH
+	var/critHealth = MOB_CRITICAL_HEALTH

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -167,3 +167,5 @@
 	var/list/datum/disease2/disease/virus2 = list()
 	var/image/pathogen
 	var/datum/immune_system/immune_system
+
+	var/minHealth = MOB_MINIMUM_HEALTH

--- a/code/modules/mob/living/simple_mob/subtypes/animal/pets/cat_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/pets/cat_vr.dm
@@ -26,7 +26,7 @@
 	if (has_polaris_AI() && friend)
 		var/friend_dist = get_dist(src,friend)
 		if (friend_dist <= 1)
-			if (friend.stat >= DEAD || friend.health <= config_legacy.health_threshold_softcrit)
+			if (friend.stat >= DEAD || friend.health <= getSoftCritHealth())
 				if (prob((friend.stat < DEAD)? 50 : 15))
 					var/verb = pick("meows", "mews", "mrowls")
 					audible_emote(pick("[verb] in distress.", "[verb] anxiously."))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -712,7 +712,7 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 /mob/proc/pull_damage()
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
-		if(H.health - H.halloss <= config_legacy.health_threshold_softcrit)
+		if(H.health - H.halloss <= H.getSoftCritHealth())
 			for(var/name in H.organs_by_name)
 				var/obj/item/organ/external/e = H.organs_by_name[name]
 				if(e && H.lying)

--- a/code/modules/organs/external/wound.dm
+++ b/code/modules/organs/external/wound.dm
@@ -17,7 +17,7 @@
 //Burn damage can cause fluid loss due to blistering and cook-off
 
 	if((damage > 5 || damage + burn_dam >= 15) && type == WOUND_TYPE_BURN && (robotic < ORGAN_ROBOT) && !(species.species_flags & NO_BLOOD))
-		var/fluid_loss = 0.4 * (damage/(owner.getMaxHealth() - config_legacy.health_threshold_dead)) * owner.species.blood_volume*(1 - owner.species.blood_level_fatal)
+		var/fluid_loss = 0.4 * (damage/(owner.getMaxHealth() - owner.getMinHealth())) * owner.species.blood_volume*(1 - owner.species.blood_level_fatal)
 		owner.remove_blood(fluid_loss)
 
 	// first check whether we can widen an existing wound

--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -92,7 +92,7 @@
 		H.add_modifier(modifier_type)
 
 	//Apply damage
-	H.adjustCloneLoss((H.getMaxHealth() - config_legacy.health_threshold_dead)*-0.75)
+	H.adjustCloneLoss((H.getMaxHealth() - H.getMinHealth())*-0.75)
 	H.afflict_unconscious(20 * 4)
 	H.update_health()
 

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -270,10 +270,14 @@
 	var/pass_flags = 0
 
 	//? Stats
-	/// Point at which the mob will enter crit.
+	/// Total health the mob has
 	var/total_health = 100
 	/// Point at which the mob will die
 	var/death_health = MOB_MINIMUM_HEALTH
+	/// Point at which the mob will enter crit
+	var/crit_health = MOB_CRITICAL_HEALTH
+	/// Point at which the mob will enter soft crit
+	var/soft_crit_health = MOB_SOFT_CRITICAL_HEALTH
 	/// Physical damage multiplier.
 	var/brute_mod = 1
 	/// Burn damage multiplier.
@@ -574,6 +578,8 @@
 
 	H.maxHealth = total_health
 	H.minHealth = death_health
+	H.critHealth = crit_health
+	H.softCritHealth = soft_crit_health
 
 	if(!isnull(mob_physiology_modifier))
 		H.add_physiology_modifier(mob_physiology_modifier)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -273,7 +273,7 @@
 	/// Point at which the mob will enter crit.
 	var/total_health = 100
 	/// Point at which the mob will die
-	var/death_health = CARBON_MINIMUM_HEALTH
+	var/death_health = MOB_MINIMUM_HEALTH
 	/// Physical damage multiplier.
 	var/brute_mod = 1
 	/// Burn damage multiplier.

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -272,6 +272,8 @@
 	//? Stats
 	/// Point at which the mob will enter crit.
 	var/total_health = 100
+	/// Point at which the mob will die
+	var/death_health = CARBON_MINIMUM_HEALTH
 	/// Physical damage multiplier.
 	var/brute_mod = 1
 	/// Burn damage multiplier.
@@ -571,6 +573,7 @@
 		H.gender = genders[1]
 
 	H.maxHealth = total_health
+	H.minHealth = death_health
 
 	if(!isnull(mob_physiology_modifier))
 		H.add_physiology_modifier(mob_physiology_modifier)

--- a/code/modules/species/station/alraune.dm
+++ b/code/modules/species/station/alraune.dm
@@ -164,7 +164,7 @@
 
 	if(!breath || (breath.total_moles == 0))
 		H.failed_last_breath = 1
-		if(H.health > config_legacy.health_threshold_crit)
+		if(H.health > H.getCritHealth())
 			H.adjustOxyLoss(ALRAUNE_MAX_OXYLOSS)
 		else
 			H.adjustOxyLoss(ALRAUNE_CRIT_MAX_OXYLOSS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds support for controlling the ~~speed~~ point at which ~~crabs~~ carbons die
required for holospheres because their hologram form has very low health which isn't possible if they die at -100

this is set in mob/living because that's where maxHealth is currently handled but right now only carbons care about minHealth because everything else ignores the old config option and dies at 0

changes are replicated to also store crit and softcrit thresholds

## Why It's Good For The Game
better control over the point at which things die

## Changelog

:cl:
add: add minHealth which controls when carbons die so we can set it in species
/:cl:
