### PR TITLE
Stops hitting rechargers on insert

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -92,6 +92,7 @@
 		charging = G
 		update_icon()
 		clickchain.performer.visible_message("[clickchain.performer] inserts [charging] into [src].", "You insert [charging] into [src].")
+		return CLICKCHAIN_DO_NOT_PROPAGATE
 
 	else if(portable && G.is_wrench())
 		if(charging)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just going by the comment describing how the proc should work, adding the CLICKCHAIN_DO_NOT_PROPAGATE makes inserting not hit the recharger with the item being inserted.

## Why It's Good For The Game

Technically, if guns gets recharged too often at a single recharger, that one will be destroyed as they get damaged from the bashing from it. Also doesn't give two messages for a single action.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: items don't bash the recharger on insert
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
