### PR TITLE
Docking update and bug fixes (i got rid of the funny name)

### DIFF
--- a/citadel.dme
+++ b/citadel.dme
@@ -5391,6 +5391,7 @@
 #include "interface\menus\main.dm"
 #include "maps\endeavour\endeavour-areas.dm"
 #include "maps\endeavour\endeavour-overmap.dm"
+#include "maps\endeavour\endeavour-papers.dm"
 #include "maps\endeavour\endeavour-sectors.dm"
 #include "maps\endeavour\endeavour-shuttle-landmarks.dm"
 #include "maps\endeavour\endeavour-turbolifts.dm"

--- a/maps/endeavour/endeavour-papers.dm
+++ b/maps/endeavour/endeavour-papers.dm
@@ -1,0 +1,5 @@
+
+/obj/item/paper/pamphlet/substation
+	name = "Notice to NSV Endeavour Auxiliary Engineering Staff"
+	desc = "Some sort of technical information regarding this generator doohickey"
+	info = "Hello! <br><br> If you are reading this, you are attempting to activate the back up supply generators for an Endeavour Class vessel! <br><br>Please take note! Distribute the fuel among four or more generators, and be sure to leave them connected to each other via the breakers! This ships is divided into power zones, rather than departmental power subgrids. Powering the generators and leaving them connected to the secondary net will combine the power of all the generators and power the ship via this combined effort. If part of the ship is damaged, and you need to get power up to your section of the ship, *then* disconnect your area of interest. <br><br> Thank you for reading, and have a secure day!"

--- a/maps/endeavour/levels/deck1.dmm
+++ b/maps/endeavour/levels/deck1.dmm
@@ -27218,6 +27218,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d1aftmaint)
 "tNd" = (

--- a/maps/endeavour/levels/deck1.dmm
+++ b/maps/endeavour/levels/deck1.dmm
@@ -9134,6 +9134,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/paper/pamphlet/substation,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/exploration)
 "gDf" = (
@@ -15488,6 +15489,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/paper/pamphlet/substation,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/command)
 "kYZ" = (
@@ -16116,11 +16118,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1portamidhall)
 "lBc" = (
-/obj/machinery/power/breakerbox{
-	RCon_tag = "MAIN - DECK 1 AFT"
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "MAIN - DECK 1 FORE"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/substation/civilian)
+/area/maintenance/substation/command)
 "lBV" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -30788,11 +30790,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1starboardafthall)
 "wmU" = (
-/obj/machinery/power/breakerbox{
-	RCon_tag = "MAIN - DECK 1 FORE"
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "MAIN - DECK 1 AFT"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/substation/command)
+/area/maintenance/substation/civilian)
 "wne" = (
 /obj/item/pen/crayon/mime,
 /obj/item/pen/crayon/marker/mime,
@@ -31249,6 +31251,7 @@
 /obj/machinery/power/port_gen/pacman/mrs{
 	anchored = 1
 	},
+/obj/item/paper/pamphlet/substation,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
 "wAB" = (
@@ -33202,7 +33205,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1starboardamidhall)
 "ybg" = (
-/obj/machinery/power/breakerbox{
+/obj/machinery/power/breakerbox/activated{
 	RCon_tag = "MAIN - DECK 1 AMIDSHIPS"
 	},
 /turf/simulated/floor/plating,
@@ -49551,7 +49554,7 @@ vDR
 hWC
 vRj
 hVP
-aVW
+wmU
 kPV
 lxO
 hnl
@@ -49742,7 +49745,7 @@ vHL
 bdJ
 eOe
 djQ
-lBc
+aVW
 pEr
 mWe
 cGJ
@@ -59834,7 +59837,7 @@ lmB
 oVe
 lCd
 ghn
-meH
+lBc
 aLV
 uhY
 jux
@@ -60025,7 +60028,7 @@ uwI
 aLV
 oZB
 cdx
-wmU
+meH
 aLV
 pIq
 uWI

--- a/maps/endeavour/levels/deck1.dmm
+++ b/maps/endeavour/levels/deck1.dmm
@@ -2610,6 +2610,12 @@
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/exploration/meeting)
+"cag" = (
+/obj/effect/shuttle_landmark/automatic{
+	name = "Deck 1, Port Side"
+	},
+/turf/space/basic,
+/area/space)
 "caS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/flora/pottedplant/orientaltree,
@@ -7723,17 +7729,17 @@
 /turf/simulated/floor/wood,
 /area/library)
 "fDY" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 4
+/obj/effect/floor_decal/corner/navgold/border{
+	dir = 1
 	},
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
 	},
-/turf/simulated/floor/tiled,
-/area/endeavour/exploration/hallway_fore)
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d1starboardafthall)
 "fEx" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -8154,6 +8160,9 @@
 	},
 /obj/machinery/door/firedoor/glass{
 	dir = 8
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway2)
@@ -12033,7 +12042,10 @@
 /obj/machinery/camera/network/exploration{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/door/firedoor{
+	dir = 1
+	},
+/turf/simulated/open,
 /area/endeavour/exploration/hallway_fore)
 "iKk" = (
 /obj/structure/cable{
@@ -13426,9 +13438,6 @@
 /area/hallway/secondary/docking_hallway)
 "jGM" = (
 /obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/machinery/light_switch{
 	pixel_x = 27
 	},
 /turf/simulated/floor/carpet/bcarpet,
@@ -14248,6 +14257,11 @@
 /obj/spawner/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
+"khe" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/map_helper/access_helper/airlock/station/exploration/department,
+/turf/simulated/floor/tiled,
+/area/endeavour/exploration/hallway_fore)
 "khl" = (
 /obj/landmark/spawnpoint/job/lawyer,
 /obj/structure/bed/chair/office/dark{
@@ -15513,6 +15527,21 @@
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/maintenance/station/exploration)
+"lbB" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/exploration/hallway_fore)
 "lbH" = (
 /obj/machinery/computer/ship/navigation{
 	dir = 1
@@ -17496,10 +17525,7 @@
 /obj/effect/floor_decal/corner/mauve/bordercorner{
 	dir = 8
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled,
 /area/exploration)
 "mDd" = (
@@ -19013,7 +19039,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "nFc" = (
-/obj/structure/loot_pile/maint,
+/obj/structure/loot_pile/maint/technical,
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d1fwdmaint)
 "nFp" = (
@@ -20077,10 +20103,14 @@
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "ovE" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/map_helper/access_helper/airlock/station/exploration/department,
-/turf/simulated/floor/plating,
-/area/endeavour/exploration/hallway_fore)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/pool)
 "owg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -22279,6 +22309,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/docking_hallway2)
+"qgb" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d1portforhall)
 "qgv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -23644,6 +23686,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1starboardforhall)
 "rfr" = (
@@ -24311,7 +24356,6 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/loot_pile/maint,
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
 "rFT" = (
@@ -26296,6 +26340,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d1starboardafthall)
+"tlw" = (
+/obj/effect/shuttle_landmark/automatic{
+	name = "Deck 1, Port Side"
+	},
+/turf/space,
+/area/space)
 "tlI" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -28380,7 +28430,8 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 8
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/exploration/hallway_aft)
@@ -32741,7 +32792,9 @@
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
 "xJO" = (
-/obj/effect/shuttle_landmark/endeavour/deck4/excursion_space,
+/obj/effect/shuttle_landmark/automatic{
+	name = "Deck 1, Starboard Side"
+	},
 /turf/space/basic,
 /area/space)
 "xKz" = (
@@ -41856,7 +41909,7 @@ xRj
 xRj
 xRj
 xRj
-xRj
+cag
 xRj
 xRj
 xRj
@@ -46191,7 +46244,7 @@ qTj
 gPV
 tHZ
 aNK
-ojQ
+qgb
 fnJ
 oxV
 piy
@@ -46203,7 +46256,7 @@ hkm
 gkp
 uru
 piy
-axR
+fDY
 oHo
 riG
 dZr
@@ -46552,8 +46605,8 @@ opm
 opm
 opm
 opm
+opm
 gtI
-bxh
 bxh
 iJn
 khD
@@ -46609,7 +46662,7 @@ eYV
 ojm
 ilO
 dJe
-sFF
+ovE
 oyz
 qTM
 qTM
@@ -46746,10 +46799,10 @@ opm
 opm
 opm
 opm
-ovE
+opm
+khe
 iyz
-fDY
-oBL
+lbB
 mZn
 nPK
 tfh
@@ -56794,7 +56847,7 @@ xRj
 xRj
 xRj
 jNg
-jNg
+tlw
 jNg
 jNg
 jNg
@@ -57237,7 +57290,7 @@ keD
 oYa
 maa
 byt
-maa
+bFR
 kfn
 maa
 dIE
@@ -58206,7 +58259,7 @@ oYa
 unB
 unB
 maa
-maa
+bFR
 byt
 maa
 maa
@@ -58484,7 +58537,7 @@ xRj
 xRj
 xRj
 xRj
-xRj
+xJO
 xRj
 xRj
 xRj
@@ -58793,7 +58846,7 @@ byt
 uTr
 maa
 maa
-nFc
+maa
 maa
 maa
 maa
@@ -58992,7 +59045,7 @@ maa
 nFc
 byt
 byt
-nFc
+jkE
 kfn
 uTr
 hYO
@@ -59179,7 +59232,7 @@ sIg
 byt
 maa
 uTr
-maa
+hPx
 byt
 byt
 byt

--- a/maps/endeavour/levels/deck1.dmm
+++ b/maps/endeavour/levels/deck1.dmm
@@ -5076,6 +5076,21 @@
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
 "dSe" = (
+/obj/machinery/camera/network/command{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/beige/bordercorner2{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway)
 "dSn" = (
@@ -5524,12 +5539,6 @@
 	},
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/beige/bordercorner2{
-	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway)
@@ -7887,12 +7896,6 @@
 /turf/simulated/floor/tiled,
 /area/exploration/explorer_prep)
 "fKd" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -18526,6 +18529,12 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
 	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/beige/bordercorner2{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway)
 "nnq" = (
@@ -25834,12 +25843,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/beige/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/beige/bordercorner2{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -65257,11 +65260,11 @@ gDf
 tIO
 fIr
 gDf
-wDH
+dSe
 fKd
 nnp
 eiM
-dSe
+mBp
 sRV
 jJL
 hcK

--- a/maps/endeavour/levels/deck2.dmm
+++ b/maps/endeavour/levels/deck2.dmm
@@ -1463,6 +1463,9 @@
 /obj/effect/floor_decal/corner/navblue/border{
 	dir = 1
 	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portamidhall)
 "aVO" = (
@@ -2632,9 +2635,17 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
 "bHu" = (
-/obj/effect/shuttle_landmark/endeavour/deck3/port,
-/turf/space,
-/area/space)
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay3)
 "bHz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -3418,6 +3429,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
+"caA" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navgold/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d1starboardamidhall)
 "cbh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4730,6 +4759,18 @@
 "cNW" = (
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"cOc" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navgold/border{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d2afthall)
 "cOu" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6699,6 +6740,9 @@
 /obj/effect/floor_decal/corner/navblue/border{
 	dir = 1
 	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portforhall)
 "eam" = (
@@ -6899,6 +6943,18 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d2portamidhall)
+"een" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portamidhall)
@@ -8209,6 +8265,9 @@
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 9
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "eUx" = (
@@ -8691,6 +8750,21 @@
 /obj/structure/flora/pottedplant/orientaltree,
 /turf/simulated/floor/tiled/dark,
 /area/endeavour/hallway/d1starboardamidhall)
+"fiR" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "fiT" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navgold/border,
@@ -14380,6 +14454,12 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"iBr" = (
+/obj/effect/shuttle_landmark/automatic{
+	name = "Deck 2, Port Side"
+	},
+/turf/space,
+/area/space)
 "iBv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -19324,6 +19404,12 @@
 /obj/machinery/artifact_scanpad,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/anomaly_lab/containment_two)
+"lIj" = (
+/obj/effect/shuttle_landmark/automatic{
+	name = "Deck 2, Port Side"
+	},
+/turf/space/basic,
+/area/space)
 "lIp" = (
 /obj/machinery/camera/network/outside,
 /turf/space/basic,
@@ -19531,6 +19617,27 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_c)
+"lRS" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "lRT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/tiled,
@@ -19696,6 +19803,24 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
+"lWH" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navgold/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d1starboardforhall)
 "lWJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21141,6 +21266,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardafthall)
 "mTN" = (
@@ -22366,6 +22494,27 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2fwdmaint)
+"nHZ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology_aft_access)
 "nIk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -22882,7 +23031,9 @@
 /turf/simulated/floor/wood/sif/indoors,
 /area/medical/reception)
 "nWQ" = (
-/obj/effect/shuttle_landmark/endeavour/deck3/starboard,
+/obj/effect/shuttle_landmark/automatic{
+	name = "Deck 2, Starboard Side"
+	},
 /turf/space,
 /area/space)
 "nXe" = (
@@ -22943,6 +23094,21 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/station/stairs_two)
+"nZt" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d2portamidhall)
 "nZC" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -27831,13 +27997,17 @@
 /turf/simulated/floor/wood,
 /area/medical/medbay4)
 "qFD" = (
-/obj/structure/window/reinforced/tinted,
-/obj/machinery/shower{
-	dir = 8
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
 	},
-/obj/structure/curtain/open/shower/medical,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/medical/medbay_primary_storage)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryprep)
 "qFO" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -29003,8 +29173,23 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology_aft_access)
 "rpi" = (
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d2portforhall)
 "rpj" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/substation/research)
@@ -30496,6 +30681,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
+/obj/machinery/vending/blood,
 /turf/simulated/floor/tiled,
 /area/medical/medbay_primary_storage)
 "snQ" = (
@@ -30540,6 +30726,15 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"soP" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/wood,
+/area/tether/station/public_meeting_room)
 "soU" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -32854,6 +33049,7 @@
 /obj/machinery/door/airlock/glass/research{
 	name = "R&D Distribution Area"
 	},
+/obj/map_helper/access_helper/airlock/station/public,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "tLU" = (
@@ -35976,6 +36172,7 @@
 /obj/machinery/door/airlock/glass/research{
 	name = "R&D Distribution Area"
 	},
+/obj/map_helper/access_helper/airlock/station/public,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "vQl" = (
@@ -36054,9 +36251,8 @@
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
 "vTa" = (
-/obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/effect/paint/babyblue,
-/obj/machinery/vending/blood,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
 /turf/simulated/floor/plating,
 /area/medical/medbay_primary_storage)
 "vTK" = (
@@ -36816,13 +37012,11 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portforhall)
 "wlZ" = (
-/obj/machinery/shower{
-	dir = 4
+/obj/effect/shuttle_landmark/automatic{
+	name = "Deck 2, Starboard Side"
 	},
-/obj/structure/window/reinforced/tinted,
-/obj/structure/curtain/open/shower/medical,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/medical/medbay_primary_storage)
+/turf/space/basic,
+/area/space)
 "wme" = (
 /obj/landmark/spawnpoint/job/pilot,
 /turf/space/basic,
@@ -37233,6 +37427,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/medbreak)
@@ -40072,6 +40269,9 @@
 	},
 /obj/effect/floor_decal/corner/navgold/border{
 	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardamidhall)
@@ -46338,7 +46538,7 @@ pNX
 pNX
 pNX
 pNX
-gOV
+lRS
 kBS
 vcY
 hgb
@@ -48080,7 +48280,7 @@ jbC
 xDZ
 dlw
 oaU
-buM
+cOc
 pdM
 kxI
 tQp
@@ -48926,7 +49126,7 @@ pRW
 pRW
 pRW
 pRW
-pRW
+wlZ
 pRW
 mDp
 mDp
@@ -49869,7 +50069,7 @@ mDp
 mDp
 mDp
 mDp
-nWQ
+mDp
 mDp
 pRW
 pRW
@@ -51394,7 +51594,7 @@ oaZ
 mZc
 qpq
 mmI
-oDK
+qFD
 wHh
 xKC
 dqJ
@@ -51887,7 +52087,7 @@ mDp
 mDp
 pRW
 pRW
-pRW
+lIj
 pRW
 pRW
 pRW
@@ -52757,7 +52957,7 @@ bdJ
 qSo
 cyt
 fwu
-vXJ
+bHu
 tCz
 aOx
 ufT
@@ -54299,7 +54499,7 @@ iAl
 jdx
 hgX
 juF
-wOk
+fiR
 sCe
 ggO
 kgh
@@ -57378,7 +57578,7 @@ qog
 qog
 xec
 dbo
-mYS
+nZt
 bfx
 oOa
 jne
@@ -58389,7 +58589,7 @@ rFw
 bNp
 bNp
 ujt
-szk
+ujt
 xFH
 xFH
 xFH
@@ -58567,7 +58767,7 @@ kYY
 kYY
 kYY
 uCH
-qan
+nHZ
 lLU
 nic
 fNZ
@@ -58581,9 +58781,9 @@ bNp
 wlg
 kTz
 bNp
-wlZ
 ujt
-ryO
+ujt
+szk
 xFH
 lmG
 qBd
@@ -58775,9 +58975,9 @@ bNp
 mnx
 kTz
 bNp
-rpi
 ujt
-szk
+ujt
+ryO
 xFH
 qBd
 jRE
@@ -58969,8 +59169,8 @@ xFH
 bxy
 peZ
 bNp
-qFD
-hQy
+ujt
+ujt
 szk
 vTa
 pRW
@@ -59163,9 +59363,9 @@ xFH
 kTz
 kTz
 xFH
-xFH
-xFH
-xFH
+ujt
+hQy
+szk
 xFH
 lIp
 pRW
@@ -59357,10 +59557,10 @@ iro
 svB
 iro
 aUR
-dYQ
-lmG
-qBd
-pRW
+xFH
+xFH
+xFH
+xFH
 pRW
 pRW
 pRW
@@ -59551,9 +59751,9 @@ pkD
 nMP
 hGE
 aUR
-jRE
+dYQ
+lmG
 qBd
-jRE
 pRW
 pRW
 pRW
@@ -59745,9 +59945,9 @@ nMP
 nMP
 sVo
 aUR
-pRW
-pRW
-pRW
+jRE
+qBd
+jRE
 pRW
 pRW
 pRW
@@ -62421,7 +62621,7 @@ wNs
 otK
 jUa
 uLo
-uza
+een
 bCK
 arL
 rBK
@@ -62629,7 +62829,7 @@ uCq
 uCq
 xgg
 jRu
-bFI
+caA
 uOw
 kdT
 vCs
@@ -63666,7 +63866,7 @@ mDp
 mDp
 mDp
 mDp
-mDp
+nWQ
 mDp
 mDp
 mDp
@@ -66424,7 +66624,7 @@ mDp
 mDp
 mDp
 mDp
-bHu
+mDp
 mDp
 mDp
 mDp
@@ -66510,7 +66710,7 @@ pIb
 pUI
 pUI
 ifg
-aua
+lWH
 vWh
 oYE
 mbs
@@ -66692,7 +66892,7 @@ jRK
 jRK
 wsu
 wMp
-ppu
+rpi
 mFT
 kXE
 iDS
@@ -67021,7 +67221,7 @@ pRW
 pRW
 pRW
 pRW
-mDp
+iBr
 mDp
 mDp
 pRW
@@ -67674,7 +67874,7 @@ ruN
 vJE
 cCs
 ifg
-aua
+lWH
 sqA
 oYE
 mbs
@@ -72510,7 +72710,7 @@ pRW
 qBd
 lmG
 agO
-xAr
+soP
 hGi
 xWm
 aiO

--- a/maps/endeavour/levels/deck2.dmm
+++ b/maps/endeavour/levels/deck2.dmm
@@ -38711,6 +38711,9 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/cockpit)
 "xiN" = (

--- a/maps/endeavour/levels/deck2.dmm
+++ b/maps/endeavour/levels/deck2.dmm
@@ -11672,8 +11672,8 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)

--- a/maps/endeavour/levels/deck2.dmm
+++ b/maps/endeavour/levels/deck2.dmm
@@ -12739,7 +12739,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
 "hBp" = (
-/obj/machinery/power/breakerbox{
+/obj/machinery/power/breakerbox/activated{
 	RCon_tag = "MAIN - DECK 2 AMIDSHIPS"
 	},
 /turf/simulated/floor/plating,
@@ -13132,7 +13132,7 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d2fwdmaint)
 "hMz" = (
-/obj/machinery/power/breakerbox{
+/obj/machinery/power/breakerbox/activated{
 	RCon_tag = "MAIN - DECK 2 FORE"
 	},
 /turf/simulated/floor/plating,
@@ -14832,8 +14832,8 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "iPG" = (
-/obj/machinery/power/breakerbox{
-	RCon_tag = "DECK 2 AFT MAIN"
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "MAIN - DECK 2 AFT"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical_science)
@@ -16313,6 +16313,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/paper/pamphlet/substation,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
 "jPA" = (
@@ -20977,6 +20978,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/paper/pamphlet/substation,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "mKe" = (
@@ -24789,6 +24791,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/paper/pamphlet/substation,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical_science)
 "oYE" = (
@@ -56427,7 +56430,7 @@ mIs
 xsd
 mHV
 rxV
-kyR
+iPG
 eEE
 cHC
 cBK
@@ -56618,7 +56621,7 @@ qIV
 ePI
 eEE
 fPm
-iPG
+kyR
 eEE
 qPc
 djp

--- a/maps/endeavour/levels/deck2.dmm
+++ b/maps/endeavour/levels/deck2.dmm
@@ -15424,6 +15424,9 @@
 /area/rnd/reception_desk)
 "jlP" = (
 /obj/structure/dispenser/oxygen,
+/obj/machinery/camera/network/outside{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay_primary_storage)
 "jlX" = (
@@ -17229,6 +17232,13 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/anomaly_lab)
+"kss" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/soap/nanotrasen,
+/obj/item/storage/belt/medical,
+/turf/simulated/floor/tiled,
+/area/medical/medbay_primary_storage)
 "ksB" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
@@ -18294,6 +18304,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
+"kZb" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/storage/belt/medical,
+/obj/item/soap/nanotrasen,
+/turf/simulated/floor/tiled,
+/area/medical/medbay_primary_storage)
 "kZg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -29528,10 +29545,6 @@
 /area/tether/station/public_meeting_room)
 "ryO" = (
 /obj/machinery/light,
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/soap/nanotrasen,
-/obj/item/storage/belt/medical,
-/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled,
 /area/medical/medbay_primary_storage)
 "rzi" = (
@@ -30685,7 +30698,6 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/machinery/vending/blood,
 /turf/simulated/floor/tiled,
 /area/medical/medbay_primary_storage)
 "snQ" = (
@@ -31024,10 +31036,10 @@
 /turf/simulated/floor/tiled,
 /area/medical/surgery)
 "szk" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/soap/nanotrasen,
-/obj/item/storage/belt/medical,
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/item/soap/nanotrasen,
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/storage/belt/medical,
 /turf/simulated/floor/tiled,
 /area/medical/medbay_primary_storage)
 "szz" = (
@@ -36069,6 +36081,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
+"vLZ" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/item/storage/belt/medical,
+/obj/item/soap/nanotrasen,
+/obj/structure/closet/secure_closet/medical3,
+/turf/simulated/floor/tiled,
+/area/medical/medbay_primary_storage)
 "vMh" = (
 /obj/machinery/air_alarm{
 	pixel_y = 22
@@ -58763,9 +58782,9 @@ bNp
 wlg
 kTz
 bNp
+kZb
 ujt
 ujt
-szk
 xFH
 lmG
 qBd
@@ -58957,7 +58976,7 @@ bNp
 mnx
 kTz
 bNp
-ujt
+vLZ
 ujt
 ryO
 xFH
@@ -59151,9 +59170,9 @@ xFH
 bxy
 peZ
 bNp
-ujt
-ujt
 szk
+ujt
+ujt
 vTa
 pRW
 pRW
@@ -59345,9 +59364,9 @@ xFH
 kTz
 kTz
 xFH
-ujt
+kss
 hQy
-szk
+ujt
 xFH
 lIp
 pRW

--- a/maps/endeavour/levels/deck2.dmm
+++ b/maps/endeavour/levels/deck2.dmm
@@ -9310,7 +9310,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "fBT" = (
-/obj/machinery/door/airlock/glass,
+/obj/machinery/door/airlock/research,
 /obj/machinery/door/firedoor,
 /obj/map_helper/access_helper/airlock/station/science/department,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -25875,10 +25875,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass/research{
-	name = "Research Lounge";
-	req_one_access = null
-	},
+/obj/machinery/door/airlock/research,
 /obj/map_helper/access_helper/airlock/station/science/department,
 /turf/simulated/floor/tiled,
 /area/rnd/breakroom)

--- a/maps/endeavour/levels/deck2.dmm
+++ b/maps/endeavour/levels/deck2.dmm
@@ -4432,6 +4432,9 @@
 "cEs" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/cockpit)
 "cEy" = (
@@ -28193,6 +28196,9 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/cockpit)
 "qLf" = (
@@ -35862,9 +35868,6 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portafthall)
 "vFG" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -38690,13 +38693,13 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/psych_ward)
 "xhP" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /obj/machinery/computer/ship/sensors{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/cockpit)

--- a/maps/endeavour/levels/deck2.dmm
+++ b/maps/endeavour/levels/deck2.dmm
@@ -20585,6 +20585,9 @@
 /obj/effect/floor_decal/corner/navblue/border{
 	dir = 5
 	},
+/obj/machinery/station_map{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portamidhall)
 "mxO" = (
@@ -22125,6 +22128,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
+"nwH" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/obj/machinery/station_map{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d2portamidhall)
 "nwK" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -24084,17 +24099,8 @@
 /obj/machinery/station_map{
 	pixel_y = 32
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/navblue/border{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/endeavour/hallway/d2portforhall)
+/turf/simulated/floor/tiled/dark,
+/area/endeavour/hallway/d2portafthall)
 "oGx" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -24323,6 +24329,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/machinery/station_map{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2portforhall)
@@ -34016,6 +34025,9 @@
 	},
 /obj/effect/floor_decal/corner/navblue/border{
 	dir = 1
+	},
+/obj/machinery/station_map{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d2fwdhall)
@@ -51180,7 +51192,7 @@ ohX
 iwg
 ohX
 rkZ
-mSd
+oGt
 uJM
 mSd
 uCx
@@ -57388,7 +57400,7 @@ gKZ
 qog
 aPb
 dbo
-uza
+nwH
 hBL
 rVF
 rBK
@@ -60491,7 +60503,7 @@ eQu
 liR
 jBH
 vez
-uza
+nwH
 wil
 wtZ
 rBK
@@ -67478,7 +67490,7 @@ jRK
 jRK
 jRK
 mai
-oGt
+eYA
 mFT
 uXO
 iDS

--- a/maps/endeavour/levels/deck2.dmm
+++ b/maps/endeavour/levels/deck2.dmm
@@ -4435,6 +4435,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/cockpit)
 "cEy" = (
@@ -10875,7 +10878,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/plating,
 /area/endeavour/hallway/d2aftmaint)
 "gwT" = (
 /turf/simulated/floor/tiled/white,
@@ -10906,14 +10909,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/station/docks)
@@ -25478,7 +25481,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/plating,
 /area/endeavour/hallway/d2aftmaint)
 "pps" = (
 /obj/machinery/computer/guestpass{
@@ -28185,14 +28188,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics/surgery)
 "qKR" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "emtblast";
-	name = "emergency blast shields";
-	pixel_y = 30
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -30928,7 +30923,7 @@
 /obj/structure/catwalk,
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "svr" = (
 /obj/effect/floor_decal/borderfloorwhite{
@@ -31028,10 +31023,6 @@
 /obj/machinery/iv_drip,
 /turf/simulated/floor/tiled,
 /area/medical/surgery)
-"szh" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/airless/ceiling,
-/area/endeavour/hallway/d2aftmaint)
 "szk" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/soap/nanotrasen,
@@ -32022,10 +32013,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d1starboardamidhall)
-"teE" = (
-/obj/random/trash_pile,
-/turf/simulated/floor/airless/ceiling,
-/area/maintenance/fpmaint2)
 "teL" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -34290,10 +34277,6 @@
 /obj/structure/flora/pottedplant/orientaltree,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
-"uAu" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/airless/ceiling,
-/area/endeavour/hallway/d2aftmaint)
 "uCm" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -35876,6 +35859,11 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "emtblast";
+	name = "emergency blast shields";
+	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/cockpit)
@@ -38244,7 +38232,7 @@
 /area/tether/surfacebase/shuttle_pad)
 "wTM" = (
 /obj/machinery/floodlight,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/plating,
 /area/endeavour/hallway/d2aftmaint)
 "wTS" = (
 /obj/machinery/power/apc/west_mount,
@@ -38861,18 +38849,6 @@
 /obj/effect/floor_decal/corner/mauve/bordercorner,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
-"xnE" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/station/docks)
 "xnM" = (
 /obj/machinery/door/window/brigdoor/eastleft{
 	name = "Containment Pen";
@@ -63215,7 +63191,7 @@ ffk
 ezg
 rBK
 oDd
-uAu
+uSX
 cHC
 qQK
 cHC
@@ -63604,7 +63580,7 @@ uMl
 iBv
 fDp
 bHC
-szh
+qQK
 oDd
 oDd
 oDd
@@ -66138,7 +66114,7 @@ dhy
 eXR
 ybr
 mbs
-xnE
+oFh
 oku
 oku
 jYD
@@ -68835,7 +68811,7 @@ sHP
 wmt
 gNW
 dQO
-teE
+blQ
 iDS
 iDS
 sUb

--- a/maps/endeavour/levels/deck3.dmm
+++ b/maps/endeavour/levels/deck3.dmm
@@ -20933,9 +20933,7 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3starboardforhall)
 "nUf" = (
-/obj/structure/toilet{
-	dir = 1
-	},
+/obj/structure/toilet,
 /obj/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
@@ -56550,7 +56548,7 @@ lUu
 ewu
 tQn
 syZ
-lGM
+syZ
 eGx
 eTv
 cLn
@@ -56742,7 +56740,7 @@ fju
 fju
 lUu
 ewu
-syZ
+lGM
 qMP
 hmk
 jLP

--- a/maps/endeavour/levels/deck3.dmm
+++ b/maps/endeavour/levels/deck3.dmm
@@ -697,7 +697,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "ayd" = (
 /obj/machinery/door/firedoor,
@@ -1759,7 +1759,7 @@
 /obj/effect/floor_decal/corner/navgold/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "bfE" = (
 /obj/machinery/fire_alarm/west_mount{
@@ -3119,7 +3119,7 @@
 /obj/effect/floor_decal/corner/navblue/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "bYP" = (
 /obj/structure/disposalpipe/segment{
@@ -6285,6 +6285,9 @@
 	name = "Powernet Sensor - Deck 3 Aft Subgrid";
 	name_tag = "Deck 3 Subgrid"
 	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
 "dYL" = (
@@ -6362,7 +6365,7 @@
 /obj/effect/floor_decal/corner/navblue/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "ecv" = (
 /obj/structure/cable/green{
@@ -10233,6 +10236,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
+/obj/item/paper/pamphlet/substation,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
 "gqN" = (
@@ -13391,6 +13395,9 @@
 	name = "Powernet Sensor - Deck 3 Fore Subgrid";
 	name_tag = "Deck 3 Fore Subgrid"
 	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
 "iFW" = (
@@ -14760,7 +14767,7 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "jDL" = (
 /obj/machinery/button/remote/blast_door{
@@ -17867,12 +17874,6 @@
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
-"lSK" = (
-/obj/machinery/power/breakerbox{
-	RCon_tag = "MAIN - DECK 3 AMIDSHIPS"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/security)
 "lTj" = (
 /turf/simulated/wall/r_wall/prepainted/civilian,
 /area/endeavour/hallway/d3fwdmaint)
@@ -18810,7 +18811,7 @@
 	dir = 4
 	},
 /obj/machinery/fire_alarm/east_mount,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "mwk" = (
 /obj/item/banner/cargo,
@@ -18911,7 +18912,7 @@
 /turf/simulated/floor/carpet,
 /area/security/brig)
 "mBj" = (
-/obj/machinery/power/breakerbox{
+/obj/machinery/power/breakerbox/activated{
 	RCon_tag = "MAIN - DECK 3 FORE"
 	},
 /turf/simulated/floor/plating,
@@ -23964,7 +23965,7 @@
 	dir = 4
 	},
 /obj/machinery/fire_alarm/east_mount,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "pSx" = (
 /obj/structure/closet/secure_closet/security,
@@ -24409,6 +24410,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
+/obj/item/paper/pamphlet/substation,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/security)
 "qeX" = (
@@ -25270,7 +25272,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "qJB" = (
 /turf/simulated/wall/prepainted/cargo,
@@ -27109,7 +27111,7 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/substation/cargo)
 "rXl" = (
-/obj/machinery/power/breakerbox{
+/obj/machinery/power/breakerbox/activated{
 	RCon_tag = "MAIN - DECK 3 AFT"
 	},
 /turf/simulated/floor/plating,
@@ -27791,7 +27793,7 @@
 /obj/effect/floor_decal/corner/navgold/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "ssY" = (
 /obj/machinery/light/small{
@@ -30660,6 +30662,9 @@
 	name = "Powernet Sensor - Deck 3 Amidships Subgrid";
 	name_tag = "Deck 3 Aft Subgrid"
 	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/security)
 "ujb" = (
@@ -30679,6 +30684,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
+/obj/item/paper/pamphlet/substation,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
 "ujB" = (
@@ -36443,7 +36449,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
 "xMC" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
@@ -57527,7 +57533,7 @@ lTw
 cjw
 mhY
 nfG
-lSK
+xfl
 mhY
 jkU
 nuP

--- a/maps/endeavour/levels/deck3.dmm
+++ b/maps/endeavour/levels/deck3.dmm
@@ -11986,7 +11986,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/sleep/Dorm_13)
+/area/crew_quarters/recreation_area)
 "hGe" = (
 /obj/machinery/door/airlock/glass{
 	desc = "A room dedicated for the repairs and recharging of adherent.";
@@ -15879,7 +15879,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/Dorm_13)
+/area/crew_quarters/recreation_area)
 "kuG" = (
 /obj/landmark/spawnpoint/latejoin/station/cryogenics,
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
@@ -16701,7 +16701,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/turcarpet,
-/area/crew_quarters/sleep/Dorm_13)
+/area/crew_quarters/recreation_area)
 "kZA" = (
 /obj/effect/floor_decal/corner/green/full{
 	dir = 1
@@ -23396,10 +23396,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/security/hallway)
-"pwn" = (
-/obj/spawner/window/low_wall/full/firelocks/nogrille,
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/Dorm_13)
 "pwo" = (
 /turf/simulated/wall/r_wall/prepainted/civilian,
 /area/crew_quarters/game_room)
@@ -23780,7 +23776,7 @@
 	},
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/carpet/turcarpet,
-/area/crew_quarters/sleep/Dorm_13)
+/area/crew_quarters/recreation_area)
 "pNn" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light/small{
@@ -26869,7 +26865,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/Dorm_13)
+/area/crew_quarters/recreation_area)
 "rPa" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/navblue/border,
@@ -55582,7 +55578,7 @@ kZu
 pMS
 kur
 rOW
-pwn
+vaf
 sTd
 bBc
 sid

--- a/maps/endeavour/levels/deck3.dmm
+++ b/maps/endeavour/levels/deck3.dmm
@@ -3719,6 +3719,8 @@
 /obj/machinery/status_display/supply_display{
 	pixel_x = -32
 	},
+/obj/structure/dogbed,
+/mob/living/simple_mob/animal/sif/fluffy,
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
 "czc" = (
@@ -36041,8 +36043,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -36290,14 +36291,16 @@
 /turf/simulated/floor/crystal,
 /area/endeavour/hallway/d3fwdhall)
 "xJa" = (
-/obj/structure/dogbed,
-/mob/living/simple_mob/animal/sif/fluffy,
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
 /obj/machinery/air_alarm{
 	dir = 4;
 	pixel_x = -23
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)

--- a/maps/endeavour/levels/deck3.dmm
+++ b/maps/endeavour/levels/deck3.dmm
@@ -4079,9 +4079,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "cLp" = (
@@ -7810,14 +7807,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/security_lockerroom)
 "eTv" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
 /obj/structure/cable/green{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
@@ -7844,16 +7838,16 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/navblue/bordercorner2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/navblue/bordercorner2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
-/area/endeavour/hallway/d3portamidhall)
+/area/endeavour/hallway/d3portforhall)
 "eVb" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bar/catwalk)
@@ -18825,6 +18819,9 @@
 	dir = 2;
 	icon_state = "pipe-j2"
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "mwM" = (
@@ -20145,10 +20142,13 @@
 "nvp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/junction,
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "nvw" = (
@@ -21990,12 +21990,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
 "oBe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3portamidhall)
 "oBE" = (
@@ -25056,7 +25057,6 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portamidhall)
 "qBU" = (
@@ -25450,13 +25450,10 @@
 /area/security/brig)
 "qQD" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Crew Quarters"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Crew Quarters"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
@@ -28778,21 +28775,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/navblue/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/navblue/bordercorner2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3portforhall)
 "sYp" = (
@@ -34263,6 +34247,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/navblue/bordercorner2{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d3portamidhall)
 "wpe" = (
@@ -36733,17 +36729,12 @@
 /turf/simulated/floor/tiled/old_cargo/red,
 /area/security/security_processing)
 "xXa" = (
-/obj/machinery/camera/network/civilian{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/navblue/border,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/endeavour/hallway/d3portamidhall)
+/area/endeavour/hallway/d3portforhall)
 "xXg" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/game_room)
@@ -56361,7 +56352,7 @@ rEX
 mkn
 jHr
 pwq
-sTd
+eUA
 bBc
 sid
 eqa
@@ -56556,8 +56547,8 @@ eTv
 cLn
 qQD
 sXK
-bBc
-sid
+xXa
+swv
 eqa
 mmq
 mmq
@@ -56751,7 +56742,7 @@ mwA
 sQO
 oBe
 qBQ
-xXa
+iIc
 mMr
 bWK
 bWK
@@ -57137,7 +57128,7 @@ qbT
 bzu
 iPO
 jiy
-eUA
+fqc
 pAU
 rPF
 mMr

--- a/maps/endeavour/levels/deck3.dmm
+++ b/maps/endeavour/levels/deck3.dmm
@@ -1551,14 +1551,14 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/spawner/window/reinforced/full,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
 "aZU" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/spawner/window/reinforced/full,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
 "bax" = (
@@ -2482,8 +2482,10 @@
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
 "bBF" = (
-/obj/effect/shuttle_landmark/endeavour/deck2/port,
-/turf/space,
+/obj/effect/shuttle_landmark/automatic{
+	name = "Deck 3, Starboard Side"
+	},
+/turf/space/basic,
 /area/space)
 "bBM" = (
 /obj/machinery/fire_alarm/north_mount,
@@ -3311,7 +3313,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/spawner/window/reinforced/full,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d3aftmaint)
 "ciU" = (
@@ -6588,6 +6590,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3portforhall)
 "ejd" = (
@@ -8549,6 +8557,9 @@
 	},
 /obj/effect/floor_decal/corner/navblue/border{
 	dir = 9
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
@@ -10660,12 +10671,6 @@
 	},
 /obj/effect/floor_decal/corner/navblue/border{
 	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/navblue/bordercorner2{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15266,6 +15271,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_3)
+"jXm" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navgold/border{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d3starboardamidhall)
 "jXM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -17403,6 +17420,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/fitness)
+"lzC" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navgold/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navgold/bordercorner2{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3starboardamidhall)
 "lAm" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/brown/border,
@@ -18224,6 +18259,21 @@
 "mfy" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/sleep/Dorm_12)
+"mfz" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navgold/border{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3starboardforhall)
 "mgD" = (
 /obj/effect/floor_decal/corner/black{
 	dir = 9
@@ -21103,6 +21153,21 @@
 /obj/effect/floor_decal/corner_oldtile/white/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
+"obX" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3portamidhall)
 "och" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -22889,6 +22954,9 @@
 	},
 /obj/effect/floor_decal/corner/navblue/border{
 	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3afthall)
@@ -27762,7 +27830,7 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/spawner/window/reinforced/full,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/security)
 "suh" = (
@@ -28688,6 +28756,21 @@
 "sWJ" = (
 /turf/simulated/floor/tiled/monodark,
 /area/prison/cell_block)
+"sWT" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3portforhall)
 "sXC" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc/south_mount,
@@ -29577,12 +29660,6 @@
 /obj/effect/floor_decal/corner/navblue/border{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/navblue/bordercorner2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -30397,6 +30474,21 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d3fwdhall)
+"ufF" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navblue/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d3portforhall)
 "ufL" = (
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/floor/tiled/steel,
@@ -30728,6 +30820,18 @@
 /obj/machinery/fire_alarm/east_mount,
 /turf/simulated/floor/tiled/dark,
 /area/endeavour/station/stairs_three)
+"unb" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/navgold/border{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d3starboardforhall)
 "uny" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -31595,7 +31699,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/spawner/window/reinforced/full,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
 "uPC" = (
@@ -32190,6 +32294,12 @@
 "vkn" = (
 /turf/simulated/wall/r_wall/prepainted/cargo,
 /area/quartermaster/cargo_shelter_dock)
+"vkt" = (
+/obj/effect/shuttle_landmark/automatic{
+	name = "Deck 3, Port Side"
+	},
+/turf/space/basic,
+/area/space)
 "vkR" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
@@ -32957,6 +33067,12 @@
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/warehouse)
+"vDG" = (
+/obj/effect/shuttle_landmark/automatic{
+	name = "Deck 3, Port Side"
+	},
+/turf/space,
+/area/space)
 "vDN" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
@@ -44347,7 +44463,7 @@ pRW
 pRW
 pRW
 pRW
-pRW
+vkt
 pRW
 pRW
 pRW
@@ -44886,7 +45002,7 @@ pRW
 pRW
 pRW
 pRW
-pRW
+bBF
 pRW
 pRW
 pRW
@@ -51199,7 +51315,7 @@ kSn
 rvL
 rvL
 xhN
-txu
+ufF
 ndp
 sid
 syH
@@ -56196,7 +56312,7 @@ mDp
 mDp
 mDp
 mDp
-bBF
+mDp
 mDp
 mDp
 mDp
@@ -57407,7 +57523,7 @@ qbT
 jUs
 pPi
 jiy
-tMK
+obX
 nTO
 pNH
 mMr
@@ -57615,7 +57731,7 @@ bCC
 stW
 mhY
 mhY
-osL
+lzC
 gVA
 fWt
 qRW
@@ -57928,7 +58044,7 @@ mDp
 mDp
 mDp
 mDp
-mDp
+vDG
 mDp
 mDp
 mDp
@@ -60331,7 +60447,7 @@ efB
 nif
 oTx
 daO
-eTx
+jXm
 okL
 pIT
 vnQ
@@ -60593,7 +60709,7 @@ pRW
 pRW
 pRW
 pRW
-pRW
+bBF
 pRW
 pRW
 pRW
@@ -61287,7 +61403,7 @@ vRl
 rBG
 qdW
 rBG
-tMK
+obX
 nTO
 goK
 xID
@@ -62659,7 +62775,7 @@ qxb
 xIo
 uhW
 qEf
-sih
+mfz
 adZ
 vWW
 gSN
@@ -65181,7 +65297,7 @@ rpK
 esO
 tOV
 orP
-gFU
+unb
 adZ
 poW
 eVN
@@ -65555,7 +65671,7 @@ alQ
 fSP
 lTw
 mMr
-qxm
+sWT
 tAU
 uIa
 qcn

--- a/maps/endeavour/levels/deck3.dmm
+++ b/maps/endeavour/levels/deck3.dmm
@@ -2684,7 +2684,7 @@
 	},
 /obj/map_helper/access_helper/airlock/station/supply/cargo_bay,
 /obj/machinery/door/airlock/glass/mining{
-	name = "Magmatic Rift Leap Pad";
+	name = "Mailing Office";
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/monodark,
@@ -2921,7 +2921,7 @@
 /area/crew_quarters/sleep/Dorm_6)
 "bTd" = (
 /obj/machinery/door/airlock/glass/mining{
-	name = "Magmatic Rift Leap Pad";
+	name = "Cargo Airlock";
 	req_one_access = null
 	},
 /obj/machinery/door/firedoor,
@@ -4999,7 +4999,7 @@
 "dkO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/mining{
-	name = "Magmatic Rift Leap Pad";
+	name = "Cargo Airlock";
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -11487,7 +11487,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/obj/machinery/recharge_station,
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "hmF" = (
@@ -14991,7 +14991,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "jMc" = (
@@ -30022,10 +30022,6 @@
 /obj/effect/paint/darkred,
 /turf/simulated/floor/plating,
 /area/security/warden)
-"tQn" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/wood,
-/area/crew_quarters/recreation_area)
 "tRb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -56546,7 +56542,7 @@ yab
 jbC
 lUu
 ewu
-tQn
+syZ
 syZ
 syZ
 eGx

--- a/maps/endeavour/levels/deck3.dmm
+++ b/maps/endeavour/levels/deck3.dmm
@@ -5004,6 +5004,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/foyer)
+"dkR" = (
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "MAIN - DECK 3 AMIDSHIPS"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/security)
 "dld" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/brown/border,
@@ -57527,7 +57533,7 @@ lTw
 cjw
 mhY
 nfG
-xfl
+dkR
 mhY
 jkU
 nuP

--- a/maps/endeavour/levels/deck4.dmm
+++ b/maps/endeavour/levels/deck4.dmm
@@ -108,6 +108,9 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
 "agJ" = (
@@ -433,6 +436,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/workshop)
+"avj" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor/eastright{
+	dir = 2;
+	req_access = null;
+	req_one_access = list(1,38)
+	},
+/turf/simulated/floor/reinforced,
+/area/endeavour/hallway/d4aftmaint)
 "avq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -896,6 +909,9 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
 "aQR" = (
@@ -1054,11 +1070,7 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4starboardamidhall)
 "bdf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4aftmaint)
 "bdx" = (
 /obj/machinery/light{
@@ -1443,9 +1455,20 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "bBM" = (
-/obj/machinery/computer/ship/navigation/telescreen,
-/turf/simulated/wall/r_wall/prepainted,
-/area/rnd/robotics/smallcraft)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/endeavour/hallway/d4starboardforhall)
 "bCk" = (
 /turf/simulated/wall/r_wall/prepainted/engineering,
 /area/engineering/engine_airlock)
@@ -1612,8 +1635,8 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
 "bKa" = (
-/obj/effect/shuttle_landmark{
-	name = "Near Endeavour - for Spacena Class Vessels"
+/obj/effect/shuttle_landmark/automatic{
+	name = "For Spacena Class Vessels"
 	},
 /turf/space/basic,
 /area/space)
@@ -1716,6 +1739,24 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/endeavour/command/turrets)
+"bPS" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/machinery/camera/network/engineering,
+/obj/machinery/air_alarm/north_mount,
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	alpha = 255;
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/endeavour/hallway/d4portafthall)
 "bQm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -1867,9 +1908,20 @@
 /turf/simulated/floor/tiled/monowhite,
 /area/engineering/shield_gen)
 "bWc" = (
-/obj/machinery/computer/ship/navigation/telescreen,
-/turf/simulated/wall/r_wall/prepainted/engineering,
-/area/engineering/engine_smes)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/endeavour/hallway/d4starboardforhall)
 "bXA" = (
 /obj/machinery/camera/network/outside{
 	dir = 8
@@ -2012,9 +2064,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/workshop)
 "chW" = (
-/obj/machinery/computer/ship/navigation/telescreen,
-/turf/simulated/wall/r_wall/prepainted/engineering,
-/area/storage/tech)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/endeavour/hallway/d4portafthall)
 "cin" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -2257,7 +2317,7 @@
 	dir = 5
 	},
 /obj/machinery/computer/ship/navigation/telescreen{
-	pixel_y = 27
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/endeavour/command/turrets)
@@ -2388,11 +2448,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/turf/simulated/floor/tiled/monofloor{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/techfloor/grid,
 /area/endeavour/hallway/d4aftmaint)
 "cyR" = (
 /obj/machinery/door/airlock/maintenance{
@@ -2491,6 +2549,19 @@
 /obj/item/circuitboard/machine/lathe/autolathe,
 /turf/simulated/floor,
 /area/storage/tech)
+"cFb" = (
+/obj/machinery/door/firedoor{
+	dir = 8
+	},
+/obj/machinery/door/airlock/glass/security{
+	id_tag = "Checkpoint";
+	layer = 2.8;
+	name = "Security";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/general,
+/turf/simulated/floor/reinforced,
+/area/endeavour/hallway/d4aftmaint)
 "cFY" = (
 /obj/effect/paint/sun,
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
@@ -2548,20 +2619,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "cGP" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/item/radio/intercom/west_mount{
 	pixel_x = 28
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/monofloor{
-	dir = 4
+	dir = 8
 	},
 /area/endeavour/hallway/d4aftmaint)
 "cGQ" = (
@@ -2590,11 +2654,12 @@
 /area/endeavour/hallway/d4starboardafthall)
 "cIi" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = null
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/monofloor{
+	dir = 4
+	},
 /area/endeavour/hallway/d4aftmaint)
 "cIU" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -2607,9 +2672,6 @@
 /area/endeavour/hallway/d4portamidhall)
 "cJh" = (
 /obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monofloor{
@@ -2730,9 +2792,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload_foyer)
 "cQM" = (
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/space)
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lightorange/border,
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/endeavour/hallway/d4starboardhall)
 "cQR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3050,6 +3116,19 @@
 	},
 /area/tcommsat/chamber)
 "dpt" = (
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	alpha = 255;
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightorange/bordercorner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightorange/bordercorner2{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
 "dpZ" = (
@@ -3185,6 +3264,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/substation)
+"dzG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced,
+/area/endeavour/hallway/d4aftmaint)
 "dAg" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
 	alpha = 255;
@@ -3208,16 +3296,8 @@
 	},
 /area/tcommsat/chamber)
 "dBH" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightorange/border{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera/network/engineering,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4portafthall)
 "dBT" = (
@@ -3510,9 +3590,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engineering_monitoring)
 "dWT" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
@@ -3588,9 +3665,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "ebQ" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/suit_storage_unit/engineering,
 /turf/simulated/floor/reinforced,
 /area/endeavour/hallway/d4aftmaint)
@@ -4089,8 +4163,8 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos/eva)
 "eDe" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/endeavour/hallway/d4aftmaint)
@@ -4293,19 +4367,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "eNP" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightorange/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	alpha = 255;
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightorange/bordercorner2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4portafthall)
@@ -4386,15 +4447,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/workshop)
 "eSP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
 /obj/map_helper/access_helper/airlock/station/engineering/department,
 /obj/machinery/door/firedoor{
 	dir = 8
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
@@ -4731,6 +4789,10 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4portforhall)
+"flc" = (
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on,
+/turf/simulated/floor/reinforced,
+/area/endeavour/hallway/d4aftmaint)
 "flu" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4802,6 +4864,9 @@
 	},
 /obj/structure/cable/orange{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
@@ -4901,6 +4966,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
+"fxl" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/starboardnacelle)
 "fxM" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 1
@@ -5083,6 +5154,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engineering_monitoring)
+"fHL" = (
+/obj/machinery/atmospherics/component/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/endeavour/hallway/d4aftmaint)
 "fHR" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/item/clothing/gloves/yellow,
@@ -5144,12 +5221,9 @@
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
 "fJK" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = null
-	},
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/endeavour/hallway/d4aftmaint)
+/area/engineering/portnacelle)
 "fJV" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -5300,6 +5374,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/engineering/shield_gen)
+"fUW" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/endeavour/hallway/d4aftmaint)
 "fVo" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
@@ -5452,6 +5529,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engineering_monitoring)
+"gdC" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/endeavour/hallway/d4aftmaint)
 "ggr" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 8
@@ -6666,6 +6752,15 @@
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
+"hxJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/reinforced,
+/area/endeavour/hallway/d4aftmaint)
 "hxV" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -6720,9 +6815,6 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4porthall)
 "hBu" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/monofloor{
 	dir = 4
 	},
@@ -6980,6 +7072,12 @@
 	},
 /turf/simulated/wall/r_wall/prepainted/engineering/atmos,
 /area/engineering/atmos)
+"hMC" = (
+/obj/effect/shuttle_landmark/automatic{
+	name = "Deck 4, Starboard Side"
+	},
+/turf/space,
+/area/space)
 "hMK" = (
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
@@ -7403,12 +7501,17 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
 "imm" = (
-/obj/machinery/light/small{
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/space)
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/endeavour/hallway/d4portamidhall)
 "imx" = (
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
@@ -8522,9 +8625,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4starboardhall)
 "jyr" = (
-/obj/effect/shuttle_landmark/endeavour/deck1/starboard,
-/turf/space,
-/area/space)
+/turf/simulated/wall/r_wall/prepainted/security,
+/area/engineering/portnacelle)
 "jyT" = (
 /obj/machinery/lathe/autolathe,
 /turf/simulated/floor/tiled/techmaint,
@@ -8597,9 +8699,17 @@
 /turf/simulated/wall/prepainted/engineering,
 /area/endeavour/hallway/d4fwdmaint)
 "jBK" = (
-/obj/machinery/computer/ship/navigation/telescreen,
-/turf/simulated/wall/r_wall/prepainted/engineering,
-/area/engineering/storage)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/endeavour/hallway/d4portafthall)
 "jBO" = (
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
@@ -9605,9 +9715,8 @@
 /turf/simulated/floor,
 /area/storage/tech)
 "kLQ" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
 "kMd" = (
@@ -9782,8 +9891,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engineering_monitoring)
 "kWc" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/endeavour/hallway/d4aftmaint)
@@ -10675,17 +10787,11 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/lightorange/border,
 /obj/map_helper/access_helper/airlock/station/engineering/department,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
@@ -11276,9 +11382,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
 "mFn" = (
@@ -11554,9 +11657,17 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
 "mTb" = (
-/obj/machinery/computer/ship/navigation/telescreen,
-/turf/simulated/wall/r_wall/prepainted/command,
-/area/ai)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d4fwdhall)
 "mTl" = (
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 4
@@ -12282,15 +12393,8 @@
 /obj/effect/floor_decal/corner/lightorange/bordercorner2{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4portafthall)
@@ -12522,6 +12626,9 @@
 	},
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 5
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d4fwdhall)
@@ -13412,10 +13519,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
-"pch" = (
-/obj/machinery/computer/ship/navigation/telescreen,
-/turf/simulated/wall/r_wall/prepainted/engineering,
-/area/tcommsat/chamber)
 "pcz" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -13512,6 +13615,9 @@
 /obj/effect/floor_decal/corner/lightorange/border,
 /obj/machinery/door/firedoor{
 	dir = 8
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4porthall)
@@ -13873,6 +13979,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
+"pJi" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/portnacelle)
 "pJw" = (
 /obj/structure/table/hardwoodtable,
 /obj/item/storage/box/snakesnackbox,
@@ -13939,8 +14051,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_airlock)
 "pNT" = (
-/obj/item/barrier_tape_segment/engineering,
-/turf/simulated/floor/reinforced,
+/turf/simulated/wall/r_wall/prepainted/security,
 /area/endeavour/hallway/d4aftmaint)
 "pOI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
@@ -14052,8 +14163,8 @@
 /turf/simulated/floor/tiled/monowhite,
 /area/engineering/drone_fabrication)
 "pTX" = (
-/obj/effect/shuttle_landmark{
-	name = "Near Endeavour - for Tug class vessels "
+/obj/effect/shuttle_landmark/automatic{
+	name = "For Tug class vessels "
 	},
 /turf/space,
 /area/space)
@@ -14143,6 +14254,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/engineering/shield_gen)
+"pYs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d4portafthall)
 "pZs" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -14155,9 +14280,6 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4starboardafthall)
 "qbg" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/air_alarm/east_mount,
 /obj/machinery/suit_storage_unit/engineering,
 /turf/simulated/floor/reinforced,
@@ -14278,6 +14400,25 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/red,
 /turf/simulated/wall/r_wall/prepainted/engineering/atmos,
 /area/engineering/atmos/workshop)
+"qmd" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	alpha = 255;
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/endeavour/hallway/d4portafthall)
 "qmW" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techmaint,
@@ -14674,6 +14815,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4porthall)
+"qNE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/reinforced,
+/area/endeavour/hallway/d4aftmaint)
 "qOR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15013,7 +15159,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 8
 	},
-/obj/machinery/light/small,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/portnacelle)
 "rgn" = (
@@ -15280,16 +15425,10 @@
 "rAt" = (
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/lightorange/bordercorner,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
 "rAC" = (
@@ -15708,6 +15847,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4starboardamidhall)
+"sbv" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/endeavour/hallway/d4aftmaint)
 "sdP" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -15755,19 +15898,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload)
 "sgN" = (
-/obj/effect/floor_decal/techfloor{
+/obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/monofloor{
-	dir = 4
+	dir = 8
 	},
 /area/endeavour/hallway/d4aftmaint)
 "sgO" = (
@@ -15795,18 +15932,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4porthall)
 "shX" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = null
+/obj/machinery/camera/network/outside{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/reinforced,
 /area/endeavour/hallway/d4aftmaint)
 "sjY" = (
 /obj/spawner/window/reinforced/full/firelocks,
@@ -15815,6 +15947,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
+"skk" = (
+/obj/machinery/door/firedoor{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass/security{
+	id_tag = "Checkpoint";
+	layer = 2.8;
+	name = "Security";
+	req_one_access = null
+	},
+/obj/map_helper/access_helper/airlock/station/security/general,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/endeavour/hallway/d4aftmaint)
 "sky" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -15869,7 +16016,7 @@
 /area/endeavour/hallway/d4starboardafthall)
 "sox" = (
 /obj/structure/sign/nanotrasen,
-/turf/simulated/wall/r_wall/prepainted/engineering,
+/turf/simulated/wall/r_wall/prepainted/security,
 /area/endeavour/hallway/d4aftmaint)
 "spe" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
@@ -16043,6 +16190,9 @@
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 1
 	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled,
 /area/endeavour/hallway/d4fwdhall)
 "sBU" = (
@@ -16196,13 +16346,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_gas)
 "sIE" = (
-/obj/structure/cable/orange{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/reinforced,
 /area/endeavour/hallway/d4aftmaint)
 "sJm" = (
 /obj/effect/floor_decal/borderfloorblack,
@@ -16764,9 +16911,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/workshop)
 "tAQ" = (
-/obj/effect/shuttle_landmark/endeavour/deck1/port,
-/turf/space,
-/area/space)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/endeavour/hallway/d4aftmaint)
 "tBv" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/spline/fancy{
@@ -16839,8 +16991,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
 "tFm" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/endeavour/hallway/d4aftmaint)
@@ -17180,13 +17333,12 @@
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 1
 	},
-/obj/machinery/computer/ship/navigation/telescreen,
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4porthall)
 "tXA" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 8
 	},
@@ -17199,6 +17351,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
+"tZd" = (
+/obj/effect/shuttle_landmark/automatic{
+	name = "Deck 4, Port Side"
+	},
+/turf/space/basic,
+/area/space)
 "uai" = (
 /obj/map_helper/access_helper/airlock/station/engineering/department,
 /obj/structure/cable{
@@ -17238,6 +17396,12 @@
 /obj/machinery/power/apc/north_mount,
 /obj/structure/cable/green{
 	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightorange/bordercorner2{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4portafthall)
@@ -17443,9 +17607,20 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload_foyer)
 "urR" = (
-/obj/machinery/computer/ship/navigation/telescreen,
-/turf/simulated/wall/prepainted/engineering,
-/area/engineering/shield_gen)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/endeavour/hallway/d4starboardamidhall)
 "usD" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -17596,9 +17771,11 @@
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
 "uBK" = (
-/obj/machinery/computer/ship/navigation/telescreen,
-/turf/simulated/wall/r_wall/prepainted/command,
-/area/ai_upload)
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/endeavour/hallway/d4porthall)
 "uCd" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -17900,10 +18077,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "uYj" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/machinery/camera/network/outside{
+	dir = 1
 	},
-/turf/simulated/floor/reinforced,
+/obj/machinery/atmospherics/component/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4aftmaint)
 "uYJ" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -19558,13 +19738,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/robotics/smallcraft)
 "wGc" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4aftmaint)
 "wGk" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -20811,6 +20991,15 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
+"xZC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/reinforced,
+/area/endeavour/hallway/d4aftmaint)
 "yaf" = (
 /turf/simulated/floor/reinforced/oxygen,
 /area/engineering/atmos)
@@ -20876,12 +21065,11 @@
 /obj/effect/floor_decal/corner/lightorange/bordercorner{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
@@ -25836,7 +26024,7 @@ jNg
 jNg
 jNg
 jNg
-jyr
+jNg
 jNg
 jNg
 jNg
@@ -26356,9 +26544,9 @@ wEN
 wEN
 aXs
 fCM
-lgz
+pJi
 eIq
-eIq
+fJK
 wEN
 wEN
 psc
@@ -27134,7 +27322,7 @@ jYW
 ain
 rga
 eIq
-eIq
+fJK
 vLd
 kdA
 lHH
@@ -27172,7 +27360,7 @@ iXz
 hHV
 jBO
 cXp
-pWy
+fxl
 pWy
 tXA
 uzl
@@ -29072,10 +29260,10 @@ wEN
 wEN
 wEN
 wEN
-wEN
-wEN
-wEN
-wEN
+jyr
+jyr
+jyr
+jyr
 iAM
 xwJ
 lgy
@@ -29258,7 +29446,7 @@ jNg
 jNg
 jNg
 jNg
-jNg
+xRj
 jNg
 jNg
 ikp
@@ -29267,12 +29455,12 @@ iYY
 jhP
 jhP
 pNT
-jhP
-jhP
-ikp
-ihs
-xwJ
-mHH
+bdf
+fUW
+pNT
+cjZ
+xwD
+gIr
 nTU
 nhY
 wyk
@@ -29452,7 +29640,7 @@ jNg
 jNg
 jNg
 jNg
-jNg
+xRj
 jNg
 jNg
 ikp
@@ -29460,10 +29648,10 @@ wom
 jhP
 jhP
 jhP
+cFb
+fUW
+bdf
 pNT
-jhP
-peM
-ikp
 iAM
 xwJ
 oSP
@@ -29646,19 +29834,19 @@ jNg
 jNg
 jNg
 jNg
-jNg
+xRj
 jNg
 jNg
 dYd
 jhP
 jhP
 jhP
-jhP
-pNT
-jhP
 wCh
-ikp
-kqk
+pNT
+bdf
+sbv
+pNT
+ihs
 xwJ
 mHH
 nTU
@@ -29840,19 +30028,19 @@ jNg
 jNg
 jNg
 jNg
-jNg
+xRj
 jNg
 jNg
 dYd
 jhP
-jhP
-jhP
-jhP
+flc
+hxJ
+shX
 pNT
-jhP
-jhP
-ikp
-iAM
+fUW
+uYj
+pNT
+bPS
 xwJ
 kab
 nTU
@@ -30034,20 +30222,20 @@ jNg
 jNg
 jNg
 jNg
-jNg
+xRj
 jNg
 jNg
 dYd
 jhP
 jhP
+kWc
 jhP
-jhP
-pNT
-jhP
-jhP
-ikp
+avj
+bdf
+wGc
+skk
 dBH
-xwJ
+pYs
 mHH
 nTU
 cvQ
@@ -30228,18 +30416,18 @@ jNg
 jNg
 jNg
 jNg
-jNg
+xRj
 jNg
 jNg
 dYd
 jhP
 jhP
-jhP
+kWc
 jhP
 pNT
-jhP
-jhP
-ikp
+fUW
+fHL
+pNT
 udi
 jzg
 kab
@@ -30422,21 +30610,21 @@ jNg
 jNg
 jNg
 jNg
+xRj
 jNg
-jNg
-jNg
+xRj
 dYd
 jhP
 jhP
+kWc
 jhP
-jhP
-ikp
+pNT
 uBe
 uXJ
-ikp
-cjZ
-xwD
-gIr
+pNT
+qmd
+xwJ
+mHH
 nTU
 nTU
 nTU
@@ -30622,12 +30810,12 @@ jNg
 dYd
 jhP
 jhP
-jhP
+kWc
 jhP
 cIi
 cJh
 hBu
-fJK
+cIi
 eNP
 gIB
 xnV
@@ -30816,12 +31004,12 @@ cuI
 ikp
 rpU
 jhP
-jhP
+kWc
 jhP
 sox
 rMc
 klx
-ikp
+pNT
 dpt
 xwJ
 mHH
@@ -31010,14 +31198,14 @@ xRj
 dYd
 jhP
 jhP
-jhP
-jhP
-shX
+tAQ
+qNE
+cyd
 cGP
 sgN
 cyd
 kLQ
-jzg
+pYs
 oSP
 nqa
 eGc
@@ -31204,12 +31392,12 @@ xRj
 dYd
 jhP
 jhP
-jhP
-jhP
-ikp
-ikp
-ikp
-ikp
+kWc
+wCh
+pNT
+pNT
+pNT
+pNT
 cLC
 xwJ
 mHH
@@ -31398,15 +31586,15 @@ xRj
 dYd
 jhP
 jhP
-jhP
+kWc
 jhP
 jhP
 jhP
 peM
-ikp
+pNT
 iAM
 xwJ
-hLB
+kab
 nqa
 fZZ
 xJp
@@ -31481,7 +31669,7 @@ xRj
 xRj
 xRj
 jNg
-jNg
+hMC
 jNg
 jNg
 jNg
@@ -31592,15 +31780,15 @@ xRj
 dYd
 jhP
 jhP
-jhP
-jhP
 kWc
-tFm
-bdf
-ikp
+jhP
+jhP
+jhP
+wCh
+pNT
 kqk
 xwJ
-cYd
+mHH
 nqa
 crO
 gnX
@@ -31785,16 +31973,16 @@ xRj
 xRj
 dYd
 jhP
-jhP
-jhP
-jhP
+sIE
 kWc
-tFm
-eDe
+jhP
+jhP
+jhP
+sIE
 jmD
 iAM
 xwJ
-hLB
+kab
 nqa
 crO
 asr
@@ -31845,10 +32033,10 @@ jNg
 jNg
 jNg
 jNg
-imm
-cQM
-jMU
-jMU
+xRj
+xRj
+xRj
+xRj
 jNg
 jNg
 jNg
@@ -31938,7 +32126,7 @@ xRj
 xRj
 xRj
 xRj
-xRj
+tZd
 xRj
 xRj
 xRj
@@ -31979,16 +32167,16 @@ xRj
 jNg
 dYd
 jhP
-jhP
-jhP
-jhP
-kWc
+xZC
+gdC
 tFm
-eDe
+tFm
+tFm
+dzG
 jmD
 okY
 xwJ
-cYd
+mHH
 nqa
 nqa
 nqa
@@ -32173,11 +32361,11 @@ jNg
 jNg
 dYd
 jhP
+eDe
 jhP
 jhP
 jhP
-kWc
-tFm
+jhP
 eDe
 jmD
 eDC
@@ -32370,10 +32558,10 @@ aKR
 ebQ
 ebQ
 qbg
-uYj
-tFm
-bdf
-ikp
+jhP
+jhP
+wCh
+pNT
 xmz
 fod
 rAt
@@ -32759,7 +32947,7 @@ uEt
 uEt
 rHl
 uEt
-wGc
+uEt
 uEt
 niS
 bXW
@@ -32953,7 +33141,7 @@ pLM
 pLM
 pLM
 pLM
-sIE
+pLM
 pLM
 fSH
 fyX
@@ -32970,8 +33158,8 @@ hER
 wNX
 tWf
 tWf
-tWf
-bWc
+uBK
+dOL
 ieH
 eOZ
 jaG
@@ -33343,7 +33531,7 @@ gMW
 gMW
 gMW
 gMW
-pch
+gMW
 iAM
 kiI
 dRg
@@ -33538,7 +33726,7 @@ gMW
 gMW
 gMW
 gMW
-ihs
+jBK
 kiI
 cYd
 ppa
@@ -34128,7 +34316,7 @@ ohO
 jZF
 jZF
 wHS
-jBK
+dpZ
 fzk
 fVD
 ayo
@@ -34323,7 +34511,7 @@ jZF
 jZF
 fSM
 dpZ
-azJ
+tWu
 atZ
 pgh
 wpR
@@ -34895,8 +35083,8 @@ kaC
 hZm
 irv
 gMW
-pch
-iAM
+gMW
+chW
 kiI
 qjJ
 jQA
@@ -36085,7 +36273,7 @@ oJl
 bAs
 icI
 xAC
-sSq
+cQM
 xsV
 dvY
 rwJ
@@ -37430,7 +37618,7 @@ fJm
 pxO
 mLz
 piY
-urR
+bAs
 bAs
 bAs
 bAs
@@ -40919,7 +41107,7 @@ avD
 wiw
 pSY
 xsV
-gzp
+imm
 gDf
 rqK
 hHC
@@ -41116,7 +41304,7 @@ xsV
 vqm
 gDf
 bne
-chW
+hHC
 hHC
 aHs
 eaG
@@ -41708,8 +41896,8 @@ rgn
 rgn
 sNu
 hHC
-chW
-aqU
+hHC
+urR
 kGS
 uXi
 xsV
@@ -45006,8 +45194,8 @@ rNG
 uAo
 rNG
 xXo
-uBK
-obt
+xXo
+bBM
 wqk
 rbo
 qBz
@@ -46099,7 +46287,7 @@ xRj
 xRj
 xRj
 xRj
-xRj
+tZd
 xRj
 xRj
 xRj
@@ -47191,7 +47379,7 @@ jNg
 jNg
 jNg
 jNg
-jNg
+hMC
 jNg
 jNg
 jNg
@@ -47285,7 +47473,7 @@ jNg
 jNg
 jNg
 jNg
-tAQ
+jNg
 jNg
 jNg
 jNg
@@ -48304,8 +48492,8 @@ gqP
 meF
 toK
 tmr
-mTb
-xNn
+tmr
+bWc
 wqk
 hKp
 qBz
@@ -51988,8 +52176,8 @@ hOM
 sRd
 tRY
 fMI
-bBM
-ebZ
+knf
+mTb
 ehr
 vdH
 qBz

--- a/maps/endeavour/levels/deck4.dmm
+++ b/maps/endeavour/levels/deck4.dmm
@@ -776,13 +776,10 @@
 	},
 /area/tcommsat/chamber)
 "aKR" = (
-/obj/machinery/power/apc/north_mount,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/suit_cycler/engineering,
 /turf/simulated/floor/reinforced,
 /area/endeavour/hallway/d4aftmaint)
 "aLa" = (
@@ -1445,6 +1442,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
+"bBM" = (
+/obj/machinery/computer/ship/navigation/telescreen,
+/turf/simulated/wall/r_wall/prepainted,
+/area/rnd/robotics/smallcraft)
 "bCk" = (
 /turf/simulated/wall/r_wall/prepainted/engineering,
 /area/engineering/engine_airlock)
@@ -1610,6 +1611,12 @@
 /obj/effect/paint/sun,
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
+"bKa" = (
+/obj/effect/shuttle_landmark{
+	name = "Near Endeavour - for Spacena Class Vessels"
+	},
+/turf/space/basic,
+/area/space)
 "bKR" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -1860,13 +1867,9 @@
 /turf/simulated/floor/tiled/monowhite,
 /area/engineering/shield_gen)
 "bWc" = (
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/lightorange/border,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/endeavour/hallway/d4portafthall)
+/obj/machinery/computer/ship/navigation/telescreen,
+/turf/simulated/wall/r_wall/prepainted/engineering,
+/area/engineering/engine_smes)
 "bXA" = (
 /obj/machinery/camera/network/outside{
 	dir = 8
@@ -1879,6 +1882,12 @@
 	},
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 9
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4portafthall)
@@ -2002,6 +2011,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/workshop)
+"chW" = (
+/obj/machinery/computer/ship/navigation/telescreen,
+/turf/simulated/wall/r_wall/prepainted/engineering,
+/area/storage/tech)
 "cin" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -2066,6 +2079,16 @@
 /obj/item/tank/emergency/oxygen/engi,
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
+"cjZ" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel_grid,
+/area/endeavour/hallway/d4portafthall)
 "ckg" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/lightorange/border,
@@ -2360,16 +2383,16 @@
 /area/engineering/atmos/workshop)
 "cyd" = (
 /obj/machinery/door/firedoor,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
 	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/endeavour/hallway/d4aftmaint)
 "cyR" = (
 /obj/machinery/door/airlock/maintenance{
@@ -2468,6 +2491,14 @@
 /obj/item/circuitboard/machine/lathe/autolathe,
 /turf/simulated/floor,
 /area/storage/tech)
+"cFY" = (
+/obj/effect/paint/sun,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/endeavour/hallway/d4portafthall)
 "cGj" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -2517,13 +2548,21 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "cGP" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/item/radio/intercom/west_mount{
+	pixel_x = 28
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/tiled/monofloor{
+	dir = 4
+	},
 /area/endeavour/hallway/d4aftmaint)
 "cGQ" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
@@ -2549,6 +2588,14 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4starboardafthall)
+"cIi" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/endeavour/hallway/d4aftmaint)
 "cIU" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -2559,17 +2606,16 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portamidhall)
 "cJh" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/lightorange/border{
-	dir = 1
+/obj/effect/floor_decal/techfloor{
+	dir = 8
 	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
+/turf/simulated/floor/tiled/monofloor{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/endeavour/hallway/d4portafthall)
+/area/endeavour/hallway/d4aftmaint)
 "cJz" = (
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4porthall)
@@ -2601,12 +2647,6 @@
 	},
 /obj/effect/floor_decal/corner/lightorange/bordercorner2{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4portafthall)
@@ -3010,9 +3050,6 @@
 	},
 /area/tcommsat/chamber)
 "dpt" = (
-/obj/structure/cable/orange{
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
 "dpZ" = (
@@ -3551,7 +3588,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "ebQ" = (
-/obj/machinery/suit_cycler/engineering,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/suit_storage_unit/engineering,
 /turf/simulated/floor/reinforced,
 /area/endeavour/hallway/d4aftmaint)
 "ebZ" = (
@@ -4895,6 +4935,18 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/tcommsat/chamber)
+"fyX" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/endeavour/hallway/d4portafthall)
 "fzb" = (
 /turf/simulated/floor/tiled/white,
 /area/engineering/shield_gen)
@@ -5091,6 +5143,13 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
+"fJK" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/endeavour/hallway/d4aftmaint)
 "fJV" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -5204,6 +5263,9 @@
 	dir = 8
 	},
 /obj/map_helper/access_helper/airlock/station/engineering/department,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
 "fSI" = (
@@ -6657,6 +6719,14 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4porthall)
+"hBu" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monofloor{
+	dir = 4
+	},
+/area/endeavour/hallway/d4aftmaint)
 "hBH" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -7508,6 +7578,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
+"ixk" = (
+/obj/effect/floor_decal/spline/fancy{
+	dir = 5
+	},
+/obj/item/paper/crumpled{
+	name = "Hastily crumpled schematics";
+	info = "Right - the equipment's all set and ready to go - as long as you can keep the ship in the drydock for another few days, we can get in, get out, and be gone before we're missed. Map's attached. Burn this if you think you're about to get pinched-"
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/engineering/engineering_monitoring)
 "ixG" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -8183,10 +8263,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "jmD" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/door/blast/regular{
+	name = "Pod Bay Inner Blast Door";
+	id = "podbayinnerhanger"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/reinforced,
 /area/endeavour/hallway/d4aftmaint)
 "jnl" = (
 /obj/effect/floor_decal/techfloor/orange,
@@ -8515,6 +8596,10 @@
 	},
 /turf/simulated/wall/prepainted/engineering,
 /area/endeavour/hallway/d4fwdmaint)
+"jBK" = (
+/obj/machinery/computer/ship/navigation/telescreen,
+/turf/simulated/wall/r_wall/prepainted/engineering,
+/area/engineering/storage)
 "jBO" = (
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
@@ -9078,10 +9163,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "klx" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
+/obj/effect/floor_decal/steeldecal/steel_decals2{
+	dir = 8
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/tiled,
 /area/endeavour/hallway/d4aftmaint)
 "kmv" = (
 /obj/effect/floor_decal/borderfloorblack,
@@ -9522,9 +9607,6 @@
 "kLQ" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
-	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
@@ -10068,6 +10150,18 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/starboardnacelle)
+"luB" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/endeavour/hallway/d4portafthall)
 "luJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
@@ -11459,6 +11553,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
+"mTb" = (
+/obj/machinery/computer/ship/navigation/telescreen,
+/turf/simulated/wall/r_wall/prepainted/command,
+/area/ai)
 "mTl" = (
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 4
@@ -11636,6 +11734,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/engineering/shield_gen)
+"niS" = (
+/obj/effect/paint/sun,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/endeavour/hallway/d4aftmaint)
 "niT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12183,6 +12289,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4portafthall)
 "nGv" = (
@@ -12467,18 +12576,13 @@
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engineering_monitoring)
 "nUo" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
+/obj/effect/paint/sun,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/lightorange/border{
-	dir = 1
-	},
-/obj/machinery/air_alarm/north_mount,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/endeavour/hallway/d4portafthall)
+/turf/simulated/floor/plating,
+/area/endeavour/hallway/d4aftmaint)
 "nUM" = (
 /obj/structure/sink{
 	pixel_y = 22
@@ -12737,9 +12841,6 @@
 	},
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4portafthall)
@@ -13311,6 +13412,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
+"pch" = (
+/obj/machinery/computer/ship/navigation/telescreen,
+/turf/simulated/wall/r_wall/prepainted/engineering,
+/area/tcommsat/chamber)
 "pcz" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -13387,6 +13492,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
@@ -13831,7 +13939,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_airlock)
 "pNT" = (
-/obj/machinery/suit_storage_unit/engineering,
+/obj/item/barrier_tape_segment/engineering,
 /turf/simulated/floor/reinforced,
 /area/endeavour/hallway/d4aftmaint)
 "pOI" = (
@@ -13944,18 +14052,11 @@
 /turf/simulated/floor/tiled/monowhite,
 /area/engineering/drone_fabrication)
 "pTX" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
+/obj/effect/shuttle_landmark{
+	name = "Near Endeavour - for Tug class vessels "
 	},
-/obj/effect/floor_decal/corner/lightorange/border{
-	dir = 1
-	},
-/obj/machinery/camera/network/engineering,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/endeavour/hallway/d4portafthall)
+/turf/space,
+/area/space)
 "pUe" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small/emergency{
@@ -14053,6 +14154,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4starboardafthall)
+"qbg" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/air_alarm/east_mount,
+/obj/machinery/suit_storage_unit/engineering,
+/turf/simulated/floor/reinforced,
+/area/endeavour/hallway/d4aftmaint)
 "qbS" = (
 /obj/structure/table/standard,
 /obj/item/aiModule/asimov,
@@ -15008,8 +15117,8 @@
 	id = "podbayouterhanger";
 	name = "Pod Bay Outer Hanger Door";
 	pixel_y = 32;
-	req_access = list(10);
-	req_one_access = list(10)
+	req_access = list(19,10,2);
+	req_one_access = list(19,10,2)
 	},
 /obj/machinery/light{
 	dir = 1
@@ -15327,10 +15436,7 @@
 /turf/simulated/floor/tiled/white,
 /area/engineering/engine_monitoring)
 "rMc" = (
-/obj/structure/cable/orange{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/tiled,
 /area/endeavour/hallway/d4aftmaint)
 "rME" = (
 /obj/machinery/camera/network/outside{
@@ -15649,10 +15755,20 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload)
 "sgN" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/tiled/monofloor{
+	dir = 4
+	},
 /area/endeavour/hallway/d4aftmaint)
 "sgO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -15679,10 +15795,18 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4porthall)
 "shX" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
 	},
-/turf/simulated/floor/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/endeavour/hallway/d4aftmaint)
 "sjY" = (
 /obj/spawner/window/reinforced/full/firelocks,
@@ -15744,26 +15868,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4starboardafthall)
 "sox" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/endeavour/hallway/d4portafthall)
+/obj/structure/sign/nanotrasen,
+/turf/simulated/wall/r_wall/prepainted/engineering,
+/area/endeavour/hallway/d4aftmaint)
 "spe" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 1
@@ -16089,11 +16196,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_gas)
 "sIE" = (
-/obj/machinery/light,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/cable/orange{
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/reinforced,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
 "sJm" = (
 /obj/effect/floor_decal/borderfloorblack,
@@ -16384,10 +16493,11 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/engineering/atmos/workshop)
 "tfb" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/power/apc/east_mount,
+/obj/structure/cable/green{
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
 "tfL" = (
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on,
@@ -17063,6 +17173,16 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/endeavour/hallway/d4starboardamidhall)
+"tWu" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen,
+/turf/simulated/floor/tiled/steel_grid,
+/area/endeavour/hallway/d4porthall)
 "tXA" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -17302,6 +17422,10 @@
 /obj/machinery/air_alarm/north_mount,
 /turf/simulated/floor/tiled/monotile,
 /area/endeavour/hallway/d4starboardhall)
+"uqH" = (
+/obj/machinery/computer/ship/navigation/telescreen,
+/turf/simulated/wall/r_wall/prepainted/command,
+/area/ai/foyer)
 "uqT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -17318,6 +17442,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload_foyer)
+"urR" = (
+/obj/machinery/computer/ship/navigation/telescreen,
+/turf/simulated/wall/prepainted/engineering,
+/area/engineering/shield_gen)
 "usD" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -17464,23 +17592,13 @@
 /turf/simulated/floor/reinforced/nitrogen,
 /area/engineering/atmos)
 "uBe" = (
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 8
-	},
-/obj/map_helper/access_helper/airlock/station/engineering/department,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/multi_tile/glass,
-/turf/simulated/floor/tiled/steel,
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
+"uBK" = (
+/obj/machinery/computer/ship/navigation/telescreen,
+/turf/simulated/wall/r_wall/prepainted/command,
+/area/ai_upload)
 "uCd" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -17758,6 +17876,22 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/portnacelle)
+"uXJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/eastright{
+	req_access = null;
+	req_one_access = list(1,38);
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/endeavour/hallway/d4aftmaint)
 "uYd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/structure/disposalpipe/segment{
@@ -18005,7 +18139,6 @@
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 8
 	},
-/obj/map_helper/access_helper/airlock/station/engineering/department,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -19117,13 +19250,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portforhall)
 "wlC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/machinery/camera/network/outside{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/plating,
 /area/endeavour/hallway/d4aftmaint)
 "wnt" = (
 /obj/structure/cable{
@@ -19886,6 +20016,10 @@
 /obj/structure/bed/chair/comfy/beige,
 /turf/simulated/floor/wood,
 /area/engineering/break_room)
+"xjr" = (
+/obj/machinery/computer/ship/navigation/telescreen,
+/turf/simulated/wall/r_wall/prepainted/command,
+/area/ai_upload_foyer)
 "xjs" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -19974,8 +20108,16 @@
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 5
 	},
+/obj/machinery/button/remote/blast_door{
+	id = "podbayinnerhanger";
+	name = "Pod Bay Inner Hanger Door";
+	pixel_y = 32;
+	req_access = list(19,10,2);
+	req_one_access = list(19,10,2);
+	pixel_x = -1
+	},
 /obj/structure/cable/orange{
-	icon_state = "2-8"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/endeavour/hallway/d4portafthall)
@@ -20114,6 +20256,29 @@
 "xwk" = (
 /turf/simulated/wall/r_wall/prepainted/engineering,
 /area/engineering/drone_fabrication)
+"xwD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 8
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/map_helper/access_helper/airlock/station/engineering/department,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel,
+/area/endeavour/hallway/d4portafthall)
 "xwH" = (
 /obj/machinery/light{
 	dir = 4
@@ -20714,6 +20879,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/endeavour/hallway/d4portafthall)
@@ -29096,11 +29264,11 @@ jNg
 ikp
 iYY
 iYY
-ebQ
+jhP
 jhP
 pNT
-pNT
-pNT
+jhP
+jhP
 ikp
 ihs
 xwJ
@@ -29292,7 +29460,7 @@ wom
 jhP
 jhP
 jhP
-jhP
+pNT
 jhP
 peM
 ikp
@@ -29486,7 +29654,7 @@ jhP
 jhP
 jhP
 jhP
-jhP
+pNT
 jhP
 wCh
 ikp
@@ -29680,7 +29848,7 @@ jhP
 jhP
 jhP
 jhP
-jhP
+pNT
 jhP
 jhP
 ikp
@@ -29874,7 +30042,7 @@ jhP
 jhP
 jhP
 jhP
-jhP
+pNT
 jhP
 jhP
 ikp
@@ -30053,7 +30221,7 @@ jNg
 jNg
 jNg
 jNg
-jNg
+pTX
 jNg
 jNg
 jNg
@@ -30068,7 +30236,7 @@ jhP
 jhP
 jhP
 jhP
-jhP
+pNT
 jhP
 jhP
 ikp
@@ -30262,13 +30430,13 @@ jhP
 jhP
 jhP
 jhP
-jhP
-jhP
-jhP
 ikp
-ihs
-xwJ
-mHH
+uBe
+uXJ
+ikp
+cjZ
+xwD
+gIr
 nTU
 nTU
 nTU
@@ -30444,11 +30612,11 @@ jNg
 jNg
 jNg
 jNg
-jNg
-jNg
-jNg
-jNg
-jNg
+xRj
+xRj
+xRj
+xRj
+xRj
 jNg
 jNg
 dYd
@@ -30456,10 +30624,10 @@ jhP
 jhP
 jhP
 jhP
-jhP
-jhP
-jhP
-bJi
+cIi
+cJh
+hBu
+fJK
 eNP
 gIB
 xnV
@@ -30638,10 +30806,10 @@ jNg
 jNg
 jNg
 jNg
-jNg
-jNg
-jNg
-jNg
+xRj
+xRj
+xRj
+xRj
 xRj
 xRj
 cuI
@@ -30650,10 +30818,10 @@ rpU
 jhP
 jhP
 jhP
-jhP
+sox
 rMc
 klx
-uBe
+ikp
 dpt
 xwJ
 mHH
@@ -30832,10 +31000,10 @@ jNg
 jNg
 jNg
 jNg
-jNg
-jNg
-jNg
-jNg
+xRj
+xRj
+xRj
+xRj
 xRj
 xRj
 xRj
@@ -31031,20 +31199,20 @@ jNg
 jNg
 jNg
 xRj
-xRj
+bKa
 xRj
 dYd
 jhP
 jhP
 jhP
 jhP
-kWc
-tFm
-tfb
-ksD
+ikp
+ikp
+ikp
+ikp
 cLC
-sox
-bWc
+xwJ
+mHH
 nqa
 pNL
 jEy
@@ -31232,11 +31400,11 @@ jhP
 jhP
 jhP
 jhP
-kWc
-tFm
-eDe
+jhP
+jhP
+peM
 ikp
-cJh
+iAM
 xwJ
 hLB
 nqa
@@ -31430,7 +31598,7 @@ kWc
 tFm
 bdf
 ikp
-nUo
+kqk
 xwJ
 cYd
 nqa
@@ -31623,8 +31791,8 @@ jhP
 kWc
 tFm
 eDe
-ikp
-cJh
+jmD
+iAM
 xwJ
 hLB
 nqa
@@ -31816,8 +31984,8 @@ jhP
 jhP
 kWc
 tFm
-wlC
-ikp
+eDe
+jmD
 okY
 xwJ
 cYd
@@ -32010,9 +32178,9 @@ jhP
 jhP
 kWc
 tFm
-sIE
-ikp
-pTX
+eDe
+jmD
+eDC
 agu
 mEZ
 jnW
@@ -32199,12 +32367,12 @@ jNg
 rME
 ikp
 aKR
-sgN
-sgN
-sgN
+ebQ
+ebQ
+qbg
 uYj
 tFm
-eDe
+bdf
 ikp
 xmz
 fod
@@ -32400,7 +32568,7 @@ ikp
 dWT
 eSP
 ikp
-gIr
+cFY
 aQr
 lZV
 dpZ
@@ -32592,8 +32760,8 @@ uEt
 rHl
 uEt
 wGc
-jmD
-ikp
+uEt
+niS
 bXW
 yeG
 nGj
@@ -32785,10 +32953,10 @@ pLM
 pLM
 pLM
 pLM
-coP
-jBO
+sIE
+pLM
 fSH
-iAM
+fyX
 hEI
 bSj
 vGs
@@ -32803,7 +32971,7 @@ wNX
 tWf
 tWf
 tWf
-dOL
+bWc
 ieH
 eOZ
 jaG
@@ -32978,11 +33146,11 @@ bJi
 jBO
 jBO
 jBO
-jBO
-jBO
-jBO
-ikp
-ihs
+tfb
+wlC
+wlC
+nUo
+luB
 pfR
 tmS
 ppa
@@ -33175,7 +33343,7 @@ gMW
 gMW
 gMW
 gMW
-gMW
+pch
 iAM
 kiI
 dRg
@@ -33960,7 +34128,7 @@ ohO
 jZF
 jZF
 wHS
-dpZ
+jBK
 fzk
 fVD
 ayo
@@ -34727,7 +34895,7 @@ kaC
 hZm
 irv
 gMW
-gMW
+pch
 iAM
 kiI
 qjJ
@@ -34747,7 +34915,7 @@ oCj
 bHY
 cQR
 bHY
-inf
+ixk
 lNQ
 jlM
 wpR
@@ -36483,7 +36651,7 @@ kuh
 ryp
 nqw
 fJm
-azJ
+tWu
 atZ
 dlT
 bAs
@@ -37262,7 +37430,7 @@ fJm
 pxO
 mLz
 piY
-bAs
+urR
 bAs
 bAs
 bAs
@@ -40948,7 +41116,7 @@ xsV
 vqm
 gDf
 bne
-hHC
+chW
 hHC
 aHs
 eaG
@@ -41540,7 +41708,7 @@ rgn
 rgn
 sNu
 hHC
-hHC
+chW
 aqU
 kGS
 uXi
@@ -43858,7 +44026,7 @@ qBz
 xmZ
 oAp
 fIT
-ocO
+uqH
 ocO
 bny
 fbf
@@ -44838,7 +45006,7 @@ rNG
 uAo
 rNG
 xXo
-xXo
+uBK
 obt
 wqk
 rbo
@@ -46186,7 +46354,7 @@ qBz
 oOK
 oAp
 fIT
-bDO
+xjr
 bDO
 bDO
 bDO
@@ -48136,7 +48304,7 @@ gqP
 meF
 toK
 tmr
-tmr
+mTb
 xNn
 wqk
 hKp
@@ -51820,7 +51988,7 @@ hOM
 sRd
 tRY
 fMI
-knf
+bBM
 ebZ
 ehr
 vdH

--- a/maps/endeavour/levels/deck4.dmm
+++ b/maps/endeavour/levels/deck4.dmm
@@ -11200,6 +11200,12 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
+"mxW" = (
+/obj/machinery/drone_fabricator/matriarch{
+	fabricator_tag = "Engineering Matriarch"
+	},
+/turf/simulated/floor/tiled/monodark,
+/area/engineering/drone_fabrication)
 "myq" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/cedouble,
@@ -36634,7 +36640,7 @@ ylp
 vLC
 tDD
 hmF
-tDD
+mxW
 vLC
 xwk
 iAM

--- a/maps/endeavour/levels/deck4.dmm
+++ b/maps/endeavour/levels/deck4.dmm
@@ -17226,6 +17226,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/item/paper/pamphlet/substation,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
 "tSk" = (

--- a/maps/sectors/nebula_tradeport/levels/nebula_tradeport.dmm
+++ b/maps/sectors/nebula_tradeport/levels/nebula_tradeport.dmm
@@ -4401,7 +4401,6 @@
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
-	icon_state = "pdoor1";
 	id = "Runabout'";
 	name = "Teshari Runabout Airlock";
 	opacity = 0
@@ -17183,9 +17182,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/trade_ship/general)
 "aTM" = (
-/obj/structure/cable/orange{
-	dir = 2
-	},
+/obj/structure/cable/orange,
 /obj/machinery/power/terminal,
 /turf/simulated/floor/tiled/monotechmaint,
 /area/shuttle/tug)
@@ -19695,7 +19692,6 @@
 "brN" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/structure/window/reinforced/polarized{
-	dir = 2;
 	id = "scoophead_office"
 	},
 /turf/simulated/floor/plating,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request


Gets docking working on Deck 4 for all traveler shuttles. This system will bypass docking code requirements, however, a member of security, engineering or command is required to open the blast doors on Deck 4 to admit entrance to a security checkpoint area.

Also, a bunch of small bug fixes to things like decals, lighting, extra switches and things out in space, and a bunch of wiring and airless tile issues on the other decks. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Enables docking for traveler shuttles on Endeavour, updates a bunch of landmarks so that shuttles can land around the Endeavour.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Docking bay and docking points around the Endeavour
fix:  A bunch of bugs and mistakes on several decks got fixed.
fix: fixed bad wiring and shuttle seating in EMT shuttle.
fix: bad wire in the dorms on deck 2
fix: bad stairs near explo between deck 4
add: numerous landing landmarks (4) to each deck of Endeavour
fix: changed several lingering airless tiles in Deck 2 maints to standard tiles
fix: floor markings on deck 1, 2, 3, & 4.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
