### PR TITLE
Effectivly gives xenochimera the weaving trait

### DIFF
--- a/code/modules/organs/internal/species/xenochimera.dm
+++ b/code/modules/organs/internal/species/xenochimera.dm
@@ -38,3 +38,6 @@
 /obj/item/organ/internal/intestine/xenochimera
 	name = "harvesting fronds"
 	icon_state = "xenoch_intestine"
+
+/obj/item/organ/internal/weaver/weak/xenochimera
+	name = "protein reservoir"

--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -78,8 +78,11 @@
 		O_BRAIN =    /obj/item/organ/internal/brain/xenochimera,
 		O_EYES =     /obj/item/organ/internal/eyes/xenochimera,
 		O_STOMACH =		/obj/item/organ/internal/stomach/xenochimera,
-		O_INTESTINE =	/obj/item/organ/internal/intestine/xenochimera
+		O_INTESTINE =	/obj/item/organ/internal/intestine/xenochimera,
+		O_WEAVER = 		/obj/item/organ/internal/weaver/weak/xenochimera
 		)
+
+
 
 	unarmed_types = list(
 		/datum/unarmed_attack/stomp,
@@ -127,6 +130,11 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_ears,
 		/mob/living/carbon/human/proc/shapeshifter_select_horns,
 		/mob/living/carbon/human/proc/shapeshifter_select_shape,
+		/mob/living/carbon/human/proc/check_silk_amount,
+		/mob/living/carbon/human/proc/toggle_silk_production,
+		/mob/living/carbon/human/proc/weave_structure,
+		/mob/living/carbon/human/proc/weave_item,
+		/mob/living/carbon/human/proc/set_silk_color,
 	)
 
 	var/has_feral_abilities = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives Xenochimeras everything the weaving trait would give a custom species. Given spider silk is protein fibers, it would also fit right in, while allowing to explain the organ as a sort of fat reserve, leaving it up to the player whether their chimera did adopt such an ability.

## Why It's Good For The Game

Gives Xenochimeras another tool to be the spooky ambush predators in the dark tunnels. It follows the comment that they get all the special verbs, as they can't pick them. The only counter point may be that they won't be affected by weaversilk traps due to having the organ, even if in character, they never have adapted such an ability.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Gave Xenochimeras the weaving abilities.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
