### PR TITLE
Fixes various door assemblies to be constructible

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -21,7 +21,7 @@
 /obj/structure/door_assembly/command
 	base_icon_state = "com"
 	base_name = "Command airlock"
-	glass_type = "/glass_command"
+	glass_type = "/glass/command"
 	airlock_type = "/command"
 
 /obj/structure/door_assembly/security
@@ -33,37 +33,37 @@
 /obj/structure/door_assembly/engi
 	base_icon_state = "eng"
 	base_name = "Engineering airlock"
-	glass_type = "/glass_engineering"
+	glass_type = "/glass/engineering"
 	airlock_type = "/engineering"
 
 /obj/structure/door_assembly/engi_atmos
 	base_icon_state = "eat"
 	base_name = "Engineering atmos airlock"
-	glass_type = "/glass_engineeringatmos"
+	glass_type = "/glass/engineeringatmos"
 	airlock_type = "/engineering"
 
 /obj/structure/door_assembly/mining
 	base_icon_state = "min"
 	base_name = "Mining airlock"
-	glass_type = "/glass_mining"
+	glass_type = "/glass/mining"
 	airlock_type = "/mining"
 
 /obj/structure/door_assembly/atmos
 	base_icon_state = "atmo"
 	base_name = "Atmospherics airlock"
-	glass_type = "/glass_atmos"
+	glass_type = "/glass/atmos"
 	airlock_type = "/atmos"
 
 /obj/structure/door_assembly/research
 	base_icon_state = "res"
 	base_name = "Research airlock"
-	glass_type = "/glass_research"
+	glass_type = "/glass/research"
 	airlock_type = "/research"
 
 /obj/structure/door_assembly/door_assembly_science
 	base_icon_state = "sci"
 	base_name = "Science airlock"
-	glass_type = "/glass_science"
+	glass_type = "/glass/science"
 	airlock_type = "/science"
 
 /obj/structure/door_assembly/medical
@@ -75,7 +75,7 @@
 /obj/structure/door_assembly/external
 	base_icon_state = "ext"
 	base_name = "External airlock"
-	glass_type = "/glass_external"
+	glass_type = "/glass/external"
 	airlock_type = "/external"
 
 /obj/structure/door_assembly/maint


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Some glass door assemblies are pointing to a typepath that does not exist. Because the typepaths are built via a string, for some ungodly reason, this is not caught in compile.

## Why It's Good For The Game

Doors: buildable. Good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Various glass airlocks are now actually buildable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
