### PR TITLE
Blindfold and disruptor cuffs fix

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -216,10 +216,15 @@ var/last_chew = 0
 	worn_state = "disruptorcuff"
 	desc = "These cutting edge handcuffs were originally designed by the PMD. Commonly deployed to restrain anomalous lifeforms, disruptor cuffs employ a form of acausal logic engine disruption, in tandem with morphogenic resonance, to neutralize the abilities of technological and biological threats."
 
-/obj/item/handcuffs/disruptor/equipped(var/mob/living/user,var/slot)
+/obj/item/handcuffs/disruptor/equipped(var/mob/living/user, var/slot)
 	. = ..()
 	if(slot == SLOT_ID_HANDCUFFED)
 		ADD_TRAIT(user, TRAIT_DISRUPTED, CLOTHING_TRAIT)
+
+/obj/item/handcuffs/disruptor/unequipped(mob/user, slot, flags)
+	. = ..()
+	if(slot == SLOT_ID_HANDCUFFED)
+		REMOVE_TRAIT(user, TRAIT_DISRUPTED, CLOTHING_TRAIT)
 
 //Legcuffs. Not /really/ handcuffs, but its close enough.
 /obj/item/handcuffs/legcuffs

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -487,12 +487,16 @@ BLIND     // can't see anything
 	drop_sound = 'sound/items/drop/gloves.ogg'
 	pickup_sound = 'sound/items/pickup/gloves.ogg'
 
-/*obj/item/clothing/glasses/sunglasses/blindfold/equipped(mob/user, slot, flags)
+/obj/item/clothing/glasses/sunglasses/blindfold/equipped(mob/user, slot, flags)
 	. = ..()
-	if(ishuman(loc))
-		var/mob/living/carbon/human/H = user
-		loc.add_modifier(/datum/modifier/sight/blindness)*/
+	if(slot == SLOT_ID_GLASSES)
+		user.add_blindness_source(CLOTHING_TRAIT)
 
+
+/obj/item/clothing/glasses/sunglasses/blindfold/unequipped(mob/user, slot, flags)
+	. = ..()
+	if(slot == SLOT_ID_GLASSES)
+		user.remove_blindness_source(CLOTHING_TRAIT)
 
 /obj/item/clothing/glasses/sunglasses/blindfold/tape
 	name = "length of tape"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes blindfolds actually blind the wearer, and disruptor cuffs to stop disrupting the protean when removed. I just found them while searching how it could be done for the blindfolds, and then noticed they never get cleared.

## Why It's Good For The Game

Less hassle when admins want to temporarily detain a protean, having to manually remove the trait when the cuffs get removed. There already are fake blindfolds for the ones we have, which effectively is just a duplicate while the real ones don't do anything.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: disruptor cuffs stop disrupting if removed
fix: real blindfolds actually blind
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
