### PR TITLE
Fix ghosts orbiting not stopping

### DIFF
--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -131,7 +131,7 @@
 		return
 	UnregisterSignal(orbiter, list(COMSIG_MOVABLE_MOVED /*, COMSIG_ATOM_BEFORE_SHUTTLE_MOVE, COMSIG_ATOM_AFTER_SHUTTLE_MOVE */))
 	// SEND_SIGNAL(parent, COMSIG_ATOM_ORBIT_STOP, orbiter) // on tg used by ghost player plays
-	orbiter.SpinAnimation(0, 0)
+	orbiter.SpinAnimation(0, 0, parallel = FALSE)
 	if(istype(orbiter_list[orbiter],/matrix)) //This is ugly.
 		orbiter.transform = orbiter_list[orbiter]
 	orbiter_list -= orbiter


### PR DESCRIPTION

## About The Pull Request
While ghosts move rather frictionless around, eternal spinning looks bad
## Why It's Good For The Game
## Changelog
:cl:
fix: Ghosts can stop spinning after they stop orbiting someone
/:cl:
