### PR TITLE
Fixes unintuitive aim mode code

### DIFF
--- a/code/game/click/click.dm
+++ b/code/game/click/click.dm
@@ -113,24 +113,31 @@
 	switch(resolved_action)
 		if(CLICK_ACTION_CTRL_LMB)
 			if(ctrl_click_on(target, location, control, params))
+				trigger_aiming(TARGET_CAN_CLICK)
 				return TRUE
 		if(CLICK_ACTION_CTRL_SHIFT_LMB)
 			if(ctrl_shift_click_on(target, location, control, params))
+				trigger_aiming(TARGET_CAN_CLICK)
 				return TRUE
 		if(CLICK_ACTION_SHIFT_LMB)
 			if(shift_click_on(target, location, control, params))
+				trigger_aiming(TARGET_CAN_CLICK)
 				return TRUE
 		if(CLICK_ACTION_ALT_LMB)
 			if(alt_click_on(target, location, control, params))
+				trigger_aiming(TARGET_CAN_CLICK)
 				return TRUE
 		if(CLICK_ACTION_MMB)
 			if(middle_click_on(target, location, control, params))
+				trigger_aiming(TARGET_CAN_CLICK)
 				return TRUE
 		if(CLICK_ACTION_SHIFT_MMB)
 			if(shift_middle_click_on(target, location, control, params))
+				trigger_aiming(TARGET_CAN_CLICK)
 				return TRUE
 
 	if(click_on_special(target, location, control, params))
+		trigger_aiming(TARGET_CAN_CLICK)
 		return TRUE
 
 	var/datum/event_args/actor/clickchain/clickchain = new
@@ -224,18 +231,12 @@
 			. = active_item.melee_interaction_chain(clickchain, clickchain_flags)
 		else
 			. = melee_interaction_chain(clickchain, clickchain_flags)
-		//! legacy
-		trigger_aiming(TARGET_CAN_CLICK)
-		//! end
 		return
 	else if(ranged_generics_allowed)
 		if(active_item)
 			. = active_item.ranged_interaction_chain(clickchain, clickchain_flags)
 		else
 			. = ranged_interaction_chain(clickchain, clickchain_flags)
-		//! legacy
-		trigger_aiming(TARGET_CAN_CLICK)
-		//! end
 		return
 
 /**

--- a/code/game/click/item_attack.dm
+++ b/code/game/click/item_attack.dm
@@ -26,7 +26,10 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /obj/item/proc/resolve_attackby(atom/target, mob/user, params, attack_modifier = 1, clickchain_flags, datum/event_args/actor/clickchain/clickchain)
 	if(!(atom_flags & NOPRINT))
 		add_fingerprint(user)
-	return target.attackby(src, user, params, clickchain_flags, attack_modifier, clickchain)
+	. = target.attackby(src, user, params, clickchain_flags, attack_modifier, clickchain)
+	if(. & CLICKCHAIN_DID_SOMETHING)
+		user.trigger_aiming(TARGET_CAN_CLICK)
+	return .
 
 /atom/proc/attackby(obj/item/tool, mob/user, list/params, clickchain_flags, damage_multiplier, datum/event_args/actor/clickchain/clickchain)
 	return tool.melee_attack_chain(clickchain, clickchain_flags)

--- a/code/game/click/items.dm
+++ b/code/game/click/items.dm
@@ -47,7 +47,10 @@
 		return
 
 	// todo: signal for afterattack here
-	return . | afterattack(clickchain.target, clickchain.performer, clickchain_flags, clickchain.click_params)
+	var/result = afterattack(clickchain.target, clickchain.performer, clickchain_flags, clickchain.click_params)
+	if(result)
+		clickchain.performer.trigger_aiming(TARGET_CAN_CLICK)
+	return . | result
 
 // TODO: lazy_ranged_interaction_chain
 
@@ -60,7 +63,10 @@
  */
 /obj/item/proc/ranged_interaction_chain(datum/event_args/actor/clickchain/clickchain, clickchain_flags)
 	// todo: signal for afterattack here
-	return clickchain_flags | afterattack(clickchain.target, clickchain.performer, clickchain_flags, clickchain.click_params)
+	. = afterattack(clickchain.target, clickchain.performer, clickchain_flags, clickchain.click_params)
+	if(.)
+		clickchain.performer.trigger_aiming(TARGET_CAN_CLICK)
+	return clickchain_flags | .
 
 /**
  * called at the start of melee attack chains

--- a/code/game/click/melee/melee_attack/unarmed.dm
+++ b/code/game/click/melee/melee_attack/unarmed.dm
@@ -89,6 +89,9 @@ GLOBAL_LIST_EMPTY(unarmed_attack_cache)
 		NONE,
 		clickchain.target_zone,
 	)
+	if(ismob(attacker))
+		var/mob/M = attacker
+		M.trigger_aiming(TARGET_CAN_CLICK)
 	clickchain.data[ACTOR_DATA_MELEE_DAMAGE_INSTANCE_RESULTS] = results
 	target.on_melee_impact(attacker, weapon, src, clickchain.target_zone, clickchain, clickchain_flags, results)
 

--- a/code/game/click/melee/melee_attack/weapon.dm
+++ b/code/game/click/melee/melee_attack/weapon.dm
@@ -21,6 +21,9 @@
 		clickchain.target_zone,
 	)
 	clickchain.data[ACTOR_DATA_MELEE_DAMAGE_INSTANCE_RESULTS] = results
+	if(ismob(attacker))
+		var/mob/M = attacker
+		M.trigger_aiming(TARGET_CAN_CLICK)
 	target.on_melee_impact(attacker, weapon, src, clickchain.target_zone, clickchain, clickchain_flags, results)
 	return clickchain_flags
 

--- a/code/game/objects/items-interaction.dm
+++ b/code/game/objects/items-interaction.dm
@@ -96,7 +96,8 @@
 	// success
 	if(isturf(old_loc))
 		new /obj/effect/temporary_effect/item_pickup_ghost(old_loc, actually_picked_up, user)
-
+	user.trigger_aiming(TARGET_CAN_CLICK)
+	
 //* Drag / Drop *//
 
 /obj/item/OnMouseDrop(atom/over, mob/user, proximity, params)
@@ -191,10 +192,13 @@
 		actor = new /datum/event_args/actor(user)
 	var/signal_return = SEND_SIGNAL(src, COMSIG_ITEM_ACTIVATE_INHAND, actor)
 	if(signal_return & RAISE_ITEM_ACTIVATE_INHAND_HANDLED)
+		user.trigger_aiming(TARGET_CAN_CLICK)
 		return TRUE
 	if(on_attack_self(actor))
+		user.trigger_aiming(TARGET_CAN_CLICK)
 		return TRUE
 	if(interaction_flags_item & INTERACT_ITEM_ATTACK_SELF)
+		user.trigger_aiming(TARGET_CAN_CLICK)
 		interact(user)
 
 /**

--- a/code/game/objects/obj.dm
+++ b/code/game/objects/obj.dm
@@ -412,9 +412,11 @@
 			visible_self = SPAN_NOTICE("You insert [I] into [src]."),
 		)
 		obj_cell_slot.insert_cell(I)
+		user.trigger_aiming(TARGET_CAN_CLICK)
 		return CLICKCHAIN_DO_NOT_PROPAGATE | CLICKCHAIN_DID_SOMETHING
 	var/datum/event_args/actor/actor = new(user)
 	if(!isnull(obj_storage) && I.allow_auto_storage_insert(actor, obj_storage) && obj_storage?.auto_handle_interacted_insertion(I, actor))
+		user.trigger_aiming(TARGET_CAN_CLICK)
 		return CLICKCHAIN_DO_NOT_PROPAGATE | CLICKCHAIN_DID_SOMETHING
 	return ..()
 

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -170,8 +170,7 @@
 
 	if(owner.client)
 		owner.client.add_gun_icons()
-	to_chat(target, "<span class='danger'>You now have a gun pointed at you. No sudden moves!</span>")
-	to_chat(target, "<span class='critical'>If you fail to comply with your assailant, you accept the consequences of your actions.</span>")
+	to_chat(target, SPAN_BIG(SPAN_DANGER("You have a gun pointed at you. No sudden movements!")))
 	aiming_with = thing
 	aiming_at = target
 	if(istype(aiming_with, /obj/item/gun))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alters the aim mode so that not every single click will trigger it if you have the "can use items" set to disallowed. Now, it checks to see if you are actually doing something. Specifically, it will trigger when:
- You attack something in melee, either unarmed or with a weapon. Some edge cases are not accounted for because of \~snowflake code\~.
- You click on yourself (e.g. to administer an injector or examine yourself for injuries).
- You fire a weapon or otherwise use a ranged attack/interaction.
- You pick something up (including from your inventory).
- You use something in your hand (which includes stuff like PDAs, signalers, grenades, or even flashing your ID card; the idea is that if you have using items disallowed, your character becomes VERY jumpy at anything your victim does!).
- You use modifier keys, and they cause you to do something. (For example, middle-clicking to use hardsuit modules, or control-shift-clicking to point at something.)

It will NOT trigger when:
- You use modifier keys, and they don't do anything. (For example, middle-clicking to swap hands, or alt-clicking on a tile away from you so that it doesn't open up the turf menu.)
- You drop something.
- You swap hands.
- **You click a turf without performing an action** (such as clicking on a tile with an empty hand to turn your character, which is something many people do and which is responsible for a lot of grief!)
- You perform less blatant actions (specifically, most `attackby` actions that result from you clicking on an item in your hand with an empty hand, which also includes stuff like inserting/removing magazines from a gun or toggling the safety of one). This is because having aim mode automatically police **everything** your victim can do takes a bit of engagement away. You still have to monitor your victim to make sure they don't do anything weird.

The other two allowables (movement and radio usage) were untouched.

There are definitely still some cracks for actions to slip through, but I don't believe them to be huge issues. Like I said previously, this is not meant to be an automatic "you can't do anything anymore" button, and the player should still have to actively keep an eye on their victim.

## Why It's Good For The Game

Very few people use aim mode because it tends to randomly shoot people when they are clicking without actually doing anything. This solves that issue and also refines some of the other conditions under which you will reflexively shoot someone, without making it too easy for you to completely lock them down.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Adjusted aim mode to not automatically shoot people for every single click and instead be more reasonable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
