### PR TITLE
helv's random bugfix pr

### DIFF
--- a/code/modules/surgery/external_repair.dm
+++ b/code/modules/surgery/external_repair.dm
@@ -90,8 +90,6 @@
 	/obj/item/surgical/hemostat = 60,
 	/obj/item/stack/medical/ointment = 50,
 	/obj/item/surgical/hemostat_primitive = 40,
-	/obj/item/duct_tape_roll = 30,
-	/obj/item/barrier_tape_roll = 10
 	)
 
 	priority = 3
@@ -103,8 +101,6 @@
 	if(..())
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		if(affected.burn_stage < 1 || !(affected.burn_dam))
-			return 0
-		if(affected.burn_dam < affected.brute_dam)
 			return 0
 		return 1
 	return 0
@@ -175,8 +171,6 @@
 	if(..())
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		if(affected.brute_stage < 1 || !(affected.brute_dam))
-			return 0
-		if(affected.brute_dam < affected.burn_dam)
 			return 0
 		return 1
 	return 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Patches as much stuff as I can fix before this PR gets reviewed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
why did they do that
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Advanced trauma treatment no longer requires you to juggle fixing burns and bruises
fix: Tyrmalin mining drills can no longer instantly destroy windows
balance: Poor quality control on Mars has impacted NanoTrasen's Tyrmalin mining equipment imports. At least these don't jam as much. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
