### PR TITLE
Hazard Bypass Update

### DIFF
--- a/code/modules/clothing/spacesuits/void/station/science.dm
+++ b/code/modules/clothing/spacesuits/void/station/science.dm
@@ -23,6 +23,6 @@
 	min_pressure_protection = 0 * ONE_ATMOSPHERE
 	max_pressure_protection = 20* ONE_ATMOSPHERE
 	integrity_flags = INTEGRITY_ACIDPROOF
-	encumbrance = 55
+	encumbrance = 40
 	worth_intrinsic = 350
 	helmet_type = /obj/item/clothing/head/helmet/space/void/science


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the encumbrance of the Bypass Voidsuits down from 55 to 40.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Just makes it more viable to use the suit, as multiple complains were noted of the suit being too slow to be all that useful. Hopefully this makes it light enough for most people to have it be worthwhile. (Took me long enough to not be lazy about changing it.)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Kade
tweak: Changes the Hazard Bypass Voidsuit to be lighter.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
