### PR TITLE
Adds two subspecies for Xenomorph hybrids, Hunter and Warrior

### DIFF
--- a/code/__DEFINES/species/species.dm
+++ b/code/__DEFINES/species/species.dm
@@ -74,6 +74,8 @@
 	#define SPECIES_ID_XENOMORPH_SENTINEL "xenomorph_sentinel"
 #define SPECIES_ID_XENOHYBRID "xenohybrid"
 	#define SPECIES_ID_XENOHYBRID_ALT "xenohybrid_alt"
+	#define SPECIES_ID_XENOHYBRID_HUNTER "xenohybrid_hunter"
+	#define SPECIES_ID_XENOHYBRID_WARRIOR "xenohybrid_warrior"
 #define SPECIES_ID_ZADDAT "zaddat"
 #define SPECIES_ID_ZORREN "zorren"
 	#define SPECIES_ID_ZORREN_HIGH "zorren_high"

--- a/code/modules/species/station/xenomorph_hybrids/xeno_hybrids.dm
+++ b/code/modules/species/station/xenomorph_hybrids/xeno_hybrids.dm
@@ -66,7 +66,6 @@
 		/datum/ability/species/sonar,
 		/datum/ability/species/toggle_agility,
 		/datum/ability/species/xenomorph_hybrid/regenerate,
-		/datum/ability/species/xenomorph_hybrid/sneak,
 	)
 	total_health = 150	//Exoskeleton makes you tougher than baseline
 	brute_mod = 0.95 // Chitin is somewhat hard to crack
@@ -81,7 +80,7 @@
 	warning_high_pressure = 325//Both baseline
 	hazard_high_pressure = 550
 
-	movement_base_speed = 5.5
+	movement_base_speed = 5.25
 
 	//Doesnt work, defaults are set at checks
 	//breath_type = null	//they don't breathe
@@ -153,3 +152,61 @@
 	if(H.blood_holder.get_total_volume() <= blood_level_safe && H.try_take_nutrition(heal_amount * 4))
 		H.regen_blood(heal_amount)
 
+/datum/species/xenohybrid/hunter
+	name = "Xenomorph Hunter Hybrid"
+	name_plural = "Xenomorph Hunter Hybrids"
+	id = SPECIES_ID_XENOHYBRID
+	uid = SPECIES_ID_XENOHYBRID_HUNTER
+	default_bodytype = BODYTYPE_XENOHYBRID
+
+	inherent_verbs = list(
+		/mob/living/proc/shred_limb,
+		/mob/living/carbon/human/proc/tie_hair,
+		/mob/living/carbon/human/proc/hide_horns,
+		/mob/living/carbon/human/proc/hide_wings,
+		/mob/living/carbon/human/proc/hide_tail,
+		)
+
+	abilities = list(
+		/datum/ability/species/sonar,
+		/datum/ability/species/toggle_agility,
+		/datum/ability/species/xenomorph_hybrid/regenerate,
+		/datum/ability/species/xenomorph_hybrid/sneak,
+	)
+
+	has_organ = list(//no resin spinner for hunters
+		O_HEART =		/obj/item/organ/internal/heart,
+		O_VOICE = 		/obj/item/organ/internal/voicebox,
+		O_LIVER =		/obj/item/organ/internal/liver,
+		O_KIDNEYS =		/obj/item/organ/internal/kidneys,
+		O_BRAIN =		/obj/item/organ/internal/brain,
+		O_PLASMA =		/obj/item/organ/internal/xenos/plasmavessel/hunter,//Important for the xenomorph abilities, hunter to have a pretty small plasma capacity
+		O_STOMACH =		/obj/item/organ/internal/stomach,
+		O_INTESTINE =	/obj/item/organ/internal/intestine,
+		)
+	// Stealthy but fragile
+	total_health = 100	//Baseline value
+	brute_mod = 1.1 // Fragile but stealthy
+	burn_mod = 1.6	// Natural enemy of xenomorphs is fire.
+	hunger_factor = 0.08 //Slightly less hungry than standard hybrid
+
+	vision_innate = /datum/vision/baseline/species_tier_3
+	movement_base_speed = 5.75 // Slightly faster than standard hybrid
+
+	heal_rate = 0.25 // Heals only half as fast as normal hybrids
+
+/datum/species/xenohybrid/warrior
+	name = "Xenomorph Warrior Hybrid"
+	name_plural = "Xenomorph Hybrids"
+	uid = SPECIES_ID_XENOHYBRID_WARRIOR
+	id = SPECIES_ID_XENOHYBRID
+	default_bodytype = BODYTYPE_XENOHYBRID
+
+	// Tough but slow
+	total_health = 200	//Double Human Baseline value
+	brute_mod = 0.9 // Chitin is somewhat hard to crack
+	burn_mod = 1.35	// Natural enemy of xenomorphs is fire. Upgraded to Major Burn Weakness. Reduce to Minor if this is too harsh.
+	radiation_mod = 0.98 // Thicker chitin plates
+	heal_rate = 0.55 // slightly higher heal rate
+
+	movement_base_speed = 5 // baseline speed, slower than other hybrids


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It adds two new xenomorph hybrid subspecies, the hunter and the warrior
The hunter is a fragile but fast and stealthy glass cannon
The warrior is a slower but much tankier variation
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hopefully balances the hybrid stealth ability better (its hunter exclusive now)
Warrior might need a bit more balancing
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added Stealthy Xenohybrid Subspecies "Xenomorph Hybrid Hunter"
add: Added Tanky Xenohybrid Subspecies "Xenomorph Hybrid Warrior"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
