### PR TITLE
Fixes the nightshift again

### DIFF
--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -47,8 +47,13 @@ SUBSYSTEM_DEF(nightshift)
 		return
 	var/emergency = GLOB.security_level > SEC_LEVEL_GREEN
 	var/announcing = TRUE
-	var/time = station_time() // more accurate since it counts for gametime offset
+
+	//station_time_in_ds = deciseconds after midnight in station time
+	//nightshift_start_time = 207,000 deciseconds after midnight (7:30 AM)
+	//nightshift_end_time = 702,000 deciseconds after midnight (7:30 PM)
+	var/time = station_time_in_ds	
 	var/night_time = (time < nightshift_end_time) || (time > nightshift_start_time)
+
 	if(high_security_mode != emergency)
 		high_security_mode = emergency
 		if(night_time)
@@ -78,7 +83,9 @@ SUBSYSTEM_DEF(nightshift)
 		currentrun -= APC
 		if (APC.area && (APC.z in (LEGACY_MAP_DATUM).station_levels))
 			APC.set_nightshift(nightshift_active && (APC.area.nightshift_level & nightshift_level), TRUE)
-		if(MC_TICK_CHECK && !forced) // subsystem will be in state SS_IDLE if forced by an admin
-			return
+		
+		//TODO: redo below logic: as-is, it does not allow the nightshift subsystem to actually finish processing
+		//if(MC_TICK_CHECK && !forced) // subsystem will be in state SS_IDLE if forced by an admin
+		//return
 
 	SSlighting.resume_instant()

--- a/code/modules/events/cult.dm
+++ b/code/modules/events/cult.dm
@@ -31,7 +31,7 @@
 	endWhen = 45
 
 /datum/event/cult/announce()
-	command_announcement.Announce("Attention [station_name()], unknown humanoid and non-humanoid entities have been detected warping into the facility! We advise crew move to a secure area immediately!", "Screaming Signals Detected", new_sound = sound('sound/effects/c_alarm.mp3',volume=2))
+	command_announcement.Announce("Attention [location_name()], unknown humanoid and non-humanoid entities have been detected warping into the facility! We advise crew move to a secure area immediately!", "Screaming Signals Detected", new_sound = sound('sound/effects/c_alarm.mp3',volume=2))
 
 
 /datum/event/cult/start()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes some code in the nightshift subsystem so that it automatically sets the nightshift and actually sets the APCs again.

Instead of `station_time()` (which seems to simply output the time since roundstart + 12 hours??), it uses `station_time_in_ds`, which was the original intended behavior when I originally adjusted the system before.

#6862 added a check during `update_nightshift()` to halt processing for the MC if needed, but it seems there is no logic for the MC to then resume processing, as the APCs don't ever get set. I removed this logic, which is not ideal (the lighting subsystem lags behind for ~1 minute while all the lights process), but I don't know enough about the MC to make a better solution. When I tested this locally, it took about 30 seconds to a minute for all lighting on the station to change, but on the production server, it will probably be a little faster.

I haven't changed the wait time between fires, so it will take 10 minutes after roundstart to turn on the nightshift if the roundstart time happens to be within the boundaries. I think this is fine.

This PR has been tested locally and works as intended.

There's also a small fix to the screaming signals overmap event, where it always uses the station name even if a different shuttle/ship ran into the overmap. This fixes it to use the proper name, like other events.

## Why It's Good For The Game

The nightshift was a nice QOL change to the game and it's better for it to actually work, even with a small hiccup in the lighting changes.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The nightshift will now work again, both automatically and manually.
fix: Fixed wrong usage of the station name when a shuttle bumps into the screaming signals overmap hazard.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
