### PR TITLE
Fixes Scorian Surgery Tools

### DIFF
--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -21,6 +21,7 @@
 /datum/surgery_step/open_encased/saw
 	allowed_tools = list(
 		/obj/item/surgical/circular_saw = 100, \
+		/obj/item/surgical/saw_bronze = 75, \
 		/obj/item/material/knife/machete/hatchet = 75,	\
 		/obj/item/surgical/saw_primitive = 60
 	)

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -24,6 +24,7 @@
 	allowed_tools = list(
 	/obj/item/surgical/scalpel = 100,		\
 	/obj/item/surgical/scalpel_primitive = 80,	\
+	/obj/item/surgical/scalpel_bronze = 90,	\
 	/obj/item/material/knife = 75,	\
 	/obj/item/material/shard = 50, 		\
 	)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -29,6 +29,7 @@
 /datum/surgery_step/generic/cut_open
 	allowed_tools = list(
 		/obj/item/surgical/scalpel = 100,
+		/obj/item/surgical/scalpel_bronze = 90,
 		/obj/item/surgical/scalpel_primitive = 80,
 		/obj/item/material/knife = 75,
 		/obj/item/material/shard = 50,
@@ -310,6 +311,7 @@
 	allowed_tools = list(
 		/obj/item/surgical/circular_saw = 100,
 		/obj/item/material/knife/machete/hatchet = 75,
+		/obj/item/surgical/saw_bronze = 75,
 		/obj/item/surgical/saw_primitive = 60,
 	)
 	req_open = 0

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -148,6 +148,7 @@
 
 	allowed_tools = list(
 	/obj/item/surgical/scalpel = 100,		\
+	/obj/item/surgical/scalpel_bronze = 90,	\
 	/obj/item/surgical/scalpel_primitive = 80,	\
 	/obj/item/material/knife = 75,	\
 	/obj/item/material/shard = 50, 		\

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -73,6 +73,7 @@
 	priority = 2
 	allowed_tools = list(
 		/obj/item/surgical/scalpel = 100,        \
+		/obj/item/surgical/scalpel_bronze = 90,	\
 		/obj/item/surgical/scalpel_primitive = 80,	\
 		/obj/item/material/knife = 75,    \
 		/obj/item/material/shard = 50,         \
@@ -196,6 +197,7 @@
 	allowed_tools = list(
 		/obj/item/weldingtool = 80,
 		/obj/item/surgical/circular_saw = 60,
+		/obj/item/surgical/saw_bronze = 30,
 		/obj/item/surgical/saw_primitive = 25,
 		/obj/item/pickaxe/plasmacutter = 100
 		)

--- a/code/modules/surgery/slimes.dm
+++ b/code/modules/surgery/slimes.dm
@@ -14,6 +14,7 @@
 /datum/surgery_step/slime/cut_flesh
 	allowed_tools = list(
 	/obj/item/surgical/scalpel = 100,
+	/obj/item/surgical/scalpel_bronze = 90,
 	/obj/item/surgical/scalpel_primitive = 80,
 	/obj/item/material/knife = 75,
 	/obj/item/material/shard = 50,
@@ -43,6 +44,7 @@
 /datum/surgery_step/slime/cut_innards
 	allowed_tools = list(
 	/obj/item/surgical/scalpel = 100,		\
+	/obj/item/surgical/scalpel_bronze = 90,	\
 	/obj/item/surgical/scalpel_primitive = 80,	\
 	/obj/item/material/knife = 75,	\
 	/obj/item/material/shard = 50, 		\
@@ -72,6 +74,7 @@
 /datum/surgery_step/slime/saw_core
 	allowed_tools = list(
 	/obj/item/surgical/circular_saw = 100, \
+	/obj/item/surgical/saw_bronze = 90, \
 	/obj/item/surgical/saw_primitive = 80, \
 	/obj/item/material/knife/machete/hatchet = 75
 	)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Scori Surgery Tools now actually surgery.
I love that each surgery step has a specific list of tools that work on it exclusively. Anyway, now scori bronze tools are also capable of being used for surgery as intended.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Scori bronze surgery tools are now actually on the surgery tool lists.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
