### PR TITLE
change micro mech size requirement to <= 50% instead of <50%

### DIFF
--- a/code/modules/vehicles/sealed/mecha/subtypes/micro.dm
+++ b/code/modules/vehicles/sealed/mecha/subtypes/micro.dm
@@ -3,6 +3,7 @@
 	var/max_micro_weapon_equip = 0
 	var/list/micro_utility_equipment = new
 	var/list/micro_weapon_equipment = new
+	var/size_requirement = 0.5
 
 
 
@@ -125,7 +126,7 @@
 
 /obj/vehicle/sealed/mecha/micro/mob_can_enter(mob/entering, datum/event_args/actor/actor, silent, suppressed)
 	var/mob/living/carbon/C = entering
-	if (C.size_multiplier >= 0.5)
+	if (C.size_multiplier > size_requirement)
 		to_chat(C, "<span class='warning'>You can't fit in this suit!</span>")
 		return FALSE
 	else
@@ -133,7 +134,7 @@
 
 /obj/vehicle/sealed/mecha/micro/move_inside_passenger()
 	var/mob/living/carbon/C = usr
-	if (C.size_multiplier >= 0.5)
+	if (C.size_multiplier > size_requirement)
 		to_chat(C, "<span class='warning'>You can't fit in this suit!</span>")
 		return
 	else


### PR DESCRIPTION
## About The Pull Request
i play a character that has scale 50% and is thereby the size of one tile
they can't fit in the micro mech and being below 50% can just obliterate you appearance-wise

## Why It's Good For The Game
let the small creatures drive the small robots

## Changelog

:cl:
tweak: change micro mech size requirement to <= 50% instead of <50%
/:cl:
