### PR TITLE
Fixes for : The Old Century Shuttle (Powerwise/Light wise) / Library scanner on Atlas / Scoophead

### DIFF
--- a/code/game/area/station/shuttle_area.dm
+++ b/code/game/area/station/shuttle_area.dm
@@ -2,3 +2,6 @@
 /area/shuttle/oldcentury
 	requires_power = 1
 	icon_state = "shuttle2"
+	requires_power = 1
+	area_flags = AREA_RAD_SHIELDED | AREA_FLAG_ERODING
+	sound_env = SMALL_ENCLOSED

--- a/code/game/area/station/shuttle_area.dm
+++ b/code/game/area/station/shuttle_area.dm
@@ -5,3 +5,4 @@
 	requires_power = 1
 	area_flags = AREA_RAD_SHIELDED | AREA_FLAG_ERODING
 	sound_env = SMALL_ENCLOSED
+	dynamic_lighting = DYNAMIC_LIGHTING_ENABLED

--- a/maps/rift/levels/rift-04-surface1.dmm
+++ b/maps/rift/levels/rift-04-surface1.dmm
@@ -29111,11 +29111,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/library)
 "rKC" = (
-/obj/machinery/photocopier,
 /obj/item/radio/intercom{
 	dir = 1;
 	pixel_y = 24
 	},
+/obj/machinery/libraryscanner,
 /turf/simulated/floor/carpet,
 /area/library)
 "rKJ" = (

--- a/maps/rift/levels/rift-06-surface3.dmm
+++ b/maps/rift/levels/rift-06-surface3.dmm
@@ -28812,7 +28812,13 @@
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = null
 	},
-/obj/map_helper/access_helper/airlock/station/external_airlock,
+/obj/machinery/airlock_sensor/airlock_exterior/shuttle{
+	frequency = 1380;
+	id_tag = "oldcentury_docker_exterior_sensor";
+	master_tag = "oldcentury_docker";
+	pixel_x = 24;
+	pixel_y = -8
+	},
 /turf/simulated/floor/tiled/old_tile/green,
 /area/shuttle/oldcentury)
 "xak" = (

--- a/maps/rift/levels/rift-06-surface3.dmm
+++ b/maps/rift/levels/rift-06-surface3.dmm
@@ -17150,7 +17150,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/high/south_mount,
 /obj/effect/debris/cleanable/dirt,
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/shuttle/oldcentury)
@@ -19246,7 +19245,6 @@
 /turf/simulated/wall/rshull,
 /area/shuttle/oldcentury)
 "fxP" = (
-/obj/machinery/power/apc/high/west_mount,
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},

--- a/maps/rift/shuttles.dm
+++ b/maps/rift/shuttles.dm
@@ -162,6 +162,7 @@
 	requires_power = 1
 	area_flags = AREA_RAD_SHIELDED | AREA_FLAG_ERODING
 	sound_env = SMALL_ENCLOSED
+	dynamic_lighting = DYNAMIC_LIGHTING_ENABLED
 
 /obj/machinery/computer/shuttle_control/explore/oldcentury
 	name = "Century jump console"

--- a/maps/rift/shuttles.dm
+++ b/maps/rift/shuttles.dm
@@ -159,6 +159,9 @@
 /area/shuttle/oldcentury
 	name = "Civilian Century Shuttle"
 	icon_state = "shuttle"
+	requires_power = 1
+	area_flags = AREA_RAD_SHIELDED | AREA_FLAG_ERODING
+	sound_env = SMALL_ENCLOSED
 
 /obj/machinery/computer/shuttle_control/explore/oldcentury
 	name = "Century jump console"

--- a/maps/sectors/nebula_tradeport/levels/nebula_tradeport.dmm
+++ b/maps/sectors/nebula_tradeport/levels/nebula_tradeport.dmm
@@ -19761,7 +19761,7 @@
 	id = "scoophead_office"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "bsc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19782,7 +19782,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "btw" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -19867,7 +19867,7 @@
 	id = "scoophead_office"
 	},
 /turf/simulated/floor/carpet/patterened/red,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "bEl" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -19910,7 +19910,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/patterened/red,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "bHd" = (
 /obj/structure/aquarium/prefilled,
 /turf/simulated/floor/carpet/turcarpet,
@@ -19947,6 +19947,9 @@
 /obj/machinery/atmospheric_field_generator/perma,
 /turf/simulated/floor/plating,
 /area/shuttle/tug)
+"bRZ" = (
+/turf/simulated/wall/prepainted/exploration,
+/area/shuttle/scoophead/cockpit)
 "bSu" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -20133,6 +20136,9 @@
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/tiled/dark,
 /area/sector/nebula_tradeport/motel/room1)
+"crT" = (
+/turf/simulated/wall/prepainted/command,
+/area/shuttle/scoophead/cockpit)
 "csb" = (
 /obj/machinery/atmospherics/component/unary/vent_pump/high_volume{
 	dir = 4;
@@ -20558,7 +20564,7 @@
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "dzE" = (
 /obj/structure/toilet{
 	dir = 4
@@ -20596,7 +20602,7 @@
 	id = "scoophead_room"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "dCd" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
@@ -20653,7 +20659,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "dGF" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/structure/curtain/black,
@@ -21116,7 +21122,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/carpet/patterened/blue,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "eEX" = (
 /obj/structure/simple_door/hardwood,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -21334,7 +21340,7 @@
 	id = "scoophead_office"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "fir" = (
 /obj/machinery/computer/ship/sensors,
 /obj/effect/floor_decal/techfloor{
@@ -21452,7 +21458,7 @@
 	},
 /obj/machinery/power/apc/alarms_hidden/south_mount,
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "fFF" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
@@ -22106,7 +22112,7 @@
 	id = "scoophead_office"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "hyI" = (
 /obj/structure/table/hardwoodtable,
 /obj/machinery/chemical_dispenser/catering/bar_coffee{
@@ -22634,7 +22640,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/patterened/red,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "iQo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/meter,
@@ -22683,7 +22689,7 @@
 /obj/structure/curtain/open/shower,
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/tiled/neutral,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "jdu" = (
 /obj/machinery/washing_machine,
 /obj/item/storage/laundry_basket{
@@ -22767,7 +22773,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/carpet/patterened/red,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "jpc" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
@@ -22775,7 +22781,7 @@
 	},
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /turf/simulated/floor/plating,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "juq" = (
 /obj/effect/debris/cleanable/dirt,
 /turf/simulated/floor/tiled/old_tile/blue,
@@ -22958,7 +22964,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "jQe" = (
 /obj/machinery/computer/ship/helm{
 	dir = 1
@@ -23579,7 +23585,7 @@
 /area/sector/nebula_tradeport/motel)
 "luK" = (
 /turf/simulated/floor/wood,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "luQ" = (
 /obj/spawner/window/low_wall/reinforced/full/firelocks,
 /obj/structure/curtain/open/black,
@@ -24262,7 +24268,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "nkf" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 8
@@ -24718,7 +24724,7 @@
 /obj/item/pen/fountain,
 /obj/item/pen,
 /turf/simulated/floor/carpet/patterened/red,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "oFP" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -24827,7 +24833,7 @@
 	id = "scoophead_room"
 	},
 /turf/simulated/floor/wood,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "pfv" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -25499,7 +25505,7 @@
 /obj/structure/bed/pod,
 /obj/item/bedsheet/brown,
 /turf/simulated/floor/carpet/patterened/blue,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "rbV" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -26270,7 +26276,7 @@
 /obj/item/storage/single_use/mre/random,
 /obj/item/storage/single_use/mre/random,
 /turf/simulated/floor/carpet/patterened/blue,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "tBI" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/storage/box/glasses/meta,
@@ -26505,7 +26511,7 @@
 	gps_tag = "SCOOP"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "umU" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -26548,7 +26554,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/prepainted/command,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "uuk" = (
 /obj/structure/noticeboard{
 	pixel_y = 29
@@ -26670,7 +26676,7 @@
 "uFC" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/patterened/red,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "uHN" = (
 /obj/machinery/light{
 	dir = 1
@@ -26798,7 +26804,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/wood,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "vff" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26830,6 +26836,10 @@
 /obj/landmark/spawnpoint/job/trader,
 /turf/simulated/floor/tiled/neutral,
 /area/tradeport/commons)
+"vkf" = (
+/obj/spawner/window/low_wall/reinforced/full/firelocks,
+/turf/simulated/floor/plating,
+/area/shuttle/scoophead/cockpit)
 "vld" = (
 /turf/simulated/wall/r_wall,
 /area/sector/nebula_tradeport/motel/room8)
@@ -27094,7 +27104,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/patterened/red,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "wlu" = (
 /obj/machinery/shipsensors,
 /turf/simulated/floor/plating,
@@ -27146,7 +27156,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/neutral,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "wqt" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4
@@ -27188,7 +27198,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/carpet/patterened/red,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "wvG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/neutral,
@@ -27574,13 +27584,13 @@
 	},
 /obj/machinery/computer/shuttle_control/explore/trade/scoophead,
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "xvE" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/scoophead/main)
+/area/shuttle/scoophead/cockpit)
 "xwL" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -27674,6 +27684,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/sector/nebula_tradeport/motel/room7)
+"xWa" = (
+/obj/machinery/door/airlock/command{
+	name = "Captain's Quarters";
+	req_access = list(160);
+	req_one_access = null
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/scoophead/cockpit)
 "xYE" = (
 /obj/structure/lattice,
 /obj/structure/railing/grey,
@@ -27724,7 +27748,7 @@
 /obj/structure/lattice,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/shuttle/scoophead)
+/area/shuttle/scoophead/cockpit)
 "ygF" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -54409,13 +54433,13 @@ aDh
 aDh
 acd
 aDh
-gsa
-gsa
-gsa
-kJj
-kJj
-kJj
-kJj
+vkf
+vkf
+vkf
+bRZ
+bRZ
+bRZ
+bRZ
 aDh
 aDh
 awV
@@ -54602,15 +54626,15 @@ aDh
 aDh
 aDh
 acd
-gsa
-gsa
+vkf
+vkf
 btq
 umb
-yfg
+crT
 wqg
 jbA
-kJj
-kJj
+bRZ
+bRZ
 aDh
 aDh
 awV
@@ -54796,11 +54820,11 @@ aDh
 aDh
 aDh
 acd
-gsa
+vkf
 xuJ
 xvE
 fES
-yfg
+crT
 rai
 luK
 eDY
@@ -54990,7 +55014,7 @@ aDh
 aDh
 aDh
 aDh
-gsa
+vkf
 dFp
 jPy
 nhC
@@ -55184,15 +55208,15 @@ aDh
 aDh
 aDh
 aDh
-kJj
-kJj
-yfg
-hIZ
-yfg
+bRZ
+bRZ
+crT
+xWa
+crT
 utC
-yfg
+crT
 jpc
-gsa
+vkf
 aDh
 aDh
 awV

--- a/maps/sectors/nebula_tradeport/nebula_tradeport-areas.dm
+++ b/maps/sectors/nebula_tradeport/nebula_tradeport-areas.dm
@@ -145,21 +145,3 @@
 	icon_state = "green"
 
 /area/sector/nebula_tradeport/expansion
-
-//Scoophead
-
-/area/shuttle/scoophead
-	requires_power = 1
-	icon_state = "shuttle2"
-	dynamic_lighting = DYNAMIC_LIGHTING_ENABLED
-	area_flags = AREA_RAD_SHIELDED | AREA_FLAG_ERODING
-	sound_env = SMALL_ENCLOSED
-
-/area/shuttle/scoophead/cockpit
-	name = "Scoophead Cockpit"
-
-/area/shuttle/scoophead/main
-	name = "Scoophead Trading Section"
-
-/area/shuttle/scoophead/engineering
-	name = "Scoophead Engine Bay"

--- a/maps/sectors/nebula_tradeport/nebula_tradeport-areas.dm
+++ b/maps/sectors/nebula_tradeport/nebula_tradeport-areas.dm
@@ -145,3 +145,21 @@
 	icon_state = "green"
 
 /area/sector/nebula_tradeport/expansion
+
+//Scoophead
+
+/area/shuttle/scoophead
+	requires_power = 1
+	icon_state = "shuttle2"
+	dynamic_lighting = DYNAMIC_LIGHTING_ENABLED
+	area_flags = AREA_RAD_SHIELDED | AREA_FLAG_ERODING
+	sound_env = SMALL_ENCLOSED
+
+/area/shuttle/scoophead/cockpit
+	name = "Scoophead Cockpit"
+
+/area/shuttle/scoophead/main
+	name = "Scoophead Trading Section"
+
+/area/shuttle/scoophead/engineering
+	name = "Scoophead Engine Bay"

--- a/maps/sectors/nebula_tradeport/nebula_tradeport-shuttles.dm
+++ b/maps/sectors/nebula_tradeport/nebula_tradeport-shuttles.dm
@@ -73,7 +73,7 @@
 /datum/shuttle/autodock/overmap/trade/scoophead
 	name = "Scoophead trade Shuttle"
 	warmup_time = 5
-	shuttle_area = list(/area/shuttle/scoophead, /area/shuttle/scoophead/cockpit, /area/shuttle/scoophead/main, /area/shuttle/scoophead/main2, /area/shuttle/scoophead/office, /area/shuttle/scoophead/engineering)
+	shuttle_area = list(/area/shuttle/scoophead/cockpit, /area/shuttle/scoophead/main, /area/shuttle/scoophead/engineering)
 	current_location = "tradeport_scoophead"
 	docking_controller_tag = "tradeport_scoophead_docker"
 	fuel_consumption = 4
@@ -84,7 +84,7 @@
 	desc = "A shuttle linked to the Nebula Gas Station. Its a cargo ship refitted to be a smaller trade ship, easier to land than the Beruang. The Free Trade Union will always deliver."
 	color = "#ff811a" //Orange
 	fore_dir = WEST
-	vessel_mass = 10000
+	vessel_mass = 8000
 	vessel_size = SHIP_SIZE_SMALL
 	shuttle = "Scoophead trade Shuttle"
 
@@ -105,14 +105,9 @@
 /area/shuttle/scoophead/main
 	name = "Scoophead Trading Section"
 
-/area/shuttle/scoophead/office
-	name = "Scoophead Office"
-
 /area/shuttle/scoophead/engineering
 	name = "Scoophead Engine Bay"
 
-/area/shuttle/scoophead/main2
-	name = "Scoophead Trader Section"
 
 //Arrowhead Shuttle
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Some simple fixes : 
- The Old Century should have its APC, exterior airlock sensor, and lighting work correctly.
- The library got its scanner back ! Before that, the scanner near the library computer was actually a photocopier  (the sprite of the Photocopier and Scanner are the same.). Books can be publised again
- The scoophead should work again. I removed the mention of a area that, I expect, was the issue with the shuttle.

## Why It's Good For The Game

Fixes are always good ! :D

