### PR TITLE
Broadcasts(like crew arrivals) are restricted to their map/overmap entity

### DIFF
--- a/code/controllers/subsystem/transcore_vr.dm
+++ b/code/controllers/subsystem/transcore_vr.dm
@@ -160,9 +160,9 @@ SUBSYSTEM_DEF(transcore)
 /datum/controller/subsystem/transcore/proc/notify(var/name, var/repeated = FALSE)
 	ASSERT(name)
 	if(repeated)
-		GLOB.global_announcer.autosay("This is a repeat notification that [name] is past-due for a mind backup.", "TransCore Oversight", "Medical")
+		GLOB.global_announcer.autosay("This is a repeat notification that [name] is past-due for a mind backup.", "TransCore Oversight", "Medical", GetStationZlevels())
 	else
-		GLOB.global_announcer.autosay("[name] is past-due for a mind backup.", "TransCore Oversight", "Medical")
+		GLOB.global_announcer.autosay("[name] is past-due for a mind backup.", "TransCore Oversight", "Medical", GetStationZlevels())
 
 // Called from mind_record to add itself to the transcore.
 /datum/controller/subsystem/transcore/proc/add_backup(datum/transhuman/mind_record/MR)
@@ -195,8 +195,8 @@ SUBSYSTEM_DEF(transcore)
 // Moves all mind records from the databaes into the disk and shuts down all backup canary processing.
 /datum/controller/subsystem/transcore/proc/core_dump(obj/item/disk/transcore/disk)
 	ASSERT(disk)
-	GLOB.global_announcer.autosay("An emergency core dump has been initiated!", "TransCore Oversight", "Command")
-	GLOB.global_announcer.autosay("An emergency core dump has been initiated!", "TransCore Oversight", "Medical")
+	GLOB.global_announcer.autosay("An emergency core dump has been initiated!", "TransCore Oversight", "Command", GetStationZlevels())
+	GLOB.global_announcer.autosay("An emergency core dump has been initiated!", "TransCore Oversight", "Medical", GetStationZlevels())
 
 	disk.stored += backed_up
 	backed_up.Cut()

--- a/code/controllers/subsystem/transcore_vr.dm
+++ b/code/controllers/subsystem/transcore_vr.dm
@@ -160,9 +160,9 @@ SUBSYSTEM_DEF(transcore)
 /datum/controller/subsystem/transcore/proc/notify(var/name, var/repeated = FALSE)
 	ASSERT(name)
 	if(repeated)
-		GLOB.global_announcer.autosay("This is a repeat notification that [name] is past-due for a mind backup.", "TransCore Oversight", "Medical", GetStationZlevels())
+		GLOB.global_announcer.autosay("This is a repeat notification that [name] is past-due for a mind backup.", "TransCore Oversight", "Medical", SSmapping.loaded_station.map_levels.Copy())
 	else
-		GLOB.global_announcer.autosay("[name] is past-due for a mind backup.", "TransCore Oversight", "Medical", GetStationZlevels())
+		GLOB.global_announcer.autosay("[name] is past-due for a mind backup.", "TransCore Oversight", "Medical", SSmapping.loaded_station.map_levels.Copy())
 
 // Called from mind_record to add itself to the transcore.
 /datum/controller/subsystem/transcore/proc/add_backup(datum/transhuman/mind_record/MR)
@@ -195,8 +195,8 @@ SUBSYSTEM_DEF(transcore)
 // Moves all mind records from the databaes into the disk and shuts down all backup canary processing.
 /datum/controller/subsystem/transcore/proc/core_dump(obj/item/disk/transcore/disk)
 	ASSERT(disk)
-	GLOB.global_announcer.autosay("An emergency core dump has been initiated!", "TransCore Oversight", "Command", GetStationZlevels())
-	GLOB.global_announcer.autosay("An emergency core dump has been initiated!", "TransCore Oversight", "Medical", GetStationZlevels())
+	GLOB.global_announcer.autosay("An emergency core dump has been initiated!", "TransCore Oversight", "Command", SSmapping.loaded_station.map_levels.Copy())
+	GLOB.global_announcer.autosay("An emergency core dump has been initiated!", "TransCore Oversight", "Medical", SSmapping.loaded_station.map_levels.Copy())
 
 	disk.stored += backed_up
 	backed_up.Cut()

--- a/code/datums/announce/_legacy.dm
+++ b/code/datums/announce/_legacy.dm
@@ -144,7 +144,7 @@
 
 /proc/AnnounceArrivalSimple(name, rank = "visitor", join_message = "will arrive at the station shortly", z_level)
 	if(z_level)
-		GLOB.global_announcer.autosay(join_message, "Arrivals Announcement Computer", zlevels = GetConnectedZlevels(z_level))
+		GLOB.global_announcer.autosay(join_message, "Arrivals Announcement Computer", zlevels = SSmapping.loaded_station.get_map_levels(z_level))
 	else
 		GLOB.global_announcer.autosay(join_message, "Arrivals Announcement Computer")
 

--- a/code/datums/announce/_legacy.dm
+++ b/code/datums/announce/_legacy.dm
@@ -140,7 +140,11 @@
 	if (SSticker.current_state == GAME_STATE_PLAYING)
 		if(character.mind.role_alt_title)
 			rank = character.mind.role_alt_title
-		AnnounceArrivalSimple(character.real_name, rank, join_message)
+		AnnounceArrivalSimple(character.real_name, rank, join_message, get_z(character))
 
-/proc/AnnounceArrivalSimple(name, rank = "visitor", join_message = "will arrive at the station shortly")
-	GLOB.global_announcer.autosay(join_message, "Arrivals Announcement Computer")
+/proc/AnnounceArrivalSimple(name, rank = "visitor", join_message = "will arrive at the station shortly", z_level)
+	if(z_level)
+		GLOB.global_announcer.autosay(join_message, "Arrivals Announcement Computer", zlevels = GetConnectedZlevels(z_level))
+	else
+		GLOB.global_announcer.autosay(join_message, "Arrivals Announcement Computer")
+

--- a/code/game/machinery/doors/door_timer.dm
+++ b/code/game/machinery/doors/door_timer.dm
@@ -114,7 +114,7 @@
 		return FALSE
 
 	if(!forced)
-		GLOB.global_announcer.autosay("Timer has expired. Releasing prisoner.", "[src.name]", "Security", GetConnectedZlevels(get_z(src)))
+		GLOB.global_announcer.autosay("Timer has expired. Releasing prisoner.", "[src.name]", "Security", SSmapping.loaded_station.get_map_levels(get_z(src)))
 
 	timing = FALSE
 	activation_time = null

--- a/code/game/machinery/doors/door_timer.dm
+++ b/code/game/machinery/doors/door_timer.dm
@@ -114,7 +114,7 @@
 		return FALSE
 
 	if(!forced)
-		GLOB.global_announcer.autosay("Timer has expired. Releasing prisoner.", "[src.name]", "Security")
+		GLOB.global_announcer.autosay("Timer has expired. Releasing prisoner.", "[src.name]", "Security", GetConnectedZlevels(get_z(src)))
 
 	timing = FALSE
 	activation_time = null

--- a/code/game/machinery/holopad.dm
+++ b/code/game/machinery/holopad.dm
@@ -392,7 +392,7 @@ GLOBAL_VAR_INIT(holopad_connectivity_rebuild_queued, FALSE)
 	if(world.time < holocall_last_radio + 30 SECONDS)
 		return
 	holocall_last_radio = world.time
-	GLOB.global_announcer.autosay("Incoming call from [incoming.caller_id_source()] at [get_area(src)].", name, zlevels = (LEGACY_MAP_DATUM).get_map_levels(get_z(src)))
+	GLOB.global_announcer.autosay("Incoming call from [incoming.caller_id_source()] at [get_area(src)].", name, zlevels = GetConnectedZlevels(get_z(src)))
 
 /**
  * get hung up by a call

--- a/code/game/machinery/holopad.dm
+++ b/code/game/machinery/holopad.dm
@@ -392,7 +392,7 @@ GLOBAL_VAR_INIT(holopad_connectivity_rebuild_queued, FALSE)
 	if(world.time < holocall_last_radio + 30 SECONDS)
 		return
 	holocall_last_radio = world.time
-	GLOB.global_announcer.autosay("Incoming call from [incoming.caller_id_source()] at [get_area(src)].", name, zlevels = GetConnectedZlevels(get_z(src)))
+	GLOB.global_announcer.autosay("Incoming call from [incoming.caller_id_source()] at [get_area(src)].", name, zlevels = SSmapping.loaded_station.get_map_levels(get_z(src)))
 
 /**
  * get hung up by a call

--- a/code/game/machinery/pointdefense.dm
+++ b/code/game/machinery/pointdefense.dm
@@ -58,7 +58,7 @@ GLOBAL_LIST_BOILERPLATE(pointdefense_turrets, /obj/machinery/power/pointdefense)
 		if(PD.id_tag != id_tag)
 			return FALSE
 
-		if(!(get_z(PD) in GetConnectedZlevels(get_z(src))))
+		if(!(get_z(PD) in SSmapping.loaded_station.get_map_levels(get_z(src))))
 			to_chat(usr, "<span class='warning'>[PD] is not within control range.</span>")
 			return FALSE
 
@@ -71,7 +71,7 @@ GLOBAL_LIST_BOILERPLATE(pointdefense_turrets, /obj/machinery/power/pointdefense)
 	data["id"] = id_tag
 	var/list/turrets = list()
 	if(id_tag)
-		var/list/connected_z_levels = GetConnectedZlevels(get_z(src))
+		var/list/connected_z_levels = SSmapping.loaded_station.get_map_levels(get_z(src))
 		for(var/i = 1 to LAZYLEN(GLOB.pointdefense_turrets))
 			var/obj/machinery/power/pointdefense/PD = GLOB.pointdefense_turrets[i]
 			if(!(PD.id_tag == id_tag && (get_z(PD) in connected_z_levels)))
@@ -199,7 +199,7 @@ GLOBAL_LIST_BOILERPLATE(pointdefense_turrets, /obj/machinery/power/pointdefense)
 /obj/machinery/power/pointdefense/proc/get_controller()
 	if(!id_tag)
 		return null
-	var/list/connected_z_levels = GetConnectedZlevels(get_z(src))
+	var/list/connected_z_levels = SSmapping.loaded_station.get_map_levels(get_z(src))
 	for(var/thing in GLOB.pointdefense_controllers)
 		var/obj/machinery/pointdefense_control/PDC = thing
 		if(PDC.id_tag == id_tag && (get_z(PDC) in connected_z_levels))
@@ -318,7 +318,7 @@ GLOBAL_LIST_BOILERPLATE(pointdefense_turrets, /obj/machinery/power/pointdefense)
 
 /obj/machinery/power/pointdefense/proc/targeting_check(obj/effect/meteor/M)
 	// Target in range
-	var/list/connected_z_levels = GetConnectedZlevels(get_z(src))
+	var/list/connected_z_levels = SSmapping.loaded_station.get_map_levels(get_z(src))
 	if(!(M.z in connected_z_levels))
 		return FALSE
 	if(get_dist(M, src) > kill_range)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -49,7 +49,7 @@
 				else
 					src.icon_state = "morgue3"
 					if(broadcast)
-						GLOB.global_announcer.autosay("[src] was able to establish a mental interface with occupant.", "[src]", "Medical", GetConnectedZlevels(get_z(src)))
+						GLOB.global_announcer.autosay("[src] was able to establish a mental interface with occupant.", "[src]", "Medical", SSmapping.loaded_station.get_map_levels(get_z(src)))
 		else
 			src.icon_state = "morgue1"
 	return

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -49,7 +49,7 @@
 				else
 					src.icon_state = "morgue3"
 					if(broadcast)
-						GLOB.global_announcer.autosay("[src] was able to establish a mental interface with occupant.", "[src]", "Medical")
+						GLOB.global_announcer.autosay("[src] was able to establish a mental interface with occupant.", "[src]", "Medical", GetConnectedZlevels(get_z(src)))
 		else
 			src.icon_state = "morgue1"
 	return

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1027,7 +1027,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		if(isAI(M))
 			var/mob/living/silicon/ai/ai = M
 			GLOB.empty_playable_ai_cores += new /obj/structure/AIcore/deactivated(ai.loc)
-			GLOB.global_announcer.autosay("[ai] has been moved to intelligence storage.", "Artificial Intelligence Oversight", GetConnectedZlevels(get_z(ai)))
+			GLOB.global_announcer.autosay("[ai] has been moved to intelligence storage.", "Artificial Intelligence Oversight", SSmapping.loaded_station.get_map_levels(get_z(ai)))
 			ai.clear_client()
 			return
 		else

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1027,7 +1027,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		if(isAI(M))
 			var/mob/living/silicon/ai/ai = M
 			GLOB.empty_playable_ai_cores += new /obj/structure/AIcore/deactivated(ai.loc)
-			GLOB.global_announcer.autosay("[ai] has been moved to intelligence storage.", "Artificial Intelligence Oversight")
+			GLOB.global_announcer.autosay("[ai] has been moved to intelligence storage.", "Artificial Intelligence Oversight", GetConnectedZlevels(get_z(ai)))
 			ai.clear_client()
 			return
 		else

--- a/code/modules/catalogue/cataloguer.dm
+++ b/code/modules/catalogue/cataloguer.dm
@@ -153,7 +153,7 @@ GLOBAL_LIST_EMPTY(all_cataloguers)
 	var/list/contributers = list()
 	var/list/contributer_names = list()
 	var/turf/T = get_turf(user) || get_turf(target)
-	var/list/contributing_z = GetConnectedZlevels(T.z)
+	var/list/contributing_z = SSmapping.loaded_station.get_map_levels(T.z)
 	for(var/thing in GLOB.player_list)
 		var/mob/living/L = thing
 		if(L == user)

--- a/code/modules/hardsuits/modules/utility_vr.dm
+++ b/code/modules/hardsuits/modules/utility_vr.dm
@@ -83,8 +83,8 @@
 
 	var/username = FindNameFromID(H) || "Unknown"
 	var/message = "[username] has overridden [A] (airlock) in \the [get_area(A)] at [A.x],[A.y],[A.z] with \the [src]."
-	GLOB.global_announcer.autosay(message, "Security Subsystem", "Command")
-	GLOB.global_announcer.autosay(message, "Security Subsystem", "Security")
+	GLOB.global_announcer.autosay(message, "Security Subsystem", "Command", GetConnectedZlevels(get_z(src)))
+	GLOB.global_announcer.autosay(message, "Security Subsystem", "Security", GetConnectedZlevels(get_z(src)))
 	return 1
 
 /obj/item/hardsuit_module/rescue_pharm

--- a/code/modules/hardsuits/modules/utility_vr.dm
+++ b/code/modules/hardsuits/modules/utility_vr.dm
@@ -83,8 +83,8 @@
 
 	var/username = FindNameFromID(H) || "Unknown"
 	var/message = "[username] has overridden [A] (airlock) in \the [get_area(A)] at [A.x],[A.y],[A.z] with \the [src]."
-	GLOB.global_announcer.autosay(message, "Security Subsystem", "Command", GetConnectedZlevels(get_z(src)))
-	GLOB.global_announcer.autosay(message, "Security Subsystem", "Security", GetConnectedZlevels(get_z(src)))
+	GLOB.global_announcer.autosay(message, "Security Subsystem", "Command", SSmapping.loaded_station.get_map_levels(get_z(src)))
+	GLOB.global_announcer.autosay(message, "Security Subsystem", "Security", SSmapping.loaded_station.get_map_levels(get_z(src)))
 	return 1
 
 /obj/item/hardsuit_module/rescue_pharm

--- a/code/modules/maps/overmap/planets/_lythios43c.dm
+++ b/code/modules/maps/overmap/planets/_lythios43c.dm
@@ -31,6 +31,7 @@
 		"NDV Quicksilver" = list("rift_specops_dock"),
 		"Pirate Skiff" = list("rift_pirate_dock"),
 		)
+	is_main_station = TRUE
 
 //Despite not being in the multi-z complex, these levels are part of the overmap sector
 /* This should be placed in the map's define files.

--- a/code/modules/mob/living/bot/medibot.dm
+++ b/code/modules/mob/living/bot/medibot.dm
@@ -181,7 +181,7 @@
 	visible_message(SPAN_WARNING("[src] is trying to inject [victim]!"))
 	if(declare_treatment)
 		var/area/location = get_area(src)
-		GLOB.global_announcer.autosay("[src] is treating <b>[victim]</b> in <b>[location]</b>", "[src]", "Medical")
+		GLOB.global_announcer.autosay("[src] is treating <b>[victim]</b> in <b>[location]</b>", "[src]", "Medical", GetConnectedZlevels(get_z(src)))
 	busy = TRUE
 	update_appearance()
 	if(do_mob(src, victim, 30))
@@ -478,7 +478,7 @@
 				"Nooo!" = 'sound/voice/medibot/nooo.ogg',
 			)
 		if(MEDIBOT_PANIC_END)
-			GLOB.global_announcer.autosay("PSYCH ALERT: Crewmember [tipper_name] recorded displaying antisocial tendencies torturing bots in [get_area(src)]. Please schedule psych evaluation.", "[src]", "Medical")
+			GLOB.global_announcer.autosay("PSYCH ALERT: Crewmember [tipper_name] recorded displaying antisocial tendencies torturing bots in [get_area(src)]. Please schedule psych evaluation.", "[src]", "Medical", GetConnectedZlevels(get_z(src)))
 			set_right() // Strong independent Medibot don't need no crew!
 
 	// if(prob(tipped_status)) // Commented out pending introduction of jitter stuff from /tg/

--- a/code/modules/mob/living/bot/medibot.dm
+++ b/code/modules/mob/living/bot/medibot.dm
@@ -181,7 +181,7 @@
 	visible_message(SPAN_WARNING("[src] is trying to inject [victim]!"))
 	if(declare_treatment)
 		var/area/location = get_area(src)
-		GLOB.global_announcer.autosay("[src] is treating <b>[victim]</b> in <b>[location]</b>", "[src]", "Medical", GetConnectedZlevels(get_z(src)))
+		GLOB.global_announcer.autosay("[src] is treating <b>[victim]</b> in <b>[location]</b>", "[src]", "Medical", SSmapping.loaded_station.get_map_levels(get_z(src)))
 	busy = TRUE
 	update_appearance()
 	if(do_mob(src, victim, 30))
@@ -478,7 +478,7 @@
 				"Nooo!" = 'sound/voice/medibot/nooo.ogg',
 			)
 		if(MEDIBOT_PANIC_END)
-			GLOB.global_announcer.autosay("PSYCH ALERT: Crewmember [tipper_name] recorded displaying antisocial tendencies torturing bots in [get_area(src)]. Please schedule psych evaluation.", "[src]", "Medical", GetConnectedZlevels(get_z(src)))
+			GLOB.global_announcer.autosay("PSYCH ALERT: Crewmember [tipper_name] recorded displaying antisocial tendencies torturing bots in [get_area(src)]. Please schedule psych evaluation.", "[src]", "Medical", SSmapping.loaded_station.get_map_levels(get_z(src)))
 			set_right() // Strong independent Medibot don't need no crew!
 
 	// if(prob(tipped_status)) // Commented out pending introduction of jitter stuff from /tg/

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -64,7 +64,7 @@
 				var/mob/living/L = pulledby
 				UnarmedAttack(L)
 				say("Do not interfere with active law enforcement routines!")
-				GLOB.global_announcer.autosay("[src] was interfered with in <b>[get_area(src)]</b>, activating defense routines.", "[src]", "Security")
+				GLOB.global_announcer.autosay("[src] was interfered with in <b>[get_area(src)]</b>, activating defense routines.", "[src]", "Security", GetConnectedZlevels(get_z(src)))
 
 /datum/category_item/catalogue/technology/bot/secbot/beepsky
 	name = "Bot - Officer Beepsky"
@@ -245,7 +245,7 @@
 
 	if(!target)
 		playsound(src.loc, pick(threat_found_sounds), 50)
-		GLOB.global_announcer.autosay("[src] was attacked by a hostile <b>[target_name(attacker)]</b> in <b>[get_area(src)]</b>.", "[src]", "Security")
+		GLOB.global_announcer.autosay("[src] was attacked by a hostile <b>[target_name(attacker)]</b> in <b>[get_area(src)]</b>.", "[src]", "Security", GetConnectedZlevels(get_z(src)))
 	target = attacker
 	attacked = TRUE
 
@@ -253,7 +253,7 @@
 /mob/living/bot/secbot/proc/demand_surrender(mob/target, var/threat)
 	var/suspect_name = target_name(target)
 	if(declare_arrests)
-		GLOB.global_announcer.autosay("[src] is [arrest_type ? "detaining" : "arresting"] a level [threat] suspect <b>[suspect_name]</b> in <b>[get_area(src)]</b>.", "[src]", "Security")
+		GLOB.global_announcer.autosay("[src] is [arrest_type ? "detaining" : "arresting"] a level [threat] suspect <b>[suspect_name]</b> in <b>[get_area(src)]</b>.", "[src]", "Security", GetConnectedZlevels(get_z(src)))
 	say("Down on the floor, [suspect_name]! You have [SECBOT_WAIT_TIME*2] seconds to comply.")
 	playsound(src.loc, pick(preparing_arrest_sounds), 50)
 	// Register to be told when the target moves
@@ -309,7 +309,7 @@
 			var/action = arrest_type ? "detaining" : "arresting"
 			if(!ishuman(target))
 				action = "fighting"
-			GLOB.global_announcer.autosay("[src] is [action] a level [threat] [action != "fighting" ? "suspect" : "threat"] <b>[target_name(target)]</b> in <b>[get_area(src)]</b>.", "[src]", "Security")
+			GLOB.global_announcer.autosay("[src] is [action] a level [threat] [action != "fighting" ? "suspect" : "threat"] <b>[target_name(target)]</b> in <b>[get_area(src)]</b>.", "[src]", "Security", GetConnectedZlevels(get_z(src)))
 		UnarmedAttack(target)
 
 /mob/living/bot/secbot/handlePanic()	// Speed modification based on alert level.

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -64,7 +64,7 @@
 				var/mob/living/L = pulledby
 				UnarmedAttack(L)
 				say("Do not interfere with active law enforcement routines!")
-				GLOB.global_announcer.autosay("[src] was interfered with in <b>[get_area(src)]</b>, activating defense routines.", "[src]", "Security", GetConnectedZlevels(get_z(src)))
+				GLOB.global_announcer.autosay("[src] was interfered with in <b>[get_area(src)]</b>, activating defense routines.", "[src]", "Security", SSmapping.loaded_station.get_map_levels(get_z(src)))
 
 /datum/category_item/catalogue/technology/bot/secbot/beepsky
 	name = "Bot - Officer Beepsky"
@@ -245,7 +245,7 @@
 
 	if(!target)
 		playsound(src.loc, pick(threat_found_sounds), 50)
-		GLOB.global_announcer.autosay("[src] was attacked by a hostile <b>[target_name(attacker)]</b> in <b>[get_area(src)]</b>.", "[src]", "Security", GetConnectedZlevels(get_z(src)))
+		GLOB.global_announcer.autosay("[src] was attacked by a hostile <b>[target_name(attacker)]</b> in <b>[get_area(src)]</b>.", "[src]", "Security", SSmapping.loaded_station.get_map_levels(get_z(src)))
 	target = attacker
 	attacked = TRUE
 
@@ -253,7 +253,7 @@
 /mob/living/bot/secbot/proc/demand_surrender(mob/target, var/threat)
 	var/suspect_name = target_name(target)
 	if(declare_arrests)
-		GLOB.global_announcer.autosay("[src] is [arrest_type ? "detaining" : "arresting"] a level [threat] suspect <b>[suspect_name]</b> in <b>[get_area(src)]</b>.", "[src]", "Security", GetConnectedZlevels(get_z(src)))
+		GLOB.global_announcer.autosay("[src] is [arrest_type ? "detaining" : "arresting"] a level [threat] suspect <b>[suspect_name]</b> in <b>[get_area(src)]</b>.", "[src]", "Security", SSmapping.loaded_station.get_map_levels(get_z(src)))
 	say("Down on the floor, [suspect_name]! You have [SECBOT_WAIT_TIME*2] seconds to comply.")
 	playsound(src.loc, pick(preparing_arrest_sounds), 50)
 	// Register to be told when the target moves
@@ -309,7 +309,7 @@
 			var/action = arrest_type ? "detaining" : "arresting"
 			if(!ishuman(target))
 				action = "fighting"
-			GLOB.global_announcer.autosay("[src] is [action] a level [threat] [action != "fighting" ? "suspect" : "threat"] <b>[target_name(target)]</b> in <b>[get_area(src)]</b>.", "[src]", "Security", GetConnectedZlevels(get_z(src)))
+			GLOB.global_announcer.autosay("[src] is [action] a level [threat] [action != "fighting" ? "suspect" : "threat"] <b>[target_name(target)]</b> in <b>[get_area(src)]</b>.", "[src]", "Security", SSmapping.loaded_station.get_map_levels(get_z(src)))
 		UnarmedAttack(target)
 
 /mob/living/bot/secbot/handlePanic()	// Speed modification based on alert level.

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_EMPTY(empty_playable_ai_cores)
 
 	// We warned you.
 	GLOB.empty_playable_ai_cores += new /obj/structure/AIcore/deactivated(loc)
-	GLOB.global_announcer.autosay("[src] has been moved to intelligence storage.", "Artificial Intelligence Oversight", GetConnectedZlevels(get_z(src)))
+	GLOB.global_announcer.autosay("[src] has been moved to intelligence storage.", "Artificial Intelligence Oversight", SSmapping.loaded_station.get_map_levels(get_z(src)))
 
 	//Handle job slot/tater cleanup.
 	set_respawn_timer()

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_EMPTY(empty_playable_ai_cores)
 
 	// We warned you.
 	GLOB.empty_playable_ai_cores += new /obj/structure/AIcore/deactivated(loc)
-	GLOB.global_announcer.autosay("[src] has been moved to intelligence storage.", "Artificial Intelligence Oversight")
+	GLOB.global_announcer.autosay("[src] has been moved to intelligence storage.", "Artificial Intelligence Oversight", GetConnectedZlevels(get_z(src)))
 
 	//Handle job slot/tater cleanup.
 	set_respawn_timer()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -499,7 +499,7 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 		if(character.mind.role_alt_title)
 			rank = character.mind.role_alt_title
 		// can't use their name here, since cyborg namepicking is done post-spawn, so we'll just say "A new Cyborg has arrived"/"A new Android has arrived"/etc.
-		GLOB.global_announcer.autosay("A new [rank] has arrived on the station.", "Arrivals Announcement Computer")
+		GLOB.global_announcer.autosay("A new [rank] has arrived on the station.", "Arrivals Announcement Computer", GetConnectedZlevels(get_z(character)))
 
 
 /mob/new_player/proc/create_character(var/turf/T)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -451,7 +451,7 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 	SP.OnSpawn(character)
 	//Announces Cyborgs early, because that is the only way it works
 	if(character.mind.assigned_role == "Cyborg")
-		AnnounceCyborg(character, rank, SP.RenderAnnounceMessage(character, name = character.name, job_name = character.mind.role_alt_title || rank), announce_channel, character.z)
+		AnnounceCyborg(character, rank, SP.RenderAnnounceMessage(character, name = character.name, job_name = character.mind.role_alt_title || rank))
 	character = SSjob.EquipRank(character, rank, 1)	// Equips the human
 	UpdateFactionList(character)
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -499,7 +499,7 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 		if(character.mind.role_alt_title)
 			rank = character.mind.role_alt_title
 		// can't use their name here, since cyborg namepicking is done post-spawn, so we'll just say "A new Cyborg has arrived"/"A new Android has arrived"/etc.
-		GLOB.global_announcer.autosay("A new [rank] has arrived on the station.", "Arrivals Announcement Computer", GetConnectedZlevels(get_z(character)))
+		GLOB.global_announcer.autosay("A new [rank] has arrived on the station.", "Arrivals Announcement Computer", SSmapping.loaded_station.get_map_levels(get_z(character)))
 
 
 /mob/new_player/proc/create_character(var/turf/T)

--- a/code/modules/multiz/basic_legacy.dm
+++ b/code/modules/multiz/basic_legacy.dm
@@ -1,6 +1,9 @@
 
 GLOBAL_LIST_EMPTY(connected_z_cache)
 
+/proc/GetStationZlevels()
+	return (LEGACY_MAP_DATUM).station_levels
+
 // todo: legacy code
 /proc/GetConnectedZlevels(z)
 	return SSmapping.get_z_stack(z)

--- a/code/modules/multiz/basic_legacy.dm
+++ b/code/modules/multiz/basic_legacy.dm
@@ -1,14 +1,8 @@
 
 GLOBAL_LIST_EMPTY(connected_z_cache)
 
-/proc/GetStationZlevels()
-	return (LEGACY_MAP_DATUM).station_levels
-
 // todo: legacy code
-/proc/GetConnectedZlevels(z)
-	return SSmapping.get_z_stack(z)
-
-// todo: legacy code
+// Only used in code\game\machinery\computer\robot.dm Line 47
 /proc/AreConnectedZLevels(zA, zB)
 	if (zA <= 0 || zB <= 0 || zA > world.maxz || zB > world.maxz)
 		return FALSE
@@ -16,7 +10,7 @@ GLOBAL_LIST_EMPTY(connected_z_cache)
 		return TRUE
 	if (length(GLOB.connected_z_cache) >= zA && length(GLOB.connected_z_cache[zA]) >= zB)
 		return GLOB.connected_z_cache[zA][zB]
-	var/list/levels = GetConnectedZlevels(zA)
+	var/list/levels = SSmapping.loaded_station.get_map_levels(zA)
 	var/list/new_entry = new(world.maxz)
 	for (var/entry in levels)
 		new_entry[entry] = TRUE

--- a/code/modules/overmap/entity/entity.dm
+++ b/code/modules/overmap/entity/entity.dm
@@ -46,6 +46,8 @@
 	///
 	/// todo: reevaluate if this is the right way to perform forced movements like wrapping.
 	var/tmp/is_forced_moving = FALSE
+	/// are we the main station
+	var/is_main_station = FALSE
 
 /obj/overmap/entity/New()
 	// assign id immediately

--- a/code/modules/overmap/legacy/disperser/disperser_fire.dm
+++ b/code/modules/overmap/legacy/disperser/disperser_fire.dm
@@ -30,7 +30,7 @@
 				else
 					LEGACY_EX_ACT(A, 1, null)
 
-	var/list/relevant_z = GetConnectedZlevels(start.z)
+	var/list/relevant_z = SSmapping.loaded_station.get_map_levels(start.z)
 	for(var/mob/M in global.GLOB.player_list)
 		var/turf/T = get_turf(M)
 		if(!T || !(T.z in relevant_z))

--- a/code/modules/overmap/legacy/sectors.dm
+++ b/code/modules/overmap/legacy/sectors.dm
@@ -88,7 +88,10 @@
 
 /obj/overmap/entity/visitable/proc/find_z_levels()
 	if(!LAZYLEN(map_z)) // If map_z is already populated use it as-is, otherwise start with connected z-levels.
-		map_z = SSmapping.loaded_station.get_map_levels(z)
+		if(is_main_station)
+			map_z = SSmapping.loaded_station.station_levels.Copy()
+		else
+			map_z = SSmapping.loaded_station.get_map_levels(z)
 	if(LAZYLEN(extra_z_levels))
 		for(var/thing in extra_z_levels)
 			var/datum/map_level/level

--- a/code/modules/overmap/legacy/sectors.dm
+++ b/code/modules/overmap/legacy/sectors.dm
@@ -88,7 +88,7 @@
 
 /obj/overmap/entity/visitable/proc/find_z_levels()
 	if(!LAZYLEN(map_z)) // If map_z is already populated use it as-is, otherwise start with connected z-levels.
-		map_z = GetConnectedZlevels(z)
+		map_z = SSmapping.loaded_station.get_map_levels(z)
 	if(LAZYLEN(extra_z_levels))
 		for(var/thing in extra_z_levels)
 			var/datum/map_level/level

--- a/code/modules/power/engines/rust/core/core_field.dm
+++ b/code/modules/power/engines/rust/core/core_field.dm
@@ -470,12 +470,12 @@ GLOBAL_VAR_INIT(max_fusion_air_heat, INFINITY)
 	var/stablemessage = "Containment field returning to stable conditions."
 
 	if(percent_unstable >= warnpoint) //we're unstable, start warning engineering
-		GLOB.global_announcer.autosay(warnmessage, "Field Stability Monitor", "Engineering", zlevels = GetConnectedZlevels(get_z(src)))
+		GLOB.global_announcer.autosay(warnmessage, "Field Stability Monitor", "Engineering", zlevels = SSmapping.loaded_station.get_map_levels(get_z(src)))
 		stable = 0 //we know we're not stable, so let's not state the safe message.
 		sleep(20)
 		return
 	if(percent_unstable < warnpoint && stable == 0) //The field is stable again. Let's set our safe variable and state the safe message.
-		GLOB.global_announcer.autosay(stablemessage, "Field Stability Monitor", "Engineering", zlevels = GetConnectedZlevels(get_z(src)))
+		GLOB.global_announcer.autosay(stablemessage, "Field Stability Monitor", "Engineering", zlevels = SSmapping.loaded_station.get_map_levels(get_z(src)))
 		stable = 1
 		return
 
@@ -536,7 +536,7 @@ GLOBAL_VAR_INIT(max_fusion_air_heat, INFINITY)
 	visible_message("<span class='danger'>\The [src] shudders like a dying animal before flaring to eye-searing brightness and rupturing!</span>")
 	set_light(15, 15, "#CCCCFF")
 	empulse(get_turf(src), CEILING(plasma_temperature/1000, 1), CEILING(plasma_temperature/300, 1))
-	GLOB.global_announcer.autosay("WARNING: FIELD RUPTURE IMMINENT!", "Containment Monitor", zlevels = GetConnectedZlevels(get_z(src)))
+	GLOB.global_announcer.autosay("WARNING: FIELD RUPTURE IMMINENT!", "Containment Monitor", zlevels = SSmapping.loaded_station.get_map_levels(get_z(src)))
 	RadiateAll()
 	var/list/things_in_range = range(10, owned_core)
 	var/list/turfs_in_range = list()
@@ -562,7 +562,7 @@ GLOBAL_VAR_INIT(max_fusion_air_heat, INFINITY)
 
 /obj/effect/fusion_em_field/proc/MRC() //spews electromagnetic pulses in an area around the core.
 	visible_message("<span class='danger'>\The [src] glows an extremely bright pink and flares out of existance!</span>")
-	GLOB.global_announcer.autosay("Warning! Magnetic Resonance Cascade detected! Brace for electronic system distruption.", "Field Stability Monitor", zlevels = GetConnectedZlevels(get_z(src)))
+	GLOB.global_announcer.autosay("Warning! Magnetic Resonance Cascade detected! Brace for electronic system distruption.", "Field Stability Monitor", zlevels = SSmapping.loaded_station.get_map_levels(get_z(src)))
 	set_light(15, 15, "#ff00d8")
 	var/list/things_in_range = range(15, owned_core)
 	var/list/turfs_in_range = list()
@@ -576,7 +576,7 @@ GLOBAL_VAR_INIT(max_fusion_air_heat, INFINITY)
 	return
 
 /obj/effect/fusion_em_field/proc/QuantumFluxCascade() //spews hot phoron and oxygen in a radius around the RUST. Will probably set fire to things
-	GLOB.global_announcer.autosay("Warning! Quantum fluxuation detected! Flammable gas release expected.", "Field Stability Monitor", zlevels = GetConnectedZlevels(get_z(src)))
+	GLOB.global_announcer.autosay("Warning! Quantum fluxuation detected! Flammable gas release expected.", "Field Stability Monitor", zlevels = SSmapping.loaded_station.get_map_levels(get_z(src)))
 	var/list/things_in_range = range(15, owned_core)
 	var/list/turfs_in_range = list()
 	var/turf/T
@@ -597,7 +597,7 @@ GLOBAL_VAR_INIT(max_fusion_air_heat, INFINITY)
 	return
 
 /obj/effect/fusion_em_field/proc/MagneticQuench() //standard hard shutdown. dumps hot oxygen/phoron into the core's area and releases an EMP in the area around the core.
-	GLOB.global_announcer.autosay("Warning! Magnetic Quench event detected, engaging hard shutdown.", "Field Stability Monitor", zlevels = GetConnectedZlevels(get_z(src)))
+	GLOB.global_announcer.autosay("Warning! Magnetic Quench event detected, engaging hard shutdown.", "Field Stability Monitor", zlevels = SSmapping.loaded_station.get_map_levels(get_z(src)))
 	empulse(owned_core, 10, 15)
 	var/turf/TT = get_turf(owned_core)
 	if(istype(TT))
@@ -617,7 +617,7 @@ GLOBAL_VAR_INIT(max_fusion_air_heat, INFINITY)
 	visible_message("<span class='danger'>\The [src] shudders like a dying animal before flaring to eye-searing brightness and rupturing!</span>")
 	set_light(15, 15, "#CCCCFF")
 	empulse(get_turf(src), CEILING(plasma_temperature/1000, 1), CEILING(plasma_temperature/300, 1))
-	GLOB.global_announcer.autosay("WARNING: FIELD RUPTURE IMMINENT!", "Containment Monitor", zlevels = GetConnectedZlevels(get_z(src)))
+	GLOB.global_announcer.autosay("WARNING: FIELD RUPTURE IMMINENT!", "Containment Monitor", zlevels = SSmapping.loaded_station.get_map_levels(get_z(src)))
 	RadiateAll()
 	var/list/things_in_range = range(10, owned_core)
 	var/list/turfs_in_range = list()

--- a/code/modules/power/engines/rust/core/core_field.dm
+++ b/code/modules/power/engines/rust/core/core_field.dm
@@ -470,12 +470,12 @@ GLOBAL_VAR_INIT(max_fusion_air_heat, INFINITY)
 	var/stablemessage = "Containment field returning to stable conditions."
 
 	if(percent_unstable >= warnpoint) //we're unstable, start warning engineering
-		GLOB.global_announcer.autosay(warnmessage, "Field Stability Monitor", "Engineering")
+		GLOB.global_announcer.autosay(warnmessage, "Field Stability Monitor", "Engineering", zlevels = GetConnectedZlevels(get_z(src)))
 		stable = 0 //we know we're not stable, so let's not state the safe message.
 		sleep(20)
 		return
 	if(percent_unstable < warnpoint && stable == 0) //The field is stable again. Let's set our safe variable and state the safe message.
-		GLOB.global_announcer.autosay(stablemessage, "Field Stability Monitor", "Engineering")
+		GLOB.global_announcer.autosay(stablemessage, "Field Stability Monitor", "Engineering", zlevels = GetConnectedZlevels(get_z(src)))
 		stable = 1
 		return
 
@@ -536,7 +536,7 @@ GLOBAL_VAR_INIT(max_fusion_air_heat, INFINITY)
 	visible_message("<span class='danger'>\The [src] shudders like a dying animal before flaring to eye-searing brightness and rupturing!</span>")
 	set_light(15, 15, "#CCCCFF")
 	empulse(get_turf(src), CEILING(plasma_temperature/1000, 1), CEILING(plasma_temperature/300, 1))
-	GLOB.global_announcer.autosay("WARNING: FIELD RUPTURE IMMINENT!", "Containment Monitor")
+	GLOB.global_announcer.autosay("WARNING: FIELD RUPTURE IMMINENT!", "Containment Monitor", zlevels = GetConnectedZlevels(get_z(src)))
 	RadiateAll()
 	var/list/things_in_range = range(10, owned_core)
 	var/list/turfs_in_range = list()
@@ -562,7 +562,7 @@ GLOBAL_VAR_INIT(max_fusion_air_heat, INFINITY)
 
 /obj/effect/fusion_em_field/proc/MRC() //spews electromagnetic pulses in an area around the core.
 	visible_message("<span class='danger'>\The [src] glows an extremely bright pink and flares out of existance!</span>")
-	GLOB.global_announcer.autosay("Warning! Magnetic Resonance Cascade detected! Brace for electronic system distruption.", "Field Stability Monitor")
+	GLOB.global_announcer.autosay("Warning! Magnetic Resonance Cascade detected! Brace for electronic system distruption.", "Field Stability Monitor", zlevels = GetConnectedZlevels(get_z(src)))
 	set_light(15, 15, "#ff00d8")
 	var/list/things_in_range = range(15, owned_core)
 	var/list/turfs_in_range = list()
@@ -576,7 +576,7 @@ GLOBAL_VAR_INIT(max_fusion_air_heat, INFINITY)
 	return
 
 /obj/effect/fusion_em_field/proc/QuantumFluxCascade() //spews hot phoron and oxygen in a radius around the RUST. Will probably set fire to things
-	GLOB.global_announcer.autosay("Warning! Quantum fluxuation detected! Flammable gas release expected.", "Field Stability Monitor")
+	GLOB.global_announcer.autosay("Warning! Quantum fluxuation detected! Flammable gas release expected.", "Field Stability Monitor", zlevels = GetConnectedZlevels(get_z(src)))
 	var/list/things_in_range = range(15, owned_core)
 	var/list/turfs_in_range = list()
 	var/turf/T
@@ -597,7 +597,7 @@ GLOBAL_VAR_INIT(max_fusion_air_heat, INFINITY)
 	return
 
 /obj/effect/fusion_em_field/proc/MagneticQuench() //standard hard shutdown. dumps hot oxygen/phoron into the core's area and releases an EMP in the area around the core.
-	GLOB.global_announcer.autosay("Warning! Magnetic Quench event detected, engaging hard shutdown.", "Field Stability Monitor")
+	GLOB.global_announcer.autosay("Warning! Magnetic Quench event detected, engaging hard shutdown.", "Field Stability Monitor", zlevels = GetConnectedZlevels(get_z(src)))
 	empulse(owned_core, 10, 15)
 	var/turf/TT = get_turf(owned_core)
 	if(istype(TT))
@@ -617,7 +617,7 @@ GLOBAL_VAR_INIT(max_fusion_air_heat, INFINITY)
 	visible_message("<span class='danger'>\The [src] shudders like a dying animal before flaring to eye-searing brightness and rupturing!</span>")
 	set_light(15, 15, "#CCCCFF")
 	empulse(get_turf(src), CEILING(plasma_temperature/1000, 1), CEILING(plasma_temperature/300, 1))
-	GLOB.global_announcer.autosay("WARNING: FIELD RUPTURE IMMINENT!", "Containment Monitor")
+	GLOB.global_announcer.autosay("WARNING: FIELD RUPTURE IMMINENT!", "Containment Monitor", zlevels = GetConnectedZlevels(get_z(src)))
 	RadiateAll()
 	var/list/things_in_range = range(10, owned_core)
 	var/list/turfs_in_range = list()

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -415,9 +415,9 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 		if(S)
 			levels = S.get_space_zlevels() //Just the spacey ones
 		else
-			levels = GetConnectedZlevels(my_z)
+			levels = SSmapping.loaded_station.get_map_levels(my_z)
 	else
-		levels = GetConnectedZlevels(my_z)
+		levels = SSmapping.loaded_station.get_map_levels(my_z)
 
 	for(var/z in levels)
 		if(!GLOB.gravity_generators["[z]"])

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -171,7 +171,7 @@
 	var/turf/TS = get_turf(src)		// The turf supermatter is on. SM being in a locker, mecha, or other container shouldn't block it's effects that way.
 	if(!TS)
 		return
-	for(var/z in GetConnectedZlevels(TS.z))
+	for(var/z in SSmapping.loaded_station.get_map_levels(TS.z))
 		z_radiation(locate(x, y, z), null, DETONATION_RADS, RAD_FALLOFF_ZLEVEL_SUPERMATTER_DELAMINATION)
 	for(var/mob/living/mob in living_mob_list)
 		var/turf/T = get_turf(mob)
@@ -220,11 +220,11 @@
 	else
 		alert_msg = null
 	if(alert_msg)
-		GLOB.global_announcer.autosay(alert_msg, "Supermatter Monitor", "Engineering", zlevels = GetConnectedZlevels(get_z(src)))
+		GLOB.global_announcer.autosay(alert_msg, "Supermatter Monitor", "Engineering", zlevels = SSmapping.loaded_station.get_map_levels(get_z(src)))
 		investigate_log("Emergency engineering announcement. Power:[power], Oxygen:[oxygen], Damage:[damage], Integrity:[get_integrity()]", INVESTIGATE_SUPERMATTER)
 		//Public alerts
 		if((damage > emergency_point) && !public_alert)
-			GLOB.global_announcer.autosay("WARNING: SUPERMATTER CRYSTAL DELAMINATION IMMINENT!", "Supermatter Monitor", zlevels = GetConnectedZlevels(get_z(src)))
+			GLOB.global_announcer.autosay("WARNING: SUPERMATTER CRYSTAL DELAMINATION IMMINENT!", "Supermatter Monitor", zlevels = SSmapping.loaded_station.get_map_levels(get_z(src)))
 			for(var/mob/M in GLOB.player_list)
 				if(!istype(M,/mob/new_player) && !isdeaf(M))
 					SEND_SOUND(M, message_sound)
@@ -232,12 +232,12 @@
 			public_alert = 1
 			investigate_log("Emergency PUBLIC announcement. Power:[power], Oxygen:[oxygen], Damage:[damage], Integrity:[get_integrity()]", INVESTIGATE_SUPERMATTER)
 		else if((damage > emergency_point) && public_alert)
-			GLOB.global_announcer.autosay("DANGER: SUPERMATTER CRYSTAL DEGRADATION IN PROGRESS! INTEGRITY AT [integrity]%", "Supermatter Monitor", zlevels = GetConnectedZlevels(get_z(src)))
+			GLOB.global_announcer.autosay("DANGER: SUPERMATTER CRYSTAL DEGRADATION IN PROGRESS! INTEGRITY AT [integrity]%", "Supermatter Monitor", zlevels = SSmapping.loaded_station.get_map_levels(get_z(src)))
 			for(var/mob/M in GLOB.player_list)
 				if(!istype(M,/mob/new_player) && !isdeaf(M))
 					SEND_SOUND(M, sound('sound/ambience/engine_alert2.ogg'))
 		else if(safe_warned && public_alert)
-			GLOB.global_announcer.autosay(alert_msg, "Supermatter Monitor", zlevels = GetConnectedZlevels(get_z(src)))
+			GLOB.global_announcer.autosay(alert_msg, "Supermatter Monitor", zlevels = SSmapping.loaded_station.get_map_levels(get_z(src)))
 			public_alert = 0
 
 /obj/machinery/power/supermatter/process(delta_time)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -220,11 +220,11 @@
 	else
 		alert_msg = null
 	if(alert_msg)
-		GLOB.global_announcer.autosay(alert_msg, "Supermatter Monitor", "Engineering")
+		GLOB.global_announcer.autosay(alert_msg, "Supermatter Monitor", "Engineering", zlevels = GetConnectedZlevels(get_z(src)))
 		investigate_log("Emergency engineering announcement. Power:[power], Oxygen:[oxygen], Damage:[damage], Integrity:[get_integrity()]", INVESTIGATE_SUPERMATTER)
 		//Public alerts
 		if((damage > emergency_point) && !public_alert)
-			GLOB.global_announcer.autosay("WARNING: SUPERMATTER CRYSTAL DELAMINATION IMMINENT!", "Supermatter Monitor")
+			GLOB.global_announcer.autosay("WARNING: SUPERMATTER CRYSTAL DELAMINATION IMMINENT!", "Supermatter Monitor", zlevels = GetConnectedZlevels(get_z(src)))
 			for(var/mob/M in GLOB.player_list)
 				if(!istype(M,/mob/new_player) && !isdeaf(M))
 					SEND_SOUND(M, message_sound)
@@ -232,12 +232,12 @@
 			public_alert = 1
 			investigate_log("Emergency PUBLIC announcement. Power:[power], Oxygen:[oxygen], Damage:[damage], Integrity:[get_integrity()]", INVESTIGATE_SUPERMATTER)
 		else if((damage > emergency_point) && public_alert)
-			GLOB.global_announcer.autosay("DANGER: SUPERMATTER CRYSTAL DEGRADATION IN PROGRESS! INTEGRITY AT [integrity]%", "Supermatter Monitor")
+			GLOB.global_announcer.autosay("DANGER: SUPERMATTER CRYSTAL DEGRADATION IN PROGRESS! INTEGRITY AT [integrity]%", "Supermatter Monitor", zlevels = GetConnectedZlevels(get_z(src)))
 			for(var/mob/M in GLOB.player_list)
 				if(!istype(M,/mob/new_player) && !isdeaf(M))
 					SEND_SOUND(M, sound('sound/ambience/engine_alert2.ogg'))
 		else if(safe_warned && public_alert)
-			GLOB.global_announcer.autosay(alert_msg, "Supermatter Monitor")
+			GLOB.global_announcer.autosay(alert_msg, "Supermatter Monitor", zlevels = GetConnectedZlevels(get_z(src)))
 			public_alert = 0
 
 /obj/machinery/power/supermatter/process(delta_time)

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -81,7 +81,7 @@
 		var/list/translation = get_turf_translation(get_turf(shuttle.current_location), get_turf(src), A.contents)
 		if(check_collision(base_area, list_values(translation)))
 			return FALSE
-	var/conn = GetConnectedZlevels(z)
+	var/conn = SSmapping.loaded_station.get_map_levels(z)
 	for(var/w in (z - shuttle.multiz) to z)
 		if(!(w in conn))
 			return FALSE

--- a/code/modules/shuttles/web_datums.dm
+++ b/code/modules/shuttles/web_datums.dm
@@ -121,7 +121,7 @@
 	if(!radio_announce)
 		command_announcement.Announce(get_departure_message(),(announcer ? announcer : "[(LEGACY_MAP_DATUM).boss_name]"))
 	else
-		GLOB.global_announcer.autosay(get_departure_message(),(announcer ? announcer : "[(LEGACY_MAP_DATUM).boss_name]"), zlevels = GetConnectedZlevels(get_z(src.my_landmark)))
+		GLOB.global_announcer.autosay(get_departure_message(),(announcer ? announcer : "[(LEGACY_MAP_DATUM).boss_name]"), zlevels = SSmapping.loaded_station.get_map_levels(get_z(src.my_landmark)))
 
 /datum/shuttle_destination/proc/get_arrival_message()
 	return null
@@ -133,7 +133,7 @@
 	if(!radio_announce)
 		command_announcement.Announce(get_arrival_message(),(announcer ? announcer : "[(LEGACY_MAP_DATUM).boss_name]"))
 	else
-		GLOB.global_announcer.autosay(get_arrival_message(),(announcer ? announcer : "[(LEGACY_MAP_DATUM).boss_name]"), zlevels = GetConnectedZlevels(get_z(src.my_landmark)))
+		GLOB.global_announcer.autosay(get_arrival_message(),(announcer ? announcer : "[(LEGACY_MAP_DATUM).boss_name]"), zlevels = SSmapping.loaded_station.get_map_levels(get_z(src.my_landmark)))
 
 /datum/shuttle_destination/proc/link_destinations(var/datum/shuttle_destination/other_place, var/interim_tag, var/travel_time = 0)
 	// First, check to make sure this doesn't cause a duplicate route.

--- a/code/modules/shuttles/web_datums.dm
+++ b/code/modules/shuttles/web_datums.dm
@@ -121,7 +121,7 @@
 	if(!radio_announce)
 		command_announcement.Announce(get_departure_message(),(announcer ? announcer : "[(LEGACY_MAP_DATUM).boss_name]"))
 	else
-		GLOB.global_announcer.autosay(get_departure_message(),(announcer ? announcer : "[(LEGACY_MAP_DATUM).boss_name]"))
+		GLOB.global_announcer.autosay(get_departure_message(),(announcer ? announcer : "[(LEGACY_MAP_DATUM).boss_name]"), zlevels = GetConnectedZlevels(get_z(src.my_landmark)))
 
 /datum/shuttle_destination/proc/get_arrival_message()
 	return null
@@ -133,7 +133,7 @@
 	if(!radio_announce)
 		command_announcement.Announce(get_arrival_message(),(announcer ? announcer : "[(LEGACY_MAP_DATUM).boss_name]"))
 	else
-		GLOB.global_announcer.autosay(get_arrival_message(),(announcer ? announcer : "[(LEGACY_MAP_DATUM).boss_name]"))
+		GLOB.global_announcer.autosay(get_arrival_message(),(announcer ? announcer : "[(LEGACY_MAP_DATUM).boss_name]"), zlevels = GetConnectedZlevels(get_z(src.my_landmark)))
 
 /datum/shuttle_destination/proc/link_destinations(var/datum/shuttle_destination/other_place, var/interim_tag, var/travel_time = 0)
 	// First, check to make sure this doesn't cause a duplicate route.

--- a/maps/endeavour/endeavour-overmap.dm
+++ b/maps/endeavour/endeavour-overmap.dm
@@ -25,3 +25,4 @@
 		"Mining Shuttle" = list("endeavour_mining_port"),
 		"NDV Quicksilver" = list("endeavour_specops_dock")
 		)
+	is_main_station = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
almost all global broadcasts, like crew arrivals, Supermatter delams and so on, can only be heard on their local Z-Level and its connected Levels. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Why should the station hear a trader thawing, or a trader hear someone arrive on station?
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: most broadcastings that used to be global, to broadcast on its respective map
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
