### PR TITLE
Lighting: Reject absurd values

### DIFF
--- a/code/__DEFINES/rendering/lighting.dm
+++ b/code/__DEFINES/rendering/lighting.dm
@@ -31,6 +31,9 @@
 
 /// Maximum light_range before forced to always queue instead of using sync updates. Setting this too high will cause server stutter with moving large lights.
 #define LIGHTING_MAXIMUM_INSTANT_RANGE 8
+#define LIGHTING_HARD_MAXIMUM_RANGE 128	//! Light ranges equal to or above this are ignored, we can't render them anyway.
+#define LIGHTING_SOFT_MAXIMUM_RANGE 64	//! Light ranges equal to or above this emit a runtime but are still allowed.
+#define LIGHTING_SOFT_MAXIMUM_POWER 10	//! Light powers equal to or above this emit a runtime but are still allowed.
 
 /**
  * Mostly identical to below, but doesn't make sure T is valid first.

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -24,6 +24,14 @@
 
 /// The proc you should always use to set the light of this atom.
 /atom/proc/set_light(l_range, l_power, l_color = NONSENSICAL_VALUE, angle = NONSENSICAL_VALUE, no_update = FALSE)
+	if (l_range >= LIGHTING_HARD_MAXIMUM_RANGE)
+		CRASH("light_range > [LIGHTING_HARD_MAXIMUM_RANGE]; ignored")
+	if (l_range >= LIGHTING_SOFT_MAXIMUM_RANGE)
+		STACK_TRACE("light_range > [LIGHTING_SOFT_MAXIMUM_RANGE]; going to lag")
+
+	if (l_power > LIGHTING_SOFT_MAXIMUM_POWER)
+		STACK_TRACE("light_power > [LIGHTING_SOFT_MAXIMUM_POWER] is not useful")
+
 	if(l_range > 0 && l_range < MINIMUM_USEFUL_LIGHT_RANGE)
 		l_range = MINIMUM_USEFUL_LIGHT_RANGE	//Brings the range up to 1.4
 	if (l_power != null)
@@ -50,6 +58,16 @@
 /atom/proc/update_light()
 	if (QDELING(src))
 		return
+
+	switch (light_range)
+		if (LIGHTING_SOFT_MAXIMUM_RANGE to LIGHTING_HARD_MAXIMUM_RANGE)
+			STACK_TRACE("light_range > [LIGHTING_SOFT_MAXIMUM_RANGE]; going to lag")
+		if (LIGHTING_HARD_MAXIMUM_RANGE to INFINITY)
+			light_range = 0
+			STACK_TRACE("light_range > [LIGHTING_HARD_MAXIMUM_RANGE]; ignored")
+
+	if (light_power > LIGHTING_SOFT_MAXIMUM_RANGE)
+		STACK_TRACE("light_power > [LIGHTING_SOFT_MAXIMUM_POWER]; not useful")
 
 	if (!light_power || !light_range) // We won't emit light anyways, destroy the light source.
 		QDEL_NULL(light)

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -355,6 +355,8 @@ BLOCK_BYOND_BUG_2072419
 	else if (needs_update == LIGHTING_CHECK_UPDATE)
 		return	// No change.
 
+	ASSERT(light_range < 128)	// This is a BYOND level limit. Failing this assertion is always a bug in your code, not lighting.
+
 	var/list/datum/lighting_corner/corners = list()
 	var/list/turf/turfs                    = list()
 	var/thing


### PR DESCRIPTION
Some things are using unreasonable lighting values, and this is probably causing lag.
Lighting values of 128 or above are now hard rejected since they already didn't work, values of 64 or above emit a runtime but are still allowed.
A warning is also emitted when extreme `light_power` values are used, since it's usually a bug for it to be set above around 10.