### PR TITLE
Shadekin-Spacekin-Futureproofing

### DIFF
--- a/code/modules/species/shadekin/shadekin.dm
+++ b/code/modules/species/shadekin/shadekin.dm
@@ -37,7 +37,7 @@
 		/datum/melee_attack/unarmed/bite/sharp/shadekin,
 	)
 
-	siemens_coefficient = 1
+	siemens_coefficient = 0
 	vision_innate = /datum/vision/baseline/species_tier_3/for_snowflake_ocs
 	vision_organ = O_EYES
 
@@ -118,8 +118,6 @@
 		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right),
 	)
 
-	vision_innate = /datum/vision/baseline/species_tier_3/for_snowflake_ocs
-
 	var/list/shadekin_abilities = list(
 		/datum/power/shadekin/phase_shift,
 		/datum/power/shadekin/regenerate_other,
@@ -181,6 +179,8 @@
 	var/brightness = T.get_lumcount() //Brightness in 0.0 to 1.0
 	darkness = 1-brightness //Invert
 	var/is_dark = (darkness >= 0.5)
+	if(isspaceturf(T))
+		is_dark = 1
 
 	if(H.ability_flags & AB_PHASE_SHIFTED)
 		dark_gains = 0
@@ -259,13 +259,13 @@
 					l_icon = 4
 
 		switch(get_energy(H))
-			if(0 to 24)
+			if(0 to 24.99)
 				e_icon = 0
-			if(25 to 49)
+			if(25 to 49.99)
 				e_icon = 1
-			if(50 to 74)
+			if(50 to 74.99)
 				e_icon = 2
-			if(75 to 99)
+			if(75 to 99.99)
 				e_icon = 3
 			if(100 to INFINITY)
 				e_icon = 4

--- a/code/modules/species/shadekin/shadekin_traits.dm
+++ b/code/modules/species/shadekin/shadekin_traits.dm
@@ -46,10 +46,10 @@
 /datum/trait/kintype/purple
 	name = "Shadekin Purple Adaptation"
 	color = PURPLE_EYES
-	desc = "Very good energy regeneration in darkness, minor degeneration in the light and increased health!"
+	desc = "Very good energy regeneration in darkness, minor regeneration in the light and increased health!"
 	var_changes = list(
 		"total_health" = 150,
-		"energy_light" = -0.5,
+		"energy_light" = 0.25,
 		"energy_dark" = 1.5,
 		"unarmed_types" = list(
 			/datum/melee_attack/unarmed/stomp,
@@ -67,10 +67,10 @@
 /datum/trait/kintype/yellow
 	name = "Shadekin Yellow Adaptation"
 	color = YELLOW_EYES
-	desc = "Highest energy regeneration in darkness, high degeneration in the light and unchanged health!"
+	desc = "Highest energy regeneration in darkness, minor regeneration in the light and unchanged health!"
 	var_changes = list(
 		"total_health" = 100,
-		"energy_light" = -1,
+		"energy_light" = 0.25,
 		"energy_dark" = 3,
 		"unarmed_types" = list(
 			/datum/melee_attack/unarmed/stomp,
@@ -109,10 +109,10 @@
 /datum/trait/kintype/orange
 	name = "Shadekin Orange Adaptation"
 	color = ORANGE_EYES
-	desc = "Good energy regeneration in darkness, small degeneration in the light and increased health!"
+	desc = "Good energy regeneration in darkness, minor regeneration in the light and increased health!"
 	var_changes = list(
 		"total_health" = 175,
-		"energy_light" = -0.5,
+		"energy_light" = 0.25,
 		"energy_dark" = 1,
 		"unarmed_types" = list(
 			/datum/melee_attack/unarmed/stomp,


### PR DESCRIPTION
## About The Pull Request

Biggest change is that Space turf counts as dark for Shadekin, and those Shadekin who would lose energy in the light (Yellow, Purple, Orange) now instead have minimal regeneration in the light. This will be important for the future change to Shadekin with them travelling through space, since space is always bright.
Siemens Coeff is also returned to the previous value, as it was before needless drama happened.
HUD values were updated since sometimes regeneration would put the value to one which wasn't checked by the switch, causing the HUD to mess up for a short time. (i.e. value goes to 24.1 which wasn't covered.)

## Why It's Good For The Game

Current plan for the future of Shadekin will have them move through space, and during such discussion I was told to go ahead and make Space tiles count as dark to ensure those Shadekin don't suddenly get stranded in space.

## Changelog

:cl:
add: Check to see if the turf is a space turf.
tweak: Degeneration values replaced with minor regeneration. (Only affects Admin Shadekin.)
/:cl: