### PR TITLE
Non-Nt workers now get their chosen title in the manifest

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -537,7 +537,7 @@ GLOBAL_LIST_EMPTY(PDA_Manifest)
 /proc/GetAssignment(var/mob/living/carbon/human/H)
 	. = "Unassigned"
 	var/faction = H.mind?.original_background_faction()?.id
-	if((faction && !(faction == "nanotrasen")) || !H.mind.role_alt_title)
+	if(!H.mind.role_alt_title)
 		. = H.mind.assigned_role
 	else if(H.mind.role_alt_title)
 		. = H.mind.role_alt_title


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes what was overlooked in #6980, which only made IDs display their alternative title, this also makes the manifest show it.

## Why It's Good For The Game

Manifest, arrivals message, and IDs agree again on what someone is.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Non-NT crew get announced and listed as their chosen job title.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
