### PR TITLE
Fixes grave digging not checking do_after

### DIFF
--- a/code/game/turfs/simulated/floor_types/snow.dm
+++ b/code/game/turfs/simulated/floor_types/snow.dm
@@ -34,10 +34,10 @@ CREATE_STANDARD_TURFS(/turf/simulated/floor/outdoors/snow)
 			to_chat(user, "<span class='notice'>You decide to not finish removing \the [src].</span>")
 	if(istype(W, /obj/item/pickaxe))
 		var/grave_type = /obj/structure/closet/grave/snow
-		do_after(user, 60)
-		to_chat(user, "<span class='warning'>You dig out a hole.</span>")
-		new grave_type(get_turf(src))
-		return
+		if(do_after(user, 60))
+			to_chat(user, "<span class='warning'>You dig out a hole.</span>")
+			new grave_type(get_turf(src))
+			return
 	else
 		..()
 

--- a/code/game/turfs/unsimulated/beach.dm
+++ b/code/game/turfs/unsimulated/beach.dm
@@ -34,10 +34,10 @@
 /turf/simulated/floor/outdoors/beach/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/shovel))
 		var/grave_type = /obj/structure/closet/grave/sand
-		do_after(user, 60)
-		to_chat(user, "<span class='warning'>You dig out a hole.</span>")
-		new grave_type(get_turf(src))
-		return
+		if(do_after(user, 60))
+			to_chat(user, "<span class='warning'>You dig out a hole.</span>")
+			new grave_type(get_turf(src))
+			return
 
 /turf/simulated/floor/outdoors/beach/sand
 	name = "sand"

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -354,10 +354,10 @@ CREATE_STANDARD_TURFS(/turf/simulated/mineral/icerock/floor/ignore_cavegen)
 			if(sand_dug)
 				if(grave_digger)
 					var/grave_type = /obj/structure/closet/grave
-					do_after(user, 60)
-					to_chat(user, "<span class='warning'>You deepen the hole.</span>")
-					new grave_type(get_turf(src))
-					return
+					if(do_after(user, 60))
+						to_chat(user, "<span class='warning'>You deepen the hole.</span>")
+						new grave_type(get_turf(src))
+						return
 				else
 					to_chat(user, "<span class='warning'>This area has already been dug.</span>")
 					return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Grave digging is supposed to take 6 seconds; instead, it takes as little time as you want, because interrupting it has it go through anyway. do_after needs to be checked, you can't just put it in on its own. There should probably be a "must use result" lint for functions.

## Why It's Good For The Game

bugfix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Gravedigging no longer goes through even if interrupted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
