### PR TITLE
Allows the lick wounds ability to target oneself

### DIFF
--- a/code/modules/vore/lick_wounds.dm
+++ b/code/modules/vore/lick_wounds.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/human/proc/lick_wounds(var/mob/living/carbon/M in living_mobs(1))
+/mob/living/carbon/human/proc/lick_wounds(var/mob/living/carbon/M in view(1))
 	set name = "Lick Wounds"
 	set category = "Abilities"
 	set desc = "Disinfect and heal small wounds with your saliva."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just changes the living_mobs(1) to view(1), which in turn includes the mob it gets checked from

## Why It's Good For The Game

"Licking your wounds" is something a person does on themselves, not on others, so the ability should probably allow it to be used on the person itself. Right-clicking on your own mob also lists it already, but can't be called, putting the verb and the argument in the command bar, without working.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: people are able to lick their own wounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
