### PR TITLE
half the slowdown from holospheres getting hungry

### DIFF
--- a/code/modules/mob/living/carbon/human/movement.dm
+++ b/code/modules/mob/living/carbon/human/movement.dm
@@ -34,7 +34,7 @@
 
 	var/hungry = (500 - nutrition)/5 // So overeat would be 100 and default level would be 80
 	if (m_intent == MOVE_INTENT_RUN && hungry >= 70)//You can walk while hungry, but you cant run so fast while hungry
-		tally += hungry/50
+		tally += (hungry/50)*species.hunger_slowdown_multiplier
 
 	if(reagents.has_reagent("numbenzyme"))
 		tally += 1.5 //A tad bit of slowdown.

--- a/code/modules/species/holosphere/holosphere.dm
+++ b/code/modules/species/holosphere/holosphere.dm
@@ -103,6 +103,8 @@
 		/datum/action/holosphere/change_loadout
 	)
 
+	hunger_slowdown_multiplier = 0.5 // they can't eat and hitting 0 hunger makes them absolutely defenceless, no need to punish them much for this
+
 	var/list/chameleon_gear = list(
 		SLOT_ID_UNIFORM = /obj/item/clothing/under/chameleon/holosphere,
 		SLOT_ID_SUIT    = /obj/item/clothing/suit/chameleon/holosphere,

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -524,6 +524,9 @@
 	var/list/actions_to_apply = list()
 	var/list/actions_applied = list()
 
+	// How much hunger slows us down
+	var/hunger_slowdown_multiplier = 1
+
 /datum/species/New()
 	//! LEGACY
 	is_subspecies = id != uid


### PR DESCRIPTION
## About The Pull Request
they can't eat normally and require recharging
they take nutrition when healing/reviving and upon hitting 0 cannot revive from their sphere (leaving them slow and defenceless)

ultimately the hunger slowdown is just too punishing for how they're currently setup, but i'm wary of completely disabling it for them, so halving it should be a pretty good measure

## Why It's Good For The Game
balance!

## Changelog

:cl:
balance: half the slowdown from holospheres getting hungry
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
