### PR TITLE
Dart Door Fix

### DIFF
--- a/maps/rift/levels/rift-06-surface3.dmm
+++ b/maps/rift/levels/rift-06-surface3.dmm
@@ -18939,11 +18939,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar_backroom)
-"eYG" = (
-/obj/map_helper/paint/silver,
-/obj/map_helper/paint_stripe/black,
-/turf/simulated/wall/rshull,
-/area/shuttle/oldcentury)
 "eZd" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -22249,7 +22244,9 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exploration/excursion_dock)
 "kux" = (
-/obj/machinery/door/window/brigdoor/northleft,
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access = null
+	},
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
@@ -26105,7 +26102,9 @@
 /turf/simulated/floor/wood,
 /area/exploration/pilot_Office)
 "shx" = (
-/obj/machinery/door/window/brigdoor/southleft,
+/obj/machinery/door/window/brigdoor/southleft{
+	req_access = null
+	},
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
@@ -34071,7 +34070,7 @@ pTC
 vKy
 pTC
 yci
-eYG
+pTC
 oWZ
 mpR
 fOO


### PR DESCRIPTION
Trying my hand at fixing a relatively simple problem. What could possibly go wrong?

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Made the partition all-access in the DART so it could actually be used. All edits were done in StrongDMM
## Why It's Good For The Game
Makes all of the doors in the DART all-access. The cockpit is already all-access so I don't see why there are two partitions with list(1) access separating the front foyer and rear foyer. It's basically useless until this gets fixed.
## Changelog
:cl:
fix: req_access set to "null" on both sliding secure doors. Otherwise, I literally have 0 idea what the other changes are in code or why they're occurring.
:cl:
![image](https://github.com/user-attachments/assets/9918f50a-692b-4396-8f5a-ee08c7c90ae1)


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
