### PR TITLE
Tajaran Speed Nerf

### DIFF
--- a/code/modules/species/station/standard/tajaran.dm
+++ b/code/modules/species/station/standard/tajaran.dm
@@ -32,11 +32,11 @@
 	vision_innate = /datum/vision/baseline/species_tier_2
 	vision_organ = O_EYES
 
-	slowdown  = -0.5
+	slowdown  = 0
 	snow_movement = -1 //Ignores half of light snow
 
-	brute_mod = 1.15
-	burn_mod  = 1.15
+	brute_mod = 1.1
+	burn_mod  = 1.1
 	flash_mod = 1.1
 
 	metabolic_rate = 1.1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tajarans sit in a weird spot where they have the same speed as the fastest species (Teshari) but with only extremely meager counterbalance, taking only 5% more brute/burn damage but having a full healthbar.

Removed Tajaran speed, returned down to human levels. Reduced Tajaran brute/burn damage down to teshari levels - that being standard 10% more damage taken. They keep their snow speed and lack of any encumbering weight maluses 

## Why It's Good For The Game

balanced species is good for the balance of the game

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Tajara speed nerf and slight stat rebalance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
