### PR TITLE
Protean "drop prey" pref fixed not to do the exact opposite of the pref

### DIFF
--- a/code/modules/species/protean/protean_blob.dm
+++ b/code/modules/species/protean/protean_blob.dm
@@ -209,7 +209,7 @@
 			if(potentials.len)
 				var/mob/living/target = pick(potentials)
 				var/allowed = TRUE
-				if(target.client && target.can_be_drop_prey)//you can still vore ai mobs with the pref off
+				if(target.client && !target.can_be_drop_prey)//you can still vore ai mobs with the pref off
 					allowed = FALSE
 				if(istype(target) && vore_selected && allowed) //no more ooc-noncon vore, thanks
 					if(target.buckled)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The "be spontaneous prey" vore setting was working the precise opposite of intended for proteans re-blobbing from flat.

## Why It's Good For The Game

Prefs Like This Should Definitely Work Exactly As Described And Not The Exact Opposite Lest Upsetting Things Happen

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: made protean dropvore(?) not check the exact opposite pref it should
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
