### PR TITLE
Update icon parent first

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -276,8 +276,8 @@
 				toggle_pump()
 
 /obj/machinery/sleeper/update_icon_state()
+	. = ..()
 	icon_state = "sleeper_[occupant ? TRUE : FALSE]"
-	return ..()
 
 /obj/machinery/sleeper/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/grab))

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -23,11 +23,11 @@
 	update_icon()
 
 /obj/machinery/ai_slipper/update_icon_state()
+	. = ..()
 	if(machine_stat & (NOPOWER|BROKEN))
 		icon_state = "motion0"
 	else
 		icon_state = disabled ? "motion0" : "motion3"
-	return ..()
 
 /obj/machinery/ai_slipper/proc/setState(var/enabled, var/uses)
 	disabled = disabled

--- a/code/game/machinery/atm_ret_field.dm
+++ b/code/game/machinery/atm_ret_field.dm
@@ -84,6 +84,7 @@
 	generate_field()
 
 /obj/machinery/atmospheric_field_generator/update_icon_state()
+	. = ..()
 	if(machine_stat & BROKEN)
 		icon_state = "arfg_broken"
 	else if(hatch_open && wires_intact)
@@ -94,7 +95,6 @@
 		icon_state = "arfg_on"
 	else
 		icon_state = "arfg_off"
-	return ..()
 
 /obj/machinery/atmospheric_field_generator/power_change()
 	var/oldstat

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -21,8 +21,8 @@
 	var/datum/radio_frequency/radio_connection
 
 /obj/machinery/air_sensor/update_icon_state()
+	. = ..()
 	icon_state = "gsensor[on]"
-	return ..()
 
 /obj/machinery/air_sensor/process(delta_time)
 	if(on)

--- a/code/game/machinery/beacon.dm
+++ b/code/game/machinery/beacon.dm
@@ -25,13 +25,13 @@
 
 // update the icon_state
 /obj/machinery/bluespace_beacon/update_icon_state()
+	. = ..()
 	var/state = "floor_beacon"
 
 	if(invisibility)
 		icon_state = "[state]f"
 	else
 		icon_state = "[state]"
-	return ..()
 
 /obj/machinery/bluespace_beacon/process(delta_time)
 	if(!Beacon)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -258,13 +258,13 @@ CREATE_WALL_MOUNTING_TYPES(/obj/machinery/camera)
 		P.SetSight(SEE_TURFS | SEE_MOBS | SEE_OBJS)
 
 /obj/machinery/camera/update_icon_state()
+	. = ..()
 	if (!status || (machine_stat & BROKEN))
 		icon_state = "[initial(icon_state)]1"
 	else if (machine_stat & EMPED)
 		icon_state = "[initial(icon_state)]emp"
 	else
 		icon_state = initial(icon_state)
-	return ..()
 
 /obj/machinery/camera/proc/triggerCameraAlarm(duration = 0)
 	alarm_on = 1

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -140,11 +140,11 @@
 	..()
 
 /obj/item/camera_assembly/update_icon_state()
+	. = ..()
 	if(anchored)
 		icon_state = "camera1"
 	else
 		icon_state = "cameracase"
-	return ..()
 
 /obj/item/camera_assembly/attack_hand(mob/user, datum/event_args/actor/clickchain/e_args)
 	if(!anchored)

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -35,13 +35,13 @@
 	. = ..()
 
 /obj/machinery/computer/timeclock/update_icon_state()
+	. = ..()
 	if(inoperable())
 		icon_state = "[initial(icon_state)]_off"
 	else if(card)
 		icon_state = "[initial(icon_state)]_card"
 	else
 		icon_state = "[initial(icon_state)]"
-	return ..()
 
 /obj/machinery/computer/timeclock/power_change()
 	var/old_stat = machine_stat

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -61,11 +61,11 @@
 	update_icon()
 
 /obj/machinery/button/remote/update_icon_state()
+	. = ..()
 	if(machine_stat & NOPOWER)
 		icon_state = "doorctrl-p"
 	else
 		icon_state = "doorctrl0"
-	return ..()
 
 /*
 	Airlock remote control
@@ -202,8 +202,8 @@
 	return
 
 /obj/machinery/button/remote/driver/update_icon_state()
+	. = ..()
 	if(!active || (machine_stat & NOPOWER))
 		icon_state = "launcherbtt"
 	else
 		icon_state = "launcheract"
-	return ..()

--- a/code/game/machinery/doorbell_vr.dm
+++ b/code/game/machinery/doorbell_vr.dm
@@ -107,11 +107,11 @@
 	update_icon()
 
 /obj/machinery/button/doorbell/update_icon_state()
+	. = ..()
 	if(machine_stat & (NOPOWER|BROKEN))
 		icon_state = "doorbell-off"
 	else
 		icon_state = "doorbell-standby"
-	return ..()
 
 /obj/machinery/button/doorbell/attack_hand(mob/user, datum/event_args/actor/clickchain/e_args)
 	user.setClickCooldownLegacy(DEFAULT_ATTACK_COOLDOWN)

--- a/code/game/machinery/doors/airlock/airlock_control.dm
+++ b/code/game/machinery/doors/airlock/airlock_control.dm
@@ -169,6 +169,7 @@
 	var/previous_temperature
 
 /obj/machinery/airlock_sensor/update_icon_state()
+	. = ..()
 	if(on)
 		if(alert)
 			icon_state = "airlock_sensor_alert"
@@ -176,7 +177,6 @@
 			icon_state = "airlock_sensor_standby"
 	else
 		icon_state = "airlock_sensor_off"
-	return ..()
 
 /obj/machinery/airlock_sensor/attack_hand(mob/user, datum/event_args/actor/clickchain/e_args)
 	var/datum/signal/signal = new
@@ -269,11 +269,11 @@
 	var/on = 1
 
 /obj/machinery/access_button/update_icon_state()
+	. = ..()
 	if(on)
 		icon_state = "access_button_standby"
 	else
 		icon_state = "access_button_off"
-	return ..()
 
 /obj/machinery/access_button/attackby(obj/item/I as obj, mob/user as mob)
 	//Swiping ID on the access button

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -291,11 +291,11 @@
 	..()
 
 /obj/machinery/door/update_icon_state()
+	. = ..()
 	if(density)
 		icon_state = "door1"
 	else
 		icon_state = "door0"
-	return ..()
 
 /obj/machinery/door/proc/do_animate(animation)
 	switch(animation)

--- a/code/game/machinery/doors/firedoor_assembly.dm
+++ b/code/game/machinery/doors/firedoor_assembly.dm
@@ -9,11 +9,11 @@
 	var/wired = 0
 
 /obj/structure/firedoor_assembly/update_icon_state()
+	. = ..()
 	if(anchored)
 		icon_state = "door_anchored"
 	else
 		icon_state = "door_construction"
-	return ..()
 
 /obj/structure/firedoor_assembly/attackby(obj/item/C, mob/user as mob)
 	if(istype(C, /obj/item/stack/cable_coil) && !wired && anchored)

--- a/code/game/machinery/embedded_controller/airlock_controllers.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers.dm
@@ -74,6 +74,7 @@
 	program = /datum/computer/file/embedded_program/airlock/access_controll
 
 /obj/machinery/embedded_controller/radio/airlock/access_controller/update_icon_state()
+	. = ..()
 	if(on && program)
 		if(program.memory["processing"])
 			icon_state = "access_control_process"
@@ -81,7 +82,6 @@
 			icon_state = "access_control_standby"
 	else
 		icon_state = "access_control_off"
-	return ..()
 
 /obj/machinery/embedded_controller/radio/airlock/access_controller/ui_data(mob/user, datum/tgui/ui)
 	. = list(

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -87,6 +87,7 @@
 	..()
 
 /obj/machinery/embedded_controller/radio/update_icon_state()
+	. = ..()
 	if(on && program)
 		if(program.memory["processing"])
 			icon_state = "airlock_control_process"
@@ -94,7 +95,6 @@
 			icon_state = "airlock_control_standby"
 	else
 		icon_state = "airlock_control_off"
-	return ..()
 
 /obj/machinery/embedded_controller/radio/post_signal(datum/signal/signal, var/radio_filter = null)
 	signal.transmission_method = TRANSMISSION_RADIO

--- a/code/game/machinery/exonet_node.dm
+++ b/code/game/machinery/exonet_node.dm
@@ -41,6 +41,7 @@ GLOBAL_LIST_EMPTY(exonet_nodes)
 // Parameters: None
 // Description: Self explanatory.
 /obj/machinery/exonet_node/update_icon_state()
+	. = ..()
 	if(on)
 		if(!allow_external_PDAs && !allow_external_communicators && !allow_external_newscasters)
 			icon_state = "[initial(icon_state)]_idle"
@@ -48,7 +49,6 @@ GLOBAL_LIST_EMPTY(exonet_nodes)
 			icon_state = initial(icon_state)
 	else
 		icon_state = "[initial(icon_state)]_off"
-	return ..()
 
 // Proc: update_power()
 // Parameters: None

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -16,8 +16,8 @@
 	cell = new(src)
 
 /obj/machinery/floodlight/update_icon_state()
+	. = ..()
 	icon_state = "flood[open ? "o" : ""][open && cell ? "b" : ""]0[on]"
-	return ..()
 
 /obj/machinery/floodlight/process(delta_time)
 	if(!on)

--- a/code/game/machinery/gear_painter.dm
+++ b/code/game/machinery/gear_painter.dm
@@ -50,6 +50,7 @@
 	)
 
 /obj/machinery/gear_painter/update_icon_state()
+	. = ..()
 	if(panel_open)
 		icon_state = "colormate_open"
 	else if(inoperable())
@@ -58,7 +59,6 @@
 		icon_state = "colormate_active"
 	else
 		icon_state = "colormate"
-	return ..()
 
 /obj/machinery/gear_painter/Destroy()
 	if(inserted) //please i beg you do not drop nulls

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -22,11 +22,11 @@
 	update_icon()
 
 /obj/machinery/holosign/update_icon_state()
+	. = ..()
 	if(!lit)
 		icon_state = off_icon
 	else
 		icon_state = on_icon
-	return ..()
 
 /obj/machinery/holosign/power_change()
 	if(machine_stat & NOPOWER)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -78,11 +78,11 @@
 	update_appearance()
 
 /obj/machinery/iv_drip/update_icon_state()
+	. = ..()
 	if(attached_victim)
 		icon_state = "[base_icon_state]_[injection_mode ? "injecting" : "donating"]"
 	else
 		icon_state = "[base_icon_state]_[injection_mode ? "injectidle" : "donateidle"]"
-	return ..()
 
 /obj/machinery/iv_drip/update_overlays()
 	. = ..()

--- a/code/game/machinery/lathes/lathe.dm
+++ b/code/game/machinery/lathes/lathe.dm
@@ -126,6 +126,7 @@
 	dump_storages()
 
 /obj/machinery/lathe/update_icon_state()
+	. = ..()
 	if(!isnull(active_icon_state) && queue_active)
 		icon_state = active_icon_state
 	else if(length(queue) && !isnull(paused_icon_state))
@@ -133,7 +134,6 @@
 	else
 		// todo: unified machinery base icon state
 		icon_state = base_icon_state
-	return ..()
 
 /obj/machinery/lathe/RefreshParts()
 	. = ..()

--- a/code/game/machinery/misc/bioscan_antenna.dm
+++ b/code/game/machinery/misc/bioscan_antenna.dm
@@ -85,8 +85,8 @@ GLOBAL_LIST_EMPTY(bioscan_antenna_list)
 	update_icon()
 
 /obj/machinery/bioscan_antenna/update_icon_state()
+	. = ..()
 	icon_state = "[base_icon_state][network_key? "_active" : ""]"
-	return ..()
 
 /obj/machinery/bioscan_antenna/permanent
 	desc = "A less fragile antenna used to locate nearby biosignatures. This one cannot be anchored or moved, only reprogrammed."

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -56,6 +56,7 @@ var/global/list/navbeacons = list()	// no I don't like putting this in, but it w
 
 // update the icon_state
 /obj/machinery/navbeacon/update_icon_state()
+	. = ..()
 	var/state="navbeacon[open]"
 
 	if(invisibility)
@@ -63,7 +64,6 @@ var/global/list/navbeacons = list()	// no I don't like putting this in, but it w
 									// in case revealed by T-scanner
 	else
 		icon_state = "[state]"
-	return ..()
 
 /obj/machinery/navbeacon/attackby(obj/item/I, mob/user)
 	var/turf/T = loc

--- a/code/game/machinery/pda_multicaster.dm
+++ b/code/game/machinery/pda_multicaster.dm
@@ -30,11 +30,11 @@
 	return ..()
 
 /obj/machinery/pda_multicaster/update_icon_state()
+	. = ..()
 	if(on)
 		icon_state = initial(icon_state)
 	else
 		icon_state = "[initial(icon_state)]-p"
-	return ..()
 
 /obj/machinery/pda_multicaster/attackby(obj/item/I, mob/user)
 	if(I.is_screwdriver())

--- a/code/game/machinery/point_redemption_vendor/point_redemption_vendor.dm
+++ b/code/game/machinery/point_redemption_vendor/point_redemption_vendor.dm
@@ -31,6 +31,7 @@
 	var/list/datum/point_redemption_item/prize_list = list()
 
 /obj/machinery/point_redemption_vendor/update_icon_state()
+	. = ..()
 	var/icon_base_state = base_icon_state || initial(icon_state)
 	var/is_broken = atom_flags & ATOM_BROKEN
 	if(is_broken && icon_state_append_broken)
@@ -41,7 +42,6 @@
 		icon_state = "[icon_base_state][icon_state_append_open]"
 	else
 		icon_state = icon_base_state
-	return ..()
 
 /obj/machinery/point_redemption_vendor/power_change()
 	var/old_stat = machine_stat

--- a/code/game/machinery/pointdefense.dm
+++ b/code/game/machinery/pointdefense.dm
@@ -154,11 +154,11 @@ GLOBAL_LIST_BOILERPLATE(pointdefense_turrets, /obj/machinery/power/pointdefense)
 		. += "[desc_panel_image("multitool", user)]to set ident tag and connect to a mainframe."
 
 /obj/machinery/power/pointdefense/update_icon_state()
+	. = ..()
 	if(!active || !id_tag || inoperable())
 		icon_state = "[initial(icon_state)]_off"
 	else
 		icon_state = initial(icon_state)
-	return ..()
 
 /obj/machinery/power/pointdefense/default_unfasten_wrench(var/mob/user, var/obj/item/W, var/time)
 	if((. = ..()))

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -211,11 +211,11 @@
 	..(severity)
 
 /obj/machinery/recharger/update_icon_state()
+	. = ..()
 	if(charging)
 		icon_state = icon_state_charging
 	else
 		icon_state = icon_state_idle
-	return ..()
 
 /obj/machinery/recharger/RefreshParts()
 	var/E = 0

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -79,13 +79,13 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 	update_icon()
 
 /obj/machinery/requests_console/update_icon_state()
+	. = ..()
 	if(machine_stat & NOPOWER)
 		if(icon_state != "req_comp_off")
 			icon_state = "req_comp_off"
 	else
 		if(icon_state == "req_comp_off")
 			icon_state = "req_comp[newmessagepriority]"
-	return ..()
 
 /obj/machinery/requests_console/Initialize(mapload, newdir)
 	. = ..()

--- a/code/game/machinery/suit_storage/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage/suit_storage_unit.dm
@@ -43,6 +43,7 @@
 		boots_stored = new boots_stored_TYPE(src)
 
 /obj/machinery/suit_storage_unit/update_icon_state()
+	. = ..()
 	var/hashelmet = 0
 	var/hassuit = 0
 	var/hashuman = 0
@@ -53,7 +54,6 @@
 	if(occupant)
 		hashuman = 1
 	icon_state = "suitstorage[hashelmet][hassuit][hashuman][isopen][islocked][isUV][ispowered][isbroken][issuperUV]"
-	return ..()
 
 /obj/machinery/suit_storage_unit/power_change()
 	..()

--- a/code/game/machinery/telecomms/_telecomms.dm
+++ b/code/game/machinery/telecomms/_telecomms.dm
@@ -160,11 +160,11 @@
 					links |= T
 
 /obj/machinery/telecomms/update_icon_state()
+	. = ..()
 	if(on)
 		icon_state = initial(icon_state)
 	else
 		icon_state = "[initial(icon_state)]_off"
-	return ..()
 
 /obj/machinery/telecomms/proc/update_power()
 	if(toggled)

--- a/code/game/machinery/virtual_reality/vr_console.dm
+++ b/code/game/machinery/virtual_reality/vr_console.dm
@@ -51,8 +51,8 @@
 		go_out()
 
 /obj/machinery/vr_sleeper/update_icon_state()
+	. = ..()
 	icon_state = "[base_state][occupant ? "1" : "0"]"
-	return ..()
 
 /obj/machinery/vr_sleeper/Topic(href, href_list)
 	if(..())

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -68,8 +68,8 @@
 		usr.loc = src.loc
 
 /obj/machinery/washing_machine/update_icon_state()
+	. = ..()
 	icon_state = "wm_[state][panel_open]"
-	return ..()
 
 /obj/machinery/washing_machine/attackby(obj/item/W as obj, mob/user as mob)
 	if(state == 2 && washing.len < 1)

--- a/code/game/objects/effects/traps.dm
+++ b/code/game/objects/effects/traps.dm
@@ -107,11 +107,11 @@ Add those other swinging traps you mentioned above!
 	update_icon()
 
 /obj/effect/trap/update_icon_state()
+	. = ..()
 	if(!tripped)
 		icon_state = "[initial(icon_state)]"
 	else if (tripped)
 		icon_state = "[initial(icon_state)]_visible"
-	return ..()
 
 //////////////////
 /// Pit Traps
@@ -405,13 +405,13 @@ Add those other swinging traps you mentioned above!
 			to_chat(user, "<span class='warning'>You can't pry this sculpture off of the wall.</span>")
 
 /obj/effect/trap/launcher/update_icon_state()
+	. = ..()
 	if(!tripped)
 		icon_state = "[initial(icon_state)]"
 	else if (tripped && !(atom_flags & ATOM_BROKEN))
 		icon_state = "[initial(icon_state)]_visible"
 	else if (tripped && (atom_flags & ATOM_BROKEN))
 		icon_state = "[initial(icon_state)]_jammed"
-	return ..()
 
 //Stake Launcher
 /obj/effect/trap/launcher/stake
@@ -483,13 +483,13 @@ Add those other swinging traps you mentioned above!
 	visible_message(SPAN_DANGER("\The [src] breaks! It was a trap!"))
 
 /obj/effect/trap/pop_up/update_icon_state()
+	. = ..()
 	if(!tripped)
 		icon_state = "[initial(icon_state)]"
 	else if(tripped && !(atom_flags & ATOM_BROKEN))
 		icon_state = "[initial(icon_state)]_visible"
 	else if (tripped && (atom_flags & ATOM_BROKEN))
 		icon_state = "[initial(icon_state)]_broken"
-	return ..()
 
 //Spear Trap
 
@@ -719,13 +719,13 @@ if (istype(AM, /mob/living))
 	desc = "The edges of this tile are lifted slightly."
 
 /obj/effect/trap/pop_up/thrower/update_icon_state()
+	. = ..()
 	if(!tripped)
 		icon_state = "[initial(icon_state)]"
 	else if (tripped && !(atom_flags & ATOM_BROKEN))
 		icon_state = "[initial(icon_state)]_visible"
 	else if (tripped && (atom_flags & ATOM_BROKEN))
 		icon_state = "[initial(icon_state)]_jammed"
-	return ..()
 
 //////////////////
 // Falling Traps
@@ -755,13 +755,13 @@ if (istype(AM, /mob/living))
 			update_icon()
 
 /obj/effect/trap/falling/update_icon_state()
+	. = ..()
 	if(!tripped)
 		icon_state = "[initial(icon_state)]"
 	else if (tripped && !(atom_flags & ATOM_BROKEN))
 		icon_state = "[initial(icon_state)]_visible"
 	else if (tripped && (atom_flags & ATOM_BROKEN))
 		icon_state = "[initial(icon_state)]_jammed"
-	return ..()
 
 //Falling Log
 /obj/effect/trap/falling/log
@@ -821,10 +821,10 @@ if (istype(AM, /mob/living))
 	update_icon()
 
 /obj/effect/trap/falling/log/update_icon_state()
+	. = ..()
 	if(!tripped)
 		icon_state = "[initial(icon_state)]"
 	else if (tripped && !(atom_flags & ATOM_BROKEN))
 		icon_state = "[initial(icon_state)]_visible"
 	else if (tripped && (atom_flags & ATOM_BROKEN))
 		icon_state = "[initial(icon_state)]_jammed"
-	return ..()

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -115,6 +115,7 @@
 		M.update(broadcast)
 
 /obj/structure/closet/body_bag/update_icon_state()
+	. = ..()
 	if(opened)
 		icon_state = icon_opened
 	else
@@ -122,7 +123,6 @@
 			icon_state = "bodybag_closed1"
 		else
 			icon_state = icon_closed
-	return ..()
 
 /obj/item/bodybag/cryobag
 	name = "stasis bag"

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -91,12 +91,13 @@
 	. += SPAN_NOTICE("The last radiation amount detected was [last_tick_amount]")
 
 /obj/item/geiger_counter/update_icon_state()
+	. = ..()
 	if(!scanning)
 		icon_state = "geiger_off"
-		return ..()
+		return
 	if(obj_flags & OBJ_EMAGGED)
 		icon_state = "geiger_on_emag"
-		return ..()
+		return
 
 	switch(radiation_count)
 		if(-INFINITY to RAD_LEVEL_NORMAL)
@@ -111,7 +112,7 @@
 			icon_state = "geiger_on_4"
 		if(RAD_LEVEL_CRITICAL + 1 to INFINITY)
 			icon_state = "geiger_on_5"
-	return ..()
+	return
 
 /obj/item/geiger_counter/proc/update_sound()
 	var/datum/looping_sound/geiger/loop = soundloop

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -130,8 +130,8 @@
 //	toggle = TRUE
 
 /obj/item/transfer_valve/update_icon_state()
+	. = ..()
 	icon_state = "[base_icon_state][(!tank_one && !tank_two && !attached_device) ? "_1" : null]"
-	return ..()
 
 /obj/item/transfer_valve/update_overlays()
 	. = ..()

--- a/code/game/objects/items/id_cards/contractor_ids.dm
+++ b/code/game/objects/items/id_cards/contractor_ids.dm
@@ -35,7 +35,7 @@
 			icon_state = "chit_purple"
 		else
 			icon_state = "chit"
-	return 0
+	return 0 //TODO: Why 0, not parent?
 
 /obj/item/card/id/contractor/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/id_cards/guest.dm
+++ b/code/game/objects/items/id_cards/guest.dm
@@ -40,8 +40,8 @@
 		expire_timerid = null
 
 /obj/item/card/id/guest/update_icon_state()
+	. = ..()
 	icon_state = expired? "guest_invalid" : "guest"
-	return ..()
 
 // todo: refactor everything below
 

--- a/code/game/objects/items/melee/types/transforming.dm
+++ b/code/game/objects/items/melee/types/transforming.dm
@@ -77,8 +77,8 @@
 	return ..()
 
 /obj/item/melee/transforming/update_icon_state()
+	. = ..()
 	icon_state = "[base_icon_state || initial(icon_state)][active && !active_via_overlay ? "-active" : ""]"
-	return ..()
 
 /obj/item/melee/transforming/update_overlays()
 	. = ..()

--- a/code/game/objects/items/shield/types/transforming.dm
+++ b/code/game/objects/items/shield/types/transforming.dm
@@ -33,8 +33,8 @@
 	return ..()
 
 /obj/item/shield/transforming/update_icon_state()
+	. = ..()
 	icon_state = "[initial(icon_state)][active && !active_via_overlay ? "-active" : ""]"
-	return ..()
 
 /obj/item/shield/transforming/update_overlays()
 	. = ..()

--- a/code/game/objects/items/stacks/marker_beacons.dm
+++ b/code/game/objects/items/stacks/marker_beacons.dm
@@ -49,8 +49,8 @@ var/list/marker_beacon_colors = list(
 	. += "<span class='notice'>Alt-click to select a color. Current color is [picked_color].</span>"
 
 /obj/item/stack/marker_beacon/update_icon_state()
+	. = ..()
 	icon_state = "[initial(icon_state)][lowertext(picked_color)]"
-	return ..()
 
 /obj/item/stack/marker_beacon/attack_self(mob/user, datum/event_args/actor/actor)
 	. = ..()

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -21,12 +21,12 @@
 	. += create_stack_recipe_datum(name = "catwalk", product = /obj/structure/catwalk, cost = 2, time = 1 SECONDS)
 
 /obj/item/stack/rods/update_icon_state()
+	. = ..()
 	var/amount = get_amount()
 	if((amount <= 5) && (amount > 0))
 		icon_state = "rods-[amount]"
 	else
 		icon_state = "rods"
-	return ..()
 
 /obj/item/stack/rods/attackby(obj/item/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weldingtool))

--- a/code/game/objects/items/stacks/sandbag.dm
+++ b/code/game/objects/items/stacks/sandbag.dm
@@ -20,6 +20,7 @@
 	update_icon()
 
 /obj/item/stack/emptysandbag/update_icon_state()
+	. = ..()
 	var/amount = get_amount()
 	if((amount >= 35))
 		icon_state = "sandbag_empty_3"
@@ -27,7 +28,6 @@
 		icon_state = "sandbag_empty_2"
 	else
 		icon_state = "sandbag_empty"
-	return ..()
 
 /obj/item/stack/emptysandbag/attackby(var/obj/item/W, var/mob/user)
 	if(istype(W, /obj/item/stack/ore/glass) && !interact(user, src))
@@ -68,6 +68,7 @@
 	update_icon()
 
 /obj/item/stack/sandbags/update_icon_state()
+	. = ..()
 	var/amount = get_amount()
 	if((amount >= 35))
 		icon_state = "sandbags_3"
@@ -75,7 +76,6 @@
 		icon_state = "sandbags_2"
 	else
 		icon_state = "sandbags"
-	return ..()
 
 /obj/item/stack/sandbags/generate_explicit_recipes()
 	. = list()

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -94,12 +94,12 @@
 	update_icon()
 
 /obj/item/stack/update_icon_state()
+	. = ..()
 	if(!use_new_icon_update)
 		return ..()
 	if(!icon_state_count)
 		return ..()
 	icon_state = "[base_icon_state || initial(icon_state)]-[get_amount_icon_notch(get_amount())]"
-	return ..()
 
 /obj/item/stack/update_icon()
 	. = ..()

--- a/code/game/objects/items/stacks/tickets.dm
+++ b/code/game/objects/items/stacks/tickets.dm
@@ -12,6 +12,7 @@
 	update_icon()
 
 /obj/item/stack/arcadeticket/update_icon_state()
+	. = ..()
 	var/amount = get_amount()
 	switch(amount)
 		if(12 to INFINITY)
@@ -22,7 +23,6 @@
 			icon_state = "arcade-ticket_2"
 		else
 			icon_state = "arcade-ticket"
-	return ..()
 
 /obj/item/stack/arcadeticket/proc/pay_tickets()
 	amount -= 2

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -85,6 +85,7 @@
 	obj_storage.update_icon_on_item_change = TRUE
 
 /obj/item/storage/bag/trash/update_icon_state()
+	. = ..()
 	switch(w_class)
 		if(3)
 			icon_state = "[initial(icon_state)]1"
@@ -94,7 +95,6 @@
 			icon_state = "[initial(icon_state)]3"
 		else
 			icon_state = "[initial(icon_state)]"
-	return ..()
 
 /obj/item/storage/bag/trash/bluespace
 	name = "trash bag of holding"

--- a/code/game/objects/items/storage/misc_legacy/fancy.dm
+++ b/code/game/objects/items/storage/misc_legacy/fancy.dm
@@ -376,8 +376,8 @@
 	create_reagents(15 * max_items)
 
 /obj/item/storage/fancy/cigar/update_icon_state()
+	. = ..()
 	icon_state = "[initial(icon_state)][contents.len]"
-	return ..()
 
 /obj/item/storage/fancy/cigar/Exited(atom/movable/AM, atom/newLoc)
 	. = ..()
@@ -491,5 +491,5 @@
 	update_icon()
 
 /obj/item/storage/fancy/heartbox/update_icon_state()
+	. = ..()
 	icon_state = length(contents) ? "chocolate" : "heartbox_empty"
-	return ..()

--- a/code/game/objects/items/storage/misc_legacy/misc.dm
+++ b/code/game/objects/items/storage/misc_legacy/misc.dm
@@ -53,8 +53,8 @@
 	obj_storage.update_icon_on_item_change = TRUE
 
 /obj/item/storage/box/wormcan/update_icon_state()
+	. = ..()
 	icon_state = length(contents) ? "wormcan" : "wormcan_empty"
-	return ..()
 
 /obj/item/storage/box/wormcan/sickly
 	icon_state = "wormcan_sickly"
@@ -64,8 +64,8 @@
 	starts_with = list(/obj/item/reagent_containers/food/snacks/wormsickly = 6)
 
 /obj/item/storage/box/wormcan/sickly/update_icon_state()
+	. = ..()
 	icon_state = length(contents) ? "wormcan_empty_sickly" : "wormcan_sickly"
-	return ..()
 
 /obj/item/storage/box/wormcan/deluxe
 	icon_state = "wormcan_deluxe"

--- a/code/game/objects/items/storage/single_use/_single_use.dm
+++ b/code/game/objects/items/storage/single_use/_single_use.dm
@@ -20,5 +20,5 @@
 	update_icon()
 
 /obj/item/storage/single_use/update_icon_state()
+	. = ..()
 	icon_state = "[base_icon_state || initial(icon_state)][torn_open]"
-	return ..()

--- a/code/game/objects/items/weapons/candle.dm
+++ b/code/game/objects/items/weapons/candle.dm
@@ -16,6 +16,7 @@
 	wax -= rand(800, 1000) // Enough for 27-33 minutes. 30 minutes on average.
 
 /obj/item/flame/candle/update_icon_state()
+	. = ..()
 	var/i
 	if(wax > 1500)
 		i = 1
@@ -23,7 +24,6 @@
 		i = 2
 	else i = 3
 	icon_state = "[icon_type][i][lit ? "_lit" : ""]"
-	return ..()
 
 /obj/item/flame/candle/attackby(obj/item/W as obj, mob/user as mob)
 	..()

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -34,8 +34,8 @@
 		playsound(user, 'sound/effects/alert.ogg', 50, 1)
 
 /obj/item/tank/jetpack/update_icon_state()
+	. = ..()
 	icon_state = "[base_icon_state || initial(icon_state)][on ? "-on" : ""]"
-	return ..()
 
 /obj/item/tank/jetpack/verb/toggle_rockets()
 	set name = "Toggle Jetpack Stabilization"

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -201,6 +201,7 @@
 				return
 
 /obj/structure/catwalk/plank/update_icon_state()
+	. = ..()
 	var/perc = percent_integrity()
 	if(perc >= 0.75)
 		icon_state = "[initial(icon_state)]"
@@ -210,7 +211,6 @@
 		icon_state = "[initial(icon_state)]_rickety"
 	else
 		icon_state = "[initial(icon_state)]_dangerous"
-	return ..()
 
 //Ashlander Catwalks, for bridges?
 /obj/structure/catwalk/ashlander

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -103,11 +103,11 @@
 	register_material(material, part == "base")
 
 /obj/structure/girder/update_icon_state()
+	. = ..()
 	if(anchored)
 		icon_state = initial(icon_state)
 	else
 		icon_state = "displaced"
-	return ..()
 
 /obj/structure/girder/displaced
 	icon_state = "displaced"

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -29,9 +29,9 @@
 	var/destroyed = 0
 
 /obj/structure/grille/update_icon_state()
+	. = ..()
 	if(atom_flags & ATOM_BROKEN)
 		icon_state = "brokengrille"
-	return ..()
 
 /obj/structure/grille/Bumped(atom/user)
 	. = ..()

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -61,11 +61,11 @@ FLOOR SAFES
 	return num
 
 /obj/structure/safe/update_icon_state()
+	. = ..()
 	if(open)
 		icon_state = "[initial(icon_state)]-open"
 	else
 		icon_state = initial(icon_state)
-	return ..()
 
 /obj/structure/safe/attack_hand(mob/user, datum/event_args/actor/clickchain/e_args)
 	user.set_machine(src)

--- a/code/game/objects/structures/simple_doors.dm
+++ b/code/game/objects/structures/simple_doors.dm
@@ -118,6 +118,7 @@
 	update_nearby_tiles()
 
 /obj/structure/simple_door/update_icon_state()
+	. = ..()
 	var/datum/prototype/material/material = get_primary_material()
 	if(isnull(material))
 		icon_state = state? "open" : "closed"
@@ -126,7 +127,6 @@
 		icon_state = "[material.door_icon_base]open"
 	else
 		icon_state = material.door_icon_base
-	return ..()
 
 /obj/structure/simple_door/attackby(obj/item/W as obj, mob/user as mob)
 	if(user.a_intent == INTENT_HARM)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -42,8 +42,8 @@
 	update_icon()
 
 /obj/structure/toilet/update_icon_state()
+	. = ..()
 	icon_state = "toilet[open][cistern]"
-	return ..()
 
 /obj/structure/toilet/attackby(obj/item/I as obj, mob/living/user as mob)
 	if(I.is_crowbar())

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -53,8 +53,8 @@
 	return ..()
 
 /obj/structure/windoor_assembly/update_icon_state()
+	. = ..()
 	icon_state = "[facing]_[secure]windoor_assembly[state]"
-	return ..()
 
 /obj/structure/windoor_assembly/CanAllowThrough(atom/movable/mover, turf/target)
 	if(!(get_dir(loc, mover) & dir))

--- a/code/game/rendering/actor_huds/huds/inventory-screen_object.dm
+++ b/code/game/rendering/actor_huds/huds/inventory-screen_object.dm
@@ -183,8 +183,8 @@
 	hud.toggle_hidden_class(INVENTORY_HUD_CLASS_DRAWER, INVENTORY_HUD_HIDE_SOURCE_DRAWER)
 
 /atom/movable/screen/actor_hud/inventory/drawer/update_icon_state()
+	. = ..()
 	icon_state = "[(INVENTORY_HUD_CLASS_DRAWER in hud.hidden_classes) ? "drawer" : "drawer-active"]"
-	return ..()
 
 /**
  * Button: 'swap hand'

--- a/code/game/turfs/simulated/wall/wall_icon.dm
+++ b/code/game/turfs/simulated/wall/wall_icon.dm
@@ -59,6 +59,7 @@ GLOBAL_LIST_EMPTY(wall_overlays_cache)
 	return ..()
 
 /turf/simulated/wall/update_icon_state()
+	. = ..()
 	// handle fakewalls
 	// TODO: MAKE FAKEWALLS NOT TURFS WTF
 	if(!density)
@@ -67,7 +68,6 @@ GLOBAL_LIST_EMPTY(wall_overlays_cache)
 	else if(icon_state == "fwall_open")
 		icon_state = cached_wall_state
 
-	return ..()
 
 /turf/simulated/wall/update_overlays()
 	var/wall_paint = paint_color || material_color

--- a/code/modules/artwork/items/spraycan.dm
+++ b/code/modules/artwork/items/spraycan.dm
@@ -40,5 +40,5 @@
 		add_overlay(cap_image)
 
 /obj/item/pen/crayon/spraycan/update_icon_state()
+	. = ..()
 	icon_state = capped? "[initial(icon_state)]_cap" : "[initial(icon_state)]"
-	return ..()

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -102,11 +102,11 @@ Thus, the two variables affect pump operation are set in New():
 	use_power = 1
 
 /obj/machinery/atmospherics/component/binary/pump/update_icon_state()
+	. = ..()
 	if(!powered())
 		icon_state = "[base_icon]-off"
 	else
 		icon_state = "[use_power ? "[base_icon]-on" : "[base_icon]-off"]"
-	return ..()
 
 /obj/machinery/atmospherics/component/binary/pump/update_underlays()
 	if(..())

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -23,10 +23,10 @@
 	icon_state = "map_valve1"
 
 /obj/machinery/atmospherics/valve/update_icon_state()
+	. = ..()
 	// if(animation)
 		// flick("valve[src.open][!src.open]",src)
 	icon_state = "valve[open]"
-	return ..()
 
 /obj/machinery/atmospherics/valve/update_underlays()
 	if(..())

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -14,8 +14,7 @@
 	icon_state = "map_on"
 
 /obj/machinery/atmospherics/component/binary/pump/high_power/update_icon_state()
-	// todo: no don't do this
-	SHOULD_CALL_PARENT(FALSE)
+	. = ..()
 	if(!powered())
 		icon_state = "off"
 	else

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -32,6 +32,7 @@
 		filtering = initial(casted.id)
 
 /obj/machinery/atmospherics/component/trinary/filter/update_icon_state()
+	. = ..()
 	if(mirrored)
 		icon_state = "m"
 	else
@@ -42,7 +43,6 @@
 		icon_state += on ? "on" : "off"
 	else
 		icon_state += "off"
-	return ..()
 
 /obj/machinery/atmospherics/component/trinary/filter/process(delta_time)
 	..()

--- a/code/modules/atmospherics/machinery/components/trinary_devices/molar_filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/molar_filter.dm
@@ -35,9 +35,9 @@
 	air3.volume = ATMOS_DEFAULT_VOLUME_FILTER
 
 /obj/machinery/atmospherics/component/trinary/molar_filter/update_icon_state()
+	. = ..()
 	var/is_on = on && powered() && (node1 && node2 && node3)
 	icon_state = "[base_icon_state][mirrored? "-f" : ""][(is_on? "-on" : "")]"
-	return ..()
 
 /obj/machinery/atmospherics/component/trinary/molar_filter/process(delta_time)
 	..()

--- a/code/modules/atmospherics/machinery/components/trinary_devices/tvalve.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/tvalve.dm
@@ -28,8 +28,8 @@
 	state = 1
 
 /obj/machinery/atmospherics/tvalve/update_icon_state()
+	. = ..()
 	icon_state = "tvalve[mirrored ? "m" : ""][state]"
-	return ..()
 
 /obj/machinery/atmospherics/tvalve/proc/animation()
 	flick("tvalve[mirrored ? "m" : ""][src.state][!src.state]",src)

--- a/code/modules/atmospherics/machinery/components/unary/gas_freezer.dm
+++ b/code/modules/atmospherics/machinery/components/unary/gas_freezer.dm
@@ -47,6 +47,7 @@
 		update_icon()
 
 /obj/machinery/atmospherics/component/unary/freezer/update_icon_state()
+	. = ..()
 	if(node)
 		if(use_power && cooling)
 			icon_state = "freezer_1"
@@ -54,7 +55,6 @@
 			icon_state = "freezer"
 	else
 		icon_state = "freezer_0"
-	return ..()
 
 /obj/machinery/atmospherics/component/unary/freezer/attack_ai(mob/user as mob)
 	ui_interact(user)

--- a/code/modules/atmospherics/machinery/components/unary/gas_heater.dm
+++ b/code/modules/atmospherics/machinery/components/unary/gas_heater.dm
@@ -38,6 +38,7 @@
 		update_icon()
 
 /obj/machinery/atmospherics/component/unary/heater/update_icon_state()
+	. = ..()
 	if(node)
 		if(use_power && heating)
 			icon_state = "heater_1"
@@ -45,7 +46,6 @@
 			icon_state = "heater"
 	else
 		icon_state = "heater_0"
-	return ..()
 
 /obj/machinery/atmospherics/component/unary/heater/process(delta_time)
 	..()

--- a/code/modules/atmospherics/machinery/components/unary/generator_input.dm
+++ b/code/modules/atmospherics/machinery/components/unary/generator_input.dm
@@ -9,11 +9,11 @@
 	var/update_cycle
 
 /obj/machinery/atmospherics/component/unary/generator_input/update_icon_state()
+	. = ..()
 	if(node)
 		icon_state = "intact"
 	else
 		icon_state = "exposed"
-	return ..()
 
 /obj/machinery/atmospherics/component/unary/generator_input/proc/return_exchange_air()
 	return air_contents

--- a/code/modules/atmospherics/machinery/components/unary/heat_exchanger.dm
+++ b/code/modules/atmospherics/machinery/components/unary/heat_exchanger.dm
@@ -17,11 +17,11 @@
 	var/thermal_conduction_power = 1
 
 /obj/machinery/atmospherics/component/unary/heat_exchanger/update_icon_state()
+	. = ..()
 	if(node)
 		icon_state = "intact"
 	else
 		icon_state = "exposed"
-	return ..()
 
 /obj/machinery/atmospherics/component/unary/heat_exchanger/process()
 	..()

--- a/code/modules/atmospherics/machinery/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary/outlet_injector.dm
@@ -32,11 +32,11 @@
 	. = ..()
 
 /obj/machinery/atmospherics/component/unary/outlet_injector/update_icon_state()
+	. = ..()
 	if(!powered())
 		icon_state = "off"
 	else
 		icon_state = "[use_power ? "on" : "off"]"
-	return ..()
 
 /obj/machinery/atmospherics/component/unary/outlet_injector/update_underlays()
 	if(..())

--- a/code/modules/atmospherics/machinery/components/unary/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary/portables_connector.dm
@@ -39,8 +39,8 @@
 	initialize_directions = dir
 
 /obj/machinery/atmospherics/portables_connector/update_icon_state()
+	. = ..()
 	icon_state = "connector"
-	return ..()
 
 /obj/machinery/atmospherics/portables_connector/update_underlays()
 	if(..())

--- a/code/modules/catalogue/cataloguer.dm
+++ b/code/modules/catalogue/cataloguer.dm
@@ -65,13 +65,13 @@ GLOBAL_LIST_EMPTY(all_cataloguers)
 	return ..()
 
 /obj/item/cataloguer/update_icon_state()
+	. = ..()
 	if(snowflake_dont_update_icon_state)
-		return ..()
+		return
 	if(busy)
 		icon_state = "[initial(icon_state)]_active"
 	else
 		icon_state = initial(icon_state)
-	return ..()
 
 /obj/item/cataloguer/afterattack(atom/target, mob/user, clickchain_flags, list/params)
 	// Things that invalidate the scan immediately.

--- a/code/modules/catalogue/cataloguer_vr.dm
+++ b/code/modules/catalogue/cataloguer_vr.dm
@@ -10,6 +10,7 @@
 	snowflake_dont_update_icon_state = TRUE
 
 /obj/item/cataloguer/compact/update_icon_state()
+	. = ..()
 	var/base_state = base_icon_state || initial(icon_state)
 	if(!deployed)
 		icon_state = "[base_state]_closed"
@@ -17,7 +18,6 @@
 		icon_state = "[base_state]_s"
 	else
 		icon_state = base_state
-	return ..()
 
 /obj/item/cataloguer/compact/ui_action_click(datum/action/action, datum/event_args/actor/actor)
 	toggle()

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -436,8 +436,8 @@ BLIND     // can't see anything
 	toggle(user)
 
 /obj/item/clothing/glasses/welding/update_icon_state()
+	. = ..()
 	icon_state = "[base_icon_state || initial(icon_state)][up ? "up" : ""]"
-	return ..()
 
 /obj/item/clothing/glasses/welding/verb/toggle_verb()
 	set category = VERB_CATEGORY_OBJECT
@@ -586,11 +586,11 @@ BLIND     // can't see anything
 		update_action_buttons()
 
 /obj/item/clothing/glasses/sunglasses/sechud/aviator/update_icon_state()
+	. = ..()
 	if(on)
 		icon_state = initial(icon_state)
 	else
 		icon_state = inactive_icon_state
-	return ..()
 
 /obj/item/clothing/glasses/sunglasses/sechud/aviator/prescription
 	name = "prescription security HUD aviators"

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -99,8 +99,8 @@
 	)
 
 /obj/item/clothing/accessory/storage/shotgun_shell_holder/update_icon_state()
+	. = ..()
 	icon_state = "shotholder-[length(contents)]"
-	return ..()
 
 ////////////////
 //Armor plates

--- a/code/modules/fishing/machinery/fishing_portal.dm
+++ b/code/modules/fishing/machinery/fishing_portal.dm
@@ -24,11 +24,11 @@
 		activate()
 
 /obj/machinery/fishing_portal/update_icon_state()
+	. = ..()
 	if(active)
 		icon_state = "portal_on"
 	else
 		icon_state = "portal_off"
-	return ..()
 
 /obj/machinery/fishing_portal/proc/activate()
 	active = TRUE

--- a/code/modules/frames/structure.dm
+++ b/code/modules/frames/structure.dm
@@ -39,8 +39,8 @@
 	return context?[key]
 
 /obj/structure/frame2/update_icon_state()
+	. = ..()
 	icon_state = "structure[frame.has_structure_stage_states? "-[stage]" : ""]"
-	return ..()
 
 /obj/structure/frame2/update_overlays()
 	. = ..()

--- a/code/modules/mining/tools/shelter_atoms.dm
+++ b/code/modules/mining/tools/shelter_atoms.dm
@@ -166,9 +166,9 @@
 		icon_state = "table" //this table doesn't care about your material nonsense. just ignore the overlays.
 
 /obj/structure/table/survival_pod/update_icon_state()
+	. = ..()
 	if(!isnull(material_base))
 		icon_state = "table"
-	return ..()
 
 /obj/structure/table/survival_pod/Initialize(mapload)
 	remove_obj_verb(src, /obj/structure/table/verb/do_flip)

--- a/code/modules/nanites/chamber.dm
+++ b/code/modules/nanites/chamber.dm
@@ -87,6 +87,7 @@
 		. += "[base_icon_state]_bolted"
 
 /obj/machinery/nanite_chamber/update_icon_state()
+	. = ..()
 	if(operating)
 		icon_state = "[base_icon_state]_active"
 	else if(occupant)
@@ -95,7 +96,6 @@
 		icon_state = "[base_icon_state]_open"
 	else
 		icon_state = "[base_icon_state]"
-	return ..()
 
 /obj/machinery/nanite_chamber/interact(mob/user)
 	. = ..()

--- a/code/modules/power/geothermal_power.dm
+++ b/code/modules/power/geothermal_power.dm
@@ -57,6 +57,7 @@
 
 
 /obj/machinery/power/geothermal_controller/update_icon_state()
+	. = ..()
 	switch(power_total)
 		if(50 to 500 KILOWATTS)
 			icon_state = "controller_low"
@@ -68,7 +69,6 @@
 			icon_state = "controller_vhigh"
 		else
 			icon_state = "controller_idle"
-	return ..()
 
 
 /obj/machinery/power/geothermal_controller/proc/scan_for_collectors(var/ran)

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -24,11 +24,11 @@
 	update_icon()
 
 /obj/machinery/power/terminal/update_icon_state()
+	. = ..()
 	if(is_hidden_underfloor())
 		icon_state = "term-f"
 	else
 		icon_state = "term"
-	return ..()
 
 // Needed so terminals are not removed from machines list.
 // Powernet rebuilds need this to work properly.

--- a/code/modules/projectiles/guns/gun/projectile/ballistic/contender.dm
+++ b/code/modules/projectiles/guns/gun/projectile/ballistic/contender.dm
@@ -18,8 +18,8 @@
 
 // todo: new rendering system
 /obj/item/gun/projectile/ballistic/contender/update_icon_state()
+	. = ..()
 	icon_state = bolt_closed ? initial(icon_state) : icon_retracted
-	return ..()
 
 /obj/item/gun/projectile/ballistic/contender/a44
 	caliber = /datum/ammo_caliber/a44

--- a/code/modules/projectiles/guns/gun/projectile/energy/special.dm
+++ b/code/modules/projectiles/guns/gun/projectile/energy/special.dm
@@ -438,8 +438,8 @@
 	)
 
 /obj/item/gun/projectile/energy/plasma/update_icon_state()
+	. = ..()
 	icon_state = "[initial(icon_state)][overheating ? "_overheat" : ""]"
-	return ..()
 
 /obj/item/gun/projectile/energy/plasma/pistol
 	name = "\improper Wyrm plasma pistol"

--- a/code/modules/projectiles/guns/gun_attachment/flashlight.dm
+++ b/code/modules/projectiles/guns/gun_attachment/flashlight.dm
@@ -38,8 +38,8 @@
 	..()
 
 /obj/item/gun_attachment/flashlight/update_icon_state()
+	. = ..()
 	icon_state = "[base_icon_state || initial(icon_state)][on ? "-on" : ""]"
-	return ..()
 
 /obj/item/gun_attachment/flashlight/proc/set_on(state, datum/event_args/actor/actor)
 	if(on == state)

--- a/code/modules/reagents/items/hypospray.dm
+++ b/code/modules/reagents/items/hypospray.dm
@@ -51,6 +51,7 @@
 			. += SPAN_NOTICE("It's unloaded.")
 
 /obj/item/hypospray/update_icon_state()
+	. = ..()
 	var/vial_state
 	if(!isnull(loaded))
 		if(istype(loaded, /obj/item/reagent_containers/glass/hypovial/bluespace))
@@ -58,7 +59,6 @@
 		else
 			vial_state = "-l"
 	icon_state = "[initial(icon_state)][vial_state]"
-	return ..()
 
 /obj/item/hypospray/update_overlays()
 	. = ..()

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -89,8 +89,8 @@
 				return
 
 /obj/machinery/chem_master/update_icon_state()
+	. = ..()
 	icon_state = "[base_icon_state][beaker ? 1 : 0][(machine_stat & BROKEN) ? "_b" : (powered() ? null : "_nopower")]"
-	return ..()
 
 /obj/machinery/chem_master/update_overlays()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I just ctrl+shift+f for ``/update_icon_state(``, and manually added ``.=..()`` at the beginning if it didn't have that. ``return ..()`` was also removed if at the end of the function, otherwise turned to plain returns. Tested only so far it compiles, and that it should be the correct logic instead.

## Why It's Good For The Game

Objects should have the icon_state and icon sheet matching, which is best known by the full path, than the parent-> modify the icon_state after the parent already was called. That likely is the cause for "Emergency Core Eject"s to be invisible, as ``/obj/machinery/button/remote/driver`` use ``'icons/obj/objects.dmi'``, but their parent uses ``'icons/obj/stationobjs.dmi'``, and sets it to a state only found there.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: update_icon_state always call parent first
fix: objects should have their intended sprite from the refactored function
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
