### PR TITLE
removes disruptor cuffs from atlas

### DIFF
--- a/maps/rift/levels/rift-04-surface1.dmm
+++ b/maps/rift/levels/rift-04-surface1.dmm
@@ -688,7 +688,6 @@
 "aAf" = (
 /obj/structure/closet/secure_closet/psych,
 /obj/item/clothing/suit/straight_jacket,
-/obj/item/handcuffs/disruptor,
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/medical/mentalhealth)
 "aAu" = (


### PR DESCRIPTION
these are meant to be adminspawn and the status of their effectiveness/lore isn't even established
why the hell are they a fucking psych tool???