### PR TITLE
you no longer visually bleed if you have no blood

### DIFF
--- a/code/modules/mob/living/carbon/human/human-defense-legacy.dm
+++ b/code/modules/mob/living/carbon/human/human-defense-legacy.dm
@@ -193,15 +193,18 @@
 	if(effective_force > 10 || effective_force >= 5 && prob(33))
 		forcesay(hit_appends)	//forcesay checks stat already
 
+	// you can't bleed, if you have no blood
+	var/can_bleed = !(species.species_flags & NO_BLOOD)
+
 	if(prob(25 + (effective_force * 2)))
 		if(!((I.damage_type == DAMAGE_TYPE_BRUTE) || (I.damage_type == DAMAGE_TYPE_HALLOSS)))
 			return
 
-		if(!(I.atom_flags & NOBLOODY))
+		if(!(I.atom_flags & NOBLOODY) && can_bleed)
 			I.add_blood(src)
 
 		var/bloody = 0
-		if(prob(33))
+		if(can_bleed && prob(33))
 			bloody = 1
 			var/turf/location = loc
 			if(istype(location, /turf/simulated))


### PR DESCRIPTION
## About The Pull Request
people with no blood cannot bleed

## Why It's Good For The Game
people with no blood should not bleed

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: you cannot bleed if you have no blood
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
