### PR TITLE
Saw traps no longer automatically chop off legs and feet

### DIFF
--- a/code/game/objects/effects/traps.dm
+++ b/code/game/objects/effects/traps.dm
@@ -611,8 +611,7 @@ if (istype(AM, /mob/living))
 		var/list/target_limbs = list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT)
 		var/selected = pick(target_limbs)
 		var/obj/item/organ/external/target = M.get_organ(selected)
-		M.apply_damage(damage, DAMAGE_TYPE_BRUTE)
-		target.droplimb()
+		target.inflict_bodypart_damage(damage, 0, DAMAGE_MODE_SHARP | DAMAGE_MODE_SHRED, "spinning saw blade")
 		M.visible_message("<span class='danger'>[M] is ripped by the whirling sawblades!</span>", \
 						"<span class='userdanger'>You are ripped open by the whirling sawblades!</span>")
 

--- a/code/game/objects/effects/traps.dm
+++ b/code/game/objects/effects/traps.dm
@@ -555,8 +555,7 @@ Add those other swinging traps you mentioned above!
 		var/list/target_limbs = list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT)
 		var/selected = pick(target_limbs)
 		var/obj/item/organ/external/target = M.get_organ(selected)
-		M.apply_damage(damage, DAMAGE_TYPE_BRUTE)
-		target.droplimb()
+		target.inflict_bodypart_damage(damage, 0, DAMAGE_MODE_SHARP | DAMAGE_MODE_SHRED, "spinning saw blade")
 		M.visible_message("<span class='danger'>[M] is slashed by the spinning blades!</span>", \
 						"<span class='userdanger'>You are slashed by the spinning blades!</span>")
 


### PR DESCRIPTION

## About The Pull Request

Changed the saw traps to apply their damage directly to their targeted limb instead of immediately severing it.

This PR has been tested locally.

## Why It's Good For The Game

The saw traps in some exploration areas, for some reason, automatically sever your feet/legs when stepped on, on top of applying their actual damage. This seems overly harsh especially given the chaotic nature of exploration, so I have changed them to simply apply their damage to a leg/foot when stepped on. Their damage is enough to significantly injure someone with even a couple steps, and repeatedly walking into them if you are careless will eventually break/sever the limb anyway.

## Changelog
:cl:
balance: Saw traps will no longer immediately sever limbs when stepped on.
/:cl:
