### PR TITLE
reworks chaplain/psych alt titles

### DIFF
--- a/code/modules/jobs/job_types/station/civillian/chaplain.dm
+++ b/code/modules/jobs/job_types/station/civillian/chaplain.dm
@@ -19,18 +19,18 @@
 
 	outfit_type = /datum/outfit/job/station/chaplain
 	desc = "The Chaplain ministers to the spiritual needs of the crew."
+	// todo: split up these into numerous civ jobs? therapist should just be a separate job lol
+	//       and keep chaplain / whatever to itself
 	alt_titles = list(
-		"Religious Counselor" = /datum/prototype/struct/alt_title/chaplain/counselor,
-		"Religious Affairs Advisor" = /datum/prototype/struct/alt_title/chaplain/advisor
-		)
+		"Therapist" = /datum/prototype/struct/alt_title/chaplain/therapist,
+		"Counselor" = /datum/prototype/struct/alt_title/chaplain/counselor,
+	)
 
-// Chaplain Alt Titles
+/datum/prototype/struct/alt_title/chaplain/therapist
+	title = "Therapist"
+
 /datum/prototype/struct/alt_title/chaplain/counselor
-	title = "Religious Counselor"
-	title_blurb = "The Religious Counselor attends to the emotional needs of the crew, usually through the lens of a religion or spiritual ideology."
-
-/datum/prototype/struct/alt_title/chaplain/advisor
-	title = "Religious Affairs Advisor"
+	title = "Counselor"
 
 /datum/role/job/station/chaplain/equip(mob/living/carbon/human/H, src)
 	. = ..()

--- a/code/modules/jobs/job_types/station/medical/psychiatrist.dm
+++ b/code/modules/jobs/job_types/station/medical/psychiatrist.dm
@@ -24,19 +24,11 @@
 					ails the mentally unwell, frequently under Security supervision. They understand the effects of various psychoactive drugs."
 	alt_titles = list(
 		"Psychologist" = /datum/prototype/struct/alt_title/psychologist,
-		"Counselor" = /datum/prototype/struct/alt_title/counselor
-		)
+	)
 
 /datum/prototype/struct/alt_title/psychologist
 	title = "Psychologist"
-	title_blurb =  "A Psychologist provides mental health services to crew members in need, focusing more on therapy than medication. They may also be \
-					called upon to determine whatever ails the mentally unwell, frequently under Security supervision."
 	title_outfit = /datum/outfit/job/station/psychiatrist/psychologist
-
-/datum/prototype/struct/alt_title/counselor
-	title = "Counselor"
-	title_blurb = "A Counselor tends to the emotional needs of the crew, and usually specializes in giving advice to those struggling with interpersonal \
-				relationships, addictions, self-esteem issues, and/or grief."
 
 /datum/outfit/job/station/psychiatrist
 	name = OUTFIT_JOB_NAME("Psychiatrist")


### PR DESCRIPTION
removes counsoler from psych
adds therapist to chaplain
removes 'religious' title from chaplain alt titles
removes RAA title from chaplain

# why?

- psych is a medical title; medical staff have medical titles. this is not what your character calls themselves this is official NT titles on manifests and paperwork.
- therapist should be its own role but i can't be bothered to add a new role before i rework jobs and roles again so here you go for now
- RAA was redundant. okay, it was funny, but we don't need "#AA" titles for everything; IAA is a very specific and important role and i'm not interested in diluting it

congratulations i am fed up over alt titles and so i'm actively going to touch them now