### PR TITLE
Fix parry required item slot

### DIFF
--- a/code/datums/components/items/passive_parry.dm
+++ b/code/datums/components/items/passive_parry.dm
@@ -92,6 +92,12 @@
 
 /datum/component/passive_parry/proc/on_equipped(obj/item/source, mob/user, slot)
 	if(!check_slot(slot))
+		if(hooked)
+			ASSERT(user == hooked)
+			hooked = null
+			user.unregister_shieldcall(hooked_shieldcall)
+			QDEL_NULL(hooked_shieldcall)
+			UnregisterSignal(user, COMSIG_ATOM_SHIELDCALL_ITERATION, PROC_REF(shieldcall_iterating))
 		return
 	if(hooked)
 		return

--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -16,6 +16,15 @@
 		parry_chance_projectile = 10;
 	}
 
+//check if held in passive_parry_intercept, if so, return ..(), else null
+/obj/item/material/sword/passive_parry_intercept()
+	var/mob/M = src.loc
+	if(M && ismob(M))
+		if(src in M.get_held_items()) //Holding it, so we can block
+			return ..()
+		else
+			return //Not held, no block
+
 /obj/item/material/sword/plasteel
 	material_parts = /datum/prototype/material/plasteel
 

--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -16,14 +16,6 @@
 		parry_chance_projectile = 10;
 	}
 
-//check if held in passive_parry_intercept, if so, return ..(), else null
-/obj/item/material/sword/passive_parry_intercept()
-	var/mob/M = src.loc
-	if(M && ismob(M))
-		if(src in M.get_held_items()) //Holding it, so we can block
-			return ..()
-		else
-			return //Not held, no block
 
 /obj/item/material/sword/plasteel
 	material_parts = /datum/prototype/material/plasteel

--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -16,7 +16,6 @@
 		parry_chance_projectile = 10;
 	}
 
-
 /obj/item/material/sword/plasteel
 	material_parts = /datum/prototype/material/plasteel
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tweaks the equip proc for any parrying equipment that it'll recheck if it's in a slot it is active in.

## Why It's Good For The Game

You probably can't really parry with a sword on your hip, and it wasn't intended to.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: parrying items now respect the required slots for them to parry.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
