### PR TITLE
Removal of the fighter event

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -169,7 +169,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		100,	list(ASSIGNMENT_SECURITY = 40), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Virology Breach",			/datum/event/prison_break/virology,		0,		list(ASSIGNMENT_MEDICAL = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Xenobiology Breach",		/datum/event/prison_break/xenobiology,	0,		list(ASSIGNMENT_SCIENCE = 100)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Fighter Attack",			/datum/event/fighter,					25,		list(ASSIGNMENT_ANY = 60)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Fighter Attack",			/datum/event/fighter,					0,		list(ASSIGNMENT_ANY = 60)),
 	)
 
 /datum/event_container/major

--- a/code/modules/events/event_container_vr.dm
+++ b/code/modules/events/event_container_vr.dm
@@ -103,7 +103,7 @@
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",		/datum/event/carp_migration,	20,		list(ASSIGNMENT_SECURITY = 5), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Containment Breach",	/datum/event/prison_break/station,0,	list(ASSIGNMENT_ANY = 5), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",			/datum/event/meteor_wave,		20,		list(ASSIGNMENT_ENGINEER = 15),	1, 0),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Fighter Attack",		/datum/event/fighter,			25,		list(ASSIGNMENT_ANY = 5), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Fighter Attack",		/datum/event/fighter,			0,		list(ASSIGNMENT_ANY = 5), 1),
 	)
 	add_disabled_events(list(
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",				/datum/event/blob, 				10,		list(ASSIGNMENT_ENGINEER = 60), 1),


### PR DESCRIPTION


## About The Pull Request

Those pesky pirates taught they could attack a base on Lythios 43c with those fighters. NSB Atlas sensor detected them, was set on blue alert... 

... But the fighter never came down. Turns out, Dukes and Baron repaired with hopes and ducktape aren't totaly made for re-entry. 

For now, the event will be removed, until we can code map based event, so the event that trigger when on a NT vessel, and not a base.
_"Lieutenant Gaeta, set the fleet to Condition Three."_

## Why It's Good For The Game

No more people scared on Atlas about non-existing Fighters.
The event will be back **event**ualy. :D