### PR TITLE
Fixes Surt Mob Factions

### DIFF
--- a/code/game/objects/mob_spawner.dm
+++ b/code/game/objects/mob_spawner.dm
@@ -118,7 +118,7 @@ It also makes it so a ghost wont know where all the goodies/mobs are.
 	icon_state = "tunnel_hole"
 	spawn_delay = 20 MINUTES
 	simultaneous_spawns = 1
-	mob_faction = "lavaland"
+	mob_faction = MOB_IFF_FACTION_BIND_TO_MAP
 	total_spawns = 6
 	integrity_flags = NONE
 	anchored = 1
@@ -133,7 +133,7 @@ It also makes it so a ghost wont know where all the goodies/mobs are.
 	icon_state = "eggy_tunnel"
 	spawn_delay = 10 MINUTES
 	simultaneous_spawns = 3
-	mob_faction = "lavaland"
+	mob_faction = MOB_IFF_FACTION_BIND_TO_MAP
 	total_spawns = 12
 	anchored = 1
 	integrity_flags = NONE
@@ -148,7 +148,7 @@ It also makes it so a ghost wont know where all the goodies/mobs are.
 	icon_state = "punch"
 	spawn_delay = 10 MINUTES
 	simultaneous_spawns = 6
-	mob_faction = "lavaland"
+	mob_faction = MOB_IFF_FACTION_BIND_TO_MAP
 	total_spawns = 12
 	anchored = 1
 	integrity_flags = NONE


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Fixes Surt Mob Factions
Ashlanders should no longer be attacked by animals they are suppose to herd. The issue was that mob spawners which is how Surt generates most of its mobs continue to use the depreciated "lavaland" faction even though Scori now use the "bind-surt" faction from the new factions system.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: spawned Surt mobs now use the BIND_TO_MAP faction like the Scori
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
