### PR TITLE
Show contractors Employing Company+Allow alt titles

### DIFF
--- a/code/game/objects/items/id_cards/contractor_ids.dm
+++ b/code/game/objects/items/id_cards/contractor_ids.dm
@@ -1,14 +1,17 @@
 /obj/item/card/id/contractor
 	var/employing_coperation = ""
-	var/extern_title = ""
+	//var/extern_title = ""
+	//There are no faction specific alt titles, so they don't have any external title, and are just using the stations
 	//var/expiry_date = ""
 	icon_state = "chit"
 
 /obj/item/card/id/contractor/dat()
-	. += "<b>Employing Company:</b> [employing_coperation]"
-	. += "<b>External Job Title:</b> [extern_title]"
+	var/dat = list()
+	dat += "<b>Employing Company:</b> [employing_coperation]"
+	//. += "<b>External Job Title:</b> [extern_title]"
 	// . += "<b>Expiration Date:</b> [expiry_date]"
-	. = ..()
+	dat += ..()
+	return dat
 
 /obj/item/card/id/contractor/update_icon()
 	return 0
@@ -39,8 +42,8 @@
 
 /obj/item/card/id/contractor/set_registered_rank(rank = src.rank, assignment)
 	src.rank = rank
-	src.extern_title = assignment
-	src.assignment = rank
+	//src.extern_title = assignment
+	src.assignment = assignment
 	update_icon_state()
 	update_name()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes that contractor IDs (The faction not being NT ones, not the Traveler title) do show which other company they are employed by. At the same time, it allows them to use alternative titles for the jobs.

## Why It's Good For The Game

Showing which company someone belongs to on the ID was intended, and did just break. Alternative titles were explicitly disabled, due to confusing titles coming with some factions, but as there no longer are any, we can allow the full range of known station alternatives. A Vey-Med nurse probably should stay a nurse, and not become a full doctor when working at an NT station, at least title wise, as example.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Allows contractors to have alt-titles
fix: Contractor IDs show the employing company
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
