### PR TITLE
Lets handheld translator work if owner can't hear, even if they understand the language

### DIFF
--- a/code/game/objects/items/devices/translator.dm
+++ b/code/game/objects/items/devices/translator.dm
@@ -141,14 +141,16 @@
 	if (visual && L.has_status_effect(/datum/status_effect/sight/blindness))
 		return //Can't see the screen, don't get the message
 
-	if (audio && ((L.sdisabilities & SDISABILITY_DEAF) || L.ear_deaf))
+	var/is_deaf = (L.sdisabilities & SDISABILITY_DEAF) || L.ear_deaf
+
+	if (audio && is_deaf)
 		return //Can't hear the translation, don't get the message
 
 	//Only translate if they can't understand, otherwise pointlessly spammy
 	//I'll just assume they don't look at the screen in that case
 
 	//They don't understand the spoken language we're translating FROM
-	if(!L.say_understands(speaker, language))
+	if(!L.say_understands(speaker, language) || (visual && is_deaf))
 		//They understand the output language
 		if(L.say_understands(null,langset))
 			to_chat(L, "<i><b>[src]</b> translates, </i>\"<span class='[langset.colour]'>[context.attempt_translation(language, speaker, message)]</span>\"")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. It's a little weird that it checks if they can _understand_ what's being said but not if they can _hear_ it.

## Why It's Good For The Game

I'm pretty sure it's supposed to work this way??

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Made universal translators display text if the user can't hear what's being said, not just if they can't understand it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
