### PR TITLE
Fixes combat mech melee

### DIFF
--- a/code/modules/vehicles/sealed/mecha/mecha.dm
+++ b/code/modules/vehicles/sealed/mecha/mecha.dm
@@ -145,7 +145,7 @@
 	var/datum/events/events
 
 	/// outgoing melee damage (legacy var)
-	var/damtype
+	var/damtype = DAMAGE_TYPE_BRUTE
 
 //mechaequipt2 stuffs
 	var/list/hull_equipment = new


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates the default melee damage type for all combat mechs to be brute, since it's a big metal fist punching you. This is placed on the abstract combat mech datum so it can be overridden. This seems to fix the issue where mech melee attacks would play the sound but then not do any damage.

I'm not well-versed enough in the mech code to know why this is marked as legacy, but it fixes the bug so that's good enough for me for now.

## Why It's Good For The Game

Fixes a pretty big bug regarding combat mechs.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Combat mechs can now melee again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
