### PR TITLE
Renamed Atlas substations/breakers to be consistent

### DIFF
--- a/maps/rift/levels/rift-02-underground2.dmm
+++ b/maps/rift/levels/rift-02-underground2.dmm
@@ -5877,7 +5877,7 @@
 /area/maintenance/chapel)
 "uN" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Underground 2"
+	RCon_tag = "Underground 2 - Main Substation"
 	},
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -11590,7 +11590,7 @@
 /area/engineering/atmos/hallway)
 "Rr" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Engineering Substation Bypass"
+	RCon_tag = "Underground 2 - Engineering Substation Bypass"
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/engineering)
@@ -13350,7 +13350,7 @@
 /area/rnd/secure_storage/critical)
 "Yd" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Underground 2"
+	RCon_tag = "Underground 2 - Main Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/atmos)
@@ -13530,7 +13530,7 @@
 /area/rnd/secure_storage/critical/records)
 "YY" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Engineering";
+	RCon_tag = "Underground 2 - Engineering Substation";
 	output_attempt = 0
 	},
 /obj/machinery/camera/network/engineering,

--- a/maps/rift/levels/rift-03-underground1.dmm
+++ b/maps/rift/levels/rift-03-underground1.dmm
@@ -2797,7 +2797,7 @@
 /area/engineering/atmos)
 "ha" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Underground 1"
+	RCon_tag = "Underground 1 - Main Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
@@ -3659,7 +3659,7 @@
 /area/engineering/atmos/hallway)
 "jU" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Underground 1"
+	RCon_tag = "Underground 1 - Main Substation"
 	},
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -14889,7 +14889,7 @@
 	dir = 5
 	},
 /obj/machinery/power/breakerbox{
-	RCon_tag = "Telecomms"
+	RCon_tag = "Underground 1 - Telecomms Substation Bypass"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)

--- a/maps/rift/levels/rift-04-surface1.dmm
+++ b/maps/rift/levels/rift-04-surface1.dmm
@@ -8885,7 +8885,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Surface 1";
+	RCon_tag = "Surface 1 - Main Substation";
 	output_attempt = 0
 	},
 /obj/structure/cable/green{
@@ -13069,7 +13069,7 @@
 /area/storage/tools)
 "irf" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Cargo Substation Bypass"
+	RCon_tag = "Surface 1 - Cargo Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
@@ -17885,7 +17885,7 @@
 /area/maintenance/evahallway)
 "lie" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Medical";
+	RCon_tag = "Surface 1 - Medical Substation";
 	output_attempt = 0
 	},
 /obj/structure/cable/green,
@@ -21702,7 +21702,7 @@
 /area/hallway/primary/surfaceone)
 "nyE" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Surface 1 Substation Bypass"
+	RCon_tag = "Surface 1 - Main Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/surface_one)
@@ -27407,7 +27407,7 @@
 /area/medical/virology)
 "qHS" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Research Southwest Wing Subgrid";
+	RCon_tag = "Surface 1 - Research Southwest Wing Subgrid";
 	cur_coils = 2;
 	output_attempt = 0
 	},
@@ -37537,7 +37537,7 @@
 /area/maintenance/tool_storage)
 "wrP" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Cargo";
+	RCon_tag = "Surface 1 - Cargo Substation";
 	output_attempt = 0
 	},
 /obj/structure/cable/green{
@@ -38461,7 +38461,7 @@
 /area/medical/psych)
 "wTn" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Medical Substation Bypass"
+	RCon_tag = "Surface 1 - Medical Substation Bypass"
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/medical)
@@ -39346,7 +39346,7 @@
 /area/rift/surfaceeva/airlock/main/secondary)
 "xsI" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Research Southwest Wing Bypass"
+	RCon_tag = "Surface 1 - Research Southwest Wing Subgrid Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research/southwest_wing)

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -13171,7 +13171,7 @@
 /area/assembly/robotics)
 "iiw" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Northwestern Outpost Substation Bypass"
+	RCon_tag = "Surface 2 - Northwestern Outpost Substation Bypass"
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/cafeteria_dock)
@@ -14937,7 +14937,7 @@
 /area/maintenance/security/upper)
 "jsh" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Research Main";
+	RCon_tag = "Surface 2 - Research Main Subgrid";
 	output_attempt = 0
 	},
 /obj/structure/cable/green,
@@ -20413,7 +20413,7 @@
 /area/rift/station/fighter_bay/transport_tunnel_garage_maint)
 "mDo" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Surface 2"
+	RCon_tag = "Surface 2 - Main Substation"
 	},
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -24466,7 +24466,7 @@
 	dir = 4
 	},
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Surface 2 Substation Bypass"
+	RCon_tag = "Surface 2 - Main Substation Bypass"
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/surface_two)
@@ -33525,7 +33525,7 @@
 /area/crew_quarters/showers)
 "uWX" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Security";
+	RCon_tag = "Surface 2 - Security Substation";
 	output_attempt = 0
 	},
 /obj/structure/cable/green{
@@ -33743,7 +33743,7 @@
 /area/maintenance/asmaint2)
 "vcn" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Northwestern Outpost";
+	RCon_tag = "Surface 2 - Northwestern Outpost Substation";
 	output_attempt = 0
 	},
 /obj/structure/cable/green,
@@ -36134,7 +36134,7 @@
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "wMk" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Security Substation Bypass"
+	RCon_tag = "Surface 2 - Security Substation Bypass"
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/security)
@@ -37782,7 +37782,7 @@
 /area/security/hallway)
 "xNq" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Research Main Substation Bypass"
+	RCon_tag = "Surface 2 - Research Main Subgrid Bypass"
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/research)

--- a/maps/rift/levels/rift-06-surface3.dmm
+++ b/maps/rift/levels/rift-06-surface3.dmm
@@ -8790,7 +8790,7 @@
 /area/bridge/bunker)
 "aBh" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Command"
+	RCon_tag = "Surface 3 - Command Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/command)
@@ -11003,7 +11003,7 @@
 /area/rift/surfaceeva/aa/cliff_north)
 "aIr" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Exploration and Research Shuttles";
+	RCon_tag = "Surface 3 - Exploration & Research Shuttles Substation";
 	inputting = 1;
 	output_attempt = 0
 	},
@@ -16333,7 +16333,7 @@
 /area/hallway/secondary/docking_hallway2)
 "aYS" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Command";
+	RCon_tag = "Surface 3 - Command Substation";
 	cur_coils = 2
 	},
 /obj/structure/cable/green{
@@ -23864,7 +23864,7 @@
 /area/maintenance/substation/surface_three)
 "nFC" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Exploration Substation Bypass"
+	RCon_tag = "Surface 3 - Exploration & Research Shuttles Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/exploration)
@@ -23904,7 +23904,7 @@
 /area/shuttle/excursion/cargo)
 "nKj" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Surface 3";
+	RCon_tag = "Surface 3 - Main Substation";
 	cur_coils = 2
 	},
 /obj/structure/cable/green{
@@ -25951,7 +25951,7 @@
 /area/exploration)
 "rMY" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Surface 3"
+	RCon_tag = "Surface 3 - Main Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/surface_three)
@@ -26819,7 +26819,7 @@
 /area/rift/surfaceeva/airlock/arrivals/secondary)
 "tIR" = (
 /obj/machinery/power/smes/buildable/power_shuttle{
-	RCon_tag = "Courser Charging Port";
+	RCon_tag = "Surface 3 - Courser Charging Port";
 	name = "Courser Charging Port"
 	},
 /obj/structure/cable/pink{

--- a/maps/rift/levels/rift-09-west_caves.dmm
+++ b/maps/rift/levels/rift-09-west_caves.dmm
@@ -2970,7 +2970,7 @@
 /area/rnd/outpost/underground)
 "IC" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Mining Outpost Substation Bypass"
+	RCon_tag = "Western Caves - Mining Outpost Substation Bypass"
 	},
 /obj/machinery/camera/network/research_outpost{
 	dir = 4
@@ -3734,7 +3734,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Mining Outpost";
+	RCon_tag = "Western Caves - Mining Outpost Substation";
 	charge = 1000
 	},
 /turf/simulated/floor,

--- a/maps/rift/levels/rift-10-west_plains.dmm
+++ b/maps/rift/levels/rift-10-west_plains.dmm
@@ -2420,7 +2420,7 @@
 /area/rnd/outpost)
 "kL" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Science Outpost Substation Bypass"
+	RCon_tag = "Western Plains - Science Outpost Substation Bypass"
 	},
 /obj/machinery/camera/network/research_outpost{
 	dir = 4
@@ -10821,7 +10821,7 @@
 /area/rnd/outpost/breakroom)
 "YM" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Geothermal Plant";
+	RCon_tag = "Power - Geothermal Plant";
 	cur_coils = 2;
 	output_level_max = 500
 	},
@@ -11058,7 +11058,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Science Outpost";
+	RCon_tag = "Western Plains - Science Outpost Substation";
 	charge = 1000
 	},
 /turf/simulated/floor,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Renames most of the NSB Atlas substations and breaker boxes to label which floor they're on and generally be more consistent. This should help managing RCON be a lot smoother. See screenshots of the new layout:
![image](https://github.com/user-attachments/assets/432b2f4d-65e2-456b-acfc-5ce875e5e5c7)
![image](https://github.com/user-attachments/assets/22e2570d-bcc8-4847-993f-3db2f346c695)
![image](https://github.com/user-attachments/assets/4b75e119-fd10-4c91-8fba-0c562f47f9cf)
![image](https://github.com/user-attachments/assets/53a8a2ef-b815-4894-af61-774be71c289b)

## Why It's Good For The Game

The old RCON labels were inconsistent and somewhat confusing. This helps engineering players, especially new ones, learn the RCON system quicker. To compare, this is what the breakers were like before:
![image](https://github.com/user-attachments/assets/82e2b80f-f92d-4426-b6a6-ebfbe0b06b82)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Adjusted the RCON labels of the substations and breaker boxes on the NSB Atlas.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
