### PR TITLE
shapeshifter copy and reset verb

### DIFF
--- a/citadel.dme
+++ b/citadel.dme
@@ -14,6 +14,7 @@
 
 // BEGIN_INCLUDE
 #include "_mapload\_basemap.dm"
+#include "_mapload\minitest.dm"
 #include "code\___compile_options.dm"
 #include "code\__byond_version_compat.dm"
 #include "code\__global_init.dm"

--- a/citadel.dme
+++ b/citadel.dme
@@ -14,7 +14,6 @@
 
 // BEGIN_INCLUDE
 #include "_mapload\_basemap.dm"
-#include "_mapload\minitest.dm"
 #include "code\___compile_options.dm"
 #include "code\__byond_version_compat.dm"
 #include "code\__global_init.dm"

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -144,6 +144,8 @@
 	var/impersonate_bodytype_legacy
 	/// for impersonating a bodytype but actually.
 	var/impersonate_bodytype
+	/// for impersonating a species
+	var/datum/species/impersonate_species_for_iconbase
 	/// Shadekin abilities/potentially other species-based?
 	var/ability_flags = NONE
 	/// Suit sensor loadout pref.

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -144,8 +144,6 @@
 	var/impersonate_bodytype_legacy
 	/// for impersonating a bodytype but actually.
 	var/impersonate_bodytype
-	/// for impersonating a species
-	var/datum/species/impersonate_species_for_iconbase
 	/// Shadekin abilities/potentially other species-based?
 	var/ability_flags = NONE
 	/// Suit sensor loadout pref.

--- a/code/modules/species/protean/protean.dm
+++ b/code/modules/species/protean/protean.dm
@@ -88,7 +88,7 @@
 		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right/unbreakable/nano)
 		)
 
-	//These verbs are hidden, for hotkey use only
+	//Some of these verbs are hidden, for hotkey use only
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/nano_regenerate, //These verbs are hidden so you can macro them,
 		/mob/living/carbon/human/proc/nano_partswap,
@@ -96,6 +96,7 @@
 		/mob/living/carbon/human/proc/nano_blobform,
 		/mob/living/carbon/human/proc/nano_set_size,
 		/mob/living/carbon/human/proc/nano_change_fitting, //These verbs are displayed normally,
+		/mob/living/carbon/human/proc/nano_copy_appearance,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
 		/mob/living/carbon/human/proc/shapeshifter_select_colour,

--- a/code/modules/species/protean/protean.dm
+++ b/code/modules/species/protean/protean.dm
@@ -157,6 +157,12 @@
 		return H.impersonate_bodytype_legacy || ..()
 	return ..()
 
+/datum/species/protean/get_icobase(mob/living/carbon/human/H, get_deform)
+	if(H)
+		return impersonate_species_for_iconbase.get_icobase(H, get_deform)
+	return ..()
+
+
 /datum/species/protean/get_worn_legacy_bodytype(mob/living/carbon/human/H)
 	return H?.impersonate_bodytype_legacy || ..()
 

--- a/code/modules/species/protean/protean.dm
+++ b/code/modules/species/protean/protean.dm
@@ -161,7 +161,7 @@
 	return H?.impersonate_bodytype_legacy || ..()
 
 /datum/species/protean/get_icobase(mob/living/carbon/human/H, get_deform)
-	if(H && !isnull(impersonate_species_for_iconbase))
+	if(H && !isnull(H.impersonate_species_for_iconbase))
 		return H.impersonate_species_for_iconbase.get_icobase(H, get_deform)
 	return ..()
 

--- a/code/modules/species/protean/protean.dm
+++ b/code/modules/species/protean/protean.dm
@@ -160,6 +160,11 @@
 /datum/species/protean/get_worn_legacy_bodytype(mob/living/carbon/human/H)
 	return H?.impersonate_bodytype_legacy || ..()
 
+/datum/species/protean/get_icobase(mob/living/carbon/human/H, get_deform)
+	if(H && !isnull(impersonate_species_for_iconbase))
+		return H.impersonate_species_for_iconbase.get_icobase(H, get_deform)
+	return ..()
+
 /datum/species/protean/create_organs(mob/living/carbon/human/H)
 	H.synth_color = TRUE
 	. = ..()

--- a/code/modules/species/protean/protean.dm
+++ b/code/modules/species/protean/protean.dm
@@ -157,12 +157,6 @@
 		return H.impersonate_bodytype_legacy || ..()
 	return ..()
 
-/datum/species/protean/get_icobase(mob/living/carbon/human/H, get_deform)
-	if(H)
-		return impersonate_species_for_iconbase.get_icobase(H, get_deform)
-	return ..()
-
-
 /datum/species/protean/get_worn_legacy_bodytype(mob/living/carbon/human/H)
 	return H?.impersonate_bodytype_legacy || ..()
 

--- a/code/modules/species/protean/protean.dm
+++ b/code/modules/species/protean/protean.dm
@@ -106,6 +106,7 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_tail,
 		/mob/living/carbon/human/proc/shapeshifter_select_ears,
 		/mob/living/carbon/human/proc/shapeshifter_select_horns,
+		/mob/living/carbon/human/proc/nano_reset_to_slot,
 		/mob/living/proc/eat_trash,
 		/mob/living/carbon/human/proc/succubus_drain,
 		/mob/living/carbon/human/proc/succubus_drain_finalize,

--- a/code/modules/species/protean/protean_blob.dm
+++ b/code/modules/species/protean/protean_blob.dm
@@ -539,7 +539,7 @@
 		return
 
 	var/list/choices = list()
-	for(var/mob/living/carbon/human/M in oviewers(1))
+	for(var/mob/living/carbon/human/M in oview(1))
 		choices += M
 
 	if(!choices.len)

--- a/code/modules/species/protean/protean_powers.dm
+++ b/code/modules/species/protean/protean_powers.dm
@@ -55,6 +55,7 @@
 
 	//Organ exists, let's reshape it
 	var/list/usable_manufacturers = list()
+	usable_manufacturers["Default - Protean"] = null
 	for(var/company in GLOB.chargen_robolimbs)
 		var/datum/robolimb/M = GLOB.chargen_robolimbs[company]
 		if(!(choice in M.parts))
@@ -108,6 +109,7 @@
 		return
 	if(swap_not_rebuild == "Reshape")
 		var/list/usable_manufacturers = list()
+		usable_manufacturers["Default - Protean"] = null
 		for(var/company in GLOB.chargen_robolimbs)
 			var/datum/robolimb/M = GLOB.chargen_robolimbs[company]
 			if(!(BP_TORSO in M.parts))
@@ -294,6 +296,7 @@
 	if(new_species)
 		impersonate_bodytype_legacy = new_species.get_bodytype_legacy()
 		impersonate_bodytype = new_species.default_bodytype
+		impersonate_species_for_iconbase = new_species
 		regenerate_icons() //Expensive, but we need to recrunch all the icons we're wearing
 
 ////
@@ -357,7 +360,7 @@
 
 	for(var/mob/living/carbon/human/M in oview(7))
 		valid_moblist |= M
-	
+
 	var/mob/living/carbon/human/target = input(src,"Who do you wish to target?","Mimic Target") as null|anything in valid_moblist
 
 	if(!istype(target))
@@ -371,74 +374,7 @@
 	if(!do_after(src, 5, target)) //.5 seconds
 		return FALSE
 
-
-	change_gender(target.gender)
-	change_gender_identity(target.identifying_gender)
-	change_hair(target.h_style)
-	change_hair_gradient(target.grad_style)
-	change_facial_hair(target.f_style)
-	change_hair_color(target.r_hair, target.g_hair, target.b_hair)
-	change_grad_color(target.r_grad, target.g_grad, target.b_grad)
-	change_facial_hair_color(target.r_facial, target.g_facial, target.b_facial)
-	change_eye_color(target.r_eyes, target.g_eyes, target.b_eyes)
-
-	if(target.species.species_appearance_flags & HAS_SKIN_COLOR)
-		change_skin_color(target.r_skin, target.g_skin, target.b_skin)
-	if(target.species.species_appearance_flags & HAS_SKIN_TONE)
-		change_skin_tone(target.s_tone)
-	
-	//why are these eploded instead of using the individual colour/style change calls?
-	//so we only have to do the render call once (per accessory). they're way more expensive than hair
-	ear_style = target.ear_style
-	r_ears = target.r_ears
-	g_ears = target.g_ears
-	b_ears = target.b_ears
-	r_ears2 = target.r_ears2
-	g_ears2 = target.g_ears2
-	b_ears2 = target.b_ears2
-	r_ears3 = target.r_ears3
-	g_ears3 = target.g_ears3
-	b_ears3 = target.b_ears3
-	render_spriteacc_ears()
-	
-	r_horn = target.r_horn
-	g_horn = target.g_horn
-	b_horn = target.b_horn
-	r_horn2 = target.r_horn2
-	g_horn2 = target.g_horn2
-	b_horn2 = target.b_horn2
-	r_horn3 = target.r_horn3
-	g_horn3 = target.g_horn3
-	b_horn3 = target.b_horn3
-	render_spriteacc_horns()
-
-	r_tail = target.r_tail
-	g_tail = target.g_tail
-	b_tail = target.b_tail
-	r_tail2 = target.r_tail2
-	g_tail2 = target.g_tail2
-	b_tail2 = target.b_tail2
-	r_tail3 = target.r_tail3
-	g_tail3 = target.g_tail3
-	b_tail3 = target.b_tail3
-	render_spriteacc_tail()
-
-	wing_style = target.wing_style
-	grad_wingstyle = target.grad_wingstyle
-
-	r_gradwing = target.r_gradwing
-	g_gradwing = target.g_gradwing
-	b_gradwing = target.b_gradwing
-	r_wing = target.r_wing
-	g_wing = target.g_wing
-	b_wing = target.b_wing
-	r_wing2 = target.r_wing2
-	g_wing2 = target.g_wing2
-	b_wing2 = target.b_wing2
-	r_wing3 = target.r_wing3
-	g_wing3 = target.g_wing3
-	b_wing3 = target.b_wing3
-	render_spriteacc_wings()
+	shapeshifter_copy_core_features(target)
 
 
 	//markings and limbs time.
@@ -453,10 +389,13 @@
 			if((their_organ.robotic >= ORGAN_ROBOT))
 				our_organ.robotize(their_organ.model)
 			our_organ.markings = their_organ.markings
+		if(our_organ)
+			our_organ.sync_colour_to_human(src)
 
 	if(target.species)
 		impersonate_bodytype_legacy = target.species.get_bodytype_legacy()
 		impersonate_bodytype = target.species.default_bodytype
+		impersonate_species_for_iconbase = target.species
 		regenerate_icons() //Expensive, but we need to recrunch all the icons we're wearing
 
 	visible_message("<span class='warning'>[src] transforms into a near-perfect visual copy of [target]!</span>") //you can clearly SEE them transform, so

--- a/code/modules/species/protean/protean_powers.dm
+++ b/code/modules/species/protean/protean_powers.dm
@@ -294,6 +294,7 @@
 	if(new_species)
 		impersonate_bodytype_legacy = new_species.get_bodytype_legacy()
 		impersonate_bodytype = new_species.default_bodytype
+		impersonate_species_for_iconbase = new_species
 		regenerate_icons() //Expensive, but we need to recrunch all the icons we're wearing
 
 ////
@@ -357,7 +358,7 @@
 
 	for(var/mob/living/carbon/human/M in oview(7))
 		valid_moblist |= M
-	
+
 	var/mob/living/carbon/human/target = input(src,"Who do you wish to target?","Mimic Target") as null|anything in valid_moblist
 
 	if(!istype(target))
@@ -372,77 +373,11 @@
 		return FALSE
 
 
-	change_gender(target.gender)
-	change_gender_identity(target.identifying_gender)
-	change_hair(target.h_style)
-	change_hair_gradient(target.grad_style)
-	change_facial_hair(target.f_style)
-	change_hair_color(target.r_hair, target.g_hair, target.b_hair)
-	change_grad_color(target.r_grad, target.g_grad, target.b_grad)
-	change_facial_hair_color(target.r_facial, target.g_facial, target.b_facial)
-	change_eye_color(target.r_eyes, target.g_eyes, target.b_eyes)
-
-	if(target.species.species_appearance_flags & HAS_SKIN_COLOR)
-		change_skin_color(target.r_skin, target.g_skin, target.b_skin)
-	if(target.species.species_appearance_flags & HAS_SKIN_TONE)
-		change_skin_tone(target.s_tone)
-	
-	//why are these eploded instead of using the individual colour/style change calls?
-	//so we only have to do the render call once (per accessory). they're way more expensive than hair
-	ear_style = target.ear_style
-	r_ears = target.r_ears
-	g_ears = target.g_ears
-	b_ears = target.b_ears
-	r_ears2 = target.r_ears2
-	g_ears2 = target.g_ears2
-	b_ears2 = target.b_ears2
-	r_ears3 = target.r_ears3
-	g_ears3 = target.g_ears3
-	b_ears3 = target.b_ears3
-	render_spriteacc_ears()
-	
-	r_horn = target.r_horn
-	g_horn = target.g_horn
-	b_horn = target.b_horn
-	r_horn2 = target.r_horn2
-	g_horn2 = target.g_horn2
-	b_horn2 = target.b_horn2
-	r_horn3 = target.r_horn3
-	g_horn3 = target.g_horn3
-	b_horn3 = target.b_horn3
-	render_spriteacc_horns()
-
-	r_tail = target.r_tail
-	g_tail = target.g_tail
-	b_tail = target.b_tail
-	r_tail2 = target.r_tail2
-	g_tail2 = target.g_tail2
-	b_tail2 = target.b_tail2
-	r_tail3 = target.r_tail3
-	g_tail3 = target.g_tail3
-	b_tail3 = target.b_tail3
-	render_spriteacc_tail()
-
-	wing_style = target.wing_style
-	grad_wingstyle = target.grad_wingstyle
-
-	r_gradwing = target.r_gradwing
-	g_gradwing = target.g_gradwing
-	b_gradwing = target.b_gradwing
-	r_wing = target.r_wing
-	g_wing = target.g_wing
-	b_wing = target.b_wing
-	r_wing2 = target.r_wing2
-	g_wing2 = target.g_wing2
-	b_wing2 = target.b_wing2
-	r_wing3 = target.r_wing3
-	g_wing3 = target.g_wing3
-	b_wing3 = target.b_wing3
-	render_spriteacc_wings()
+	shapeshifter_copy_core_and_accessories(target)
 
 
 	//markings and limbs time.
-	//ensure we get synthlimb markings if target has them
+	//ensure we get synthlimb markings if target has them. this is just true/false
 	synth_markings = target.synth_markings
 
 	//copies all of the target's markings.

--- a/code/modules/species/protean/protean_powers.dm
+++ b/code/modules/species/protean/protean_powers.dm
@@ -367,7 +367,7 @@
 		return FALSE
 
 	if(get_dist(src,target) > 7)
-		to_chat(src,"<span class='warning'>There's nobody nearby to use this on.</span>")
+		to_chat(src,"<span class='warning'>That person is too far away.</span>")
 		return FALSE
 
 	visible_message("<span class='warning'>[src] deforms and contorts strangely...</span>")
@@ -433,7 +433,7 @@
 		BP_R_LEG,
 		BP_R_FOOT
 	))
-		var/status = pref.organ_data[name]
+
 		var/obj/item/organ/external/O = src.organs_by_name[name]
 		if(O)
 			if(pref.rlimb_data[name])

--- a/code/modules/species/protean/protean_powers.dm
+++ b/code/modules/species/protean/protean_powers.dm
@@ -409,7 +409,7 @@
 	if(stat || world.time < last_special)
 		return
 
-	last_special = world.time + 1 MINUTE
+	last_special = world.time + 20 SECONDS
 
 	visible_message("<span class='warning'>[src] deforms and contorts strangely...</span>")
 	
@@ -435,14 +435,10 @@
 		var/status = pref.organ_data[name]
 		var/obj/item/organ/external/O = src.organs_by_name[name]
 		if(O)
-			if(status == "amputated")
-				O.remove_rejuv()
-			else if(status == "cyborg")
-				if(pref.rlimb_data[name])
-					// use force to override prior robotizations oh god THIS IS BAD
-					O.robotize(pref.rlimb_data[name], null, null, TRUE)
-				else
-					O.robotize()
+			if(pref.rlimb_data[name])
+				O.robotize(pref.rlimb_data[name])
+			else
+				O.robotize()
 
 //protean
 	impersonate_bodytype_legacy = null

--- a/code/modules/species/protean/protean_powers.dm
+++ b/code/modules/species/protean/protean_powers.dm
@@ -343,6 +343,124 @@
 
 	user.visible_message("<span class='notice'>Black mist swirls around [user] as they change size.</span>")
 
+
+/mob/living/carbon/human/proc/nano_copy_appearance()
+	set name = "Mimic Appearance"
+	set category = "Abilities"
+
+	if(stat || world.time < last_special)
+		return
+
+	last_special = world.time + 50 //eh, i'll just leave it as an additional cooldown
+
+	var/list/valid_moblist = list()
+
+	for(var/mob/living/carbon/human/M in oview(7))
+		valid_moblist |= M
+	
+	var/mob/living/carbon/human/target = input(src,"Who do you wish to target?","Mimic Target") as null|anything in valid_moblist
+
+	if(!istype(target))
+		return FALSE
+
+	if(get_dist(src,target) > 7)
+		to_chat(src,"<span class='warning'>There's nobody nearby to use this on.</span>")
+		return FALSE
+
+	visible_message("<span class='warning'>[src] deforms and contorts strangely...</span>")
+	if(!do_after(src, 5, target)) //.5 seconds
+		return FALSE
+
+
+	change_gender(target.gender)
+	change_gender_identity(target.identifying_gender)
+	change_hair(target.h_style)
+	change_hair_gradient(target.grad_style)
+	change_facial_hair(target.f_style)
+	change_hair_color(target.r_hair, target.g_hair, target.b_hair)
+	change_grad_color(target.r_grad, target.g_grad, target.b_grad)
+	change_facial_hair_color(target.r_facial, target.g_facial, target.b_facial)
+	change_eye_color(target.r_eyes, target.g_eyes, target.b_eyes)
+
+	if(target.species.species_appearance_flags & HAS_SKIN_COLOR)
+		change_skin_color(target.r_skin, target.g_skin, target.b_skin)
+	if(target.species.species_appearance_flags & HAS_SKIN_TONE)
+		change_skin_tone(target.s_tone)
+	
+	//why are these eploded instead of using the individual colour/style change calls?
+	//so we only have to do the render call once (per accessory). they're way more expensive than hair
+	ear_style = target.ear_style
+	r_ears = target.r_ears
+	g_ears = target.g_ears
+	b_ears = target.b_ears
+	r_ears2 = target.r_ears2
+	g_ears2 = target.g_ears2
+	b_ears2 = target.b_ears2
+	r_ears3 = target.r_ears3
+	g_ears3 = target.g_ears3
+	b_ears3 = target.b_ears3
+	render_spriteacc_ears()
+	
+	r_horn = target.r_horn
+	g_horn = target.g_horn
+	b_horn = target.b_horn
+	r_horn2 = target.r_horn2
+	g_horn2 = target.g_horn2
+	b_horn2 = target.b_horn2
+	r_horn3 = target.r_horn3
+	g_horn3 = target.g_horn3
+	b_horn3 = target.b_horn3
+	render_spriteacc_horns()
+
+	r_tail = target.r_tail
+	g_tail = target.g_tail
+	b_tail = target.b_tail
+	r_tail2 = target.r_tail2
+	g_tail2 = target.g_tail2
+	b_tail2 = target.b_tail2
+	r_tail3 = target.r_tail3
+	g_tail3 = target.g_tail3
+	b_tail3 = target.b_tail3
+	render_spriteacc_tail()
+
+	wing_style = target.wing_style
+	wing_gradstyle = target.grad_wingstyle
+
+	r_gradwing = target.r_gradwing
+	g_gradwing = target.g_gradwing
+	b_gradwing = target.b_gradwing
+	r_wing = target.r_wing
+	g_wing = target.g_wing
+	b_wing = target.b_wing
+	r_wing2 = target.r_wing2
+	g_wing2 = target.g_wing2
+	b_wing2 = target.b_wing2
+	r_wing3 = target.r_wing3
+	g_wing3 = target.g_wing3
+	b_wing3 = target.b_wing3
+	render_spriteacc_wings()
+
+
+	//markings and limbs time.
+	//ensure we get synthlimb markings if target has them
+	synth_markings = target.synth_markings
+
+	//copies all of the target's markings.
+	for(var/BP in target.organs_by_name)
+		var/obj/item/organ/external/their_organ = target.organs_by_name[BP]
+		var/obj/item/organ/external/our_organ = organs_by_name[BP]
+		if(their_organ && our_organ)
+			if((their_bp.robotic >= ORGAN_ROBOT))
+				our_organ.robotize(their_organ.model)
+			our_organ.markings = their_organ.markings
+
+	if(target.species)
+		impersonate_bodytype_legacy = target.species.get_bodytype_legacy()
+		impersonate_bodytype = target.species.default_bodytype
+		regenerate_icons() //Expensive, but we need to recrunch all the icons we're wearing
+
+	visible_message("<span class='warning'>[src] transforms into a near-perfect visual copy of [target]!</span>") //you can clearly SEE them transform, so
+
 /// /// /// A helper to reuse
 /mob/living/proc/nano_get_refactory(obj/item/organ/internal/nano/refactory/R)
 	if(istype(R))

--- a/code/modules/species/protean/protean_powers.dm
+++ b/code/modules/species/protean/protean_powers.dm
@@ -371,7 +371,7 @@
 		return FALSE
 
 	visible_message("<span class='warning'>[src] deforms and contorts strangely...</span>")
-	if(!do_after(src, 5, target)) //.5 seconds
+	if(!do_after(src, 5)) //.5 seconds
 		return FALSE
 
 	shapeshifter_copy_core_features(target)
@@ -400,6 +400,55 @@
 	regenerate_icons() //Expensive, but we need to recrunch all the icons we're wearing
 
 	visible_message("<span class='warning'>[src] transforms into a near-perfect visual copy of [target]!</span>") //you can clearly SEE them transform, so
+
+/mob/living/carbon/human/proc/nano_reset_to_slot()
+	set name = "Reset Appearance to Slot"
+	set category = "Abilities"
+	set desc = "Resets your character's appearance to the CURRENTLY-SELECTED slot."
+
+	if(stat || world.time < last_special)
+		return
+
+	last_special = world.time + 1 MINUTE
+
+	visible_message("<span class='warning'>[src] deforms and contorts strangely...</span>")
+	
+	if(!do_after(src, 50)) //5 seconds
+		return FALSE
+
+	shapeshifter_reset_to_slot_core(src)
+
+	var/datum/preferences/pref = src.client.prefs
+	for(var/name in list(
+		BP_TORSO,
+		BP_GROIN,
+		BP_HEAD,
+		BP_L_ARM,
+		BP_L_HAND,
+		BP_R_ARM,
+		BP_R_HAND,
+		BP_L_LEG,
+		BP_L_FOOT,
+		BP_R_LEG,
+		BP_R_FOOT
+	))
+		var/status = pref.organ_data[name]
+		var/obj/item/organ/external/O = src.organs_by_name[name]
+		if(O)
+			if(status == "amputated")
+				O.remove_rejuv()
+			else if(status == "cyborg")
+				if(pref.rlimb_data[name])
+					// use force to override prior robotizations oh god THIS IS BAD
+					O.robotize(pref.rlimb_data[name], null, null, TRUE)
+				else
+					O.robotize()
+
+//protean
+	impersonate_bodytype_legacy = null
+	impersonate_bodytype = null
+
+	regenerate_icons()
 
 /// /// /// A helper to reuse
 /mob/living/proc/nano_get_refactory(obj/item/organ/internal/nano/refactory/R)

--- a/code/modules/species/protean/protean_powers.dm
+++ b/code/modules/species/protean/protean_powers.dm
@@ -294,7 +294,6 @@
 	if(new_species)
 		impersonate_bodytype_legacy = new_species.get_bodytype_legacy()
 		impersonate_bodytype = new_species.default_bodytype
-		impersonate_species_for_iconbase = new_species
 		regenerate_icons() //Expensive, but we need to recrunch all the icons we're wearing
 
 ////
@@ -358,7 +357,7 @@
 
 	for(var/mob/living/carbon/human/M in oview(7))
 		valid_moblist |= M
-
+	
 	var/mob/living/carbon/human/target = input(src,"Who do you wish to target?","Mimic Target") as null|anything in valid_moblist
 
 	if(!istype(target))
@@ -373,11 +372,77 @@
 		return FALSE
 
 
-	shapeshifter_copy_core_and_accessories(target)
+	change_gender(target.gender)
+	change_gender_identity(target.identifying_gender)
+	change_hair(target.h_style)
+	change_hair_gradient(target.grad_style)
+	change_facial_hair(target.f_style)
+	change_hair_color(target.r_hair, target.g_hair, target.b_hair)
+	change_grad_color(target.r_grad, target.g_grad, target.b_grad)
+	change_facial_hair_color(target.r_facial, target.g_facial, target.b_facial)
+	change_eye_color(target.r_eyes, target.g_eyes, target.b_eyes)
+
+	if(target.species.species_appearance_flags & HAS_SKIN_COLOR)
+		change_skin_color(target.r_skin, target.g_skin, target.b_skin)
+	if(target.species.species_appearance_flags & HAS_SKIN_TONE)
+		change_skin_tone(target.s_tone)
+	
+	//why are these eploded instead of using the individual colour/style change calls?
+	//so we only have to do the render call once (per accessory). they're way more expensive than hair
+	ear_style = target.ear_style
+	r_ears = target.r_ears
+	g_ears = target.g_ears
+	b_ears = target.b_ears
+	r_ears2 = target.r_ears2
+	g_ears2 = target.g_ears2
+	b_ears2 = target.b_ears2
+	r_ears3 = target.r_ears3
+	g_ears3 = target.g_ears3
+	b_ears3 = target.b_ears3
+	render_spriteacc_ears()
+	
+	r_horn = target.r_horn
+	g_horn = target.g_horn
+	b_horn = target.b_horn
+	r_horn2 = target.r_horn2
+	g_horn2 = target.g_horn2
+	b_horn2 = target.b_horn2
+	r_horn3 = target.r_horn3
+	g_horn3 = target.g_horn3
+	b_horn3 = target.b_horn3
+	render_spriteacc_horns()
+
+	r_tail = target.r_tail
+	g_tail = target.g_tail
+	b_tail = target.b_tail
+	r_tail2 = target.r_tail2
+	g_tail2 = target.g_tail2
+	b_tail2 = target.b_tail2
+	r_tail3 = target.r_tail3
+	g_tail3 = target.g_tail3
+	b_tail3 = target.b_tail3
+	render_spriteacc_tail()
+
+	wing_style = target.wing_style
+	grad_wingstyle = target.grad_wingstyle
+
+	r_gradwing = target.r_gradwing
+	g_gradwing = target.g_gradwing
+	b_gradwing = target.b_gradwing
+	r_wing = target.r_wing
+	g_wing = target.g_wing
+	b_wing = target.b_wing
+	r_wing2 = target.r_wing2
+	g_wing2 = target.g_wing2
+	b_wing2 = target.b_wing2
+	r_wing3 = target.r_wing3
+	g_wing3 = target.g_wing3
+	b_wing3 = target.b_wing3
+	render_spriteacc_wings()
 
 
 	//markings and limbs time.
-	//ensure we get synthlimb markings if target has them. this is just true/false
+	//ensure we get synthlimb markings if target has them
 	synth_markings = target.synth_markings
 
 	//copies all of the target's markings.

--- a/code/modules/species/protean/protean_powers.dm
+++ b/code/modules/species/protean/protean_powers.dm
@@ -389,7 +389,8 @@
 			if((their_organ.robotic >= ORGAN_ROBOT))
 				our_organ.robotize(their_organ.model)
 			our_organ.s_col_blend = their_organ.s_col_blend
-			our_organ.markings = their_organ.markings
+			var/list/markings_to_copy = their_organ.markings.Copy()
+			our_organ.markings = markings_to_copy
 		if(our_organ)
 			our_organ.sync_colour_to_human(src)
 

--- a/code/modules/species/protean/protean_powers.dm
+++ b/code/modules/species/protean/protean_powers.dm
@@ -424,7 +424,7 @@
 	render_spriteacc_tail()
 
 	wing_style = target.wing_style
-	wing_gradstyle = target.grad_wingstyle
+	grad_wingstyle = target.grad_wingstyle
 
 	r_gradwing = target.r_gradwing
 	g_gradwing = target.g_gradwing
@@ -450,7 +450,7 @@
 		var/obj/item/organ/external/their_organ = target.organs_by_name[BP]
 		var/obj/item/organ/external/our_organ = organs_by_name[BP]
 		if(their_organ && our_organ)
-			if((their_bp.robotic >= ORGAN_ROBOT))
+			if((their_organ.robotic >= ORGAN_ROBOT))
 				our_organ.robotize(their_organ.model)
 			our_organ.markings = their_organ.markings
 

--- a/code/modules/species/protean/protean_powers.dm
+++ b/code/modules/species/protean/protean_powers.dm
@@ -388,6 +388,7 @@
 		if(their_organ && our_organ)
 			if((their_organ.robotic >= ORGAN_ROBOT))
 				our_organ.robotize(their_organ.model)
+			our_organ.s_col_blend = their_organ.s_col_blend
 			our_organ.markings = their_organ.markings
 		if(our_organ)
 			our_organ.sync_colour_to_human(src)
@@ -396,7 +397,7 @@
 		impersonate_bodytype_legacy = target.species.get_bodytype_legacy()
 		impersonate_bodytype = target.species.default_bodytype
 		impersonate_species_for_iconbase = target.species
-		regenerate_icons() //Expensive, but we need to recrunch all the icons we're wearing
+	regenerate_icons() //Expensive, but we need to recrunch all the icons we're wearing
 
 	visible_message("<span class='warning'>[src] transforms into a near-perfect visual copy of [target]!</span>") //you can clearly SEE them transform, so
 

--- a/code/modules/species/species_shapeshift.dm
+++ b/code/modules/species/species_shapeshift.dm
@@ -576,6 +576,10 @@ var/list/wrapped_species_by_ref = list()
 	if(!istype(target))
 		return FALSE
 
+	if(target.client.prefs.resleeve_lock)
+		to_chat(src,"<span class='warning'>This person has enabled Prevent Body Impersonation, you cannot copy them!</span>")
+		return FALSE
+
 	if(get_dist(src,target) > 3)
 		to_chat(src,"<span class='warning'>There's nobody nearby to use this on.</span>")
 		return FALSE

--- a/code/modules/species/species_shapeshift.dm
+++ b/code/modules/species/species_shapeshift.dm
@@ -596,6 +596,7 @@ var/list/wrapped_species_by_ref = list()
 		var/obj/item/organ/external/their_organ = target.organs_by_name[BP]
 		var/obj/item/organ/external/our_organ = organs_by_name[BP]
 		if(their_organ && our_organ)
+			our_organ.s_col_blend = their_organ.s_col_blend
 			our_organ.markings = their_organ.markings
 		if(our_organ)
 			our_organ.sync_colour_to_human(src)
@@ -603,7 +604,7 @@ var/list/wrapped_species_by_ref = list()
 	//for xenochim and prommies only
 	if(target.species && istype(target.species, /datum/species))
 		wrapped_species_by_ref["\ref[src]"] = target.species.name
-		regenerate_icons()
+	regenerate_icons()
 
 
 

--- a/code/modules/species/species_shapeshift.dm
+++ b/code/modules/species/species_shapeshift.dm
@@ -214,6 +214,7 @@ var/list/wrapped_species_by_ref = list()
 		g_facial = g_skin
 		b_facial = b_skin
 
+
 	for(var/obj/item/organ/external/E in organs)
 		E.sync_colour_to_human(src)
 
@@ -556,8 +557,8 @@ var/list/wrapped_species_by_ref = list()
 	..()
 
 
-/mob/living/carbon/human/proc/copy_appearance()
-	set name = "Mimic Appearance" 
+/mob/living/carbon/human/proc/shapeshifter_copy_appearance()
+	set name = "Mimic Appearance"
 	set category = "Abilities"
 
 	if(stat || world.time < last_special)
@@ -569,21 +570,39 @@ var/list/wrapped_species_by_ref = list()
 
 	for(var/mob/living/carbon/human/M in oview(7))
 		valid_moblist |= M
-	
+
 	var/mob/living/carbon/human/target = input(src,"Who do you wish to target?","Mimic Target") as null|anything in valid_moblist
 
 	if(!istype(target))
 		return FALSE
 
-	if(get_dist(src,target) > 7)
+	if(get_dist(src,target) > 3)
 		to_chat(src,"<span class='warning'>There's nobody nearby to use this on.</span>")
 		return FALSE
 
 	visible_message("<span class='warning'>[src] deforms and contorts strangely...</span>")
-	if(!do_after(src, 5, target)) //.5 seconds
+	if(!do_after(src, 50, target)) //5 seconds
 		return FALSE
 
+	shapeshifter_copy_core_and_accessories(target)
+	//markings and limbs time.
 
+	//copies all of the target's markings.
+	for(var/BP in target.organs_by_name)
+		var/obj/item/organ/external/their_organ = target.organs_by_name[BP]
+		var/obj/item/organ/external/our_organ = organs_by_name[BP]
+		if(their_organ && our_organ)
+			our_organ.markings = their_organ.markings
+		if(our_organ)
+			our_organ.sync_colour_to_human(src)
+
+	// for xenochim only
+	if(target.species && istype(target.species, /datum/species) && (wrapped_species_by_ref["\ref[src]"] != target.species) )
+		wrapped_species_by_ref["\ref[src]"] = target.species.name
+		regenerate_icons()
+
+
+/mob/living/carbon/human/proc/shapeshifter_copy_core_and_accessories(var/mob/living/carbon/human/target)
 	change_gender(target.gender)
 	change_gender_identity(target.identifying_gender)
 	change_hair(target.h_style)
@@ -596,9 +615,12 @@ var/list/wrapped_species_by_ref = list()
 
 	if(target.species.species_appearance_flags & HAS_SKIN_COLOR)
 		change_skin_color(target.r_skin, target.g_skin, target.b_skin)
+		r_synth = r_skin
+		g_synth = g_skin
+		b_synth = b_skin
 	if(target.species.species_appearance_flags & HAS_SKIN_TONE)
 		change_skin_tone(target.s_tone)
-	
+
 	//why are these eploded instead of using the individual colour/style change calls?
 	//so we only have to do the render call once (per accessory). they're way more expensive than hair
 	ear_style = target.ear_style
@@ -612,7 +634,8 @@ var/list/wrapped_species_by_ref = list()
 	g_ears3 = target.g_ears3
 	b_ears3 = target.b_ears3
 	render_spriteacc_ears()
-	
+
+	horn_style = target.horn_style
 	r_horn = target.r_horn
 	g_horn = target.g_horn
 	b_horn = target.b_horn
@@ -624,6 +647,7 @@ var/list/wrapped_species_by_ref = list()
 	b_horn3 = target.b_horn3
 	render_spriteacc_horns()
 
+	tail_style = target.tail_style
 	r_tail = target.r_tail
 	g_tail = target.g_tail
 	b_tail = target.b_tail
@@ -651,27 +675,3 @@ var/list/wrapped_species_by_ref = list()
 	g_wing3 = target.g_wing3
 	b_wing3 = target.b_wing3
 	render_spriteacc_wings()
-
-
-	//markings and limbs time.
-	//ensure we get synthlimb markings if target has them
-	synth_markings = target.synth_markings
-
-	//copies all of the target's markings.
-	for(var/BP in target.organs_by_name)
-		var/obj/item/organ/external/their_organ = target.organs_by_name[BP]
-		var/obj/item/organ/external/our_organ = organs_by_name[BP]
-		if(their_organ && our_organ)
-			our_organ.markings = their_organ.markings
-
-/* for xenochim and prommies only
-	if(target.species && istype(target.species, /datum/species) && (wrapped_species_by_ref["\ref[src]"] != target.species) )
-		wrapped_species_by_ref["\ref[src]"] = target.species
-		regenerate_icons()
-	*/
-
-	/*if(target.species)
-		impersonate_bodytype_legacy = target.species.get_bodytype_legacy()
-		impersonate_bodytype = target.species.default_bodytype
-		regenerate_icons() //Expensive, but we need to recrunch all the icons we're wearing
-		*/

--- a/code/modules/species/species_shapeshift.dm
+++ b/code/modules/species/species_shapeshift.dm
@@ -554,3 +554,126 @@ var/list/wrapped_species_by_ref = list()
 			H.nutrition -= (2 * nutrition_cost) //Costs Nutrition when damage is being repaired, corresponding to the amount of damage being repaired.
 			H.nutrition = max(0, H.nutrition) //Ensure it's not below 0.
 	..()
+
+
+/mob/living/carbon/human/proc/copy_appearance()
+	set name = "Mimic Appearance" 
+	set category = "Abilities"
+
+	if(stat || world.time < last_special)
+		return
+
+	last_special = world.time + 50 //eh, i'll just leave it as an additional cooldown
+
+	var/list/valid_moblist = list()
+
+	for(var/mob/living/carbon/human/M in oview(7))
+		valid_moblist |= M
+	
+	var/mob/living/carbon/human/target = input(src,"Who do you wish to target?","Mimic Target") as null|anything in valid_moblist
+
+	if(!istype(target))
+		return FALSE
+
+	if(get_dist(src,target) > 7)
+		to_chat(src,"<span class='warning'>There's nobody nearby to use this on.</span>")
+		return FALSE
+
+	visible_message("<span class='warning'>[src] deforms and contorts strangely...</span>")
+	if(!do_after(src, 5, target)) //.5 seconds
+		return FALSE
+
+
+	change_gender(target.gender)
+	change_gender_identity(target.identifying_gender)
+	change_hair(target.h_style)
+	change_hair_gradient(target.grad_style)
+	change_facial_hair(target.f_style)
+	change_hair_color(target.r_hair, target.g_hair, target.b_hair)
+	change_grad_color(target.r_grad, target.g_grad, target.b_grad)
+	change_facial_hair_color(target.r_facial, target.g_facial, target.b_facial)
+	change_eye_color(target.r_eyes, target.g_eyes, target.b_eyes)
+
+	if(target.species.species_appearance_flags & HAS_SKIN_COLOR)
+		change_skin_color(target.r_skin, target.g_skin, target.b_skin)
+	if(target.species.species_appearance_flags & HAS_SKIN_TONE)
+		change_skin_tone(target.s_tone)
+	
+	//why are these eploded instead of using the individual colour/style change calls?
+	//so we only have to do the render call once (per accessory). they're way more expensive than hair
+	ear_style = target.ear_style
+	r_ears = target.r_ears
+	g_ears = target.g_ears
+	b_ears = target.b_ears
+	r_ears2 = target.r_ears2
+	g_ears2 = target.g_ears2
+	b_ears2 = target.b_ears2
+	r_ears3 = target.r_ears3
+	g_ears3 = target.g_ears3
+	b_ears3 = target.b_ears3
+	render_spriteacc_ears()
+	
+	r_horn = target.r_horn
+	g_horn = target.g_horn
+	b_horn = target.b_horn
+	r_horn2 = target.r_horn2
+	g_horn2 = target.g_horn2
+	b_horn2 = target.b_horn2
+	r_horn3 = target.r_horn3
+	g_horn3 = target.g_horn3
+	b_horn3 = target.b_horn3
+	render_spriteacc_horns()
+
+	r_tail = target.r_tail
+	g_tail = target.g_tail
+	b_tail = target.b_tail
+	r_tail2 = target.r_tail2
+	g_tail2 = target.g_tail2
+	b_tail2 = target.b_tail2
+	r_tail3 = target.r_tail3
+	g_tail3 = target.g_tail3
+	b_tail3 = target.b_tail3
+	render_spriteacc_tail()
+
+	wing_style = target.wing_style
+	wing_gradstyle = target.grad_wingstyle
+
+	r_gradwing = target.r_gradwing
+	g_gradwing = target.g_gradwing
+	b_gradwing = target.b_gradwing
+	r_wing = target.r_wing
+	g_wing = target.g_wing
+	b_wing = target.b_wing
+	r_wing2 = target.r_wing2
+	g_wing2 = target.g_wing2
+	b_wing2 = target.b_wing2
+	r_wing3 = target.r_wing3
+	g_wing3 = target.g_wing3
+	b_wing3 = target.b_wing3
+	render_spriteacc_wings()
+
+
+	//markings and limbs time.
+	//ensure we get synthlimb markings if target has them
+	synth_markings = target.synth_markings
+
+	//copies all of the target's markings.
+	for(var/BP in target.organs_by_name)
+		var/obj/item/organ/external/their_organ = target.organs_by_name[BP]
+		var/obj/item/organ/external/our_organ = organs_by_name[BP]
+		if(their_organ && our_organ)
+			if((their_bp.robotic >= ORGAN_ROBOT))
+				our_organ.robotize(their_organ.model)
+			our_organ.markings = their_organ.markings
+
+/* for xenochim and prommies only
+	if(target.species && istype(target.species, /datum/species) && (wrapped_species_by_ref["\ref[src]"] != target.species) )
+		wrapped_species_by_ref["\ref[src]"] = target.species
+		regenerate_icons()
+	*/
+
+	/*if(target.species)
+		impersonate_bodytype_legacy = target.species.get_bodytype_legacy()
+		impersonate_bodytype = target.species.default_bodytype
+		regenerate_icons() //Expensive, but we need to recrunch all the icons we're wearing
+		*/

--- a/code/modules/species/species_shapeshift.dm
+++ b/code/modules/species/species_shapeshift.dm
@@ -556,63 +556,6 @@ var/list/wrapped_species_by_ref = list()
 	..()
 
 
-/mob/living/carbon/human/proc/shapeshifter_copy_appearance()
-	set name = "Mimic Appearance"
-	set category = "Abilities"
-
-	if(stat || world.time < last_special)
-		return
-
-	last_special = world.time + 50 //eh, i'll just leave it as an additional cooldown
-
-	var/list/valid_moblist = list()
-
-	for(var/mob/living/carbon/human/M in oview(7))
-		valid_moblist |= M
-
-	var/mob/living/carbon/human/target = input(src,"Who do you wish to target?","Mimic Target") as null|anything in valid_moblist
-
-	if(!istype(target))
-		return FALSE
-
-	if(target.client.prefs.resleeve_lock)
-		to_chat(src,"<span class='warning'>This person has enabled Prevent Body Impersonation, you cannot copy them!</span>")
-		return FALSE
-
-	if(get_dist(src,target) > 3)
-		to_chat(src,"<span class='warning'>There's nobody nearby to use this on.</span>")
-		return FALSE
-
-	visible_message("<span class='warning'>[src] deforms and contorts strangely...</span>")
-	if(!do_after(src, 50)) //5 seconds
-		return FALSE
-
-
-	shapeshifter_copy_core_features(target)
-
-
-	//markings and limbs time.
-	//ensure we get synthlimb markings if target has them
-	synth_markings = target.synth_markings
-
-	//copies all of the target's markings.
-	for(var/BP in target.organs_by_name)
-		var/obj/item/organ/external/their_organ = target.organs_by_name[BP]
-		var/obj/item/organ/external/our_organ = organs_by_name[BP]
-		if(their_organ && our_organ)
-			our_organ.s_col_blend = their_organ.s_col_blend
-			var/list/markings_to_copy = their_organ.markings.Copy()
-			our_organ.markings = markings_to_copy
-		if(our_organ)
-			our_organ.sync_colour_to_human(src)
-
-	//for xenochim and prommies only
-	if(target.species && istype(target.species, /datum/species))
-		wrapped_species_by_ref["\ref[src]"] = target.species.name
-	regenerate_icons()
-
-
-
 
 /mob/living/carbon/human/proc/shapeshifter_copy_core_features(var/mob/living/carbon/human/target)
 	change_gender(target.gender)

--- a/code/modules/species/species_shapeshift.dm
+++ b/code/modules/species/species_shapeshift.dm
@@ -601,7 +601,8 @@ var/list/wrapped_species_by_ref = list()
 		var/obj/item/organ/external/our_organ = organs_by_name[BP]
 		if(their_organ && our_organ)
 			our_organ.s_col_blend = their_organ.s_col_blend
-			our_organ.markings = their_organ.markings
+			var/list/markings_to_copy = their_organ.markings.Copy()
+			our_organ.markings = markings_to_copy
 		if(our_organ)
 			our_organ.sync_colour_to_human(src)
 

--- a/code/modules/species/species_shapeshift.dm
+++ b/code/modules/species/species_shapeshift.dm
@@ -556,8 +556,8 @@ var/list/wrapped_species_by_ref = list()
 	..()
 
 
-/mob/living/carbon/human/proc/copy_appearance()
-	set name = "Mimic Appearance" 
+/mob/living/carbon/human/proc/shapeshifter_copy_appearance()
+	set name = "Mimic Appearance"
 	set category = "Abilities"
 
 	if(stat || world.time < last_special)
@@ -569,7 +569,7 @@ var/list/wrapped_species_by_ref = list()
 
 	for(var/mob/living/carbon/human/M in oview(7))
 		valid_moblist |= M
-	
+
 	var/mob/living/carbon/human/target = input(src,"Who do you wish to target?","Mimic Target") as null|anything in valid_moblist
 
 	if(!istype(target))
@@ -598,7 +598,7 @@ var/list/wrapped_species_by_ref = list()
 		change_skin_color(target.r_skin, target.g_skin, target.b_skin)
 	if(target.species.species_appearance_flags & HAS_SKIN_TONE)
 		change_skin_tone(target.s_tone)
-	
+
 	//why are these eploded instead of using the individual colour/style change calls?
 	//so we only have to do the render call once (per accessory). they're way more expensive than hair
 	ear_style = target.ear_style
@@ -612,7 +612,7 @@ var/list/wrapped_species_by_ref = list()
 	g_ears3 = target.g_ears3
 	b_ears3 = target.b_ears3
 	render_spriteacc_ears()
-	
+
 	r_horn = target.r_horn
 	g_horn = target.g_horn
 	b_horn = target.b_horn

--- a/code/modules/species/species_shapeshift.dm
+++ b/code/modules/species/species_shapeshift.dm
@@ -214,7 +214,6 @@ var/list/wrapped_species_by_ref = list()
 		g_facial = g_skin
 		b_facial = b_skin
 
-
 	for(var/obj/item/organ/external/E in organs)
 		E.sync_colour_to_human(src)
 
@@ -557,8 +556,8 @@ var/list/wrapped_species_by_ref = list()
 	..()
 
 
-/mob/living/carbon/human/proc/shapeshifter_copy_appearance()
-	set name = "Mimic Appearance"
+/mob/living/carbon/human/proc/copy_appearance()
+	set name = "Mimic Appearance" 
 	set category = "Abilities"
 
 	if(stat || world.time < last_special)
@@ -570,39 +569,21 @@ var/list/wrapped_species_by_ref = list()
 
 	for(var/mob/living/carbon/human/M in oview(7))
 		valid_moblist |= M
-
+	
 	var/mob/living/carbon/human/target = input(src,"Who do you wish to target?","Mimic Target") as null|anything in valid_moblist
 
 	if(!istype(target))
 		return FALSE
 
-	if(get_dist(src,target) > 3)
+	if(get_dist(src,target) > 7)
 		to_chat(src,"<span class='warning'>There's nobody nearby to use this on.</span>")
 		return FALSE
 
 	visible_message("<span class='warning'>[src] deforms and contorts strangely...</span>")
-	if(!do_after(src, 50, target)) //5 seconds
+	if(!do_after(src, 5, target)) //.5 seconds
 		return FALSE
 
-	shapeshifter_copy_core_and_accessories(target)
-	//markings and limbs time.
 
-	//copies all of the target's markings.
-	for(var/BP in target.organs_by_name)
-		var/obj/item/organ/external/their_organ = target.organs_by_name[BP]
-		var/obj/item/organ/external/our_organ = organs_by_name[BP]
-		if(their_organ && our_organ)
-			our_organ.markings = their_organ.markings
-		if(our_organ)
-			our_organ.sync_colour_to_human(src)
-
-	// for xenochim only
-	if(target.species && istype(target.species, /datum/species) && (wrapped_species_by_ref["\ref[src]"] != target.species) )
-		wrapped_species_by_ref["\ref[src]"] = target.species.name
-		regenerate_icons()
-
-
-/mob/living/carbon/human/proc/shapeshifter_copy_core_and_accessories(var/mob/living/carbon/human/target)
 	change_gender(target.gender)
 	change_gender_identity(target.identifying_gender)
 	change_hair(target.h_style)
@@ -615,12 +596,9 @@ var/list/wrapped_species_by_ref = list()
 
 	if(target.species.species_appearance_flags & HAS_SKIN_COLOR)
 		change_skin_color(target.r_skin, target.g_skin, target.b_skin)
-		r_synth = r_skin
-		g_synth = g_skin
-		b_synth = b_skin
 	if(target.species.species_appearance_flags & HAS_SKIN_TONE)
 		change_skin_tone(target.s_tone)
-
+	
 	//why are these eploded instead of using the individual colour/style change calls?
 	//so we only have to do the render call once (per accessory). they're way more expensive than hair
 	ear_style = target.ear_style
@@ -634,8 +612,7 @@ var/list/wrapped_species_by_ref = list()
 	g_ears3 = target.g_ears3
 	b_ears3 = target.b_ears3
 	render_spriteacc_ears()
-
-	horn_style = target.horn_style
+	
 	r_horn = target.r_horn
 	g_horn = target.g_horn
 	b_horn = target.b_horn
@@ -647,7 +624,6 @@ var/list/wrapped_species_by_ref = list()
 	b_horn3 = target.b_horn3
 	render_spriteacc_horns()
 
-	tail_style = target.tail_style
 	r_tail = target.r_tail
 	g_tail = target.g_tail
 	b_tail = target.b_tail
@@ -675,3 +651,27 @@ var/list/wrapped_species_by_ref = list()
 	g_wing3 = target.g_wing3
 	b_wing3 = target.b_wing3
 	render_spriteacc_wings()
+
+
+	//markings and limbs time.
+	//ensure we get synthlimb markings if target has them
+	synth_markings = target.synth_markings
+
+	//copies all of the target's markings.
+	for(var/BP in target.organs_by_name)
+		var/obj/item/organ/external/their_organ = target.organs_by_name[BP]
+		var/obj/item/organ/external/our_organ = organs_by_name[BP]
+		if(their_organ && our_organ)
+			our_organ.markings = their_organ.markings
+
+/* for xenochim and prommies only
+	if(target.species && istype(target.species, /datum/species) && (wrapped_species_by_ref["\ref[src]"] != target.species) )
+		wrapped_species_by_ref["\ref[src]"] = target.species
+		regenerate_icons()
+	*/
+
+	/*if(target.species)
+		impersonate_bodytype_legacy = target.species.get_bodytype_legacy()
+		impersonate_bodytype = target.species.default_bodytype
+		regenerate_icons() //Expensive, but we need to recrunch all the icons we're wearing
+		*/

--- a/code/modules/species/species_shapeshift.dm
+++ b/code/modules/species/species_shapeshift.dm
@@ -10,6 +10,7 @@ var/list/wrapped_species_by_ref = list()
 		/mob/living/carbon/human/proc/shapeshifter_select_shape,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair,
 		/mob/living/carbon/human/proc/shapeshifter_select_gender,
+		/mob/living/carbon/human/proc/shapeshifter_copy_appearance,
 	)
 
 	var/list/valid_transform_species = list()

--- a/code/modules/species/species_shapeshift.dm
+++ b/code/modules/species/species_shapeshift.dm
@@ -636,7 +636,7 @@ var/list/wrapped_species_by_ref = list()
 	render_spriteacc_tail()
 
 	wing_style = target.wing_style
-	wing_gradstyle = target.grad_wingstyle
+	grad_wingstyle = target.grad_wingstyle
 
 	r_gradwing = target.r_gradwing
 	g_gradwing = target.g_gradwing
@@ -662,8 +662,6 @@ var/list/wrapped_species_by_ref = list()
 		var/obj/item/organ/external/their_organ = target.organs_by_name[BP]
 		var/obj/item/organ/external/our_organ = organs_by_name[BP]
 		if(their_organ && our_organ)
-			if((their_bp.robotic >= ORGAN_ROBOT))
-				our_organ.robotize(their_organ.model)
 			our_organ.markings = their_organ.markings
 
 /* for xenochim and prommies only

--- a/code/modules/species/species_shapeshift.dm
+++ b/code/modules/species/species_shapeshift.dm
@@ -601,7 +601,7 @@ var/list/wrapped_species_by_ref = list()
 			our_organ.sync_colour_to_human(src)
 
 	//for xenochim and prommies only
-	if(target.species && istype(target.species, /datum/species) && (wrapped_species_by_ref["\ref[src]"] != target.species) )
+	if(target.species && istype(target.species, /datum/species))
 		wrapped_species_by_ref["\ref[src]"] = target.species.name
 		regenerate_icons()
 

--- a/code/modules/species/species_shapeshift.dm
+++ b/code/modules/species/species_shapeshift.dm
@@ -10,7 +10,6 @@ var/list/wrapped_species_by_ref = list()
 		/mob/living/carbon/human/proc/shapeshifter_select_shape,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair,
 		/mob/living/carbon/human/proc/shapeshifter_select_gender,
-		/mob/living/carbon/human/proc/shapeshifter_copy_appearance,
 	)
 
 	var/list/valid_transform_species = list()

--- a/code/modules/species/species_shapeshift.dm
+++ b/code/modules/species/species_shapeshift.dm
@@ -580,7 +580,7 @@ var/list/wrapped_species_by_ref = list()
 		return FALSE
 
 	visible_message("<span class='warning'>[src] deforms and contorts strangely...</span>")
-	if(!do_after(src, 50, target)) //5 seconds
+	if(!do_after(src, 50)) //5 seconds
 		return FALSE
 
 
@@ -679,3 +679,133 @@ var/list/wrapped_species_by_ref = list()
 	g_wing3 = target.g_wing3
 	b_wing3 = target.b_wing3
 	render_spriteacc_wings()
+
+/mob/living/carbon/human/proc/shapeshifter_reset_to_slot()
+	set name = "Reset Appearance to Slot"
+	set category = "Abilities"
+	set desc = "Resets your character's appearance to the CURRENTLY-SELECTED slot."
+
+	if(stat || world.time < last_special)
+		return
+
+	last_special = world.time + 1 MINUTE
+
+	visible_message("<span class='warning'>[src] deforms and contorts strangely...</span>")
+
+	if(!do_after(src, 50)) //5 seconds
+		return FALSE
+
+	shapeshifter_reset_to_slot_core(src)
+
+
+
+	//sigh
+	if(istype(src.species, /datum/species/shapeshifter))
+		var/datum/species/shapeshifter/SS = src.species
+		wrapped_species_by_ref["\ref[src]"] = SS.default_form
+
+	regenerate_icons()
+
+//i cant wait for characters v2
+/mob/living/carbon/human/proc/shapeshifter_reset_to_slot_core(var/mob/living/carbon/human/character)
+
+	var/datum/preferences/pref = character.client.prefs
+
+	character.gender = pref.biological_gender
+	character.identifying_gender = pref.identifying_gender
+
+	character.r_eyes			= pref.r_eyes
+	character.g_eyes			= pref.g_eyes
+	character.b_eyes			= pref.b_eyes
+	character.r_hair			= pref.r_hair
+	character.g_hair			= pref.g_hair
+	character.b_hair			= pref.b_hair
+	character.r_grad			= pref.r_grad
+	character.g_grad			= pref.g_grad
+	character.b_grad			= pref.b_grad
+	character.r_facial			= pref.r_facial
+	character.g_facial			= pref.g_facial
+	character.b_facial			= pref.b_facial
+	character.r_skin			= pref.r_skin
+	character.g_skin			= pref.g_skin
+	character.b_skin			= pref.b_skin
+	character.s_tone			= pref.s_tone
+	var/datum/sprite_accessory/S = GLOB.sprite_accessory_hair[pref.h_style_id]
+	character.h_style = S.name
+	S = GLOB.sprite_accessory_facial_hair[pref.f_style_id]
+	character.f_style = S.name
+	character.grad_style		= pref.grad_style
+	character.b_type			= pref.b_type
+	character.synth_color 		= pref.synth_color
+	character.r_synth			= pref.r_synth
+	character.g_synth			= pref.g_synth
+	character.b_synth			= pref.b_synth
+	character.synth_markings 	= pref.synth_markings
+	character.s_base			= pref.s_base
+	character.body_alpha        = pref.body_alpha
+	character.hair_alpha        = pref.hair_alpha
+
+	character.ear_style = GLOB.sprite_accessory_ears[pref.ear_style_id]
+	character.tail_style = GLOB.sprite_accessory_tails[pref.tail_style_id]
+	character.wing_style = GLOB.sprite_accessory_wings[pref.wing_style_id]
+	character.horn_style = GLOB.sprite_accessory_ears[pref.horn_style_id]
+
+	character.r_ears			= pref.r_ears
+	character.b_ears			= pref.b_ears
+	character.g_ears			= pref.g_ears
+	character.r_ears2			= pref.r_ears2
+	character.b_ears2			= pref.b_ears2
+	character.g_ears2			= pref.g_ears2
+	character.r_ears3			= pref.r_ears3
+	character.b_ears3			= pref.b_ears3
+	character.g_ears3			= pref.g_ears3
+
+	character.r_horn			= pref.r_horn
+	character.b_horn			= pref.b_horn
+	character.g_horn			= pref.g_horn
+	character.r_horn2			= pref.r_horn2
+	character.b_horn2			= pref.b_horn2
+	character.g_horn2			= pref.g_horn2
+	character.r_horn3			= pref.r_horn3
+	character.b_horn3			= pref.b_horn3
+	character.g_horn3			= pref.g_horn3
+
+	character.r_tail			= pref.r_tail
+	character.b_tail			= pref.b_tail
+	character.g_tail			= pref.g_tail
+	character.r_tail2			= pref.r_tail2
+	character.b_tail2			= pref.b_tail2
+	character.g_tail2			= pref.g_tail2
+	character.r_tail3			= pref.r_tail3
+	character.b_tail3			= pref.b_tail3
+	character.g_tail3			= pref.g_tail3
+
+	character.r_wing			= pref.r_wing
+	character.b_wing			= pref.b_wing
+	character.g_wing			= pref.g_wing
+	character.r_wing2			= pref.r_wing2
+	character.b_wing2			= pref.b_wing2
+	character.g_wing2			= pref.g_wing2
+	character.r_wing3			= pref.r_wing3
+	character.b_wing3			= pref.b_wing3
+	character.g_wing3			= pref.g_wing3
+	character.r_gradwing		= pref.r_gradwing
+	character.g_gradwing		= pref.g_gradwing
+	character.b_gradwing		= pref.b_gradwing
+
+
+	for(var/N in character.organs_by_name)
+		var/obj/item/organ/external/O = character.organs_by_name[N]
+		if(!istype(O))
+			continue
+		O.markings.Cut()
+		O.sync_colour_to_human(character)
+
+	for(var/id in pref.body_marking_ids)
+		var/datum/sprite_accessory/marking/mark_datum = GLOB.sprite_accessory_markings[id]
+		var/mark_color = "[pref.body_marking_ids[id]]"
+
+		for(var/BP in mark_datum.body_parts)
+			var/obj/item/organ/external/O = character.organs_by_name[BP]
+			if(O)
+				O.markings[id] = list("color" = mark_color, "datum" = mark_datum)

--- a/code/modules/species/species_shapeshift.dm
+++ b/code/modules/species/species_shapeshift.dm
@@ -575,15 +575,40 @@ var/list/wrapped_species_by_ref = list()
 	if(!istype(target))
 		return FALSE
 
-	if(get_dist(src,target) > 7)
+	if(get_dist(src,target) > 3)
 		to_chat(src,"<span class='warning'>There's nobody nearby to use this on.</span>")
 		return FALSE
 
 	visible_message("<span class='warning'>[src] deforms and contorts strangely...</span>")
-	if(!do_after(src, 5, target)) //.5 seconds
+	if(!do_after(src, 50, target)) //5 seconds
 		return FALSE
 
 
+	shapeshifter_copy_core_features(target)
+
+
+	//markings and limbs time.
+	//ensure we get synthlimb markings if target has them
+	synth_markings = target.synth_markings
+
+	//copies all of the target's markings.
+	for(var/BP in target.organs_by_name)
+		var/obj/item/organ/external/their_organ = target.organs_by_name[BP]
+		var/obj/item/organ/external/our_organ = organs_by_name[BP]
+		if(their_organ && our_organ)
+			our_organ.markings = their_organ.markings
+		if(our_organ)
+			our_organ.sync_colour_to_human(src)
+
+	//for xenochim and prommies only
+	if(target.species && istype(target.species, /datum/species) && (wrapped_species_by_ref["\ref[src]"] != target.species) )
+		wrapped_species_by_ref["\ref[src]"] = target.species.name
+		regenerate_icons()
+
+
+
+
+/mob/living/carbon/human/proc/shapeshifter_copy_core_features(var/mob/living/carbon/human/target)
 	change_gender(target.gender)
 	change_gender_identity(target.identifying_gender)
 	change_hair(target.h_style)
@@ -613,6 +638,7 @@ var/list/wrapped_species_by_ref = list()
 	b_ears3 = target.b_ears3
 	render_spriteacc_ears()
 
+	horn_style = target.horn_style
 	r_horn = target.r_horn
 	g_horn = target.g_horn
 	b_horn = target.b_horn
@@ -624,6 +650,7 @@ var/list/wrapped_species_by_ref = list()
 	b_horn3 = target.b_horn3
 	render_spriteacc_horns()
 
+	tail_style = target.tail_style
 	r_tail = target.r_tail
 	g_tail = target.g_tail
 	b_tail = target.b_tail
@@ -651,27 +678,3 @@ var/list/wrapped_species_by_ref = list()
 	g_wing3 = target.g_wing3
 	b_wing3 = target.b_wing3
 	render_spriteacc_wings()
-
-
-	//markings and limbs time.
-	//ensure we get synthlimb markings if target has them
-	synth_markings = target.synth_markings
-
-	//copies all of the target's markings.
-	for(var/BP in target.organs_by_name)
-		var/obj/item/organ/external/their_organ = target.organs_by_name[BP]
-		var/obj/item/organ/external/our_organ = organs_by_name[BP]
-		if(their_organ && our_organ)
-			our_organ.markings = their_organ.markings
-
-/* for xenochim and prommies only
-	if(target.species && istype(target.species, /datum/species) && (wrapped_species_by_ref["\ref[src]"] != target.species) )
-		wrapped_species_by_ref["\ref[src]"] = target.species
-		regenerate_icons()
-	*/
-
-	/*if(target.species)
-		impersonate_bodytype_legacy = target.species.get_bodytype_legacy()
-		impersonate_bodytype = target.species.default_bodytype
-		regenerate_icons() //Expensive, but we need to recrunch all the icons we're wearing
-		*/

--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -131,6 +131,7 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_ears,
 		/mob/living/carbon/human/proc/shapeshifter_select_horns,
 		/mob/living/carbon/human/proc/shapeshifter_select_shape,
+		/mob/living/carbon/human/proc/shapeshifter_reset_to_slot,
 		/mob/living/carbon/human/proc/check_silk_amount,
 		/mob/living/carbon/human/proc/toggle_silk_production,
 		/mob/living/carbon/human/proc/weave_structure,

--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -120,7 +120,6 @@
 		/mob/living/carbon/human/proc/resp_biomorph,
 		/mob/living/carbon/human/proc/biothermic_adapt,
 		/mob/living/carbon/human/proc/atmos_biomorph,
-		/mob/living/carbon/human/proc/shapeshifter_copy_appearance,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
 		/mob/living/carbon/human/proc/shapeshifter_select_colour,

--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -130,7 +130,6 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_ears,
 		/mob/living/carbon/human/proc/shapeshifter_select_horns,
 		/mob/living/carbon/human/proc/shapeshifter_select_shape,
-		/mob/living/carbon/human/proc/shapeshifter_copy_appearance,
 		/mob/living/carbon/human/proc/check_silk_amount,
 		/mob/living/carbon/human/proc/toggle_silk_production,
 		/mob/living/carbon/human/proc/weave_structure,

--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -120,6 +120,7 @@
 		/mob/living/carbon/human/proc/resp_biomorph,
 		/mob/living/carbon/human/proc/biothermic_adapt,
 		/mob/living/carbon/human/proc/atmos_biomorph,
+		/mob/living/carbon/human/proc/shapeshifter_copy_appearance,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
 		/mob/living/carbon/human/proc/shapeshifter_select_colour,

--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -130,6 +130,7 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_ears,
 		/mob/living/carbon/human/proc/shapeshifter_select_horns,
 		/mob/living/carbon/human/proc/shapeshifter_select_shape,
+		/mob/living/carbon/human/proc/shapeshifter_copy_appearance,
 		/mob/living/carbon/human/proc/check_silk_amount,
 		/mob/living/carbon/human/proc/toggle_silk_production,
 		/mob/living/carbon/human/proc/weave_structure,


### PR DESCRIPTION
## About The Pull Request

gives a verb to proteans and xenochimera that let them mimic another person within range.

this copies:
gender and identity

skin colour, skin tone and eye colour
hair and gradients
ears, horns, tail and wings
markings

target's icon base (for xenochimera ONLY. this, again, cannot work with proteans due to how limbs work. protean limbs are always robotic)
robot limbs (for proteans ONLY. this, again, cannot work with xenochimera due to how limbs work)



gives a verb to proteans and xenochimera that let them reset appearance to the currently-selected character slot.



## Changelog

:cl:
add: mimic-appearance verb, which lets you mimic the appearance of someone in range. for xenochimera and proteans only, because they're the only real shapeshifting races we have)
/:cl:
