### PR TITLE
Adds navigation screens to Atlas

### DIFF
--- a/maps/rift/levels/rift-02-underground2.dmm
+++ b/maps/rift/levels/rift-02-underground2.dmm
@@ -1223,6 +1223,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
+"eQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 27
+	},
+/turf/simulated/floor/tiled/steel,
+/area/hallway/primary/undertwo)
 "eT" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -1920,6 +1941,12 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_gas)
+"hs" = (
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/foyer)
 "hy" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -5410,6 +5437,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 27
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/undertwo)
@@ -27846,7 +27876,7 @@ hV
 nz
 Zj
 nb
-jU
+eQ
 ll
 fY
 Fa
@@ -30375,7 +30405,7 @@ Fa
 bL
 wp
 qk
-wp
+hs
 Fa
 Pj
 SI

--- a/maps/rift/levels/rift-03-underground1.dmm
+++ b/maps/rift/levels/rift-03-underground1.dmm
@@ -8113,6 +8113,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/elevator)
+"yw" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/table/bench/standard,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 27
+	},
+/turf/simulated/floor/tiled/steel,
+/area/hallway/primary/underone)
 "yx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -8622,6 +8644,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 27
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/underone)
@@ -9426,6 +9451,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"CX" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 27
+	},
+/turf/simulated/floor/tiled/steel,
+/area/hallway/primary/underone)
 "CY" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/drone_fabrication)
@@ -30890,7 +30933,7 @@ ae
 bF
 bV
 ae
-df
+yw
 LC
 fQ
 gv
@@ -35158,7 +35201,7 @@ FI
 Ph
 gi
 aG
-dM
+CX
 tg
 dp
 am

--- a/maps/rift/levels/rift-04-surface1.dmm
+++ b/maps/rift/levels/rift-04-surface1.dmm
@@ -658,6 +658,22 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rnd/hallway)
+"axG" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -37
+	},
+/turf/simulated/floor/tiled/steel,
+/area/hallway/primary/surfaceone)
 "ayM" = (
 /turf/simulated/wall/wood/hardwood,
 /area/rift/surfacebase/outside/outside1)
@@ -5970,6 +5986,26 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/rnd/tankstorage)
+"dVb" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -37
+	},
+/turf/simulated/floor/tiled/steel,
+/area/hallway/primary/surfaceone)
 "dVj" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
@@ -7875,6 +7911,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maint_bar)
+"fii" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/purple/border,
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -37
+	},
+/turf/simulated/floor/tiled/steel,
+/area/rnd/hallway)
 "fiF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -22087,6 +22131,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"nJr" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/rift/stairwell/primary/surfaceone)
 "nJF" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 6
@@ -35291,6 +35353,18 @@
 "uWy" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/foyer)
+"uWN" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/hallway/secondary/civilian_hallway_mid)
 "uXi" = (
 /obj/structure/railing{
 	dir = 8
@@ -37877,6 +37951,19 @@
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_south_airlock)
+"wzv" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_wing)
 "wzP" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -39374,6 +39461,21 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"xte" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/rift/stairwell/primary/surfaceone)
 "xtl" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -54177,7 +54279,7 @@ fYd
 wrw
 qPo
 jrC
-jrC
+xte
 hvo
 dsf
 iqR
@@ -54335,7 +54437,7 @@ vkl
 rbA
 dNN
 yja
-yja
+wzv
 yja
 yja
 yja
@@ -55153,7 +55255,7 @@ kHP
 otM
 oiR
 oiR
-pBu
+axG
 bQA
 bQA
 bQA
@@ -56724,7 +56826,7 @@ dYA
 qeb
 ctb
 tSZ
-wAv
+fii
 foD
 bnG
 wdf
@@ -57093,7 +57195,7 @@ pcC
 otM
 oiR
 oiR
-tBz
+dVb
 bQA
 bQA
 bQA
@@ -58057,7 +58159,7 @@ fYd
 spM
 oDo
 gGU
-gGU
+nJr
 hKV
 pyX
 tsg
@@ -62312,7 +62414,7 @@ gav
 bFm
 bFm
 bFm
-bFm
+uWN
 bFm
 bFm
 bFm

--- a/maps/rift/levels/rift-05-surface2.dmm
+++ b/maps/rift/levels/rift-05-surface2.dmm
@@ -5390,6 +5390,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 27
+	},
 /turf/simulated/floor/tiled/steel,
 /area/security/hallway)
 "dsj" = (
@@ -11167,6 +11170,24 @@
 	},
 /turf/simulated/floor/outdoors/snow/lythios43c,
 /area/rift/surfacebase/outside/outside2)
+"hbM" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 4
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 27
+	},
+/turf/simulated/floor/tiled/steel,
+/area/crew_quarters/sleep)
 "hbT" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable/green{
@@ -11514,6 +11535,20 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/crew_quarters/heads/hor)
+"hpp" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/purple/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/purple/bordercorner2{
+	dir = 9
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -37
+	},
+/turf/simulated/floor/tiled/steel,
+/area/rnd/research/researchdivision)
 "hpv" = (
 /obj/machinery/conveyor{
 	dir = 9;
@@ -29134,6 +29169,9 @@
 	light_range = 12;
 	old_wall = 1
 	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/lounge)
 "rWX" = (
@@ -30152,6 +30190,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -37
 	},
 /turf/simulated/floor/wood,
 /area/security/breakroom)
@@ -31430,6 +31471,18 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/pool)
+"tED" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 27
+	},
+/turf/simulated/floor/tiled/steel,
+/area/hallway/primary/surfacetwo)
 "tFm" = (
 /obj/machinery/iv_drip,
 /obj/effect/floor_decal/corner/paleblue{
@@ -32796,6 +32849,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/breakroom)
+"uHg" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/security/hallway)
 "uHm" = (
 /obj/structure/closet/bombclosetsecurity,
 /obj/effect/floor_decal/industrial/outline/blue,
@@ -33628,6 +33695,9 @@
 	},
 /obj/effect/floor_decal/borderfloor/corner2,
 /obj/effect/floor_decal/corner/purple/bordercorner2,
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -37
+	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacetwo)
 "uZq" = (
@@ -52949,7 +53019,7 @@ quS
 bno
 nqz
 cRG
-dTd
+hpp
 siA
 oBj
 xBE
@@ -56595,7 +56665,7 @@ hSr
 elc
 aWT
 fUV
-llR
+uHg
 llR
 jLI
 jLN
@@ -57193,7 +57263,7 @@ rTT
 rWX
 rWX
 rWX
-gbY
+tED
 hhN
 fWX
 vnU
@@ -61081,7 +61151,7 @@ tSC
 cUU
 qHc
 itG
-yli
+hbM
 auZ
 orZ
 oJG

--- a/maps/rift/levels/rift-06-surface3.dmm
+++ b/maps/rift/levels/rift-06-surface3.dmm
@@ -16160,6 +16160,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/steel,
 /area/exploration/excursion_dock)
 "aYx" = (
@@ -18765,6 +18768,9 @@
 /obj/machinery/camera/network/civilian,
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway)
@@ -21536,6 +21542,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/steel,
 /area/exploration)
 "jvL" = (
@@ -21691,6 +21700,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/surfacethree)
@@ -23633,6 +23645,9 @@
 /obj/machinery/camera/network/civilian,
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/docking_hallway)
@@ -25770,6 +25785,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/emt/cockpit)
+"rtM" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -37
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/bridge_hallway)
 "rtY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -26479,6 +26501,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -37
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "sYo" = (
@@ -26529,6 +26554,15 @@
 /obj/structure/symbol/sa,
 /turf/simulated/wall/prepainted/exploration,
 /area/exploration)
+"taT" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 27
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/bridge_hallway)
 "taW" = (
 /obj/structure/shuttle/engine/heater,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -51887,7 +51921,7 @@ aZO
 acj
 afO
 hgO
-adh
+taT
 aYL
 qKs
 vwG
@@ -51899,7 +51933,7 @@ qKs
 vwG
 qKs
 lSn
-apg
+rtM
 aEj
 aJs
 aFb

--- a/maps/rift/levels/rift-08-west_deep.dmm
+++ b/maps/rift/levels/rift-08-west_deep.dmm
@@ -548,6 +548,9 @@
 /obj/item/roller,
 /obj/item/roller,
 /obj/machinery/camera/network/research_outpost,
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 27
+	},
 /turf/simulated/floor/tiled/dark,
 /area/gateway/prep_room)
 "fx" = (
@@ -657,6 +660,12 @@
 "gI" = (
 /turf/simulated/floor/lythios43c/indoors,
 /area/rift/exterior/bunker/bottom)
+"gJ" = (
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -37
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/rnd/outpost/underground)
 "gS" = (
 /obj/random/obstruction,
 /turf/simulated/floor/lythios43c/indoors,
@@ -35972,7 +35981,7 @@ pI
 An
 kt
 KF
-KF
+gJ
 QM
 EY
 EY

--- a/maps/rift/levels/rift-09-west_caves.dmm
+++ b/maps/rift/levels/rift-09-west_caves.dmm
@@ -943,6 +943,9 @@
 /obj/effect/floor_decal/corner/purple/bordercorner{
 	dir = 4
 	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/outpost/underground)
 "kQ" = (
@@ -1027,6 +1030,14 @@
 /obj/item/towel/random,
 /turf/simulated/floor/tiled/steel_grid,
 /area/outpost/mining_main/outpost/washrooms)
+"lO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/outpost/mining_main/outpost)
 "lR" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -3538,6 +3549,9 @@
 /obj/structure/table/steel_reinforced,
 /obj/machinery/camera/network/mining{
 	dir = 4
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/outpost)
@@ -36385,7 +36399,7 @@ Ph
 fa
 SO
 SO
-SO
+lO
 QZ
 km
 XL

--- a/maps/rift/levels/rift-10-west_plains.dmm
+++ b/maps/rift/levels/rift-10-west_plains.dmm
@@ -4221,6 +4221,9 @@
 /obj/effect/floor_decal/corner/purple/bordercorner2{
 	dir = 6
 	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -37
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost)
 "tr" = (
@@ -5599,6 +5602,20 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty/lythios43c,
 /area/construction/solars)
+"zp" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/purple/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -37
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost)
 "zq" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
@@ -39560,7 +39577,7 @@ Lf
 dd
 qw
 RQ
-Um
+zp
 bO
 ui
 ba


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds wall-mounted navigation consoles to most areas of the Atlas station and outposts.

## Why It's Good For The Game

While the Atlas is a planetary installation, there are literally zero ways to see the overmap outside of the bridge or the cockpit of a shuttle. It would understandably be nice to be able to see what's around the planet.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Added navigation screens to the NSB Atlas.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
