### PR TITLE
Racking guns is now much quieter

### DIFF
--- a/code/modules/projectiles/guns/gun/projectile/ballistic.dm
+++ b/code/modules/projectiles/guns/gun/projectile/ballistic.dm
@@ -860,7 +860,7 @@
 	load_chamber()
 	if(!silent)
 		if(!from_fire)
-			playsound(src, chamber_manual_cycle_sound, 75, TRUE)
+			playsound(src, chamber_manual_cycle_sound, 25, TRUE)
 
 /**
  * Loads the chamber from magazine immediately, if it is separated


### PR DESCRIPTION

## About The Pull Request

The gun racking sound is now significantly quieter.

## Why It's Good For The Game

The previous volume was almost comically loud, especially considering how sharp the sound byte itself is. This makes it much more reasonable (and less panic-inducing whenever someone does rack a gun).

## Changelog
:cl:
tweak: Racking a gun's slide is now much quieter.
/:cl:
