### PR TITLE
A couple more fixes

### DIFF
--- a/code/modules/reagents/chemistry/reagents/blood/blood_holder.dm
+++ b/code/modules/reagents/chemistry/reagents/blood/blood_holder.dm
@@ -154,7 +154,7 @@
 	if(!total)
 		return null
 	amount = min(amount, total)
-	if(amount <= 0) return null
+	if(amount < 0) return null
 	var/multiplier = max(0, 1 - (amount / total))
 
 	var/datum/blood_mixture/creating = new

--- a/code/modules/reagents/machinery/coffeemaker.dm
+++ b/code/modules/reagents/machinery/coffeemaker.dm
@@ -279,6 +279,8 @@
 /obj/machinery/coffeemaker/ui_interact(mob/user) // The microwave Menu //I am reasonably certain that this is not a microwave //I am positively certain that this is not a microwave
 	. = ..()
 
+	if(!can_interact(user) || !user.canUseTopic(src, !issilicon(user)))
+		return FALSE
 	if(brewing)
 		return
 

--- a/code/modules/vore/fluffstuff/life_crystals.dm
+++ b/code/modules/vore/fluffstuff/life_crystals.dm
@@ -37,8 +37,14 @@
 	. = ..()
 	if(.)
 		return
-	if(state > 0) //Can't re-pair, one time only, for security reasons.
-		to_chat(user, "<span class='notice'>The [name] doesn't do anything.</span>")
+	if(state > 0) //Can't re-pair, one time only, for security reasons. But you can prematurely deactivate it so you can take it off freely.
+		if(alert(user, "Would you like to permanently deactivate \the [name]?",, "Yes", "No") == "Yes")
+			to_chat(user, SPAN_NOTICE("\The [name] quietly crumbles into dust in your hand as its connection to you is severed."))
+			update_state(3)
+			name = "broken [initial(name)]"
+			desc = "This seems like a necklace, but the actual pendant is missing."
+			return
+		to_chat(user, SPAN_NOTICE("The [name] doesn't do anything."))
 		return 0
 
 	owner = user	//We're paired to this person
@@ -66,17 +72,17 @@
 
 /obj/item/clothing/accessory/collar/vmcrystal/proc/become_alert()
 	update_state(2)
-	audible_message(SPAN_WARNING("The [name] begins flashing red and vibrating in at a low frequency."),
-			SPAN_WARNING("The [name] begins vibrating in at a low frequency."))
+	audible_message(SPAN_WARNING("\The [name] begins flashing red and vibrating in at a low frequency."),
+			SPAN_WARNING("\The [name] begins vibrating in at a low frequency."))
 	last_vitals = world.time
 
 /obj/item/clothing/accessory/collar/vmcrystal/proc/become_calm()
 	update_state(1)
-	audible_message(SPAN_NOTICE("[src] stops flashing red and vibrating as it resyncronises with its linked owner."),
-			SPAN_NOTICE("[src] stops vibrating in at a low frequency"))
+	audible_message(SPAN_NOTICE("\The [src] stops flashing red and vibrating as it resyncronises with its linked owner."),
+			SPAN_NOTICE("\The [src] stops vibrating in at a low frequency"))
 
 /obj/item/clothing/accessory/collar/vmcrystal/proc/send_message()
-	visible_message(SPAN_WARNING("The [name] shatters into dust!"))
+	visible_message(SPAN_WARNING("\The [name] shatters into dust!"))
 	GLOB.global_announcer.autosay("[owner] has died!", "[owner]'s Life Crystal")
 	if(owner_c)
 		to_chat(owner_c, "<span class='notice'>The HAVENS system is notified of your demise via \the [name].</span>")

--- a/code/modules/vore/fluffstuff/life_crystals.dm
+++ b/code/modules/vore/fluffstuff/life_crystals.dm
@@ -37,13 +37,14 @@
 	. = ..()
 	if(.)
 		return
-	if(state > 0) //Can't re-pair, one time only, for security reasons. But you can prematurely deactivate it so you can take it off freely.
+	if(state > 0) //Can't re-pair, one time only, for security reasons. But you can prematurely deactivate it if you're the owner, so you can take it off freely.
 		if(alert(user, "Would you like to permanently deactivate \the [name]?",, "Yes", "No") == "Yes")
-			to_chat(user, SPAN_NOTICE("\The [name] quietly crumbles into dust in your hand as its connection to you is severed."))
-			update_state(3)
-			name = "broken [initial(name)]"
-			desc = "This seems like a necklace, but the actual pendant is missing."
-			return
+			if(user == owner)
+				to_chat(user, SPAN_NOTICE("\The [name] quietly crumbles into dust in your hand as its connection to you is severed."))
+				update_state(3)
+				name = "broken [initial(name)]"
+				desc = "This seems like a necklace, but the actual pendant is missing."
+				return
 		to_chat(user, SPAN_NOTICE("The [name] doesn't do anything."))
 		return 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- You can now deactive a life crystal by using it in your hand. This is permanent (it breaks it), since not being able to reuse them seems to be intentional according to a code comment.
- Ghosts can no longer interact with the coffeemaker.
- Blood splatters from bleeding now correctly use a species' blood color (or custom blood color for custom species).

## Why It's Good For The Game

The life crystal one is arguably very QOL for people who use them but want to take off their uniforms for whatever reason. Blood color is also a nice touch for people who use custom blood colors for their species (or really, for any species that doesn't use the usual blood color). The other is a simple bugfix.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: You can now deactivate a life crystal by using it in your hand.
fix: Ghosts can no longer brew coffee.
fix: Bleeding now respects a species' blood color (including custom blood color).

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
