### PR TITLE
Z-Mimic: Speculative glass layering fix

### DIFF
--- a/code/controllers/subsystem/zcopy.dm
+++ b/code/controllers/subsystem/zcopy.dm
@@ -375,7 +375,7 @@ SUBSYSTEM_DEF(zcopy)
 			var/atom/movable/openspace/turf_mimic/DC = T.below.mimic_above_copy
 			DC.appearance = T.below
 			DC.mouse_opacity = initial(DC.mouse_opacity)
-			DC.plane = OPENTURF_MAX_PLANE
+			DC.plane = OPENTURF_MAX_PLANE - 1	// virtual depth of 1
 
 		else if (T.below.mimic_above_copy)
 			QDEL_NULL(T.below.mimic_above_copy)


### PR DESCRIPTION
changes:
- Wide mobs standing on the edge of a glass turf should no longer layer under the glass turf.