### PR TITLE
several bugfixes

### DIFF
--- a/code/datums/design/design.dm
+++ b/code/datums/design/design.dm
@@ -143,6 +143,7 @@
 /datum/prototype/design/proc/ui_data_list()
 	return list(
 		"name" = name,
+		"truncated_name" = length(name) <= 18 ? name : copytext(name, 1, 19) + "..",
 		"desc" = desc,
 		"id" = id,
 		"work" = work,

--- a/code/game/machinery/pda_multicaster.dm
+++ b/code/game/machinery/pda_multicaster.dm
@@ -2,7 +2,7 @@
 	name = "\improper PDA multicaster"
 	desc = "This machine mirrors messages sent to it to specific departments."
 	icon = 'icons/obj/stationobjs.dmi'
-	icon_state = "controller"
+	icon_state = "pdamulti"
 	density = 1
 	anchored = 1
 	circuit = /obj/item/circuitboard/telecomms/pda_multicaster
@@ -33,7 +33,7 @@
 	if(on)
 		icon_state = initial(icon_state)
 	else
-		icon_state = "[initial(icon_state)]-p"
+		icon_state = "[initial(icon_state)]_off"
 	return ..()
 
 /obj/machinery/pda_multicaster/attackby(obj/item/I, mob/user)

--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -11,9 +11,14 @@
 
 	//materials_base = list("metal" = 50, MAT_GLASS = 50)
 
-
 /obj/item/binoculars/attack_self(mob/user, datum/event_args/actor/actor)
 	. = ..()
 	if(.)
 		return
 	zoom()
+
+// the zoom proc needs taking out back but this fixes binoculars being janky for now
+/obj/item/binoculars/unequipped(mob/user, slot, flags)
+	. = ..()
+	if(zoom)
+		zoom()

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -44,7 +44,8 @@
 		/obj/item/clothing/under/rank/nursesuit,
 		/obj/item/clothing/head/nursehat,
 		/obj/item/gps/medical,
-		/obj/item/storage/box/freezer = 3)
+		/obj/item/storage/box/freezer = 3,
+		/obj/item/clothing/glasses/hud/health)
 
 /obj/structure/closet/secure_closet/medical3/Initialize(mapload)
 	if(prob(50))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1756,13 +1756,10 @@
 
 	if(modifiers && modifiers.len)
 		for(var/datum/modifier/mod in modifiers)
-			if(isnull(modifier_set) && !isnull(mod.pulse_set_level))
+			if(isnull(mod.pulse_set_level))
+				continue
+			if(isnull(modifier_set) || mod.pulse_set_level > modifier_set)
 				modifier_set = round(mod.pulse_set_level)	// Should be a whole number, but let's not take chances.
-			else if(mod.pulse_set_level > modifier_set)
-				modifier_set = round(mod.pulse_set_level)
-
-			modifier_set = max(0, modifier_set)	// No setting to negatives.
-
 			if(mod.pulse_modifier)
 				modifier_shift += mod.pulse_modifier
 

--- a/code/modules/multiz/structures/ladder.dm
+++ b/code/modules/multiz/structures/ladder.dm
@@ -94,6 +94,9 @@
 	if(incapacitated())
 		to_chat(src, "<span class='warning'>You are physically unable to climb \the [ladder].</span>")
 		return FALSE
+	if(is_buckled())
+		to_chat(src, "<spab class='warning'>You can't do this while buckled to \the [buckled]!</span>")
+		return FALSE
 	return TRUE
 
 /mob/observer/ghost/may_climb_ladders(var/ladder)

--- a/code/modules/reagents/chemistry/reactions/paint.dm
+++ b/code/modules/reagents/chemistry/reactions/paint.dm
@@ -1,5 +1,6 @@
 /datum/chemical_reaction/paint
 	abstract_type = /datum/chemical_reaction/paint
+	has_data_semantics = TRUE
 	var/result_color
 
 /datum/chemical_reaction/paint/compute_result_data_initializer(datum/reagent_holder/holder, multiplier)

--- a/code/modules/reagents/chemistry/reagents/other/paint.dm
+++ b/code/modules/reagents/chemistry/reagents/other/paint.dm
@@ -46,9 +46,16 @@
 	var/total_volume = old_volume + new_volume
 	var/old_hex = uppertext(old_data || "#ffffff")
 	var/new_hex = uppertext(new_data || "#ffffff")
+
+	if(isnull(old_data))
+		return rgb(
+			hex2num(copytext(new_hex, 2, 4)),
+			hex2num(copytext(new_hex, 4, 6)),
+			hex2num(copytext(new_hex, 6, 8))
+		)
+
 	return rgb(
 		((hex2num(copytext(old_hex, 2, 4)) * old_volume) + (hex2num(copytext(new_hex, 2, 4)))) / total_volume,
 		((hex2num(copytext(old_hex, 4, 6)) * old_volume) + (hex2num(copytext(new_hex, 4, 6)))) / total_volume,
-		((hex2num(copytext(old_hex, 6, 8)) * old_volume) + (hex2num(copytext(new_hex, 6, 8)))) / total_volume,
-		((hex2num(length(old_hex) > 7 ? copytext(old_hex, 8, 10) : 255) * old_volume) + (hex2num(length(new_hex) > 7 ? copytext(new_hex, 8, 10) : 255))) / total_volume,
+		((hex2num(copytext(old_hex, 6, 8)) * old_volume) + (hex2num(copytext(new_hex, 6, 8)))) / total_volume
 	)

--- a/code/modules/reagents/chemistry/reagents/other/paint.dm
+++ b/code/modules/reagents/chemistry/reagents/other/paint.dm
@@ -47,13 +47,6 @@
 	var/old_hex = uppertext(old_data || "#ffffff")
 	var/new_hex = uppertext(new_data || "#ffffff")
 
-	if(isnull(old_data))
-		return rgb(
-			hex2num(copytext(new_hex, 2, 4)),
-			hex2num(copytext(new_hex, 4, 6)),
-			hex2num(copytext(new_hex, 6, 8))
-		)
-
 	return rgb(
 		((hex2num(copytext(old_hex, 2, 4)) * old_volume) + (hex2num(copytext(new_hex, 2, 4)))) / total_volume,
 		((hex2num(copytext(old_hex, 4, 6)) * old_volume) + (hex2num(copytext(new_hex, 4, 6)))) / total_volume,

--- a/code/modules/species/holosphere/holosphere.dm
+++ b/code/modules/species/holosphere/holosphere.dm
@@ -163,8 +163,10 @@
 
 // hotfix: they're synthetic without synthetic parts, oops!
 /datum/species/shapeshifter/holosphere/get_blood_colour(mob/living/carbon/human/H)
-	if(H)
-		return blood_color
+	return blood_color
+
+/datum/species/shapeshifter/holosphere/get_blood_name(mob/living/carbon/human/H)
+	return "coolant"
 
 /datum/species/shapeshifter/holosphere/get_valid_shapeshifter_forms()
 	return list(

--- a/tgui/packages/tgui/interfaces/common/Design.tsx
+++ b/tgui/packages/tgui/interfaces/common/Design.tsx
@@ -9,6 +9,7 @@ import { IngredientsNeeded } from "./Ingredients";
  */
 export interface Design {
   name: string;
+  truncated_name: string;
   desc: string;
   categories: string[];
   subcategories: string[];

--- a/tgui/packages/tgui/interfaces/modules/TGUILatheControl.tsx
+++ b/tgui/packages/tgui/interfaces/modules/TGUILatheControl.tsx
@@ -125,7 +125,7 @@ export const TGUILatheControl = (props: TGUILatheControlProps, context) => {
 
   const windowProps: WindowProps = {
     title: data.latheName,
-    width: 1100,
+    width: 1200,
     height: 700,
   };
 
@@ -410,7 +410,7 @@ const LatheQueued = (props: LatheQueuedProps) => {
       color="transparent"
       title={
         <>
-          {`${props.entry.amount}x ${props.design !== undefined ? props.design.name : "Error - Design Unloaded"}`}
+          {`${props.entry.amount}x ${props.design !== undefined ? props.design.truncated_name : "Error - Design Unloaded"}`}
           {progressRender}
         </>
       }


### PR DESCRIPTION
## About The Pull Request

- fixes the icon for PDA multicaster
- you can no longer climb ladders while buckled to something
- you stop looking through binoculars when unequipping them now (i.e. slipping)
- medical scanner HUDs have been added to medical doctors lockers **(i guess this technically isn't a fix??? but they should be there, given paramedic lockers have them and doctors can take it in the loadout!!)**
- holospheres no longer throw an exception when get_blood_name is called on them
- autolathe menu is slightly wider (1100 to 1200)
- autolathe designs in the queue that are longer than 20 characters get shortened to 18 with ".." at the end to show they have been shortened, it's not perfect but i'm not a webdev
- being colourblind no longer stops you having a pulse
- paint no longer causes things to become invisible

<img width="317" height="232" alt="image" src="https://github.com/user-attachments/assets/ede2550f-22c1-4355-afb7-eb2be1d04f36" />

everything above has been tested by me locally

## Why It's Good For The Game
it fixes bugs

## Changelog

:cl:
fix: fixes the icon for PDA multicaster
fix: you can no longer climb ladders while buckled to something
fix: you stop looking through binoculars when unequipping them now (i.e. slipping)
add: medical scanner HUDs have been added to medical doctors lockers
fix: holospheres no longer throw an exception when get_blood_name is called on them
fix: autolathe menu is slightly wider (1100 to 1200)
fix: autolathe designs in the queue that are longer than 20 characters get shortened to 18 with ".." at the end to show they have
fix: being colourblind no longer stops you having a pulse
fix: paint no longer causes things to become invisible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
