### PR TITLE
Z-Mimic: Fix recursive lighting copy

### DIFF
--- a/code/controllers/subsystem/zcopy.dm
+++ b/code/controllers/subsystem/zcopy.dm
@@ -398,7 +398,8 @@ SUBSYSTEM_DEF(zcopy)
 
 			// Special case: these are merged into the shadower to reduce memory usage.
 			if (object.type == /atom/movable/lighting_overlay)
-				T.shadower.copy_lighting(object, !(T.below.mz_flags & MZ_NO_SHADOW))
+				shadower_set = TRUE
+				T.shadower.copy_lighting(object)
 				continue
 
 			// If an atom already has an overlay, we probably don't need to discover it again.

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -111,35 +111,19 @@
 		color = null
 	else
 		icon_state = LIGHTING_BASE_ICON_STATE
-		if (islist(color))
-			// Does this even save a list alloc?
-			var/list/c_list = color
-			c_list[CL_MATRIX_RR] = rr
-			c_list[CL_MATRIX_RG] = rg
-			c_list[CL_MATRIX_RB] = rb
-			c_list[CL_MATRIX_GR] = gr
-			c_list[CL_MATRIX_GG] = gg
-			c_list[CL_MATRIX_GB] = gb
-			c_list[CL_MATRIX_BR] = br
-			c_list[CL_MATRIX_BG] = bg
-			c_list[CL_MATRIX_BB] = bb
-			c_list[CL_MATRIX_AR] = ar
-			c_list[CL_MATRIX_AG] = ag
-			c_list[CL_MATRIX_AB] = ab
-			color = c_list
-		else
-			color = list(
-				rr, rg, rb, 0,
-				gr, gg, gb, 0,
-				br, bg, bb, 0,
-				ar, ag, ab, 0,
-				0, 0, 0, 1
-			)
+		color = list(
+			rr, rg, rb, 0,
+			gr, gg, gb, 0,
+			br, bg, bb, 0,
+			ar, ag, ab, 0,
+			0, 0, 0, 1
+		)
 
 	// If there's a Z-turf above us, update its shadower.
 	if (T.above)
 		if (T.above.shadower)
-			T.above.shadower.copy_lighting(src)
+			if (!T.above.z_queued)	// If the turf is queued for update, that will do this update.
+				T.above.shadower.copy_lighting(src)
 		else
 			T.above.update_mimic()
 

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -22,10 +22,14 @@
 		bound_overlay.setDir(ndir)
 
 /atom/movable/update_above()
-	if (!bound_overlay || !isturf(loc))
+	if (!isturf(loc))
 		return
 
 	if (MOVABLE_IS_BELOW_ZTURF(src))
+		if (!bound_overlay)
+			SSzcopy.discover_movable(src)
+			return
+
 		SSzcopy.queued_overlays += bound_overlay
 		bound_overlay.queued += 1
 	else
@@ -101,14 +105,18 @@
 
 	return ..()
 
-/atom/movable/openspace/multiplier/proc/copy_lighting(atom/movable/lighting_overlay/LO, use_shadower_mult = TRUE)
+/atom/movable/openspace/multiplier/proc/copy_lighting(atom/movable/lighting_overlay/LO)
+	if (LO.needs_update)
+		// If this LO is pending an update, avoid this update and just let it update us.
+		return
 	appearance = LO
 	layer = MIMICED_LIGHTING_LAYER_MAIN
 	plane = OPENTURF_MAX_PLANE
 	blend_mode = BLEND_MULTIPLY
 	invisibility = 0
 
-	if (use_shadower_mult)
+	var/turf/T = loc
+	if (!(T.below.mz_flags & MZ_NO_SHADOW))
 		if (icon_state == LIGHTING_BASE_ICON_STATE)
 			// We're using a color matrix, so just darken the colors across the board.
 			var/list/c_list = color


### PR DESCRIPTION
changes:
- Glass turfs now actually work properly.
- `hard_reset()` now resets harder.
- ZM now avoids some redundant lighting copies.
- `update_above()` will now force a discovery if the movable is undiscovered.
- `NO_SHADOW` is more reliable.