### PR TITLE
Removed Tajaran, Unathi, and Promethean centric xenowear lock

### DIFF
--- a/code/modules/loadout/loadout_xeno.dm
+++ b/code/modules/loadout/loadout_xeno.dm
@@ -38,7 +38,6 @@
 //**Species-Specific Datum Declarations
 //*Tajaran
 /datum/loadout_entry/xeno/tajaran
-	legacy_species_lock = SPECIES_TAJ
 
 /datum/loadout_entry/xeno/tajaran/accessories
 	slot = /datum/inventory_slot/abstract/attach_as_accessory
@@ -63,7 +62,6 @@
 
 //*Promethean
 /datum/loadout_entry/xeno/promethean
-	legacy_species_lock = SPECIES_PROMETHEAN
 
 /datum/loadout_entry/xeno/promethean/accessories
 	slot = /datum/inventory_slot/abstract/attach_as_accessory
@@ -186,7 +184,6 @@
 
 //*Unathi
 /datum/loadout_entry/xeno/unathi
-	legacy_species_lock = SPECIES_UNATHI
 
 /datum/loadout_entry/xeno/unathi/accessories
 	slot = /datum/inventory_slot/abstract/attach_as_accessory


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just removes the lines that make only specific species be able to spawn with certain loadout items. Doesn't touch Phoronoids and Vox equipment, as it's more specialized.

## Why It's Good For The Game

Allows everyone to pick specific clothing, as it's just that. I don't think there could be a way you couldn't get your hands on any of them. It was already removed for other species (and called legacy_species_lock, so while working, maybe not quite up to date?)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Allows everyone to pick some more xenowear options
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
