### PR TITLE
orderable blood and injectable iron

### DIFF
--- a/code/game/content/factions/corporations/nanotrasen/nanotrasen-supply/medical.dm
+++ b/code/game/content/factions/corporations/nanotrasen/nanotrasen-supply/medical.dm
@@ -29,9 +29,9 @@
 /datum/supply_pack/nanotrasen/medical/bloodpack
 	name = "BloodPack crate"
 	contains = list(
-		/obj/item/storage/box/bloodpacks = 3,
+		/obj/item/storage/box/bloodpacks_filled = 3,
 	)
-	worth = 250
+	worth = 750
 	container_type = /obj/structure/closet/crate/medical/blood
 	container_name = "BloodPack crate"
 

--- a/code/modules/reagents/chemistry/reagents/core/elements.dm
+++ b/code/modules/reagents/chemistry/reagents/core/elements.dm
@@ -111,6 +111,10 @@
 	if(alien != IS_DIONA)
 		M.add_chemical_effect(CE_BLOODRESTORE, 8 * removed)
 
+/datum/reagent/iron/legacy_affect_blood(mob/living/carbon/M, alien, removed, datum/reagent_metabolism/metabolism)
+	if(alien != IS_DIONA)
+		M.add_chemical_effect(CE_BLOODRESTORE, 12 * removed)
+
 /datum/reagent/lithium
 	name = "Lithium"
 	id = "lithium"

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -1,6 +1,6 @@
 /obj/item/storage/box/bloodpacks
-	name = "blood packs bags"
-	desc = "This box contains blood packs."
+	name = "empty blood packs bags"
+	desc = "This box contains empty blood packs."
 	icon_state = "sterile"
 
 /obj/item/storage/box/bloodpacks/Initialize(mapload)
@@ -12,6 +12,22 @@
 		new /obj/item/reagent_containers/blood/empty(src)
 		new /obj/item/reagent_containers/blood/empty(src)
 		new /obj/item/reagent_containers/blood/empty(src)
+
+/obj/item/storage/box/bloodpacks_filled
+	name = "blood packs bags"
+	desc = "This box contains blood packs."
+	icon_state = "sterile"
+
+/obj/item/storage/box/bloodpacks_filled/Initialize(mapload)
+		. = ..()
+		new /obj/item/reagent_containers/blood/APlus(src)
+		new /obj/item/reagent_containers/blood/AMinus(src)
+		new /obj/item/reagent_containers/blood/BPlus(src)
+		new /obj/item/reagent_containers/blood/BMinus(src)
+		new /obj/item/reagent_containers/blood/ABMinus(src)
+		new /obj/item/reagent_containers/blood/OPlus(src)
+		new /obj/item/reagent_containers/blood/OMinus(src)
+
 
 /obj/item/reagent_containers/blood
 	name = "IV pack"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Iron is now injectable and is so 50% more efficient.

The blood crate in cargo now actually contains blood instead of empty bags. Increased its price to match clotting meds.

## Why It's Good For The Game

Iron not being injectable is something I scratched my head around for a while. Technically speaking your stomach absorbs it into your blood anyways so it should theoretically be a more direct and efficient method.

There is actually no way to resupply on universal blood except for blood tomatoes which after testing takes literal hours to get any decent quantity. Blood donations have a funny quirk where the species type and name has to match the donator with the receiver or it is just toxic.
