### PR TITLE
holosphere fixes

### DIFF
--- a/code/modules/organs/external/external.dm
+++ b/code/modules/organs/external/external.dm
@@ -1275,7 +1275,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	implants += W
 	owner.embedded_flag = 1
 	add_verb(owner, /mob/proc/yank_out_object)
-	W.add_blood(owner)
+	if(!(owner.species.species_flags & NO_BLOOD))
+		W.add_blood(owner)
 	W.forceMove(owner)
 
 /obj/item/organ/external/removed(var/mob/living/user, var/ignore_children = 0)

--- a/code/modules/species/holosphere/appearance.dm
+++ b/code/modules/species/holosphere/appearance.dm
@@ -53,7 +53,8 @@
 	equip_loadout(source, loadout)
 
 // essentially a copy of the normal loadout behaviour and we then apply it to the chameleon outfit
-/datum/species/holosphere/proc/equip_loadout(mob/living/carbon/human/H, list/datum/loadout_entry/loadout)
+/datum/species/holosphere/proc/equip_loadout(mob/living/carbon/human/H, list/datum/loadout_entry/loadout, ignore_unused_slots = TRUE)
+	slots_used = list()
 	for(var/datum/loadout_entry/entry as anything in loadout)
 		var/use_slot = entry.slot
 		if(isnull(use_slot))
@@ -89,16 +90,13 @@
 		slots_used += use_slot
 		loadout -= entry
 
-	// no loadout items in that slot, hide the items icon
-	for(var/slot in equipped_chameleon_gear)
-		if(!(slot in slots_used))
-			var/obj/item/chameleon_item = equipped_chameleon_gear[slot]
-			chameleon_item.icon = initial(chameleon_item.icon)
-			chameleon_item.icon_state = CLOTHING_BLANK_ICON_STATE
-			var/obj/item/clothing/under/chameleon_uniform = chameleon_item
-			if(istype(chameleon_uniform))
-				chameleon_uniform.snowflake_worn_state = CLOTHING_BLANK_ICON_STATE
-			chameleon_item.update_worn_icon()
+	if(!ignore_unused_slots)
+		// no loadout items in that slot, hide the items icon
+		for(var/slot in equipped_chameleon_gear)
+			if(!(slot in slots_used))
+				var/obj/item/chameleon_item = equipped_chameleon_gear[slot]
+				chameleon_item.disguise_blank()
+				chameleon_item.update_worn_icon()
 
 /datum/species/holosphere/handle_species_job_outfit(mob/living/carbon/human/H, datum/outfit/outfit)
 	handle_specific_job_clothing(H, outfit.uniform, SLOT_ID_UNIFORM)
@@ -134,7 +132,7 @@
 	var/loadout_option = tgui_input_list(usr, "Choose Loadout", "Loadout", loadout_options)
 	var/loadout_slot = loadout_options[loadout_option]
 	var/list/datum/loadout_entry/loadout_entries = client.prefs.generate_loadout_entry_list(holosphere_species.cached_loadout_flags, holosphere_species.cached_loadout_role, loadout_slot)
-	holosphere_species.equip_loadout(src, loadout_entries)
+	holosphere_species.equip_loadout(src, loadout_entries, FALSE)
 
 /datum/species/holosphere/proc/get_alpha_from_key(var/mob/living/carbon/human/H, var/key)
 	switch(key)

--- a/code/modules/species/holosphere/holosphere_shell.dm
+++ b/code/modules/species/holosphere/holosphere_shell.dm
@@ -170,3 +170,6 @@
 	var/language_name = message_args["language_name"]
 	var/language_flags = message_args["language_flags"]
 	message_args["message"] = hologram.handle_autohiss(message, language_name, language_flags, TRUE)
+
+/mob/living/simple_mob/holosphere_shell/say_understands()
+	return hologram?.say_understands(arglist(args)) || ..()


### PR DESCRIPTION
## About The Pull Request
if you switch to a loadout using the change loadout verb/ability then unused slots get replaced with a blank icon / 'nothing'
when embedding an object into a bodypart, don't try covering the object in blood if the species has no blood
the holosphere's shell understands whatever the hologram understands, thereby fixing things like the AI's name becoming "synthesized voice"

## Why It's Good For The Game
fixes to intended behaviour

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: if you switch to a loadout using the change loadout verb/ability then unused slots get replaced with a blank icon / 'nothing'
fix: when embedding an object into a bodypart, don't try covering the object in blood if the species has no blood
fix: the holosphere's shell understands whatever the hologram understands
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
