### PR TITLE
Easy and simple fix to the Scoophead

### DIFF
--- a/maps/sectors/nebula_tradeport/levels/nebula_tradeport.dmm
+++ b/maps/sectors/nebula_tradeport/levels/nebula_tradeport.dmm
@@ -19712,9 +19712,6 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/wood,
 /area/sector/nebula_tradeport/motel)
-"bqy" = (
-/turf/simulated/wall/prepainted/exploration,
-/area/shuttle/scoophead/main2)
 "bqF" = (
 /obj/effect/floor_decal/corner/red/border{
 	dir = 9
@@ -19761,7 +19758,7 @@
 	id = "scoophead_office"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "bsc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19782,7 +19779,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "btw" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -19867,7 +19864,7 @@
 	id = "scoophead_office"
 	},
 /turf/simulated/floor/carpet/patterened/red,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "bEl" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -19910,7 +19907,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/patterened/red,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "bHd" = (
 /obj/structure/aquarium/prefilled,
 /turf/simulated/floor/carpet/turcarpet,
@@ -20558,7 +20555,7 @@
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "dzE" = (
 /obj/structure/toilet{
 	dir = 4
@@ -20596,7 +20593,7 @@
 	id = "scoophead_room"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "dCd" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
@@ -20653,7 +20650,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "dGF" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/structure/curtain/black,
@@ -21126,7 +21123,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/carpet/patterened/blue,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "eEX" = (
 /obj/structure/simple_door/hardwood,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -21344,7 +21341,7 @@
 	id = "scoophead_office"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "fir" = (
 /obj/machinery/computer/ship/sensors,
 /obj/effect/floor_decal/techfloor{
@@ -21462,7 +21459,7 @@
 	},
 /obj/machinery/power/apc/alarms_hidden/south_mount,
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "fFF" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
@@ -22116,7 +22113,7 @@
 	id = "scoophead_office"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "hyI" = (
 /obj/structure/table/hardwoodtable,
 /obj/machinery/chemical_dispenser/catering/bar_coffee{
@@ -22641,7 +22638,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/patterened/red,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "iQo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/meter,
@@ -22690,7 +22687,7 @@
 /obj/structure/curtain/open/shower,
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/tiled/neutral,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "jdu" = (
 /obj/machinery/washing_machine,
 /obj/item/storage/laundry_basket{
@@ -22774,7 +22771,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/carpet/patterened/red,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "jpc" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
@@ -22782,7 +22779,7 @@
 	},
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /turf/simulated/floor/plating,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "juq" = (
 /obj/effect/debris/cleanable/dirt,
 /turf/simulated/floor/tiled/old_tile/blue,
@@ -22965,7 +22962,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "jQe" = (
 /obj/machinery/computer/ship/helm{
 	dir = 1
@@ -23271,6 +23268,10 @@
 /area/sector/nebula_tradeport/motel/room2)
 "kII" = (
 /obj/machinery/atmospherics/pipe/tank/air{
+	dir = 8
+	},
+/obj/structure/cable/pink{
+	icon_state = "2-4";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -23585,7 +23586,7 @@
 /area/sector/nebula_tradeport/motel)
 "luK" = (
 /turf/simulated/floor/wood,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "luQ" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/structure/curtain/open/black,
@@ -24113,9 +24114,6 @@
 	},
 /turf/simulated/wall/r_wall/prepainted/command,
 /area/shuttle/arrowhead)
-"mLx" = (
-/turf/simulated/wall/prepainted/command,
-/area/shuttle/scoophead/main2)
 "mMt" = (
 /obj/effect/shuttle_landmark/triumph/trade/arrowhead,
 /obj/overmap/entity/visitable/ship/landable/trade/arrowhead,
@@ -24271,7 +24269,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "nkf" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 8
@@ -24730,7 +24728,7 @@
 /obj/item/pen/fountain,
 /obj/item/pen,
 /turf/simulated/floor/carpet/patterened/red,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "oFP" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -24839,7 +24837,7 @@
 	id = "scoophead_room"
 	},
 /turf/simulated/floor/wood,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "pfv" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -25485,10 +25483,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
-/obj/structure/cable/pink{
-	icon_state = "2-4";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/scoophead/engineering)
 "qYk" = (
@@ -25512,7 +25506,7 @@
 /obj/structure/bed/pod,
 /obj/item/bedsheet/brown,
 /turf/simulated/floor/carpet/patterened/blue,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "rbV" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -25809,20 +25803,6 @@
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood,
 /area/sector/nebula_tradeport/motel/room7)
-"rYx" = (
-/obj/machinery/door/airlock/command{
-	name = "Captain's Quarters";
-	req_access = list(160);
-	req_one_access = null
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
-/obj/structure/cable/pink{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/scoophead/main2)
 "rYV" = (
 /obj/machinery/light,
 /obj/structure/flora/pottedplant/drooping,
@@ -26303,7 +26283,7 @@
 /obj/item/storage/single_use/mre/random,
 /obj/item/storage/single_use/mre/random,
 /turf/simulated/floor/carpet/patterened/blue,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "tBI" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/storage/box/glasses/meta,
@@ -26516,10 +26496,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
 	},
+/obj/machinery/power/apc/hyper/west_mount,
 /obj/structure/cable/pink{
+	icon_state = "0-8";
 	dir = 1
 	},
-/obj/machinery/power/apc/hyper/west_mount,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/scoophead/engineering)
 "umb" = (
@@ -26534,7 +26515,7 @@
 	gps_tag = "SCOOP"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "umU" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -26577,7 +26558,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/prepainted/command,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "uuk" = (
 /obj/structure/noticeboard{
 	pixel_y = 29
@@ -26699,7 +26680,7 @@
 "uFC" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/patterened/red,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "uHN" = (
 /obj/machinery/light{
 	dir = 1
@@ -26827,7 +26808,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/wood,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "vff" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -27123,7 +27104,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/patterened/red,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "wlu" = (
 /obj/machinery/shipsensors,
 /turf/simulated/floor/plating,
@@ -27175,7 +27156,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/neutral,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "wqt" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4
@@ -27217,7 +27198,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/carpet/patterened/red,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "wvG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/neutral,
@@ -27371,6 +27352,9 @@
 	icon_state = "2-4";
 	dir = 8
 	},
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/scoophead/engineering)
 "wQZ" = (
@@ -27389,10 +27373,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/sector/nebula_tradeport/motel/room7)
-"wSZ" = (
-/obj/spawner/window/low_wall/reinforced/full/firelocks,
-/turf/simulated/floor/plating,
-/area/shuttle/scoophead/main2)
 "wUd" = (
 /obj/structure/bed/padded,
 /obj/machinery/fire_alarm/north_mount,
@@ -27619,13 +27599,13 @@
 	},
 /obj/machinery/computer/shuttle_control/explore/trade/scoophead,
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "xvE" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/scoophead/main2)
+/area/shuttle/scoophead/main)
 "xwL" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -54454,13 +54434,13 @@ aDh
 aDh
 acd
 aDh
-wSZ
-wSZ
-wSZ
-bqy
-bqy
-bqy
-bqy
+gsa
+gsa
+gsa
+kJj
+kJj
+kJj
+kJj
 aDh
 aDh
 awV
@@ -54647,15 +54627,15 @@ aDh
 aDh
 aDh
 acd
-wSZ
-wSZ
+gsa
+gsa
 btq
 umb
-mLx
+yfg
 wqg
 jbA
-bqy
-bqy
+kJj
+kJj
 aDh
 aDh
 awV
@@ -54841,11 +54821,11 @@ aDh
 aDh
 aDh
 acd
-wSZ
+gsa
 xuJ
 xvE
 fES
-mLx
+yfg
 rai
 luK
 eDY
@@ -55035,7 +55015,7 @@ aDh
 aDh
 aDh
 aDh
-wSZ
+gsa
 dFp
 jPy
 nhC
@@ -55229,15 +55209,15 @@ aDh
 aDh
 aDh
 aDh
-bqy
-bqy
-mLx
-rYx
-mLx
+kJj
+kJj
+yfg
+hIZ
+yfg
 utC
-mLx
+yfg
 jpc
-wSZ
+gsa
 aDh
 aDh
 awV

--- a/maps/sectors/nebula_tradeport/nebula_tradeport-shuttles.dm
+++ b/maps/sectors/nebula_tradeport/nebula_tradeport-shuttles.dm
@@ -112,7 +112,7 @@
 	name = "Scoophead Engine Bay"
 
 /area/shuttle/scoophead/main2
-	name = "Scoophead TraderSection"
+	name = "Scoophead Trader Section"
 
 //Arrowhead Shuttle
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- When taking off with the Scoophead trade shuttle, the cockpit and office part of the shuttle will get disconected from the rest of the ship for no reason. Worst : When moving the jumping console to the powered are of the shuttle : The shuttle will simply land / Dock... Without the office and cockpit.

This fix puts the still working part of the shuttle in the same area as teh cockpit.