### PR TITLE
Some adjustments for guest passes

### DIFF
--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -93,6 +93,8 @@
 	issued.given_reason = guest_reason || "NOT SPECIFIED"
 	issued.registered_name = guest_name || "NOT SPECIFIED"
 	issued.rank = "Guest"
+	issued.name += " ([issued.registered_name])"
+
 	// todo: way to bypass this, maybe with hacking or emag?
 	if(!isnull(giver))
 		issued.giver_name = giver.registered_name

--- a/code/game/objects/items/id_cards/guest.dm
+++ b/code/game/objects/items/id_cards/guest.dm
@@ -31,16 +31,17 @@
 
 /obj/item/card/id/guest/proc/expire()
 	visible_message("<span class='warning'>\The [src] flashes a few times before turning red.</span>")
-	update_icon()
 	expire_time = world.time
 	expired = TRUE
+	update_icon()
 	access.len = 0
 	if(expire_timerid)
 		deltimer(expire_timerid)
 		expire_timerid = null
 
 /obj/item/card/id/guest/update_icon_state()
-	icon_state = expired? "guest_invalid" : "guest"
+	icon_state = expired ? "guest-invalid" : "guest"
+	base_icon_state = expired ? "guest-invalid" : "guest"
 	return ..()
 
 // todo: refactor everything below
@@ -54,28 +55,28 @@
 
 /obj/item/card/id/guest/get_description_info()
 	. = ..()
+	. += "This guest pass provides time-limited access to an area, similar to an ID card. Use it in your hand on harm intent to prematurely deactivate it.<br><br>"
 	if (expired)
-		. += SPAN_NOTICE("This pass expired at [worldtime2stationtime(expire_time)].")
+		. += SPAN_NOTICE("This pass expired at [worldtime2stationtime(expire_time)].<br>")
 	else
-		. += SPAN_NOTICE("This pass expires at [worldtime2stationtime(expire_time)].")
-	. += SPAN_NOTICE("It grants access to following areas:")
+		. += SPAN_NOTICE("This pass expires at [worldtime2stationtime(expire_time)].<br>")
+	. += SPAN_NOTICE("It grants access to following areas:<br>")
 	for (var/A in access)
-		. += SPAN_NOTICE("[get_access_desc(A)].")
-	. += SPAN_NOTICE("Issuing reason: [given_reason].")
-	. += SPAN_NOTICE("Issuer name: [giver_name]")
-	. += SPAN_NOTICE("Issuer rank: [giver_rank]")
+		. += SPAN_NOTICE("[get_access_desc(A)].<br>")
+	. += "<br>"
+	. += SPAN_NOTICE("Issuing reason: [given_reason].<br>")
+	. += SPAN_NOTICE("Issuer name: [giver_name]<br>")
+	. += SPAN_NOTICE("Issuer rank: [giver_rank]<br>")
 
 /obj/item/card/id/guest/attack_self(mob/user, datum/event_args/actor/actor)
-	. = ..()
-	if(.)
-		return
 	if(user.a_intent == INTENT_HARM)
-		if(icon_state == "guest_invalid")
+		if(expired)
 			to_chat(user, "<span class='warning'>This guest pass is already deactivated!</span>")
-			return
+			return ..()
 
 		var/confirm = alert("Do you really want to deactivate this guest pass? (you can't reactivate it)", "Confirm Deactivation", "Yes", "No")
 		if(confirm == "Yes")
 			//rip guest pass </3
 			user.visible_message("<span class='notice'>\The [user] deactivates \the [src].</span>")
 			expire()
+	else return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates some guest pass code to fix a bug where they were not turning red when expiring. Also cleans up their examine text, and adds the person's name to the title to more easily identify who it's meant for (similar to an actual ID).


<img width="888" height="261" alt="image" src="https://github.com/user-attachments/assets/016cf9b1-bc27-4bad-b461-2ad7cdb55c70" />

<img width="1064" height="78" alt="image" src="https://github.com/user-attachments/assets/5c430b63-ffb6-4e7e-8027-291f91cde445" />


## Why It's Good For The Game

The sprite fix is arguably necessary as it helps clarify immensely whether a guest pass has expired or not. The rest are minor QOL adjustments.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The stripe on guest passes will now turn red when they expire.
tweak: The examine text on a guest pass is now formatted correctly.
tweak: Guest passes will now show the issued person's name on them, similar to an ID.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
