### PR TITLE
stops gibbing people killing them twice

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -18,7 +18,7 @@
 		vr_link = null
 
 	for(var/obj/item/organ/I in internal_organs)
-		I.removed()
+		I.removed(src, TRUE)
 		if(istype(loc,/turf))
 			I.throw_at_old(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),30)
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -353,7 +353,7 @@
 /obj/item/organ/proc/digitize()
 	robotize()
 
-/obj/item/organ/proc/removed(var/mob/living/user)
+/obj/item/organ/proc/removed(var/mob/living/user, var/ignore_vital = FALSE)
 	if(owner)
 		owner.internal_organs_by_name[organ_tag] = null
 		owner.internal_organs_by_name -= organ_tag
@@ -371,7 +371,7 @@
 		if(!organ_blood || !organ_blood.data["blood_DNA"])
 			owner.vessel.trans_to(src, 5, 1, 1)
 
-		if(owner && vital)
+		if(owner && vital && !ignore_vital)
 			if(user)
 				add_attack_logs(user, owner, "Removed vital organ [src.name]")
 			if(owner.stat != DEAD)


### PR DESCRIPTION
## About The Pull Request
gib removes your organs
removing your brain kills you
you are then killed by being gibbed
thus, you have died twice

(this is bad because we want to know if the source of someone's death was being gibbed or not for species handle_death proc!!!)

## Why It's Good For The Game
you shouldn't kill someone who is already dead

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: stops gibbing people killing them twice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
