### PR TITLE
Exploration kaboom.dm

### DIFF
--- a/code/game/machinery/point_redemption_vendor/types/survey.dm
+++ b/code/game/machinery/point_redemption_vendor/types/survey.dm
@@ -44,6 +44,7 @@
 		new /datum/point_redemption_item("Binoculars",					/obj/item/binoculars,										100),
 		new /datum/point_redemption_item("100 Thalers",					/obj/item/spacecash/c100,									100),
 		new /datum/point_redemption_item("Defense Equipment - Razor Drone Deployer",	/obj/item/grenade/simple/spawner/manhacks/station/locked,		100),
+		new /datum/point_redemption_item("Explosive Excavation Kit - Plastic Charge",/obj/item/plastique/seismic/locked,					100),
 		new /datum/point_redemption_item("Mini-Translocator",			/obj/item/perfect_tele/one_beacon,							120),
 		new /datum/point_redemption_item("Extraction Equipment - Fulton Pack",		/obj/item/extraction_pack,						125),
 		new /datum/point_redemption_item("Defense Equipment - Sentry Drone Deployer",	/obj/item/grenade/simple/spawner/ward,							150),


### PR DESCRIPTION
Added plastic charges to the vendor list. For polite kaboom.

## About The Pull Request

Added Station-locked plastic charges (from mining vendor) to the exploration vendor, at a point cost of 100 (in-line with deployable sentry drone).

## Why It's Good For The Game

Gives exploration access to a conventional path-clearing option for hard surfaces, since they already have access to phoron bores and kinetic tools for rocky targets. Less collaterally destructive than traditionally science-sourced demo (I.E potassium grenades)

## Changelog


:cl:
add: Added plastic demo charge to exploration vendor list @ 100 point cost
/:cl: