### PR TITLE
Trashbag Nerf

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -77,8 +77,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	max_single_weight_class = WEIGHT_CLASS_NORMAL
 	max_combined_volume = WEIGHT_CLASS_SMALL * 21
-	insertion_whitelist = list() // any
-	insertion_blacklist = list(/obj/item/disk/nuclear)
+	insertion_whitelist = list(/obj/item/trash) // any
+	insertion_blacklist = list()
 
 /obj/item/storage/bag/trash/initialize_storage()
 	. = ..()
@@ -102,6 +102,9 @@
 	max_combined_volume = WEIGHT_CLASS_SMALL * 56
 	desc = "The latest and greatest in custodial convenience, a trashbag that is capable of holding vast quantities of garbage."
 	icon_state = "bluetrashbag"
+	insertion_whitelist = list(/obj/item/trash) // any
+	insertion_blacklist = list()
+
 
 /obj/item/storage/bag/trash/bluespace/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/storage/backpack/holding) || istype(W, /obj/item/storage/bag/trash/bluespace))

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -135,7 +135,7 @@
 	id = "blutrash"
 	category = DESIGN_CATEGORY_STORAGE
 	req_tech = list(TECH_BLUESPACE = 5, TECH_MATERIAL = 6)
-	materials_base = list(MAT_PLASTIC = 5000, MAT_GOLD = 1500, MAT_URANIUM = 250, MAT_PHORON = 1500)
+	materials_base = list(MAT_PLASTIC = 2000, MAT_GOLD = 1000, MAT_URANIUM = 200, MAT_PHORON = 1000)
 	build_path = /obj/item/storage/bag/trash/bluespace
 
 /datum/prototype/design/science/reagent_synth_chemistry


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so trashbags and bluespace trashbags only hold trash and can't be abused for extensively expanded storage.
Decreases cost of bluespace trashbags in protolathe.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Using trashbags for theoretically infinite storage seems like unintended design.
Backpacks exist for a reason.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: made it so trashbags can only hold trash. Decreased cost of bluespace trashbags in protolathe.
fix: made it so trashbags can only hold trash.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
