### PR TITLE
Makes "Give" verb show a message if you clicked it and it's showing a prompt

### DIFF
--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -15,6 +15,8 @@
 		to_chat(src, "<span class='warning'>You don't have anything in your hands to give to \the [target].</span>")
 		return
 
+	to_chat(src,SPAN_NOTICE("You offer \the [I] to \the [target]."))
+
 	if(alert(target,"[src] wants to give you \a [I]. Will you accept it?","Item Offer","Yes","No") == "No")
 		target.visible_message("<span class='notice'>\The [src] tried to hand \the [I] to \the [target], \
 		but \the [target] didn't want it.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

why do i have to do this

## Why It's Good For The Game

i think literally anyone who has ever tried to use it can tell you why it's good

## Changelog

:cl:
qol: the "Give" verb is no longer completely without feedback if you're giving to one person
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
