### PR TITLE
Don't drown while flying over the water

### DIFF
--- a/code/game/turfs/simulated/floor_types/water.dm
+++ b/code/game/turfs/simulated/floor_types/water.dm
@@ -51,7 +51,7 @@
 	else return ..()
 
 /turf/simulated/floor/water/return_air_for_internal_lifeform(var/mob/living/L)
-	if(L && L.lying)
+	if(L && L.lying && !L.is_avoiding_ground())
 		if(L.can_breathe_water()) // For squid.
 			var/datum/gas_mixture/water_breath = new()
 			var/datum/gas_mixture/above_air = return_air()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the check that someone's actually touching the water for the breathing check

## Why It's Good For The Game

You don't end up being drowned when being fireman carried by someone flying over the water

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You no longer can breath water while flying over it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
