### PR TITLE
Fix nightshift again

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -28,7 +28,7 @@
 #define WORLDTIME2TEXT(format) GAMETIMESTAMP(format, world.time)
 #define WORLDTIMEOFDAY2TEXT(format) GAMETIMESTAMP(format, world.timeofday)
 #define TIME_STAMP(format, showds) showds ? "[WORLDTIMEOFDAY2TEXT(format)]:[world.timeofday % 10]" : WORLDTIMEOFDAY2TEXT(format)
-#define STATION_TIME(display_only, wtime) ((((wtime - SSticker.SSticker.round_start_time) * SSticker.station_time_rate_multiplier) + SSticker.gametime_offset) % 864000) - (display_only? GLOB.timezoneOffset : 0)
+#define STATION_TIME(display_only, wtime) ((((wtime - SSticker.SSticker.round_start_time) * SSticker.station_time_rate_multiplier) + SSticker.gametime_offset) % 864000)
 #define STATION_TIME_TIMESTAMP(format, wtime) time2text(STATION_TIME(TRUE, wtime), format)
 
 #define JANUARY		1

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -27,13 +27,13 @@ GLOBAL_VAR_INIT(roundstart_hour, pick(2,7,12,17))
 
 // todo: better subsystem based way of tracking this, this is fucky.
 
-#define duration2stationtime(time) time2text(station_time_in_ds + GLOB.timezoneOffset + time, "hh:mm")
-#define worldtime2stationtime(time) time2text((GLOB.roundstart_hour HOURS) - SSticker.round_start_time + GLOB.timezoneOffset + time, "hh:mm")
+#define duration2stationtime(time) time2text(station_time_in_ds + time, "hh:mm")
+#define worldtime2stationtime(time) time2text((GLOB.roundstart_hour HOURS) - SSticker.round_start_time + time, "hh:mm")
 #define round_duration_in_ds (SSticker.round_start_time ? world.time - SSticker.round_start_time : 0)
 #define station_time_in_ds (GLOB.roundstart_hour HOURS + round_duration_in_ds)
 
 /proc/stationtime2text()
-	return time2text(station_time_in_ds + GLOB.timezoneOffset, "hh:mm")
+	return time2text(station_time_in_ds, "hh:mm", 0)
 
 /proc/stationdate2text()
 	var/update_time = FALSE
@@ -62,7 +62,7 @@ GLOBAL_VAR_INIT(roundstart_hour, pick(2,7,12,17))
 /proc/gameTimestamp(format = "hh:mm:ss", wtime=null)
 	if(!wtime)
 		wtime = world.time
-	return time2text(wtime - GLOB.timezoneOffset, format)
+	return time2text(wtime, format, 0)
 
 /**
  * This is used for displaying the "station time" equivelent of a world.time value
@@ -70,11 +70,11 @@ GLOBAL_VAR_INIT(roundstart_hour, pick(2,7,12,17))
  * - You can use this, for example, to do "This will expire at [station_time_at(world.time + 500)]" to display a "station time" expiration date
  *   which is much more useful for a player).
  */
-/proc/station_time(time=world.time, display_only=FALSE)
-	return ((((time - SSticker.round_start_time)) + GLOB.gametime_offset) % 864000) - (display_only ? GLOB.timezoneOffset : 0)
+/proc/station_time(time=world.time)
+	return ((((time - SSticker.round_start_time)) + GLOB.gametime_offset) % 864000)
 
 /proc/station_time_timestamp(format = "hh:mm:ss", time=world.time)
-	return time2text(station_time(time, TRUE), format)
+	return time2text(station_time(time), format, 0)
 
 /**
  * Returns 1 if it is the selected month and day.

--- a/code/_globals/time_vars.dm
+++ b/code/_globals/time_vars.dm
@@ -1,5 +1,3 @@
-/// The difference betwen midnight (of the host computer) and 0 world.ticks.
-GLOBAL_VAR_INIT(timezoneOffset, 0)
 /// 12:00 in seconds
 GLOBAL_VAR_INIT(gametime_offset, 432000)
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -92,8 +92,6 @@ GLOBAL_LIST(topic_status_cache)
 	// if(config && Configuration.get_entry(/datum/toml_config_entry/backend/logging/toggles/runtime))
 	// 	log = file("data/logs/runtime/[time2text(world.realtime,"YYYY-MM-DD-(hh-mm-ss)")]-runtime.log")
 
-	GLOB.timezoneOffset = get_timezone_offset()
-
 	callHook("startup")
 	//Emergency Fix
 	load_mods()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR removes the `GLOB.timezoneOffset` variable, as it appears Byond 514 added timezone support for the `time2text` proc. So, that variable was made redundant, and in fact caused more headaches, as the nightshift was working with a different time entirely than what the actual station time said.

Based on more intensive local testing, this seems to have actually fixed the problem, and the nightshift will now properly engage and disengage at the stated times. There do not appear to be any side effects to removing the variable that I am aware of.

This has a side effect tha,t because station times were distorted for a while, **station time is effectively rolled back 2 hours.** E.g. whereas station time would start at 19:00, it now starts at 17:00 as the code dictates.

## Why It's Good For The Game

The nightshift still had a flaw that it turned on and off inconsistently and seemingly at random. This fixes that, hopefully.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed the nightshift to start and end at the actual times.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
