### PR TITLE
Pulls Monarch, adds other mobs to compensate

### DIFF
--- a/maps/submaps/level_specific/osiris_field/cargo_vessel1.dmm
+++ b/maps/submaps/level_specific/osiris_field/cargo_vessel1.dmm
@@ -159,6 +159,10 @@
 /obj/machinery/door/blast/regular,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/submap/osiris_field/cargo_vessel1)
+"if" = (
+/mob/living/simple_mob/animal/space/xenomorph/berserker,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/osiris_field/cargo_vessel1)
 "iz" = (
 /obj/random/gun/random,
 /turf/simulated/floor/plating,
@@ -269,9 +273,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/submap/osiris_field/cargo_vessel1)
 "nZ" = (
-/obj/structure/alien/weeds,
-/mob/living/simple_mob/animal/space/xenomorph/monarch,
-/turf/simulated/floor/plating,
+/mob/living/simple_mob/animal/space/xenomorph/warrior,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/submap/osiris_field/cargo_vessel1)
 "oh" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -355,6 +358,11 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
+"tm" = (
+/obj/structure/alien/weeds,
+/mob/living/simple_mob/animal/space/xenomorph/vanguard,
+/turf/simulated/floor/plating,
+/area/submap/osiris_field/cargo_vessel1)
 "tK" = (
 /obj/machinery/light/small/emergency/flicker{
 	dir = 4
@@ -1328,7 +1336,7 @@ jJ
 xR
 Ou
 Ou
-Ou
+nZ
 Lv
 fp
 lo
@@ -1423,7 +1431,7 @@ Pd
 Pd
 hX
 Ik
-wf
+tm
 wf
 Ik
 ye
@@ -1454,7 +1462,7 @@ wf
 wf
 Ik
 ye
-nZ
+wf
 wf
 lr
 jJ
@@ -1481,7 +1489,7 @@ FK
 FK
 Ik
 ye
-wf
+tm
 wf
 lr
 jJ
@@ -1539,7 +1547,7 @@ ln
 ln
 un
 jJ
-jJ
+if
 jJ
 Up
 yi


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request


Pulls the frankly overpowered xenomorph monarch from the debris field spawns.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The scale of threat of this mob compared to the rest in the POI is completely out of scale, as the monarch can leap *across screens* and stun people. Other mobs have been added as a replacement, as well as the number of other mobs in the POI has been increased. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: pulled overpowered boss mob from debris field POI, added multiple less powerful mobs as bosses as replacement.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
