### PR TITLE
Less invasive chimera regenerate

### DIFF
--- a/code/modules/mob/living/carbon/human/human-damage-legacy.dm
+++ b/code/modules/mob/living/carbon/human/human-damage-legacy.dm
@@ -343,7 +343,7 @@ This function restores the subjects blood to max.
 This function restores all organs.
 */
 /mob/living/carbon/human/restore_all_organs(var/ignore_prosthetic_prefs)
-	for(var/obj/item/organ/external/current_organ in organs)
+	for(var/obj/item/organ/current_organ in organs)
 		current_organ.rejuvenate_legacy(ignore_prosthetic_prefs)
 
 /mob/living/carbon/human/apply_damage(var/damage = 0, var/damagetype = DAMAGE_TYPE_BRUTE, var/def_zone = null, var/blocked = 0, var/soaked = 0, var/sharp = 0, var/edge = 0, var/obj/used_weapon = null)

--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -680,6 +680,9 @@
 			H.internal_organs_by_name[organ_tag] = O
 	for(var/limb_type in H.species.has_limbs)
 		var/obj/item/organ/I = H.organs_by_name[limb_type]
+		if(istype(I, /obj/item/organ/external/stump))
+			I.removed(null, TRUE)//Shouldn't have a vital stump that can be removed, but no need to kill if that somehow is the case, as it'll be replaced.
+			I = null
 		if(!I)
 			var/list/organ_data = H.species.has_limbs[limb_type]
 			var/limb_path = organ_data["path"]

--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -668,10 +668,27 @@
 		return
 	var/mob/living/carbon/human/H = owner
 	H.restore_blood()
-	H.species.create_organs(H, TRUE)
-	H.restore_all_organs()
-	H.adjustBruteLoss(-healing_amount)
-	H.adjustFireLoss(-healing_amount)
+	//Go through all the organs and limbs we should have, if one's missing, grow it.
+	for(var/organ_tag in H.species.has_organ)
+		var/obj/item/organ/I = H.internal_organs_by_name[name]
+		if(!I)
+			var/organ_type = H.species.has_organ[organ_tag]
+			var/obj/item/organ/O = new organ_type(H,1)
+			if(organ_tag != O.organ_tag)
+				warning("[O.type] has a default organ tag \"[O.organ_tag]\" that differs from the species' organ tag \"[organ_tag]\". Updating organ_tag to match.")
+				O.organ_tag = organ_tag
+			H.internal_organs_by_name[organ_tag] = O
+	for(var/limb_type in H.species.has_limbs)
+		var/obj/item/organ/I = H.organs_by_name[limb_type]
+		if(!I)
+			var/list/organ_data = H.species.has_limbs[limb_type]
+			var/limb_path = organ_data["path"]
+			var/obj/item/organ/O = new limb_path(H)
+			organ_data["descriptor"] = O.name
+			if(O.parent_organ)
+				organ_data = H.species.has_limbs[O.parent_organ]
+				organ_data["has_children"] = organ_data["has_children"]+1
+	H.restore_all_organs(ignore_prosthetic_prefs=TRUE) //A chimera couldn't make a limb robotic by this, should remove robotic parts, though.
 	H.adjustOxyLoss(-healing_amount)
 	H.adjustCloneLoss(-healing_amount)
 	H.adjustBrainLoss(-healing_amount)

--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -688,7 +688,7 @@
 			if(O.parent_organ)
 				organ_data = H.species.has_limbs[O.parent_organ]
 				organ_data["has_children"] = organ_data["has_children"]+1
-	H.restore_all_organs(ignore_prosthetic_prefs=TRUE) //A chimera couldn't make a limb robotic by this, should remove robotic parts, though.
+	H.restore_all_organs(ignore_prosthetic_prefs=TRUE) //A chimera couldn't make a limb robotic by this, shouldn't remove robotic parts, though.
 	H.adjustOxyLoss(-healing_amount)
 	H.adjustCloneLoss(-healing_amount)
 	H.remove_status_effect(/datum/status_effect/sight/blindness)

--- a/code/modules/species/station/xenochimera.dm
+++ b/code/modules/species/station/xenochimera.dm
@@ -691,7 +691,6 @@
 	H.restore_all_organs(ignore_prosthetic_prefs=TRUE) //A chimera couldn't make a limb robotic by this, should remove robotic parts, though.
 	H.adjustOxyLoss(-healing_amount)
 	H.adjustCloneLoss(-healing_amount)
-	H.adjustBrainLoss(-healing_amount)
 	H.remove_status_effect(/datum/status_effect/sight/blindness)
 	H.eye_blurry = FALSE
 	H.ear_deaf = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the chimera regenerate only replace missing organ/limbs, and fully heal them all, rather than deleting and respawning everything. This makes them not lose implants from it. It's done by making restore_all_organs actually restore ALL organs, and not just bodyparts. It's only used for aheals otherwise, and that already replaces every organ before, so there aren't any changes. The other part is copying the create_organs part where they are actually made, after checking the chimera would be missing a limb they should have. Should they somehow have another limb grafted to them, they'll heal it, but not regenerate if it gets amputated again. They will still heal robotic limbs, but that's not avoidable without more checks.

## Why It's Good For The Game

An ability that needs 10 seconds of their concentration currently removes any implant, which includes tracking ones. Lore wise, they would be required to have one, and it probably wouldn't make sense if it's that easily (and probably more likely accidentally) removed like that. There is also no indication this ability would do such, neither before or after, like a nif being thrown to the ground.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Xenochimera regenerate is less destructive, only regenerates what's needed, and heals the rest.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
