### PR TITLE
Updates nightshift colors

### DIFF
--- a/code/__DEFINES/color/lights.dm
+++ b/code/__DEFINES/color/lights.dm
@@ -37,12 +37,27 @@
 #define LIGHT_COLOR_INCANDESCENT_BULB       "#FFFEB8" // rgb(255, 254, 184) Slightly yellowish white.
 #define LIGHT_COLOR_INCANDESCENT_FLASHLIGHT "#FFCC66" // rgb(255, 204, 102) Slightly yellowish white.
 
-/// Nightshift Light Color
-/// Used on full-strength light tubes.
-#define LIGHT_COLOR_NIGHTSHIFT              "#c7c7ff"
-/// Nightshift Light Power
-/// Used on full-strength light tubes.
-#define LIGHT_POWER_NIGHTSHIFT                0.435
-/// Nightshift Light Range
-/// Used on full-strength light tubes.
-#define LIGHT_RANGE_NIGHTSHIFT                7
+
+// Nightshift Light Colors, Powers, & Ranges
+
+//For recordkeeping's sake: Older, warm nightshift color is "#EFCC86" and the newer, cold nightshift color is "#C7C7FF".
+
+// Default
+#define LIGHT_COLOR_NIGHTSHIFT_DEFAULT   "#EFCC86"
+#define LIGHT_POWER_NIGHTSHIFT_DEFAULT    0.435  //Normal power is 0.8
+#define LIGHT_RANGE_NIGHTSHIFT_DEFAULT    7      //Normal range is 8
+
+// Tube lights
+#define LIGHT_COLOR_NIGHTSHIFT_TUBE      "#EFCC86"
+#define LIGHT_POWER_NIGHTSHIFT_TUBE       0.5    //Normal power is 0.8
+#define LIGHT_RANGE_NIGHTSHIFT_TUBE       6      //Normal range is 8
+
+// Small lights
+#define LIGHT_COLOR_NIGHTSHIFT_SMALL     "#EFCC86"
+#define LIGHT_POWER_NIGHTSHIFT_SMALL      0.45   //Normal power is 0.8
+#define LIGHT_RANGE_NIGHTSHIFT_SMALL      3      //Normal range is 4
+
+// Fairy lights
+#define LIGHT_COLOR_NIGHTSHIFT_FAIRY     "#EFCC86"
+#define LIGHT_POWER_NIGHTSHIFT_FAIRY      0.45   //Normal power is 0.8
+#define LIGHT_RANGE_NIGHTSHIFT_FAIRY      4      //Normal range is 5

--- a/code/modules/power/lighting/lights.dm
+++ b/code/modules/power/lighting/lights.dm
@@ -28,11 +28,11 @@
 	var/brightness_color = LIGHT_COLOR_HALOGEN
 
 	/// range of light under nightshift; null for no change
-	var/nightshift_range = LIGHT_RANGE_NIGHTSHIFT
+	var/nightshift_range = LIGHT_RANGE_NIGHTSHIFT_DEFAULT
 	/// power of light under nightshift; null for no change
-	var/nightshift_power = LIGHT_POWER_NIGHTSHIFT
+	var/nightshift_power = LIGHT_POWER_NIGHTSHIFT_DEFAULT
 	/// color of light under nightshift; null for no change
-	var/nightshift_color = LIGHT_COLOR_NIGHTSHIFT
+	var/nightshift_color = LIGHT_COLOR_NIGHTSHIFT_DEFAULT
 
 /obj/item/light/tube
 	name = "light tube"
@@ -45,8 +45,9 @@
 	brightness_power = 0.8
 	brightness_color = LIGHT_COLOR_HALOGEN
 
-	nightshift_range = 6
-	nightshift_power = 0.5
+	nightshift_color = LIGHT_COLOR_NIGHTSHIFT_TUBE
+	nightshift_range = LIGHT_RANGE_NIGHTSHIFT_TUBE
+	nightshift_power = LIGHT_POWER_NIGHTSHIFT_TUBE
 
 	worth_intrinsic = 5
 
@@ -118,12 +119,9 @@
 	brightness_range = 4
 	brightness_power = 0.8
 
-	// todo: bulb nightshift stuff needs to be defines
-	// we basically disable it because bulbs are already pretty weak
-
-	nightshift_color = null
-	nightshift_range = null
-	nightshift_power = null
+	nightshift_color = LIGHT_COLOR_NIGHTSHIFT_SMALL
+	nightshift_range = LIGHT_RANGE_NIGHTSHIFT_SMALL
+	nightshift_power = LIGHT_POWER_NIGHTSHIFT_SMALL
 
 	worth_intrinsic = 2
 
@@ -207,6 +205,10 @@
 	base_icon_state = "fbulb"
 	materials_base = list(MAT_GLASS = 10)
 	brightness_range = 5
+
+	nightshift_color = LIGHT_COLOR_NIGHTSHIFT_FAIRY
+	nightshift_power = LIGHT_POWER_NIGHTSHIFT_FAIRY
+	nightshift_range = LIGHT_RANGE_NIGHTSHIFT_FAIRY
 
 // update the icon state and description of the light
 /obj/item/light/update_icon()


### PR DESCRIPTION
- Changes overall color back to warm colors
- Moves color, power, and range to a proper define
- Small bulbs and fairy lights now respect the nightshift

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates the nightshift colors to be warm again (pending the conclusion of a vote in devlog). Creates more defines for nightshift color settings, and allows small lightbulbs and fairy lights (which are the main lightsources alongside tubes) to respect the nightshift as well.

## Why It's Good For The Game

Letting small lights and fairy lights be affected by the nightshift is arguably good, especially on maps like the Strelka where they make up the majority of light sources. Making the colors warmer can help make the nightshift more cozy, though it is still up to a vote.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Small lightbulbs and fairy lights now respect the nightshift.
tweak: The nightshift color is now warm instead of cold.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
