### PR TITLE
Drone matrix upgrades touchup

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/matrix_hive.dm
+++ b/code/modules/mob/living/silicon/robot/drone/matrix_hive.dm
@@ -76,18 +76,22 @@ var/global/list/drone_matrices = list()
 /datum/drone_matrix/proc/set_upgrade(mob/living/silicon/robot/drone/D, var/upgrade_type)
 	switch(upgrade_type)
 		if(MTX_UPG_SPEED)
-			D.movement_base_speed = initial(D.movement_base_speed) - 1
+			D.movement_base_speed = initial(D.movement_base_speed) + 1
 			D.update_movespeed_base()
 		if(MTX_UPG_CELL)
-			D.cell.maxcharge = D.cell.maxcharge * 1.5
+			D.cell.maxcharge = initial(D.cell.maxcharge) * 1.5
 		if(MTX_UPG_HEALTH)
-			D.maxHealth += 15
+			D.maxHealth = initial(D.maxHealth) + 15
 		if(MTX_UPG_MOP)
-			D.module.modules -= locate(/obj/item/mop) in D.module.modules
-			D.module.modules += new/obj/item/mop/advanced(D.module)
+			var/obj/item/mop/current_mop = locate(/obj/item/mop) in D.module.modules
+			if(!istype(current_mop, /obj/item/mop/advanced))
+				D.module.modules -= current_mop
+				D.module.modules += new/obj/item/mop/advanced(D.module)
 		if(MTX_UPG_T)
-			D.module.modules -= locate(/obj/item/t_scanner) in D.module.modules
-			D.module.modules += new/obj/item/t_scanner/upgraded(D.module)
+			var/obj/item/t_scanner/current_scanner = locate(/obj/item/t_scanner) in D.module.modules
+			if(!istype(current_scanner, /obj/item/t_scanner/upgraded))
+				D.module.modules -= current_scanner
+				D.module.modules += new/obj/item/t_scanner/upgraded(D.module)
 	LAZYADD(D.matrix_upgrades, upgrade_type)
 
 /proc/assign_drone_to_matrix(mob/living/silicon/robot/drone/D, var/matrix_tag)

--- a/code/modules/mob/living/silicon/robot/drone/matrix_hive.dm
+++ b/code/modules/mob/living/silicon/robot/drone/matrix_hive.dm
@@ -67,7 +67,7 @@ var/global/list/drone_matrices = list()
 /datum/drone_matrix/proc/apply_upgrades(mob/living/silicon/robot/drone/D)
 	var/list/applied_upgrades = list()
 	for(var/upgrade in bought_upgrades)
-		if(!LAZYACCESS(D.matrix_upgrades, upgrade))
+		if(!LAZYFIND(D.matrix_upgrades, upgrade))
 			applied_upgrades += upgrade
 			set_upgrade(D, upgrade)
 	if(length(applied_upgrades))
@@ -76,12 +76,12 @@ var/global/list/drone_matrices = list()
 /datum/drone_matrix/proc/set_upgrade(mob/living/silicon/robot/drone/D, var/upgrade_type)
 	switch(upgrade_type)
 		if(MTX_UPG_SPEED)
-			D.movement_base_speed = initial(D.movement_base_speed) + 1
+			D.movement_base_speed += 1
 			D.update_movespeed_base()
 		if(MTX_UPG_CELL)
-			D.cell.maxcharge = initial(D.cell.maxcharge) * 1.5
+			D.cell.maxcharge *= * 1.5
 		if(MTX_UPG_HEALTH)
-			D.maxHealth = initial(D.maxHealth) + 15
+			D.maxHealth += 15
 		if(MTX_UPG_MOP)
 			var/obj/item/mop/current_mop = locate(/obj/item/mop) in D.module.modules
 			if(!istype(current_mop, /obj/item/mop/advanced))

--- a/code/modules/mob/living/silicon/robot/drone/matrix_hive.dm
+++ b/code/modules/mob/living/silicon/robot/drone/matrix_hive.dm
@@ -87,11 +87,13 @@ var/global/list/drone_matrices = list()
 			if(!istype(current_mop, /obj/item/mop/advanced))
 				D.module.modules -= current_mop
 				D.module.modules += new/obj/item/mop/advanced(D.module)
+				qdel(current_mop)
 		if(MTX_UPG_T)
 			var/obj/item/t_scanner/current_scanner = locate(/obj/item/t_scanner) in D.module.modules
 			if(!istype(current_scanner, /obj/item/t_scanner/upgraded))
 				D.module.modules -= current_scanner
 				D.module.modules += new/obj/item/t_scanner/upgraded(D.module)
+				qdel(current_scanner)
 	LAZYADD(D.matrix_upgrades, upgrade_type)
 
 /proc/assign_drone_to_matrix(mob/living/silicon/robot/drone/D, var/matrix_tag)

--- a/code/modules/mob/living/silicon/robot/drone/matrix_hive.dm
+++ b/code/modules/mob/living/silicon/robot/drone/matrix_hive.dm
@@ -79,7 +79,7 @@ var/global/list/drone_matrices = list()
 			D.movement_base_speed += 1
 			D.update_movespeed_base()
 		if(MTX_UPG_CELL)
-			D.cell.maxcharge *= * 1.5
+			D.cell.maxcharge *= 1.5
 		if(MTX_UPG_HEALTH)
 			D.maxHealth += 15
 		if(MTX_UPG_MOP)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just a slight change to how the drone upgrades are applied. Mostly ensures they get only applied once, and don't delete and re-add the upgraded item. The potential for infinite growth remains, although it would need admin intervention to remove the already applied upgrades from the list. It still will allow it to be upgrades even if the drone got edited before, why I removed the initial() call for it.

## Why It's Good For The Game

As fun as exponentially growing power storage is, and with enough time, an extremely tanky drone, upgrades should only apply once. The speed upgrade actually is an upgrade again, as it's no delay anymore, but tiles per seconds, so the sign had to switch.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Actuator enhancement is actually an enhancement again.
tweak: drone upgrades only get applied once
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
