### PR TITLE
shuttles no longer add sector name infront of the Landingpoint name, landingpoints should do that themselves

### DIFF
--- a/code/modules/overmap/legacy/overmap_shuttle.dm
+++ b/code/modules/overmap/legacy/overmap_shuttle.dm
@@ -68,7 +68,7 @@
 		var/list/waypoints = S.get_waypoints(name)
 		for(var/obj/effect/shuttle_landmark/LZ in waypoints)
 			if(LZ.is_valid(src))
-				res["[waypoints[LZ]] - [LZ.name]"] = LZ
+				res[LZ.name] = LZ
 	return res
 
 /datum/shuttle/autodock/overmap/get_location_name()

--- a/code/modules/overmap/legacy/ships/computers/shuttle.dm
+++ b/code/modules/overmap/legacy/ships/computers/shuttle.dm
@@ -39,7 +39,7 @@
 			var/list/possible_d = shuttle.get_possible_destinations()
 			var/D
 			if(possible_d.len)
-				D = input("Choose shuttle destination", "Shuttle Destination") as null|anything in possible_d
+				D = tgui_input_list(usr, "Choose shuttle destination", "Shuttle Destination", possible_d)
 			else
 				to_chat(usr,"<span class='warning'>No valid landing sites in range.</span>")
 			possible_d = shuttle.get_possible_destinations()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Look on the title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
we dont need two sector names on landingspot selection
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: shuttle landing spot selection is now tgui
tweak: shuttles no longer prepend sector name to a landing spot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
