### PR TITLE
No runtime if the blood_holder is empty

### DIFF
--- a/code/modules/reagents/chemistry/reagents/blood/blood_holder.dm
+++ b/code/modules/reagents/chemistry/reagents/blood/blood_holder.dm
@@ -106,6 +106,8 @@
 /datum/blood_holder/proc/erase(amount)
 	var/total = host_blood_volume + cached_guest_blood_volume
 	. = min(amount, total)
+	if(total==0) //No divide by zero, return value's set already
+		return
 	var/multiplier = max(0, 1 - (. / total))
 
 	host_blood_volume *= multiplier


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A quick check if the total is zero, before trying to divide through it.

## Why It's Good For The Game

No runtimes while a body grills on Lythios 43a, all blood already evaporated, and more tries to do so.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: No runtime if a bloodless corpse gets more blood erased
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
