### PR TITLE
Using the is_avoiding_ground() check: Flying no longer has you touching the ground.

### DIFF
--- a/code/game/objects/effects/debris/cleanable/blood.dm
+++ b/code/game/objects/effects/debris/cleanable/blood.dm
@@ -85,7 +85,7 @@ var/global/list/image/splatter_cache=list()
 
 /obj/effect/debris/cleanable/blood/Crossed(mob/living/carbon/human/perp)
 	. = ..()
-	if(perp.is_incorporeal())
+	if(perp.is_incorporeal() || perp.is_avoiding_ground())
 		return
 	if (!istype(perp))
 		return

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -51,7 +51,7 @@
 		return
 
 	if(istype(M, /mob/living/))
-		if(!M.hovering)
+		if(!M.is_avoiding_ground())
 			explode(M)
 
 /obj/effect/mine/attackby(obj/item/W as obj, mob/living/user as mob)
@@ -302,6 +302,6 @@
 
 // This tells AI mobs to not be dumb and step on mines willingly.
 /obj/item/mine/is_safe_to_step(mob/living/L)
-	if(!L.hovering)
+	if(!L.is_avoiding_ground())
 		return FALSE
 	return ..()

--- a/code/game/objects/structures/cliff.dm
+++ b/code/game/objects/structures/cliff.dm
@@ -136,7 +136,7 @@ two tiles on initialization, and which way a cliff is facing may change during m
 /obj/structure/cliff/CanAllowThrough(atom/movable/mover, turf/target)
 	if(isliving(mover))
 		var/mob/living/L = mover
-		if(L.hovering) // Flying mobs can always pass.
+		if(L.is_avoiding_ground()) // Flying mobs can always pass.
 			return TRUE
 		return ..()
 

--- a/code/game/turfs/simulated/floor_types/snow.dm
+++ b/code/game/turfs/simulated/floor_types/snow.dm
@@ -15,7 +15,7 @@ CREATE_STANDARD_TURFS(/turf/simulated/floor/outdoors/snow)
 
 
 /turf/simulated/floor/outdoors/snow/Entered(atom/movable/AM)
-	if(AM.hovering || AM.is_incorporeal()) // Flying things shouldn't make footprints.
+	if(AM.is_avoiding_ground() || AM.is_incorporeal()) // Flying/riding things shouldn't make footprints. The mount still may
 		return ..()
 	if(isliving(AM))
 		if(!(crossed_dirs & AM.dir))

--- a/code/game/turfs/simulated/floor_types/water.dm
+++ b/code/game/turfs/simulated/floor_types/water.dm
@@ -137,7 +137,7 @@
 /mob/living/proc/check_submerged()
 	if(buckled)
 		return 0
-	if(hovering)
+	if(is_avoiding_ground())
 		return 0
 	if(locate(/obj/structure/catwalk) in loc)
 		return 0
@@ -275,14 +275,14 @@ CREATE_STANDARD_TURFS(/turf/simulated/floor/water/acid)
 
 		else if(isliving(thing))
 			var/mob/living/L = thing
-			if(L.hovering || L.throwing)
+			if(L.is_avoiding_ground() || L.throwing)
 				continue
 			. = TRUE
 			L.acid_act()
 
 // Tells AI mobs to not suicide by pathing into acid if it would hurt them.
 /turf/simulated/floor/water/acid/is_safe_to_enter(mob/living/L)
-	if(!L.hovering)
+	if(!L.is_avoiding_ground())
 		return FALSE
 	return ..()
 
@@ -357,7 +357,7 @@ CREATE_STANDARD_TURFS(/turf/simulated/floor/water/acid/deep)
 
 // Tells AI mobs to not suicide by pathing into lava if it would hurt them.
 /turf/simulated/floor/water/blood/is_safe_to_enter(mob/living/L)
-	if(!L.hovering)
+	if(!L.is_avoiding_ground())
 		return FALSE
 	return ..()
 

--- a/code/game/turfs/simulated/flooring/flooring_premade.dm
+++ b/code/game/turfs/simulated/flooring/flooring_premade.dm
@@ -431,7 +431,7 @@ CREATE_STANDARD_TURFS(/turf/simulated/floor/tiled/white)
 /turf/simulated/floor/bananium/Entered(atom/A)
 	if(isliving(A))
 		var/mob/living/L = A
-		if(L.hovering) // Flying things shouldn't make footprints.
+		if(L.is_avoiding_ground()) // Flying things shouldn't make footprints.
 			return ..()
 		playsound(src, 'sound/items/bikehorn.ogg', 75, 1)
 	..()

--- a/code/game/turfs/simulated/flooring/flooring_traps.dm
+++ b/code/game/turfs/simulated/flooring/flooring_traps.dm
@@ -11,7 +11,7 @@
 /turf/simulated/floor/trap/Entered(atom/A)
 	if(isliving(A) && !tripped)
 		var/mob/living/L = A
-		if(L.hovering) // Flying things shouldn't trigger pressure plates.
+		if(L.is_avoiding_ground()) // Flying things shouldn't trigger pressure plates.
 			return ..()
 		trigger()
 	else

--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -91,7 +91,7 @@
 
 // Tells AI mobs to not suicide by pathing into lava if it would hurt them.
 /turf/simulated/lava/is_safe_to_enter(mob/living/L)
-	if(!is_safe() && !L.hovering)
+	if(!is_safe() && !L.is_avoiding_ground())
 		return FALSE
 	return ..()
 

--- a/code/game/turfs/simulated/sky.dm
+++ b/code/game/turfs/simulated/sky.dm
@@ -33,11 +33,8 @@
 	if(istype(AM, /obj/effect/projectile))
 		return // ...neither should the effects be falling
 
-	var/mob/living/L
-	if(isliving(AM))
-		L = AM
-		if(L.is_floating || L.flying)
-			return //Flyers/nograv can ignore it
+	if(AM.is_avoiding_ground())
+		return //Either flying/hovering or buckled that at least has long legs. If that falls, they'll follow
 
 	do_fall(AM)
 

--- a/code/modules/mob/living/carbon/human/movement.dm
+++ b/code/modules/mob/living/carbon/human/movement.dm
@@ -99,7 +99,7 @@
 	if(!T)
 		return 0
 
-	if(T.slowdown)
+	if(T.slowdown && !is_avoiding_ground()) //Only if we are touching the ground
 		var/turf_move_cost = T.slowdown
 		if(istype(T, /turf/simulated/floor/water))
 			if(species.water_movement)

--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -357,7 +357,7 @@
 
 	// Turf related slowdown
 	var/turf/T = get_turf(src)
-	if(T && T.slowdown && !hovering) // Flying mobs ignore turf-based slowdown. Aquatic mobs ignore water slowdown, and can gain bonus speed in it.
+	if(T && T.slowdown && !is_avoiding_ground()) // Flying mobs ignore turf-based slowdown. Aquatic mobs ignore water slowdown, and can gain bonus speed in it.
 		if(istype(T,/turf/simulated/floor/water) && aquatic_movement)
 			tally -= aquatic_movement - 1
 		else

--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/leech.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/leech.dm
@@ -93,7 +93,7 @@
 	if(!istype(H))
 		return .
 
-	if(istype(L.buckled, /obj/vehicle_old) || L.hovering) // Ignore people hovering or on boats.
+	if(istype(L.buckled, /obj/vehicle_old) || L.is_avoiding_ground()) // Ignore people hovering or on boats.
 		return TRUE
 
 	if(!.)

--- a/code/modules/mob/living/simple_mob/subtypes/vore/mimic.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/mimic.dm
@@ -308,7 +308,7 @@
 	if(!isliving(victim))
 		return
 	var/mob/living/L = victim
-	if(L.hovering)
+	if(L.is_avoiding_ground())
 		return
 	awaken(L)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1304,4 +1304,4 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
  * Checks if we can avoid things like landmine, lava, etc, whether beneficial or harmful.
  */
 /mob/is_avoiding_ground()
-	return ..() || hovering || (buckled?.buckle_flags & BUCKLING_GROUND_HOIST)
+	return ..() || hovering || flying || (buckled?.buckle_flags & BUCKLING_GROUND_HOIST) || buckled?.is_avoiding_ground()

--- a/maps/generic/objects/legacy_zlevel_fall.dm
+++ b/maps/generic/objects/legacy_zlevel_fall.dm
@@ -23,7 +23,7 @@
 		return
 	if(isliving(A))
 		var/mob/living/L = A
-		if(L.is_floating || L.flying)
+		if(L.is_floating || L.is_avoiding_ground())
 			return //Flyers/nograv can ignore it
 
 	var/attempts = 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves a few checks if someone's flying/hovering to use the is_avoiding_ground check. It also removes the slowdown of a tile if you aren't actually stepping on it. This check does include more, like if you are only riding on something that's lifting you up enough, but unless it flies itself, it'll trigger what you may be avoiding, and in turn, will be affected by it (i.E falling down the chasm, there is no delay in my test, so no Yoshiing over a single tile.) 
Draft for now to see if there are more places to check for it, and as the balance change is big enough to warrant additional thoughts.

## Why It's Good For The Game

Flying people no longer leave footprints, nor touch the ground for water or lava. Logically, they aren't even slowed down by the tiles. This heavily buffs flying, at least the ignoring the slowdown part, so that may be removed for the sake of balance. The rest should be more flavorful, or just making sense.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: If you aren't touching the ground, don't interact with things there.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
