### PR TITLE
Fast lazy fix for drawing or erasing blood

### DIFF
--- a/code/modules/reagents/chemistry/reagents/blood/blood_holder.dm
+++ b/code/modules/reagents/chemistry/reagents/blood/blood_holder.dm
@@ -105,6 +105,7 @@
  */
 /datum/blood_holder/proc/erase(amount)
 	var/total = host_blood_volume + cached_guest_blood_volume
+	if(total <= 0) return 0
 	. = min(amount, total)
 	var/multiplier = max(0, 1 - (. / total))
 
@@ -146,6 +147,7 @@
 /datum/blood_holder/proc/draw(amount, infinite) as /datum/blood_mixture
 	var/total = host_blood_volume + cached_guest_blood_volume
 	amount = min(amount, total)
+	if(amount <= 0) return null
 	var/multiplier = max(0, 1 - (amount / total))
 
 	var/datum/blood_mixture/creating = new


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://github.com/user-attachments/assets/f955535f-50f4-48bd-897d-32c2dd1bc801)
Implements silicons fix in 2 lines
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Not crashing on build is healthy for future development
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
Checks if the divisor amount for draw() and erase() are equal to or less than zero and returns immediately the appropriate value instead of diving by zero.
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed a divide-by-zero exception caused by blood erase() and draw()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
