### PR TITLE
Fix space dust event

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -122,6 +122,7 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 #define EVENT_LEVEL_MUNDANE		1
 #define EVENT_LEVEL_MODERATE	2
 #define EVENT_LEVEL_MAJOR		3
+#define EVENT_LEVEL_EXTREME		4
 
 /// General-purpose life speed define for plants.
 #define HYDRO_SPEED_MULTIPLIER	1

--- a/code/game/gamemodes/events/dust.dm
+++ b/code/game/gamemodes/events/dust.dm
@@ -2,29 +2,36 @@
 /*
 Space dust
 Commonish random event that causes small clumps of "space dust" to hit the station at high speeds.
-No command report on the common version of this event.
-The "dust" will damage the hull of the station causin minor hull breaches.
+The "dust" will damage the hull of the station causing minor hull breaches.
 */
 
-/proc/dust_swarm(var/strength = "weak", var/list/affecting_z)
+
+/**
+ * Spawns a random amount of space_dust thrown in random directions
+ * dust_swarm(severity, list/affecting_z)
+ *
+ * severity - Takes a value from 1 to 4, defaults to 2.
+ * affecting_z - Takes a list of z_levels to randomly target, defaults to main station levels.
+ */
+/proc/dust_swarm(var/severity = EVENT_LEVEL_MODERATE, var/list/affecting_z = (LEGACY_MAP_DATUM).station_levels.Copy())
 	var/numbers = 1
 	var/dust_type = /obj/effect/space_dust
-	switch(strength)
-		if("weak")
+	switch(severity)
+		if(EVENT_LEVEL_MUNDANE)
 			numbers = rand(2,4)
 			dust_type = /obj/effect/space_dust/weak
-		if("norm")
+		if(EVENT_LEVEL_MODERATE)
 			numbers = rand(5,10)
 			dust_type = /obj/effect/space_dust
-		if("strong")
+		if(EVENT_LEVEL_MAJOR)
 			numbers = rand(10,15)
 			dust_type = /obj/effect/space_dust/strong
-		if("super")
+		if(EVENT_LEVEL_EXTREME)
 			numbers = rand(15,25)
 			dust_type = /obj/effect/space_dust/super
 
 	var/startside = pick(GLOB.cardinal)
-	for(var/i = 0 to numbers)
+	for(var/i in 1 to numbers)
 		var/startx = 0
 		var/starty = 0
 		var/endy = 0
@@ -62,7 +69,7 @@ The "dust" will damage the hull of the station causin minor hull breaches.
 	name = "Space Dust"
 	desc = "Dust in space."
 	icon = 'icons/obj/meteor.dmi'
-	icon_state = "space_dust"
+	icon_state = "dust"
 	density = 1
 	anchored = 1
 	var/strength = 2	// legacy_ex_act severity number
@@ -95,11 +102,7 @@ The "dust" will damage the hull of the station causin minor hull breaches.
 				shake_camera(M, 3, 1)
 	if (A)
 		playsound(src.loc, 'sound/effects/meteorimpact.ogg', 40, 1)
-
-		if(ismob(A))
-			LEGACY_EX_ACT(A, strength, null)	// This should work for now I guess
-		else if(!istype(A,/obj/machinery/power/emitter) && !istype(A,/obj/machinery/field_generator))	// Protect the singularity from getting released every round!
-			LEGACY_EX_ACT(A, strength, null)	// Changing emitter/field gen legacy_ex_act would make it immune to bombs and C4
+		LEGACY_EX_ACT(A, strength, null)
 
 		life--
 		if(life <= 0)

--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -2,7 +2,7 @@
 	startWhen	= 10
 	endWhen		= 30
 
-/datum/event/carp_migration/start()
+/datum/event/dust/start()
 	affecting_z -= (LEGACY_MAP_DATUM).sealed_levels	// Space levels only please!
 	..()
 

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -1,25 +1,3 @@
-
-/*
-/proc/start_events()
-	//changed to a while(1) loop since they are more efficient.
-	//Moved the spawn in here to allow it to be called with advance proc call if it crashes.
-	//and also to stop spawn copying variables from the game SSticker
-	spawn(3000)
-		while(1)
-			/*if(prob(50))//Every 120 seconds and prob 50 2-4 weak spacedusts will hit the station
-				spawn(1)
-					dust_swarm("weak")*/
-			if(!event)
-				//CARN: checks to see if random events are enabled.
-				if(config_legacy.allow_random_events)
-					hadevent = event()
-				else
-					Holiday_Random_Event()
-			else
-				event = 0
-			sleep(2400)
-			*/
-
 var/list/event_last_fired = list()
 
 //Always triggers an event when called, dynamically chooses events based on job population

--- a/code/modules/gamemaster/actions/dust.dm
+++ b/code/modules/gamemaster/actions/dust.dm
@@ -14,4 +14,4 @@
 
 /datum/gm_action/dust/start()
 	..()
-	dust_swarm("norm")
+	dust_swarm(EVENT_LEVEL_MODERATE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Space dust has had an incorrect icon_state for 7+ years, this makes it visible again. Updates the space_dust event to actually work if triggered by the GM events. It was using specific strings while being fed integer defines instead.

Cleans up some older code, a commented out call to space_dust that is older than the hard sync and can just go away. Removes space_dust not damaging singulo engine equipment since we don't use the singulo and its a skill issue if your singulo gets sniped by space dust.

I think the entire event system on its own may have issues actually turning on but this event can at least be manually triggered by GMs and work now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lowers legacy tech debt, increases shareholder value.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
-Fix the icon for space dust.
-Modernize severity value to use EVENT_LEVEL_* defines. 
-Add EVENT_LEVEL_EXTREME define for a severity 4 choice.
-Remove old code for protecting singulo equipment. 
-Remove commented out code for dust swarm older than the hardsync. 
-Update gm event system to correctly call dust_swarm.
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed space dust
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
