### PR TITLE
No belter slowdown

### DIFF
--- a/code/modules/mob/living/carbon/human/movement.dm
+++ b/code/modules/mob/living/carbon/human/movement.dm
@@ -5,7 +5,8 @@
 	var/tally = 0
 
 	if (istype(loc, /turf/space))
-		return 1		//until tg movement slowdown + modifiers is a thing I guess ...
+		return 0		//until tg movement slowdown + modifiers is a thing I guess ...
+						//Also has no effect unless there is gravity in space... which kinda does make no sense, but is the case for the random asteroid mining, so lets return 0
 
 	if(embedded_flag)
 		handle_embedded_objects() //Moving with objects stuck in you can cause bad times.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A single return value change to have no slowdown for the belter space.

## Why It's Good For The Game

It does seem like a slowdown for no reason, and that value is only having an effect when the area is also under gravity, which only is the case for belter space, and never really makes sense. I suppose it was an early return to not go through all the other checks because it can usually be assumed you aren't moving without special equipment.
Also currently, besides flying to another planet it is the only reliable material source while Surt has problems, so this annoyance got more focus

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: there is no forced slowdown in the belts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
