### PR TITLE
Gives station reporters a press badge and tape recorder

### DIFF
--- a/code/modules/jobs/job_types/station/civillian/librarian.dm
+++ b/code/modules/jobs/job_types/station/civillian/librarian.dm
@@ -27,11 +27,6 @@
 		"Philosopher" = /datum/prototype/struct/alt_title/librarian/philosopher
 	)
 
-/datum/prototype/struct/alt_title/librarian/librarian/reporter
-	title = "Reporter"
-	title_blurb = "Although Nanotrasen's official Press outlet is managed by Central Command, they often hire freelance journalists for local coverage."
-	title_outfit = /datum/outfit/job/station/librarian/reporter
-
 // Librarian Alt Titles
 /datum/prototype/struct/alt_title/librarian/journalist
 	title = "Journalist"
@@ -44,6 +39,7 @@
 /datum/prototype/struct/alt_title/librarian/reporter
 	title = "Reporter"
 	title_blurb = "The Reporter uses the Library as a base of operations, from which they can report the news and goings-on on the station with their camera."
+	title_outfit = /datum/outfit/job/station/librarian/reporter
 
 /datum/prototype/struct/alt_title/librarian/historian
 	title = "Historian"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the reporter alt title to also get their reporter outfit, which is a camera with film, a press badge, and a tape recorder

## Why It's Good For The Game

Gives press a thing to show, besides providing them with the gear they may need. The outfit was already made like it, and works, only was assigned to a `librarian/librarian/reporter` alt title, rather than just the librarian/reporter one that's in use.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Reporter librarians start with press gear.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
