### PR TITLE
Makes horror aura only active when players are present in z-level

### DIFF
--- a/code/datums/components/horror_aura.dm
+++ b/code/datums/components/horror_aura.dm
@@ -23,7 +23,7 @@ It also serves the purposes of portraying the Lore accurate effect of "Acausal L
 	return ..()
 
 /datum/component/horror_aura/process()
-	var/atom/A = parent //Not bothering to check if it's an atom. If someone attaches a horror aura component to a mere datum, they're a dumbass.
+	var/atom/A = parent //Not bothering to check if it's an atom. If someone attaches a horror aura component to a mere datum, they're out of their mind.
 	if(ismob(A) && !remain_while_dead)
 		var/mob/M = parent
 		if(IS_DEAD(M))

--- a/code/datums/components/horror_aura.dm
+++ b/code/datums/components/horror_aura.dm
@@ -23,12 +23,14 @@ It also serves the purposes of portraying the Lore accurate effect of "Acausal L
 	return ..()
 
 /datum/component/horror_aura/process()
-	if(ismob(parent) && !remain_while_dead)
+	var/atom/A = parent //Not bothering to check if it's an atom. If someone attaches a horror aura component to a mere datum, they're a dumbass.
+	if(ismob(A) && !remain_while_dead)
 		var/mob/M = parent
 		if(IS_DEAD(M))
 			qdel(src)
 			return
-	aura_effect()
+	if(A.z in SSmobs.busy_z_levels) //don't spam EMP admin logs when nobody's around. :^)
+		aura_effect()
 
 /datum/component/horror_aura/proc/aura_effect()
 	for(var/mob/living/carbon/human/H in range(radius, parent))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

## Why It's Good For The Game

Do you have any idea how THICK the admin logs get when there's horror mobs around?

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: A spooky mob's horror aura will only be active if a player mob is present on the same z-level they are.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
