### PR TITLE
Makes cigarette butts go to hand instead of drop by default

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -189,6 +189,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			var/mob/living/M = loc
 			if (!nomessage)
 				to_chat(M, "<span class='notice'>Your [name] goes out.</span>")
+			if(ishuman(M))
+				var/mob/living/carbon/human/H=M
+				if(H.a_intent!=INTENT_HARM && !H.incapacitated())
+					H.put_in_hands(butt)
 		qdel(src)
 	else
 		new /obj/effect/debris/cleanable/ash(T)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -191,7 +191,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				to_chat(M, "<span class='notice'>Your [name] goes out.</span>")
 			if(ishuman(M))
 				var/mob/living/carbon/human/H=M
-				if(H.a_intent!=INTENT_HARM && !H.incapacitated())
+				if(H.a_intent==INTENT_HELP && !H.incapacitated())
 					H.put_in_hands(butt)
 		qdel(src)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. On harm intent, it drops it to the ground, instead (both for the funny and because this is actually required to get the "put it out by stomping it" thing to work)

## Why It's Good For The Game

Y'all know I'm a hater and I still unironically think that making every smoker a litterer by default too is a bit goofy

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Cigarette butts go to a free hand if available, instead of dropping to the ground
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
