### PR TITLE
Make showing status in who verb on by default.

### DIFF
--- a/code/modules/client/game_preferences/game_preference_toggle.dm
+++ b/code/modules/client/game_preferences/game_preference_toggle.dm
@@ -261,7 +261,7 @@
 	name = "Show Status in Advanced Who"
 	description = "Show your playing status in advanced who."
 	key = "advanced_who_status"
-	default_value = FALSE
+	default_value = TRUE
 
 /datum/game_preference_toggle/presence/announce_ghost_joinleave
 	name = "Announce Observer Join/Leave"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Make showing status in who verb on by default.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Will make it clearer who's AFK, who's playing, who's observing, etc. without making people dig around in settings t turn it on specifically.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->