### PR TITLE
A couple minor fixes

### DIFF
--- a/code/_globals/regexes.dm
+++ b/code/_globals/regexes.dm
@@ -21,4 +21,4 @@ GLOBAL_PROTECT(filename_forbidden_chars)
 GLOBAL_DATUM_INIT(multi_space_splitter, /regex, regex("\[ \]+"))
 
 //Finds if a string started with "," or "'", used for me messages
-GLOBAL_DATUM_INIT(valid_starting_punctuation, /regex, regex("^\[,\]|(&#39;)"))
+GLOBAL_DATUM_INIT(valid_starting_punctuation, /regex, regex("^(\[,\]|(&#39;))"))

--- a/code/_globals/regexes.dm
+++ b/code/_globals/regexes.dm
@@ -19,3 +19,6 @@ GLOBAL_PROTECT(filename_forbidden_chars)
 // had to use the OR operator for quotes instead of putting them in the character class because it breaks the syntax highlighting otherwise.
 
 GLOBAL_DATUM_INIT(multi_space_splitter, /regex, regex("\[ \]+"))
+
+//Finds if a string started with "," or "'", used for me messages
+GLOBAL_DATUM_INIT(valid_starting_punctuation, /regex, regex("^\[,\]|(&#39;)"))

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -17,7 +17,8 @@
 		input = message
 	if(input)
 		log_emote(message,src) //Log before we add junk
-		message = "<span class='emote'><B>[src]</B> [input]</span>"
+		//If the message starts with a comma, no space after the name.
+		message = "<span class='emote'><B>[src]</B>[copytext(input, 1, 2) == "," ? "" : " "][input]</span>"
 	else
 		return
 

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -17,8 +17,10 @@
 		input = message
 	if(input)
 		log_emote(message,src) //Log before we add junk
-		//If the message starts with a comma, no space after the name.
-		message = "<span class='emote'><B>[src]</B>[copytext(input, 1, 2) == "," ? "" : " "][input]</span>"
+		//If the message starts with a comma or apostrophe, no space after the name.
+		//We have to account for sanitization so we take the whole first word to see if it's a character code.
+		var/nospace = GLOB.valid_starting_punctuation.Find(input)
+		message = "<span class='emote'><B>[src]</B>[nospace ? "" : " "][input]</span>"
 	else
 		return
 

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -112,8 +112,9 @@
 	// standing is poor
 	if(stance_damage >= 4 || (stance_damage >= 2 && prob(5)))
 		if(!(lying || resting) && !buckled && !isbelly(loc))
-			if(limb_pain)
+			if(limb_pain && can_feel_pain())
 				emote_nosleep("scream")
+				adjustHalLoss(10) //Attempting to use a broken bone hurts.
 			custom_emote(1, "collapses!")
 		afflict_paralyze(20 * 5) //can't emote while weakened, apparently.
 
@@ -131,6 +132,7 @@
 		if(((hand.is_broken() || hand.is_dislocated()) && !hand.splinted) || ((arm.is_broken() || arm.is_dislocated()) && !arm.splinted))
 			var/emote_scream = pick("screams in pain and ", "lets out a sharp cry and ", "cries out and ")
 			emote("me", 1, "[(can_feel_pain()) ? emote_scream : ""]drops what they were holding in their [hand.name]!")
+			adjustHalLoss(10) //Attempting to use a broken bone hurts.
 			drop_item_to_ground(held, INV_OP_FORCE)
 			continue
 		else if(hand.is_malfunctioning())

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -130,7 +130,7 @@
 			continue
 		if(((hand.is_broken() || hand.is_dislocated()) && !hand.splinted) || ((arm.is_broken() || arm.is_dislocated()) && !arm.splinted))
 			var/emote_scream = pick("screams in pain and ", "lets out a sharp cry and ", "cries out and ")
-			emote("me", 1, "[(can_feel_pain()) ? "" : emote_scream ]drops what they were holding in their [hand.name]!")
+			emote("me", 1, "[(can_feel_pain()) ? emote_scream : ""]drops what they were holding in their [hand.name]!")
 			drop_item_to_ground(held, INV_OP_FORCE)
 			continue
 		else if(hand.is_malfunctioning())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- If you start a `me` message with a comma or an apostrophe, there will no longer be a space between your name and the message. I.e. "**John Trasen** , being hungry, eats." -> "**John Trasen**, being hungry, eats."
- Fixes reversed logic with dropping things with a broken hand. Your character will now correctly cry in pain when trying to do this.
- Also potentially fixes reversed logic with collapsing with a broken leg and screaming in pain.
- In both of the above cases, it will deal halloss (pain) damage, since using a broken bone tends to hurt a lot.

## Why It's Good For The Game

Small fix and improvement.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed erroneous space when starting a me message with a comma or apostrophe.
fix: Your character will now cry in pain when trying to hold something with a broken hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
