### PR TITLE
Adds combat belts to Miaphus SDF lockers

### DIFF
--- a/maps/sectors/miaphus/levels/miaphus_beach.dmm
+++ b/maps/sectors/miaphus/levels/miaphus_beach.dmm
@@ -4934,6 +4934,7 @@
 /obj/item/clothing/accessory/storage/pouches/large/tan,
 /obj/item/clothing/accessory/armor/legguards/tan,
 /obj/item/clothing/accessory/storage/laconic,
+/obj/item/storage/belt/security/tactical,
 /turf/simulated/floor/tiled/monotechmaint,
 /area/shuttle/miaphus/sdf)
 "zV" = (
@@ -5806,6 +5807,7 @@
 /obj/item/clothing/accessory/storage/pouches/large/tan,
 /obj/item/clothing/accessory/armor/legguards/tan,
 /obj/item/clothing/accessory/storage/laconic,
+/obj/item/storage/belt/security/tactical,
 /turf/simulated/floor/tiled/monotechmaint,
 /area/shuttle/miaphus/sdf)
 "Ev" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The weapon lockers for the Miaphus'irra SDF soldiers now have combat belts for holding ammunition and other equipment.

## Why It's Good For The Game

Surely the budget cuts can't be that bad. Otherwise, you have to carry spare magazines and such in your backpack which isn't ideal (especially considering the atrocious mag capacity of the tajara guns).

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added storage belts for Miaphus SDF soldiers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
