### PR TITLE
fix two sprite accessories sharing an id

### DIFF
--- a/code/modules/sprite_accessories/tail/wide_tail.dm
+++ b/code/modules/sprite_accessories/tail/wide_tail.dm
@@ -27,6 +27,7 @@
 
 /datum/sprite_accessory/tail/wide/largeshark/stripes2
 	name = "Large Shark (striped, underbelly)"
+	id = "large_shark_stripes_underbelly"
 	extra_overlay = "large_shark_underbelly"
 	extra_overlay2 = "large_shark_stripes_underbelly"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title

## Why It's Good For The Game
fixes a bug

## Changelog

:cl:
fix: fix two sprite accessories sharing an id
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
