### PR TITLE
Allows a few more common languages to be picked.

### DIFF
--- a/code/game/objects/items/weapons/implants/implantlanguage.dm
+++ b/code/game/objects/items/weapons/implants/implantlanguage.dm
@@ -61,7 +61,7 @@
 /obj/item/implant/language/skrellian
 	name = "Skrellian language implant"
 	desc = "An implant allowing someone to speak the range of frequencies used in Skrellian, as well as produce any phonemes that they usually cannot. Only helps with hearing and producing sounds, not understanding them."
-	languages = list(LANGUAGE_SKRELLIAN)
+	languages = list(LANGUAGE_SKRELLIAN, LANGUAGE_SKRELLIANFAR)
 
 /obj/item/implant/language/skrellian/get_data()
 	var/dat = {"

--- a/code/modules/language/languages/species/skrell.dm
+++ b/code/modules/language/languages/species/skrell.dm
@@ -26,7 +26,6 @@
 	colour = "skrellfar"
 	key = "p"
 	space_chance = 30
-	language_flags = LANGUAGE_WHITELISTED
 	syllables = list("qr","qrr","xuq","qil","quum","xuqm","vol","xrim","zaoo","qu-uu","qix","qoo","zix", "...", "oo", "q", "nq", "x", "xq", "ll", "...", "...", "...") //should sound like there's holes in it
 	shorthand = "SKRLFR"
 

--- a/code/modules/language/languages/species/tajaran.dm
+++ b/code/modules/language/languages/species/tajaran.dm
@@ -32,7 +32,6 @@
 	exclaim_verb = "wails"
 	colour = "akhani"
 	key = "h"
-	language_flags = LANGUAGE_WHITELISTED
 	syllables = list("mrr","rr","marr","tar","ahk","ket","hal","kah","dra","nal","kra","vah","dar","hrar", "eh",
 	"ara","ka","zar","mah","ner","zir","mur","hai","raz","ni","ri","nar","njar","jir","ri","ahn","kha","sir",
 	"kar","yar","kzar","rha","hrar","err","fer","rir","rar","yarr","arr","ii'r","jar","kur","ran","rii","ii",
@@ -47,7 +46,7 @@
 	signlang_verb = list("gestures with their hands", "gestures with their ears and tail", "gestures with their ears, tail and hands")
 	colour = "tajaran"
 	key = "l"
-	language_flags = LANGUAGE_WHITELISTED | LANGUAGE_SIGNLANG | LANGUAGE_NO_STUTTER | LANGUAGE_NONVERBAL
+	language_flags = LANGUAGE_SIGNLANG | LANGUAGE_NO_STUTTER | LANGUAGE_NONVERBAL
 	shorthand = "TAJR"
 
 /datum/prototype/language/tajsign/can_speak_special(var/mob/speaker)	// TODO: If ever we make external organs assist languages, convert this over to the new format


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows everyone to pick Akhani, High Skrellian, and Siik'tajr. High Skrellian will need the implant for non-Skrells, not changing that from the current state with common skrellian. Siik'tajr keeps the requirement to have the tails and ears to speak it (a tajaran/teshari form), while Akhani is a normal language.

## Why It's Good For The Game

There doesn't seem to be a reason someone wouldn't be able to learn them, especially for a character that's supposed to be the base species, but genemodded enough to be a custom species codewise.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Allows everyone to pick Akhani, Siik'tajr, and High Skrellian. Speaking it may be a different problem.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
