### PR TITLE
Adds nuke codes to admin secrets

### DIFF
--- a/citadel.dme
+++ b/citadel.dme
@@ -2343,6 +2343,7 @@
 #include "code\modules\admin\secrets\admin_secrets\show_crew_manifest.dm"
 #include "code\modules\admin\secrets\admin_secrets\show_game_mode.dm"
 #include "code\modules\admin\secrets\admin_secrets\show_law_changes.dm"
+#include "code\modules\admin\secrets\admin_secrets\show_nuke_codes.dm"
 #include "code\modules\admin\secrets\admin_secrets\show_signalers.dm"
 #include "code\modules\admin\secrets\admin_secrets\traitors_and_objectives.dm"
 #include "code\modules\admin\secrets\final_solutions\summon_narsie.dm"

--- a/code/modules/admin/secrets/admin_secrets/show_nuke_codes.dm
+++ b/code/modules/admin/secrets/admin_secrets/show_nuke_codes.dm
@@ -1,0 +1,14 @@
+/datum/admin_secret_item/admin_secret/show_nuke_codes
+	name = "Show Nuclear Codes"
+
+/datum/admin_secret_item/admin_secret/show_nuke_codes/execute(var/mob/user)
+	. = ..()
+	if(!.)
+		return
+
+	var/dat = "<B>All codes for all nuclear devices:</B><HR>"
+
+	for(var/obj/machinery/nuclearbomb/bomb in world)
+		dat += "[bomb] at ([bomb.x], [bomb.y], [bomb.z]): [bomb.r_code]<BR>"
+
+	user << browse(HTML_SKELETON(dat), "window=nukecodes;size=400x400")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a button in the admin secrets panel to show the nuke codes of all explosives in the world, to make it easier to share them with players.

<img width="943" height="545" alt="image" src="https://github.com/user-attachments/assets/2431926a-a56e-4503-80af-78781ad9e5df" />


## Why It's Good For The Game

Right now, an admin would literally have to VV the nuclear device and get the codes that way, which isn't ideal. We aren't exactly blowing up the station every round, but I figure it's better to have a tool like this can be quickly and easily used, just in the chance that it becomes necessary.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Admins can now view the authentication codes for all nuclear devices in the Secrets panel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
