### PR TITLE
Two fixes for hardsuits IIS

### DIFF
--- a/code/game/click/rig.dm
+++ b/code/game/click/rig.dm
@@ -53,6 +53,9 @@
 /mob/living/carbon/human/can_use_hardsuit()
 	return 1
 
+/mob/living/simple_mob/holosphere_shell/can_use_hardsuit()
+	return 1
+
 /mob/living/carbon/brain/can_use_hardsuit()
 	return istype(loc, /obj/item/mmi)
 

--- a/code/modules/hardsuits/_rig.dm
+++ b/code/modules/hardsuits/_rig.dm
@@ -842,11 +842,11 @@
 		return 0
 
 	if(href_list["toggle_piece"])
-		if(ishuman(usr) && !CHECK_MOBILITY(usr, MOBILITY_CAN_STORAGE))
+		if(ishuman(wearer) && !CHECK_MOBILITY(usr, MOBILITY_CAN_STORAGE))
 			return 0
-		toggle_piece(href_list["toggle_piece"], usr)
+		toggle_piece(href_list["toggle_piece"], wearer)
 	else if(href_list["toggle_seals"])
-		toggle_seals(usr)
+		toggle_seals(wearer)
 	else if(href_list["interact_module"])
 
 		var/module_index = text2num(href_list["interact_module"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows Holospheres to actually use modules, and stops seals from breaking it an intelligence does it from inside the suit, telling the game to do it on the wearer, not user.

## Why It's Good For The Game

Code should work as intended, and especially the second part softlocks one.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Holosphere can make use of installed modules, not just toggle and select them.
fix: Hardsuits seal around the wearer, not user, can be different with IIS module
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
