### PR TITLE
"Common" becomes a NT encripted frequency on 143.7, while frequency 145.9 becomes a open ATC frequency

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -19,11 +19,12 @@
 #define FREQ_EXPLORER 1361
 #define FREQ_TALON 1363
 
-#define FREQ_ENTERTAINMENT 1461
 #define FREQ_SECURITY_INTERNAL 1475
 #define FREQ_MEDICAL_INTERNAL 1485
 
 #define FREQ_STATUS_DISPLAYS 1435
+
+#define FREQ_COMMON 1437 // Common comms frequency, dark green, now encrypted
 
 #define MIN_FREQ 1441 // ------------------------------------------------------
 // Only the 1441 to 1489 range is freely available for general conversation.
@@ -33,7 +34,8 @@
 
 #define FREQ_LOCATOR_IMPLANT 1451
 #define FREQ_SIGNALER 1457 // the default for new signalers
-#define FREQ_COMMON 1459 // Common comms frequency, dark green
+#define FREQ_ATC 1459 // NEw Common comms frequency, dark blue
+#define FREQ_ENTERTAINMENT 1461
 
 #define MAX_FREQ 1489 // ------------------------------------------------------
 

--- a/code/__DEFINES/spans.dm
+++ b/code/__DEFINES/spans.dm
@@ -17,6 +17,7 @@
 #define SPAN_ALIEN(str) ("<span class='alien'>[str]</span>")
 #define SPAN_ALLOY(str) ("<span class = 'alloy'>[str]</span>")
 #define SPAN_ALLOYH(str) ("<span class = 'heavy_alloy'>[str]</span>")
+#define SPAN_ATCRADIO(str) ("<span class='atcradio'>[str]</span>")
 #define SPAN_ANNOUNCE(str) ("<span class='announce'>[str]</span>")
 #define SPAN_BIG(str) ("<span class='big'>[str]</span>")
 #define SPAN_BIGICON(str) ("<span class='bigicon'>[str]</span>")

--- a/code/__HELPERS/radio.dm
+++ b/code/__HELPERS/radio.dm
@@ -8,7 +8,7 @@
 	if(!(. % 2)) // Ensure the last digit is an odd number
 		. += 1
 	if(. == FREQ_SYNDICATE && !syndie) // Prevents people from picking (or rounding up) into the syndie frequency
-		. = FREQ_COMMON
+		. = FREQ_ATC
 
 /// Format frequency by moving the decimal.
 /proc/format_frequency(frequency)

--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -99,6 +99,7 @@ On the map:
 
 var/list/radiochannels = list(
 	"Common"		= FREQ_COMMON,
+	"ATC"			= FREQ_ATC,
 	"Science"		= FREQ_SCIENCE,
 	"Command"		= FREQ_COMMAND,
 	"Medical"		= FREQ_MEDICAL,
@@ -130,6 +131,7 @@ var/list/DEPT_FREQS = list(FREQ_AI_PRIVATE, FREQ_COMMAND, FREQ_ENGINEERING, FREQ
 
 // TODO: move me to say or something
 GLOBAL_LIST_INIT(freqtospan, list(
+	"[FREQ_ATC]" = "atcradio",
 	"[FREQ_SCIENCE]" = "sciradio",
 	"[FREQ_EXPLORER]" = "expradio",
 	"[FREQ_MEDICAL]" = "medradio",

--- a/code/controllers/subsystem/legacy_atc.dm
+++ b/code/controllers/subsystem/legacy_atc.dm
@@ -26,6 +26,8 @@ SUBSYSTEM_DEF(legacy_atc)
 	var/secchannel
 	var/sdfchannel
 
+	var/frequency = FREQ_ATC
+
 /datum/controller/subsystem/legacy_atc/Initialize()
 	//generate our static event frequencies for the shift. alternately they can be completely fixed, up in the core block
 	ertchannel = "[rand(700,749)].[rand(1,9)]"

--- a/code/datums/announce/_legacy.dm
+++ b/code/datums/announce/_legacy.dm
@@ -17,6 +17,7 @@
 	var/newscast = 0
 	var/channel_name = "Station Announcements"
 	var/announcement_type = "Announcement"
+	var/frequency = FREQ_COMMON
 
 /datum/legacy_announcement/New(do_log = 0, new_sound = null, do_newscast = 0)
 	sound = new_sound

--- a/code/game/antagonist/outsider/trader.dm
+++ b/code/game/antagonist/outsider/trader.dm
@@ -49,7 +49,7 @@ var/datum/antagonist/trader/traders
 	player.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel(src), SLOT_ID_BACK)
 	player.equip_to_slot_or_del(new /obj/item/radio/headset/trader(src), SLOT_ID_LEFT_EAR)
 
-	create_radio(FREQ_COMMON, player) //Assume they tune their headsets into the station's public radio as they approach
+	create_radio(FREQ_ATC, player) //Assume they tune their headsets into the station's public radio as they approach
 
 	var/obj/item/card/id/id = create_id("Trader", player, equip = 0)
 	id.name = "[player.real_name]'s Passport"

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -571,7 +571,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 		"done" = 0,
 		"level" = pos_z // The level it is being broadcasted at.
 	)
-	signal.frequency = FREQ_COMMON// Common channel
+	signal.frequency = FREQ_ATC // Common channel
 
   //#### Sending the signal to all subspace receivers ####//
 	for(var/obj/machinery/telecomms/receiver/R in GLOB.telecomms_list)

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -168,7 +168,7 @@
 
 /obj/machinery/telecomms/server/presets/common
 	id = "Common Server"
-	freq_listening = list(FREQ_COMMON, FREQ_AI_PRIVATE, FREQ_ENTERTAINMENT) // AI Private and Common
+	freq_listening = list(FREQ_COMMON, FREQ_ATC, FREQ_AI_PRIVATE, FREQ_ENTERTAINMENT) // AI Private and Common
 	autolinkers = list("common")
 
 // "Unused" channels, AKA all others.
@@ -179,7 +179,7 @@
 
 /obj/machinery/telecomms/server/presets/unused/Initialize(mapload)
 	for(var/i = MIN_FREQ, i < MAX_FREQ, i += 2)
-		if(i == FREQ_AI_PRIVATE || i == FREQ_COMMON)
+		if(i == FREQ_AI_PRIVATE || i == FREQ_COMMON || i == FREQ_ATC)
 			continue
 		freq_listening |= i
 	return ..()

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -15,19 +15,19 @@
 
 /obj/item/encryptionkey/syndicate
 	icon_state = "syn_cypherkey"
-	channels = list("Mercenary" = 1)
+	channels = list("Mercenary" = 1, "Common" = 1)
 	origin_tech = list(TECH_ILLEGAL = 3)
 	syndie = 1//Signifies that it de-crypts Syndicate transmissions
 
 /obj/item/encryptionkey/raider
 	icon_state = "cypherkey"
-	channels = list("Raider" = 1)
+	channels = list("Raider" = 1, "ATC" = 1)
 	origin_tech = list(TECH_ILLEGAL = 2)
 	syndie = 1
 
 /obj/item/encryptionkey/trader
 	icon_state = "cypherkey"
-	channels = list("Trader" = 1, "Common" = 1)
+	channels = list("Trader" = 1, "ATC" = 1)
 	origin_tech = list(TECH_ILLEGAL = 2)
 	syndie = 1
 
@@ -36,45 +36,52 @@
 	translate_binary = 1
 	origin_tech = list(TECH_ILLEGAL = 3)
 
+/obj/item/encryptionkey/headset_station
+	name = "standard station encryption key"
+	desc = "An encryption key for a radio headset. Contains the commun frequency."
+	icon = 'icons/obj/radio.dmi'
+	icon_state = "cypherkey"
+	channels = list("Common" = 1, "ATC" = 1, , "Common" = 1)
+
 /obj/item/encryptionkey/headset_sec
 	name = "security radio encryption key"
 	icon_state = "sec_cypherkey"
-	channels = list("Security" = 1)
+	channels = list("Security" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/headset_eng
 	name = "engineering radio encryption key"
 	icon_state = "eng_cypherkey"
-	channels = list("Engineering" = 1)
+	channels = list("Engineering" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/headset_rob
 	name = "robotics radio encryption key"
 	icon_state = "rob_cypherkey"
-	channels = list("Engineering" = 1, "Science" = 1)
+	channels = list("Engineering" = 1, "Science" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/headset_med
 	name = "medical radio encryption key"
 	icon_state = "med_cypherkey"
-	channels = list("Medical" = 1)
+	channels = list("Medical" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/headset_sci
 	name = "science radio encryption key"
 	icon_state = "sci_cypherkey"
-	channels = list("Science" = 1)
+	channels = list("Science" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/headset_medsci
 	name = "medical research radio encryption key"
 	icon_state = "medsci_cypherkey"
-	channels = list("Medical" = 1, "Science" = 1)
+	channels = list("Medical" = 1, "Science" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/headset_com
 	name = "command radio encryption key"
 	icon_state = "com_cypherkey"
-	channels = list("Command" = 1)
+	channels = list("Command" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/headset_adj //Command Secretary's Headset Key
 	name = "secretary radio encryption key"
 	icon_state = "com_cypherkey"
-	channels = list("Command" = 1, "Service" = 0)
+	channels = list("Command" = 1, "Service" = 0, "Common" = 1, "ATC" = 1)
 /*
 /obj/item/encryptionkey/heads/captain
 	name = "Facility Director's encryption key"
@@ -95,17 +102,17 @@
 /obj/item/encryptionkey/heads/hos
 	name = "head of security's encryption key"
 	icon_state = "hos_cypherkey"
-	channels = list("Security" = 1, "Command" = 1)
+	channels = list("Security" = 1, "Command" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/heads/ce
 	name = "chief engineer's encryption key"
 	icon_state = "ce_cypherkey"
-	channels = list("Engineering" = 1, "Command" = 1)
+	channels = list("Engineering" = 1, "Command" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/heads/cmo
 	name = "chief medical officer's encryption key"
 	icon_state = "cmo_cypherkey"
-	channels = list("Medical" = 1, "Command" = 1)
+	channels = list("Medical" = 1, "Command" = 1, "Common" = 1, "ATC" = 1)
 /*
 /obj/item/encryptionkey/heads/hop
 	name = "head of personnel's encryption key"
@@ -125,72 +132,72 @@
 /obj/item/encryptionkey/headset_cargo
 	name = "supply radio encryption key"
 	icon_state = "cargo_cypherkey"
-	channels = list("Supply" = 1)
+	channels = list("Supply" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/headset_service
 	name = "service radio encryption key"
 	icon_state = "srv_cypherkey"
-	channels = list("Service" = 1)
+	channels = list("Service" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/ert
 	name = "\improper ERT radio encryption key"
 	icon_state = "cent_cypherkey"
-	channels = list("Response Team" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Supply" = 1, "Service" = 1)
+	channels = list("Response Team" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Supply" = 1, "Service" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/omni		//Literally only for the admin intercoms
-	channels = list("Mercenary" = 1, "Raider" = 1, "Trader" = 1, "Response Team" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Supply" = 1, "Service" = 1)
+	channels = list("Mercenary" = 1, "Raider" = 1, "Trader" = 1, "Response Team" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Supply" = 1, "Service" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/heads/hop
 	name = "head of personnel's encryption key"
 	icon_state = "hop_cypherkey"
-	channels = list("Supply" = 1, "Service" = 1, "Command" = 1, "Security" = 0, "Explorer" = 0)
+	channels = list("Supply" = 1, "Service" = 1, "Command" = 1, "Security" = 1, "Explorer" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/heads/ai_integrated
 	name = "ai integrated encryption key"
 	desc = "Integrated encryption key"
 	icon_state = "cap_cypherkey"
-	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "AI Private" = 1, "Explorer" = 1)
+	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "AI Private" = 1, "Explorer" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/heads/captain
 	name = "Facility Director's encryption key"
 	icon_state = "cap_cypherkey"
-	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "Explorer" = 1) //Edited to all be on by default.
+	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "Explorer" = 1, "Common" = 1, "ATC" = 1) //Edited to all be on by default.
 
 /obj/item/encryptionkey/heads/rd
 	name = "research director's encryption key"
 	icon_state = "rd_cypherkey"
-	channels = list("Command" = 1, "Science" = 1, "Explorer" = 1)
+	channels = list("Command" = 1, "Science" = 1, "Explorer" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/ert
 	name = "ert encryption key"
 	icon_state = "cap_cypherkey"
-	channels = list("Response Team" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Supply" = 1, "Service" = 1, "Explorer" = 1)
+	channels = list("Response Team" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Supply" = 1, "Service" = 1, "Explorer" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/omni		//Literally only for the admin intercoms
 	name = "omni encryption key"
 	icon_state = "cap_cypherkey"
-	channels = list("Mercenary" = 1, "Raider" = 1, "Trader" = 1, "Response Team" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Supply" = 1, "Service" = 1, "Explorer" = 1)
+	channels = list("Mercenary" = 1, "Raider" = 1, "Trader" = 1, "Response Team" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Supply" = 1, "Service" = 1, "Explorer" = 1, "Common" = 1, "ATC" = 1)
 
 //Southern Cross file port. _sc
 /obj/item/encryptionkey/pilot
 	name = "pilot's encryption key"
 	icon_state = "com_cypherkey"
-	channels = list("Supply" = 1, "Explorer" = 1)
+	channels = list("Supply" = 1, "Explorer" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/explorer
 	name = "explorer radio encryption key"
 	icon_state = "com_cypherkey"
-	channels = list("Science" = 1, "Explorer" = 1)
+	channels = list("Science" = 1, "Explorer" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/sar
 	name = "sar's encryption key"
 	icon_state = "med_cypherkey"
-	channels = list("Medical" = 1, "Explorer" = 1)
+	channels = list("Medical" = 1, "Explorer" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/pathfinder
 	name = "pathfinder radio encryption key"
 	icon_state = "com_cypherkey"
-	channels = list("Supply" = 1, "Explorer" = 1, "Science" = 1)
+	channels = list("Supply" = 1, "Explorer" = 1, "Science" = 1, "Common" = 1, "ATC" = 1)
 
 /obj/item/encryptionkey/talon
-	channels = list("Talon" = 1)
+	channels = list("Talon" = 1, "Common" = 1, "ATC" = 1)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -114,6 +114,10 @@
 	desc = "While being a normal headset, it was upgraded with a shortwave frenquency... Altho the upgrade was done with just duck taping circuits of a shortwave radio to the headset"
 	adhoc_fallback = TRUE
 
+/obj/item/radio/headset/trader/Initialize(mapload)
+	. = ..()
+	set_frequency(FREQ_ATC)
+
 /obj/item/radio/headset/headset_sec
 	name = "security radio headset"
 	desc = "This is used by your elite security force."

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -1,6 +1,7 @@
 // Access check is of the type requires one. These have been carefully selected to avoid allowing the janitor to see channels he shouldn't
 GLOBAL_LIST_INIT(default_internal_channels, list(
 	num2text(FREQ_COMMON) = list(),
+	num2text(FREQ_ATC) = list(),
 	num2text(FREQ_AI_PRIVATE)  = list(ACCESS_SPECIAL_SILICONS),
 	num2text(FREQ_ENTERTAINMENT) = list(),
 	num2text(FREQ_ERT) = list(ACCESS_CENTCOM_ERT),
@@ -32,7 +33,7 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	///FALSE for off
 	var/on = TRUE
 	var/last_transmission
-	var/frequency = FREQ_COMMON //common chat
+	var/frequency = FREQ_ATC //common chat
 	///Tune to frequency to unlock traitor supplies
 	var/traitor_frequency = 0
 	///The range which mobs can hear this radio from

--- a/code/modules/mapping/map.dm
+++ b/code/modules/mapping/map.dm
@@ -402,6 +402,7 @@
 /datum/map/station/proc/default_internal_channels()
 	return list(
 		num2text(FREQ_COMMON) = list(),
+		num2text(FREQ_ATC) = list(),
 		num2text(FREQ_AI_PRIVATE)  = list(ACCESS_SPECIAL_SILICONS),
 		num2text(FREQ_ENTERTAINMENT) = list(),
 		num2text(FREQ_ERT) = list(ACCESS_CENTCOM_ERT),

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -18,6 +18,7 @@ var/list/department_radio_keys = list(
 	  ":y" = "Explorer",	".y" = "Explorer",
 	  ":f" = "Trader",		".f" = "Trader",
 	  ":g" = "Common",		".g" = "Common",
+	  ":a" = "ATC",			".a" = "ATC",
 
 	  ":R" = "right ear",	".R" = "right ear",
 	  ":L" = "left ear",	".L" = "left ear",
@@ -37,6 +38,7 @@ var/list/department_radio_keys = list(
 	  ":Y" = "Explorer",	".Y" = "Explorer",
 	  ":F" = "Trader",		".F" = "Trader",
 	  ":G" = "Common",		".G" = "Common",
+	  ":A" = "ATC",			".A" = "ATC",
 
 	  //kinda localization -- rastaf0
 	  //same keys as above, but on russian keyboard layout. This file uses cp1251 as encoding.

--- a/code/modules/overmap/legacy/sectors.dm
+++ b/code/modules/overmap/legacy/sectors.dm
@@ -196,7 +196,7 @@
 	has_distress_beacon = TRUE
 
 	admin_chat_message(message = "Overmap panic button hit on z[z] ([name]) by '[user?.ckey || "Unknown"]'", color = "#FF2222")
-	var/message = "This is an automated distress signal from a MIL-DTL-93352-compliant beacon transmitting on [FREQ_COMMON*0.1]kHz. \
+	var/message = "This is an automated distress signal from a MIL-DTL-93352-compliant beacon transmitting on [FREQ_ATC*0.1]kHz. \
 	This beacon was launched from '[initial(name)]'. I can provide this additional information to rescuers: [get_distress_info()]. \
 	Per the Interplanetary Convention on Space SAR, those receiving this message must attempt rescue, \
 	or relay the message to those who can. This message will repeat one time in 5 minutes. Thank you for your urgent assistance."

--- a/code/modules/xenoarcheaology/tools/tools.dm
+++ b/code/modules/xenoarcheaology/tools/tools.dm
@@ -233,7 +233,7 @@
 	item_state = "electronic"
 	origin_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 2, TECH_BLUESPACE = 3)
 	materials_base = list(MAT_STEEL = 1000, MAT_GLASS = 500)
-	var/frequency = FREQ_COMMON
+	var/frequency = FREQ_ATC
 	var/scan_ticks = 0
 	var/obj/item/radio/target_radio
 

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -74,6 +74,7 @@ em						{font-style: normal;font-weight: bold;}
 .centradio				{color: #5C5C8A;}
 .aiprivradio			{color: #FF00FF;}
 .entradio				{color: #339966;}
+.atcradio				{color: #1008ff;}
 
 .secradio				{color: #A30000;}
 .engradio				{color: #A66300;}

--- a/nano/templates/radio_basic.tmpl
+++ b/nano/templates/radio_basic.tmpl
@@ -5,6 +5,7 @@ Used In File(s): /code/game/objects/item/devices/radio/radio.dm
 <head>
 	<style type="text/css">
 		.radio					{color: #008000;}
+		.atcradion				{color: #1008ff;}
 		.deptradio				{color: #993399;}
 		.comradio				{color: #395A9A;}
 		.syndradio				{color: #6D3F40;}

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -405,6 +405,10 @@ em {
   color: #1ecc43;
 }
 
+.atcradio {
+  color: #1008ff;
+}
+
 .sciradio {
   color: #c68cfa;
 }

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -423,6 +423,10 @@ em {
   color: #008000;
 }
 
+.atcradio {
+  color: #1008ff;
+}
+
 .sciradio {
   color: #993399;
 }

--- a/tgui/packages/tgui/constants.js
+++ b/tgui/packages/tgui/constants.js
@@ -144,8 +144,13 @@ export const RADIO_CHANNELS = [
   },
   {
     name: 'Common',
-    freq: 1459,
+    freq: 1437,
     color: '#1ecc43',
+  },
+  {
+    name: 'ATC',
+    freq: 1459,
+    color: '#1008ff',
   },
 ];
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- - -
_-";Hey baby, what are you wearing ?"
-";Hihi, nothing right now~"_
**_Those two phrases, pronounced by 2 crewmember of NSV Von Braun during a calm shift where they were the only ones on ship, was actually heard by a lot more ships._** 

**_Indeed, a Occulum radio vessel was passing by, and reported on it. While a funny minor news item, and a stern yelling from IAAs toward those crewmembers, it does raise a few question : Why does NT doesnt have their own encrypted general frequencie ?_**
- - -

This PR aims to make that the common, previously on 145.9, now is on 143.7, widely used by everyone to communicate to everyone on board, becomes encrypted and impossible for outsiders to hear (except Centcom),
While a new ATC frequency, now on 145.9, becomes the frequency to use to communicate with outsiders, and other vessels.

All headsets and radios will use the ATC frequency, but Traders, Travellers, Pirates, and other outside roles will not have access to common.

The Random ATC messages will also be broadcasted on the ATC.

To use the ATC frequency, the prefix will be :a / .a / :A / .A

## Why It's Good For The Game

It was requested multiple times in the past :
Indeed, a lot of players to this day aren't aware of the fact that common isn't secured. And to their defences, it is not explained anywhere, and may even make no sense since all other departments' frequencies are encrypted. 

And the use of Common for communication is important and shouldn't change.

Having an additional ATC frequency will make it more clear that one is for crew communication, and the other is for general communication.
