### PR TITLE
Touches up xenochimera adaptations

### DIFF
--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -382,7 +382,7 @@
 		to_chat(src,"<span class = 'Notice'>We begin modifying our internal structure.</span>")
 	else
 		target.visible_message("<span class = 'danger'>[src] begins to burrow their digits into [target], slithering down their throat!</span>", "<span class = 'warning'>You feel an extremely uncomfortable slithering sensation going through your throat and into your chest...</span>")
-	if(do_after(src,15 SECONDS))
+	if(do_after(src,15 SECONDS, flags = ((target == src)? NONE : DO_AFTER_IGNORE_MOVEMENT)))
 		switch(resp_biomorph)
 			if(GAS_ID_OXYGEN)
 				target.species.breath_type = GAS_ID_OXYGEN
@@ -440,7 +440,7 @@
 		to_chat(src, "<span class = 'Notice'>We begin modifying our internal biothermic structure.</span>")
 	else
 		target.visible_message("<span class = 'danger'>[src] has fleshy tendrils emerge and begin slither inside the veins of [target]!</span>", "<span class = 'warning'>You feel an extremely uncomfortable slithering sensation going through your skin, your veins suddenly feeling as if they have bugs crawling inside...</span>")
-	if(do_after(src,15 SECONDS))
+	if(do_after(src,15 SECONDS, flags = ((target == src)? NONE : DO_AFTER_IGNORE_MOVEMENT)))
 		switch(biothermic_adapt)
 			if("warm-blooded")	//reverts to default
 				if(target.species.cold_discomfort_level != -1) target.species.cold_discomfort_level = 285
@@ -543,7 +543,7 @@
 		to_chat(src, "<span class = 'Notice'>We begin modifying our skin...</span>")
 	else
 		target.visible_message("<span class = 'danger'>[src] has fleshy tendrils emerge and begin to merge and mold with [target]!</span>", "<span class = 'warning'>You feel an extremely uncomfortable slithering sensation going through your skin, it begins to feel foreign and dead, emanating from them...</span>")
-	if(do_after(src,15 SECONDS))
+	if(do_after(src,15 SECONDS, flags = ((target == src)? NONE : DO_AFTER_IGNORE_MOVEMENT)))
 		switch(atmos_biomorph)
 			if("flexible")
 				if(target.species.warning_low_pressure != -1) target.species.warning_low_pressure = WARNING_LOW_PRESSURE

--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -120,6 +120,7 @@
 		/mob/living/carbon/human/proc/resp_biomorph,
 		/mob/living/carbon/human/proc/biothermic_adapt,
 		/mob/living/carbon/human/proc/atmos_biomorph,
+		/mob/living/carbon/human/proc/hemophagic_biomorph,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
 		/mob/living/carbon/human/proc/shapeshifter_select_colour,
@@ -573,6 +574,25 @@
 				SPAN_DANGER("[src] pulls the tendrils out!"),
 				SPAN_WARNING("The sensation fades. You feel made anew."),
 			)
+
+/mob/living/carbon/human/proc/hemophagic_biomorph() //just toggle the is_vampire flag.
+	set name = "Hemophagic Biomorph"
+	set desc = "Changes our digestion focus between blood and general proteins."
+	set category = "Abilities"
+	//No option to change others as that probably would need to go through the whole vetalan infection thing, and a chimera could only mimic it
+	var/list/food_options = list("carnivorous","hemophagous")
+	var/selected_food
+	selected_food = input(src, "How should we modify our diet?") as null|anything in food_options
+	if(!selected_food)
+		return
+	to_chat(src, "<span class = 'Notice'>We begin refocusing our harvesting fronds...</span>") //Saying the intestines are getting modified.
+	if(do_after(src,10 SECONDS, flags = DO_AFTER_IGNORE_MOVEMENT))
+		switch(selected_food)
+			if("carnivorous")
+				src.species.is_vampire = 0
+			if("hemophagous")
+				src.species.is_vampire = 1
+		to_chat(src, "<span class = 'notice'>It is done.</span>")
 
 //? Abilities
 

--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -152,7 +152,12 @@
 	else
 		//Cold hurts and gives them pain messages, eventually weakening and paralysing, but doesn't damage or trigger feral.
 		//NB: 'body_temperature' used here is the 'setpoint' species var
-		var/temp_diff = body_temperature - H.bodytemperature
+		var/effective_goal_temperature
+		if(body_temperature)
+			effective_goal_temperature = body_temperature
+		else //They have no internal body heating from being cold blooded, so let them freeze upon hitting 0C
+			effective_goal_temperature = T0C + 51
+		var/temp_diff = effective_goal_temperature - H.bodytemperature
 		if(temp_diff >= 50)
 			H.shock_stage = min(H.shock_stage + (temp_diff/20), 160) // Divided by 20 is the same as previous numbers, but a full scale
 			H.eye_blurry = max(5,H.eye_blurry)
@@ -385,13 +390,15 @@
 				target.species.exhale_type = GAS_ID_CARBON_DIOXIDE
 			if(GAS_ID_PHORON)
 				target.species.breath_type = GAS_ID_PHORON
-				target.species.poison_type = null
-				target.species.exhale_type = GAS_ID_NITROGEN
+				target.species.poison_type = GAS_ID_OXYGEN //If there's no poison type, it defaults to phoron
+				target.species.exhale_type = GAS_ID_CARBON_DIOXIDE //Other phoron breathers also exhale it
 			if(GAS_ID_NITROGEN)
 				target.species.breath_type = GAS_ID_NITROGEN
-				target.species.poison_type = null
+				target.species.poison_type = GAS_ID_PHORON
+				target.species.exhale_type = GAS_ID_CARBON_DIOXIDE
 			if(GAS_ID_CARBON_DIOXIDE)
 				target.species.breath_type = GAS_ID_CARBON_DIOXIDE
+				target.species.poison_type = GAS_ID_PHORON
 				target.species.exhale_type = GAS_ID_OXYGEN
 		if(target == src)
 			to_chat(src, "<span class = 'Notice'>It is done.</span>")
@@ -436,59 +443,66 @@
 	if(do_after(src,15 SECONDS))
 		switch(biothermic_adapt)
 			if("warm-blooded")	//reverts to default
-				target.species.cold_discomfort_level = 285
-				target.species.cold_level_1 = 260
-				target.species.cold_level_2 = 180
-				target.species.cold_level_3 = 100
+				if(target.species.cold_discomfort_level != -1) target.species.cold_discomfort_level = 285
+				if(target.species.cold_level_1 != -1) target.species.cold_level_1 = 260
+				if(target.species.cold_level_2 != -1) target.species.cold_level_2 = 180
+				if(target.species.cold_level_3 != -1) target.species.cold_level_3 = 100
 
-				target.species.breath_cold_level_1 = 240
-				target.species.breath_cold_level_2 = 160
-				target.species.breath_cold_level_3 = 80
+				if(target.species.breath_cold_level_1 != -1) target.species.breath_cold_level_1 = 240
+				if(target.species.breath_cold_level_2 != -1) target.species.breath_cold_level_2 = 160
+				if(target.species.breath_cold_level_3 != -1) target.species.breath_cold_level_3 = 80
 
-				target.species.heat_level_1 = 360
-				target.species.heat_level_2 = 400
-				target.species.heat_level_3 = 1000
+				if(target.species.heat_level_1 != -1) target.species.heat_level_1 = 360
+				if(target.species.heat_level_2 != -1) target.species.heat_level_2 = 400
+				if(target.species.heat_level_3 != -1) target.species.heat_level_3 = 1000
 
-				target.species.breath_heat_level_1 = 380
-				target.species.breath_heat_level_2 = 450
-				target.species.breath_heat_level_3 = 1250
+				if(target.species.breath_heat_level_1 != -1) target.species.breath_heat_level_1 = 380
+				if(target.species.breath_heat_level_2 != -1) target.species.breath_heat_level_2 = 450
+				if(target.species.breath_heat_level_3 != -1) target.species.breath_heat_level_3 = 1250
 
-				target.species.heat_discomfort_level = 315
+				if(target.species.heat_discomfort_level != -1) target.species.heat_discomfort_level = 315
+
+				target.species.body_temperature = T0C+37 //Default target body temperature the body tries to reach
+
 			if("cold-blooded")
-				target.species.cold_discomfort_level = T0C+21
+				if(target.species.cold_discomfort_level != -1) target.species.cold_discomfort_level = T0C+21
 
-				target.species.cold_level_1 = T0C+19
-				target.species.cold_level_2 = T0C
-				target.species.cold_level_3 = T0C - 15
+				if(target.species.cold_level_1 != -1) target.species.cold_level_1 = T0C+19
+				if(target.species.cold_level_2 != -1) target.species.cold_level_2 = T0C
+				if(target.species.cold_level_3 != -1) target.species.cold_level_3 = T0C - 15
 
-				target.species.breath_cold_level_1 = T0C + 5
-				target.species.breath_cold_level_2 = T0C - 10
-				target.species.breath_cold_level_3 = T0C - 25
+				if(target.species.breath_cold_level_1 != -1) target.species.breath_cold_level_1 = T0C + 5
+				if(target.species.breath_cold_level_2 != -1) target.species.breath_cold_level_2 = T0C - 10
+				if(target.species.breath_cold_level_3 != -1) target.species.breath_cold_level_3 = T0C - 25
+				//Extremely resistant, but that how it was before (besides decimal points, so technically nerfed)
+				if(target.species.heat_level_1 != -1) target.species.heat_level_1 = T0C+726
+				if(target.species.heat_level_2 != -1) target.species.heat_level_2 = T0C+926
+				if(target.species.heat_level_3 != -1) target.species.heat_level_3 = T0C+1126
 
-				target.species.heat_level_1 = 1000
-				target.species.heat_level_2 = 1200
-				target.species.heat_level_3 = 1400
+				if(target.species.breath_heat_level_1 != -1) target.species.breath_heat_level_1 = T0C+526
+				if(target.species.breath_heat_level_2 != -1) target.species.breath_heat_level_2 = T0C+726
+				if(target.species.breath_heat_level_3 != -1) target.species.breath_heat_level_3 = T0C+926
 
-				target.species.breath_heat_level_1 = 800
-				target.species.breath_heat_level_2 = 1000
-				target.species.breath_heat_level_3 = 1200
+				target.species.body_temperature = null //cold-blooded like unathi
 
 			if("hot-blooded")
-				target.species.cold_level_1 = T0C - 75
-				target.species.cold_level_2 = T0C - 100
-				target.species.cold_level_3 = T0C - 125
+				if(target.species.cold_level_1 != -1) target.species.cold_level_1 = T0C - 75
+				if(target.species.cold_level_2 != -1) target.species.cold_level_2 = T0C - 100
+				if(target.species.cold_level_3 != -1) target.species.cold_level_3 = T0C - 125
 
-				target.species.breath_cold_level_1 = T0C - 75
-				target.species.breath_cold_level_2 = T0C - 100
-				target.species.breath_cold_level_3 = T0C - 125
+				if(target.species.breath_cold_level_1 != -1) target.species.breath_cold_level_1 = T0C - 75
+				if(target.species.breath_cold_level_2 != -1) target.species.breath_cold_level_2 = T0C - 100
+				if(target.species.breath_cold_level_3 != -1) target.species.breath_cold_level_3 = T0C - 125
 
-				target.species.heat_level_1 = T0C + 25
-				target.species.heat_level_2 = T0C + 50
-				target.species.heat_level_3 = T0C + 100
+				//The body aims for 37 degrees C, so already damaging itself there. It also should be noticeably warmer, so one can be detected as being hot blooded, so we need to be able to tolerate at least that.
+				target.species.body_temperature = T0C+40
+				if(target.species.heat_level_1 != -1) target.species.heat_level_1 = T0C + 41 //If we get warmed at all, that'll suck
+				if(target.species.heat_level_2 != -1) target.species.heat_level_2 = T0C + 61
+				if(target.species.heat_level_3 != -1) target.species.heat_level_3 = T0C + 100
 
-				target.species.breath_heat_level_1 = T0C + 50
-				target.species.breath_heat_level_2 = T0C + 75
-				target.species.breath_heat_level_3 = T0C + 100
+				if(target.species.breath_heat_level_1 != -1) target.species.breath_heat_level_1 = T0C + 50
+				if(target.species.breath_heat_level_2 != -1) target.species.breath_heat_level_2 = T0C + 75
+				if(target.species.breath_heat_level_3 != -1) target.species.breath_heat_level_3 = T0C + 100
 
 				target.species.heat_discomfort_level = T0C+19
 		if(target == src)
@@ -532,20 +546,20 @@
 	if(do_after(src,15 SECONDS))
 		switch(atmos_biomorph)
 			if("flexible")
-				target.species.warning_low_pressure = WARNING_LOW_PRESSURE
-				target.species.hazard_low_pressure = HAZARD_LOW_PRESSURE
-				target.species.warning_high_pressure = WARNING_HIGH_PRESSURE
-				target.species.hazard_high_pressure = HAZARD_HIGH_PRESSURE
+				if(target.species.warning_low_pressure != -1) target.species.warning_low_pressure = WARNING_LOW_PRESSURE
+				if(target.species.hazard_low_pressure != -1) target.species.hazard_low_pressure = HAZARD_LOW_PRESSURE
+				if(target.species.warning_high_pressure != -1) target.species.warning_high_pressure = WARNING_HIGH_PRESSURE
+				if(target.species.hazard_high_pressure != -1) target.species.hazard_high_pressure = HAZARD_HIGH_PRESSURE
 			if("compact")
-				target.species.warning_low_pressure = 50
-				target.species.hazard_low_pressure = 0
-				target.species.warning_high_pressure = WARNING_HIGH_PRESSURE
-				target.species.hazard_high_pressure = HAZARD_HIGH_PRESSURE
+				if(target.species.warning_low_pressure != -1) target.species.warning_low_pressure = 50
+				if(target.species.hazard_low_pressure != -1) target.species.hazard_low_pressure = 0
+				if(target.species.warning_high_pressure != -1) target.species.warning_high_pressure = WARNING_HIGH_PRESSURE
+				if(target.species.hazard_high_pressure != -1) target.species.hazard_high_pressure = HAZARD_HIGH_PRESSURE
 			if("elastic")
-				target.species.warning_low_pressure = WARNING_LOW_PRESSURE
-				target.species.hazard_low_pressure = HAZARD_LOW_PRESSURE
-				target.species.warning_high_pressure = WARNING_HIGH_PRESSURE + 200
-				target.species.hazard_high_pressure = HAZARD_HIGH_PRESSURE + 400
+				if(target.species.warning_low_pressure != -1) target.species.warning_low_pressure = WARNING_LOW_PRESSURE
+				if(target.species.hazard_low_pressure != -1) target.species.hazard_low_pressure = HAZARD_LOW_PRESSURE
+				if(target.species.warning_high_pressure != -1) target.species.warning_high_pressure = WARNING_HIGH_PRESSURE + 200
+				if(target.species.hazard_high_pressure != -1) target.species.hazard_high_pressure = HAZARD_HIGH_PRESSURE + 400
 
 		if(target == src)
 			to_chat(src, "<span class = 'notice'>It is done.</span>")

--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -382,7 +382,7 @@
 		to_chat(src,"<span class = 'Notice'>We begin modifying our internal structure.</span>")
 	else
 		target.visible_message("<span class = 'danger'>[src] begins to burrow their digits into [target], slithering down their throat!</span>", "<span class = 'warning'>You feel an extremely uncomfortable slithering sensation going through your throat and into your chest...</span>")
-	if(do_after(src,15 SECONDS, flags = ((target == src)? NONE : DO_AFTER_IGNORE_MOVEMENT)))
+	if(do_after(src,15 SECONDS, flags = ((target == src)? DO_AFTER_IGNORE_MOVEMENT : NONE )))
 		switch(resp_biomorph)
 			if(GAS_ID_OXYGEN)
 				target.species.breath_type = GAS_ID_OXYGEN
@@ -440,7 +440,7 @@
 		to_chat(src, "<span class = 'Notice'>We begin modifying our internal biothermic structure.</span>")
 	else
 		target.visible_message("<span class = 'danger'>[src] has fleshy tendrils emerge and begin slither inside the veins of [target]!</span>", "<span class = 'warning'>You feel an extremely uncomfortable slithering sensation going through your skin, your veins suddenly feeling as if they have bugs crawling inside...</span>")
-	if(do_after(src,15 SECONDS, flags = ((target == src)? NONE : DO_AFTER_IGNORE_MOVEMENT)))
+	if(do_after(src,15 SECONDS, flags = ((target == src)? DO_AFTER_IGNORE_MOVEMENT : NONE )))
 		switch(biothermic_adapt)
 			if("warm-blooded")	//reverts to default
 				if(target.species.cold_discomfort_level != -1) target.species.cold_discomfort_level = 285
@@ -543,7 +543,7 @@
 		to_chat(src, "<span class = 'Notice'>We begin modifying our skin...</span>")
 	else
 		target.visible_message("<span class = 'danger'>[src] has fleshy tendrils emerge and begin to merge and mold with [target]!</span>", "<span class = 'warning'>You feel an extremely uncomfortable slithering sensation going through your skin, it begins to feel foreign and dead, emanating from them...</span>")
-	if(do_after(src,15 SECONDS, flags = ((target == src)? NONE : DO_AFTER_IGNORE_MOVEMENT)))
+	if(do_after(src,15 SECONDS, flags = ((target == src)? DO_AFTER_IGNORE_MOVEMENT : NONE )))
 		switch(atmos_biomorph)
 			if("flexible")
 				if(target.species.warning_low_pressure != -1) target.species.warning_low_pressure = WARNING_LOW_PRESSURE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hopefully makes the code a bit clearer to see, being a bit explicit with what the respiratory biomorph changes.
Biothermic biomorph was changed, to both make it actually change the temperature the body will reach naturally (so hot blooded actually is warmer, and cold blooded only takes the enviroments temperature). Hot blooded is resistant to warmer temperatures now, as the heat level checks your body temperature, not the enviroments one, and as the default is 37°C, you were always going to burn yourself switching to it, unless you were in a cold enviroment. But there, you may be breathing in too cold air, and hurt yourself there, which is what hot blooded would be stopping. There are also checks to not add the normal temperature handling, if the species is already doing it in a special way. The alternative would have been giving them the breath_cold_levels of -1, at which point they could have just ignored any cold, short of the shock-stasis they would be thrown into.
Also, as I'm already touching it, I figured to allow them to adapt themselves while moving, there is no forced visible message, so it should be possible for it to not need too much concentration that would make it impossible.

## Why It's Good For The Game

Allows a chimera knowing a change is coming to prepare without needing equipment, or getting hurt in the process. Especially switching to hot blooded can't be done, without cooling a body down below the 20°C mark, which realistically would be unhealthy by itself. 
For respiratory morph, it fixed phoron breathing, as with poison_type nulled, it defaulted to phoron being toxic. It also blocks mixing, as you could have selected carbon breathing, then nitrogen, and the chimera would be able to breath nitrogen, and exhale oxygen, instead of carbon dioxide. It's now fixed to what any station species can have, normal oxygen breathing, vox phoron breathing, nitrogen breathing only replaces the oxygen part, and carbon breathing swaps the two around. If we would want to be able to mix and match there, probably should be done through three choices.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: respiratory biomorph has 4 exact and working breathing modes you can select, instead of allowing some combinations cycling through them.
fix: biothermic biomorph hot-blooded shouldn't burn you under normal circumstances
tweak: chimeras can biomorph themselves while moving.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
