### PR TITLE
Shadekin atom huds are now invisible

### DIFF
--- a/code/modules/species/shadekin/shadekin_abilities.dm
+++ b/code/modules/species/shadekin/shadekin_abilities.dm
@@ -98,6 +98,10 @@
 		incorporeal_move = initial(incorporeal_move)
 		density = initial(density)
 		remove_movespeed_modifier(/datum/movespeed_modifier/forced_speedup/shadein_jaunt)
+		for(var/id in atom_huds)
+			var/image/image = atom_huds[id]
+			image.alpha = initial(image.alpha)
+
 		update_icon()
 
 		//Cosmetics mostly
@@ -151,6 +155,12 @@
 		sleep(5)
 		invisibility = INVISIBILITY_LEVEL_TWO
 		see_invisible = INVISIBILITY_LEVEL_TWO
+
+		//Medical/security/etc. HUD displays should not be able to see us.
+		for(var/id in atom_huds)
+			var/image/image = atom_huds[id]
+			image.alpha = 0
+
 		// cut_overlays()
 		update_icon()
 		alpha = 127


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If you're wearing medical/security HUDs, you can no longer see them on a phased shadekin, making them actually invisible. (Previously, although you could not see their sprite, you could see their atom HUDs, which gave away their location.)

This PR has been tested and works locally.

## Why It's Good For The Game

This seems like an oversight given phased shadekin are meant to be in a completely different dimension and invisible to normal detection.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: You can no longer see a phased shadekin using hud glasses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
