### PR TITLE
Stops logging radiation emitter map effects

### DIFF
--- a/code/game/objects/effects/map_effects/radiation_emitter.dm
+++ b/code/game/objects/effects/map_effects/radiation_emitter.dm
@@ -1,10 +1,11 @@
-// Constantly emites radiation from the tile it's placed on.
+// Constantly emits radiation from the tile it's placed on.
 /obj/effect/map_effect/radiation_emitter
 	name = "radiation emitter"
 	icon_state = "radiation_emitter"
 	rad_flags = RAD_NO_CONTAMINATE | RAD_BLOCK_CONTENTS
 	var/radiation_power = 200 // Bigger numbers means more radiation.
 	var/radiation_falloff = RAD_FALLOFF_NORMAL
+	var/log_pulses = FALSE //mappers can choose exceptions for when this is logged if they really want to. It's spammy, however.
 
 /obj/effect/map_effect/radiation_emitter/Initialize(mapload)
 	START_PROCESSING(SSobj, src)
@@ -15,7 +16,7 @@
 	return ..()
 
 /obj/effect/map_effect/radiation_emitter/process(delta_time)
-	radiation_pulse(src, radiation_power, radiation_falloff)
+	radiation_pulse(src, radiation_power, radiation_falloff, log_pulses)
 
 /obj/effect/map_effect/radiation_emitter/strong
 	radiation_power = 750


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

## Why It's Good For The Game
![image](https://github.com/user-attachments/assets/f6a78516-91f5-4f1e-b535-6d3e352610b7)
Reduces admin log bloating. Admins/EMs spawning new radiation emitters are logged, if that's any concern at all. But generally these map effects exist only through mappers just putting them in otherwise.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Map effect radiation emitters will no longer be logged to admins by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
