### PR TITLE
Fixes Snack & Drink Contraband Prices + small extras

### DIFF
--- a/code/game/machinery/vending/drinks.dm
+++ b/code/game/machinery/vending/drinks.dm
@@ -23,6 +23,7 @@
 		/obj/item/reagent_containers/food/drinks/h_chocolate = 3,
 		/obj/item/reagent_containers/food/drinks/cans/robustexpress = 2,
 		/obj/item/reagent_containers/food/drinks/cans/robustexpresslatte = 2,
+		/obj/item/reagent_containers/food/drinks/ice = 1
 	)
 
 /obj/machinery/vending/cola
@@ -83,8 +84,8 @@
 		/obj/item/reagent_containers/food/drinks/cans/battery = 5,
 		/obj/item/reagent_containers/food/drinks/cans/crystalgibb = 2,
 		/obj/item/reagent_containers/food/drinks/cans/gondola_energy = 5,
-		/obj/item/reagent_containers/food/drinks/bludbox = 25,
-		/obj/item/reagent_containers/food/drinks/bludboxlight = 35,
+		/obj/item/reagent_containers/food/drinks/bludbox = 10, //vetalan care package costs 30 in Cargo.
+		/obj/item/reagent_containers/food/drinks/bludboxlight = 15,
 		/obj/item/reagent_containers/food/drinks/cans/coconutwater = 6,
 		/obj/item/reagent_containers/food/drinks/cans/kyocola = 2,
 		/obj/item/reagent_containers/food/drinks/cans/kyocola_fire = 2,
@@ -94,6 +95,10 @@
 		/obj/item/reagent_containers/food/drinks/cans/cola_cherry = 2,
 		/obj/item/reagent_containers/food/drinks/cans/cola_coffee = 2,
 		/obj/item/reagent_containers/food/drinks/cans/robustexpressiced = 2,
+		/obj/item/reagent_containers/food/drinks/cans/thirteenloko = 8,
+		/obj/item/reagent_containers/food/snacks/liquid = 8, //SweatMAX LiquidFood costs 15. Making the contraband version cheaper can be rewarding.
+		/obj/item/reagent_containers/food/drinks/cans/dumbjuice = 1,
+		/obj/item/reagent_containers/food/drinks/cans/geometer = 15, //Geometer Energy contains actual blood.
 	)
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 
@@ -104,6 +109,7 @@
 	product_ads = "For Tsar and Country.;Have you fulfilled your nutrition quota today?;Very nice!;We are simple people, for this is all we eat.;If there is a person, there is a problem. If there is no person, then there is no problem."
 	products = list(
 		/obj/item/reagent_containers/food/drinks/bottle/space_up = 30,
+		/obj/item/reagent_containers/food/snacks/tofu = 20,
 	)
 	contraband = list(
 		/obj/item/reagent_containers/food/drinks/bottle/cola = 20,

--- a/code/game/machinery/vending/drinks.dm
+++ b/code/game/machinery/vending/drinks.dm
@@ -104,12 +104,11 @@
 
 /obj/machinery/vending/sovietsoda
 	name = "BODA"
-	desc = "An old sweet water vending machine,how did this end up here?"
+	desc = "An old sweet water vending machine. How did this end up here?"
 	icon_state = "sovietsoda"
 	product_ads = "For Tsar and Country.;Have you fulfilled your nutrition quota today?;Very nice!;We are simple people, for this is all we eat.;If there is a person, there is a problem. If there is no person, then there is no problem."
 	products = list(
 		/obj/item/reagent_containers/food/drinks/bottle/space_up = 30,
-		/obj/item/reagent_containers/food/snacks/tofu = 20,
 	)
 	contraband = list(
 		/obj/item/reagent_containers/food/drinks/bottle/cola = 20,

--- a/code/game/machinery/vending/loadout.dm
+++ b/code/game/machinery/vending/loadout.dm
@@ -793,7 +793,8 @@
 		/obj/item/storage/backpack/dufflebag = 10,
 	)
 	premium = list(
-		/obj/item/clothing/under/color/rainbow = 1,
+		/obj/item/clothing/under/color/rainbow = 5,
+		/obj/item/clothing/under/color/rainbow_skirt = 5,
 	)
 	contraband = list(
 		/obj/item/clothing/under/rank/clown = 1,

--- a/code/game/machinery/vending/snacks.dm
+++ b/code/game/machinery/vending/snacks.dm
@@ -8,7 +8,7 @@
 	products = list(
 		/obj/item/reagent_containers/food/snacks/wrapped/candy = 6,
 		/obj/item/reagent_containers/food/drinks/dry_ramen = 6,
-		/obj/item/reagent_containers/food/snacks/bagged/chips =6,
+		/obj/item/reagent_containers/food/snacks/bagged/chips = 6,
 		/obj/item/reagent_containers/food/snacks/bagged/sosjerky = 6,
 		/obj/item/reagent_containers/food/snacks/boxed/no_raisin = 6,
 		/obj/item/reagent_containers/food/snacks/wrapped/spacetwinkie = 6,
@@ -43,7 +43,9 @@
 		/obj/item/reagent_containers/hard_candy/lollipop = 2,
 		/obj/item/reagent_containers/food/snacks/wrapped/spunow = 4,
 		/obj/item/reagent_containers/food/snacks/wrapped/glad2nut = 4,
-		/obj/item/reagent_containers/food/snacks/wrapped/natkat = 4
+		/obj/item/reagent_containers/food/snacks/wrapped/natkat = 4,
+		/obj/item/reagent_containers/food/snacks/syndicake = 7,
+		/obj/item/reagent_containers/food/snacks/boxed/unajerky = 6,
 	)
 
 /obj/machinery/vending/fitness // Added Liquid Protein and slightly adjusted price of liquid food items due to buff.
@@ -62,6 +64,9 @@
 		/obj/item/towel/random = 8,
 		/obj/item/reagent_containers/food/snacks/brainsnax = 5,
 	)
+	contraband = list(
+		/obj/item/reagent_containers/syringe/steroid = 4
+	)
 	// yes, it's a ripoff, much like real sports food.
 	prices = list(
 		/obj/item/reagent_containers/food/drinks/smallmilk = 3,
@@ -74,10 +79,9 @@
 		/obj/item/reagent_containers/pill/diet = 10,
 		/obj/item/towel/random = 15,
 		/obj/item/reagent_containers/food/snacks/brainsnax = 10,
+		/obj/item/reagent_containers/syringe/steroid = 12,
 	)
-	contraband = list(
-		/obj/item/reagent_containers/syringe/steroid = 4
-	)
+
 /obj/machinery/vending/weeb
 	name = "Nippon-Tan!"
 	desc = "A vendor full of asian snackfood variety!"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Makes it so the contraband items in the snack and drink vendors are no longer free.
- Makes the bludboxes in the vendor cheaper. Justification for this is because the Vetalan care package costs 30 thalers in Cargo, and if we're to think realistically on this, competitors will actually try to make their prices more reasonable. Why would you buy cheap shit that's overpriced when you can ask a cargo tech for the real deal? You still get a better bargain with **two** bloodpacks full of some good blood too. Arguably, the bludboxes are still overpriced even when they cost 10-15 thaler.
- adds one piece of missing clothing that I forgot in a previous PR to the loadout vendors.

## Why It's Good For The Game

Fixes gud.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Contraband snack and drink food now has costs.
tweak: Bludboxes are cheaper in cost in the drinks vendor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
