### PR TITLE
Small gun fixes

### DIFF
--- a/code/modules/projectiles/guns/gun/launcher.dm
+++ b/code/modules/projectiles/guns/gun/launcher.dm
@@ -34,7 +34,10 @@
 
 /obj/item/gun/launcher/proc/launch_throwable(datum/gun_firing_cycle/cycle, atom/movable/launching)
 	update_release_force(launching)
-	launching.forceMove(cycle.firing_atom)
+	var/turf/T = cycle.firing_atom //Unlikely if there ever is a turf that could initiate the fire, but just to be sure
+	if (!istype(T))
+		T = get_turf(cycle.firing_atom)
+	launching.forceMove(T)
 	launching.throw_at_old(cycle.original_target, throw_distance, release_force, cycle.firing_actor?.performer)
 
 /**

--- a/code/modules/projectiles/guns/gun/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/gun/launcher/crossbow.dm
@@ -91,6 +91,10 @@
 	. = ..()
 	tension = 0
 
+/obj/item/gun/launcher/crossbow/should_attack_self_switch_firemodes()
+	//True is normally returned if we have firemodes set, and that would make attack_self return early, never to draw
+	return FALSE
+
 /obj/item/gun/launcher/crossbow/attack_self(mob/user, datum/event_args/actor/actor)
 	. = ..()
 	if(.)

--- a/code/modules/projectiles/guns/gun/projectile/ballistic.dm
+++ b/code/modules/projectiles/guns/gun/projectile/ballistic.dm
@@ -132,6 +132,8 @@
 	///   be the round at [internal_magazine_revolver_offset].
 	///   Basically, [chamber_simulation] is disabled if this is on.
 	var/internal_magazine_revolver_mode = FALSE
+	/// A flag to disable the spin, for multi-barreled weapons that fire in sequence
+	var/internal_magazine_revolver_spinnable = TRUE
 	/// The current position in [internal_magazine_vec] we are at.
 	/// * This is to avoid duplicate references, as those are pretty much asking for trouble.
 	/// * This is only used if [internal_magazine_revolver_mode] is enabled.
@@ -374,7 +376,7 @@
 
 /obj/item/gun/projectile/ballistic/register_item_actions(mob/user)
 	. = ..()
-	if(internal_magazine && internal_magazine_revolver_mode)
+	if(internal_magazine && internal_magazine_revolver_mode && internal_magazine_revolver_spinnable)
 		if(!chamber_spin_action)
 			chamber_spin_action = new(src)
 		chamber_spin_action.grant(user.inventory.actions)

--- a/code/modules/projectiles/guns/gun/projectile/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/gun/projectile/ballistic/shotgun.dm
@@ -110,6 +110,10 @@
 	//SPEEDLOADER because rapid unloading.
 	//In principle someone could make a speedloader for it, so it makes sense.
 	internal_magazine_size = 2
+	internal_magazine = TRUE
+	internal_magazine_revolver_mode = TRUE
+	chamber_simulation = FALSE
+	internal_magazine_revolver_spinnable = FALSE
 	w_class = WEIGHT_CLASS_BULKY
 	heavy = TRUE
 	damage_force = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Potentially dirty fixes, although there is only one new var to stop the revolver spinning to use the full magazine equals chamber logic of that, which does seem like it has the intended effect for double-barrel shotguns.
The crossbow attack_self returns early as it attempts to switch firemodes, which is why it can't be drawn, object to be thrown was just moved into the shooter.

## Why It's Good For The Game

Double barrel shotguns should actually load two shells, and crossbows are currently spawned in, but don't work.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: crossbows can be drawn
fix: double-barrel is actually two barrels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
