### PR TITLE
gives holospheres the reset to slot and set size verbs

### DIFF
--- a/code/modules/species/holosphere/holosphere.dm
+++ b/code/modules/species/holosphere/holosphere.dm
@@ -71,6 +71,7 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_tail,
 		/mob/living/carbon/human/proc/shapeshifter_select_ears,
 		/mob/living/carbon/human/proc/shapeshifter_select_horns,
+		/mob/living/carbon/human/proc/hologram_reset_to_slot,
 	)
 
 	minimum_hair_alpha = MINIMUM_HOLOGRAM_HAIR_ALPHA

--- a/code/modules/species/holosphere/holosphere.dm
+++ b/code/modules/species/holosphere/holosphere.dm
@@ -72,6 +72,7 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_ears,
 		/mob/living/carbon/human/proc/shapeshifter_select_horns,
 		/mob/living/carbon/human/proc/hologram_reset_to_slot,
+		/mob/living/proc/set_size,
 	)
 
 	minimum_hair_alpha = MINIMUM_HOLOGRAM_HAIR_ALPHA

--- a/code/modules/species/species_shapeshift.dm
+++ b/code/modules/species/species_shapeshift.dm
@@ -633,19 +633,27 @@ var/list/wrapped_species_by_ref = list()
 	set category = "Abilities"
 	set desc = "Resets your character's appearance to the CURRENTLY-SELECTED slot."
 
+	shapeshifter_reset_to_slot_generic(1 MINUTE, "<span class='warning'>[src] deforms and contorts strangely...</span>", 5 SECONDS)
+
+/mob/living/carbon/human/proc/hologram_reset_to_slot()
+	set name = "Reset Appearance to Slot"
+	set category = "Abilities"
+	set desc = "Resets your character's appearance to the CURRENTLY-SELECTED slot."
+
+	shapeshifter_reset_to_slot_generic(1 MINUTE, "<span class='warning'>[src]'s hologram flickers briefly...</span>", 5 SECONDS)
+
+/mob/living/carbon/human/proc/shapeshifter_reset_to_slot_generic(transform_cooldown, transform_text, transform_duration)
 	if(stat || world.time < last_special)
 		return
 
-	last_special = world.time + 1 MINUTE
+	last_special = world.time + transform_cooldown
 
-	visible_message("<span class='warning'>[src] deforms and contorts strangely...</span>")
+	visible_message(transform_text)
 
-	if(!do_after(src, 50)) //5 seconds
+	if(!do_after(src, transform_duration))
 		return FALSE
 
 	shapeshifter_reset_to_slot_core(src)
-
-
 
 	//sigh
 	if(istype(src.species, /datum/species/shapeshifter))


### PR DESCRIPTION
## About The Pull Request
title

shapeshifter_reset_to_slot is now shapeshifter_reset_to_slot_generic which has parameters for the duration, cooldown and text


## Why It's Good For The Game
someone asked for it and it feels like something they should be able to do

## Changelog

:cl:
add: gives holospheres the reset to slot and set size verbs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
