### PR TITLE
Mech Strafe Fix (Marauder)

### DIFF
--- a/code/modules/vehicles/sealed/mecha/subtypes/combat/marauder.dm
+++ b/code/modules/vehicles/sealed/mecha/subtypes/combat/marauder.dm
@@ -79,6 +79,7 @@
 	wreckage = /obj/effect/decal/mecha_wreckage/mauler
 	mech_faction = MECH_FACTION_SYNDI
 
+
 //I'll break this down later
 /obj/vehicle/sealed/mecha/combat/marauder/relaymove(mob/user,direction)
 	if(user != src.occupant_legacy) //While not "realistic", this piece is player friendly.
@@ -107,9 +108,13 @@
 	if(internal_damage&MECHA_INT_CONTROL_LOST)
 		move_result = mechsteprand()
 	else if(src.dir!=direction)
-		move_result = mechturn(direction)
+		if(strafing)
+			move_result = mechstep(direction)
+		else
+			move_result = mechturn(direction)
 	else
 		move_result	= mechstep(direction)
+
 	if(move_result)
 		if(istype(src.loc, /turf/space))
 			if(!src.check_for_support())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds a few lines of code that fixes the strafe mechanic for the Marauder/Mauler/Seraph.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It gives it the ability to do what all other mechs can do.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Kade

fix: fixed the Marauder series of mechs not having their strafe work.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
