### PR TITLE
catch a frequent runtime related to clickchains

### DIFF
--- a/code/game/click/items-melee_attack_chain.dm
+++ b/code/game/click/items-melee_attack_chain.dm
@@ -19,7 +19,7 @@
 		return CLICKCHAIN_DO_NOT_ATTACK
 	if(item_flags & ITEM_NO_BLUDGEON)
 		return CLICKCHAIN_DO_NOT_ATTACK
-	if(!clickchain.target?.is_melee_targetable(clickchain))
+	if(!clickchain?.target?.is_melee_targetable(clickchain))//Why is clickchain null so often?
 		return CLICKCHAIN_DO_NOT_ATTACK
 
 	clickchain.performer.legacy_alter_melee_clickchain(clickchain)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
For some reason the clickchain parameter is very often null, this causes runtime errors and weird floorswiping with items you dont wanna floor swipe.
I am not expecting this to be a perfect fix, just a temporary patch until I find the time to disect @silicons unholy abomination
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
less runtimes and weird floor swiping
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed runtime related to clickchains
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
