### PR TITLE
Don't disable chimera eyeglow if they use thermal sight

### DIFF
--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -707,22 +707,25 @@
 	if(!ishuman(owner))
 		return
 	var/mob/living/carbon/human/H = owner
-	toggle_sight(owner)
-	addtimer(CALLBACK(src, PROC_REF(toggle_sight),H), duration, TIMER_UNIQUE)
+	var/toggle = !H.species.has_glowing_eyes //Only toggle the eye glow if we aren't already glowing with them
+	toggle_sight(owner, toggle)
+	addtimer(CALLBACK(src, PROC_REF(toggle_sight), H, toggle), duration, TIMER_UNIQUE)
 
-/datum/ability/species/xenochimera/thermal_sight/proc/toggle_sight(mob/living/carbon/human/H)
+/datum/ability/species/xenochimera/thermal_sight/proc/toggle_sight(mob/living/carbon/human/H, toggle_eye_glow)
 	if(!active)
 		to_chat(H, "<span class='notice'>We focus outward, gaining a keen sense of all those around us.</span>")
 		H.species.vision_flags |= SEE_MOBS
 		H.species.vision_flags &= ~SEE_BLACKNESS
-		H.species.has_glowing_eyes = TRUE
+		if(toggle_eye_glow)
+			H.species.has_glowing_eyes = TRUE
 		H.add_vision_modifier(/datum/vision/augmenting/legacy_ghetto_nvgs)
 		active = TRUE
 	else
 		to_chat(H, "<span class='notice'>Our senses dull.</span>")
 		H.species.vision_flags &= ~SEE_MOBS
 		H.species.vision_flags |= SEE_BLACKNESS
-		H.species.has_glowing_eyes = FALSE
+		if(toggle_eye_glow)
+			H.species.has_glowing_eyes = FALSE
 		H.remove_vision_modifier(/datum/vision/augmenting/legacy_ghetto_nvgs)
 		active = FALSE
 	H.update_eyes()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tell the thermal sight to only toggle when the eyes aren't already glowing. That way, it remains ensured that they have the glow while the sight is active, but it lets them have a passive glow afterwards, too, if they spawned with it.

## Why It's Good For The Game

Lets xenochimeras decide to be always visible in the dark, instead of only when they use the thermal sight

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Eyeglow sticks to Xenochimeras as they selected it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
