### PR TITLE
Adds gas storage and fixes disposals in Endeavor Atmos

### DIFF
--- a/maps/stations/endeavour/levels/deck4.dmm
+++ b/maps/stations/endeavour/levels/deck4.dmm
@@ -59,11 +59,6 @@
 /obj/machinery/air_alarm/south_mount,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/chief)
-"acp" = (
-/obj/machinery/portable_atmospherics/canister/phoron,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled,
-/area/space)
 "add" = (
 /obj/machinery/door/airlock/hatch{
 	req_one_access = null
@@ -566,16 +561,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
-"ayC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/hydrogen,
-/obj/machinery/door/window/northright{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/space)
 "azA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -3199,13 +3184,6 @@
 /obj/item/flashlight/lamp/green/on,
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/heads/chief)
-"cLp" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/simulated/floor/tiled,
-/area/space)
 "cLC" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -5539,14 +5517,6 @@
 /obj/map_helper/paint/sun,
 /turf/simulated/floor/plating,
 /area/tcommsat/computer)
-"eQT" = (
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/northright{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/helium,
-/turf/simulated/floor/tiled,
-/area/space)
 "eRm" = (
 /obj/landmark/spawnpoint/job/botanist,
 /turf/simulated/floor/tiled,
@@ -7363,13 +7333,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_cyborg_station)
-"gwn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/hydrogen,
-/turf/simulated/floor/tiled,
-/area/space)
 "gww" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -8277,11 +8240,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/d4afthall/endeavour)
-"hoD" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled,
-/area/space)
 "hpu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 8
@@ -9155,16 +9113,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
-"hZT" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/northright{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/simulated/floor/tiled,
-/area/space)
 "ibo" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/structure/disposalpipe/segment{
@@ -13800,11 +13748,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/engineering/break_room/lower)
-"mlq" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled,
-/area/space)
 "mlO" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -17649,12 +17592,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/d4starboardforhall/endeavour)
 "pQq" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/northright{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/space/basic,
 /area/space)
 "pRw" = (
 /obj/effect/floor_decal/rust,
@@ -18789,14 +18727,6 @@
 	},
 /turf/simulated/wall/r_wall/prepainted/engineering,
 /area/tcommsat/chamber)
-"qRZ" = (
-/obj/machinery/portable_atmospherics/canister/phoron,
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/northright{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/space)
 "qSb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -19117,14 +19047,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/substation/deck4forward/endeavour)
-"rmP" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/structure/window/reinforced,
-/obj/machinery/camera/network/engineering{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/space)
 "rni" = (
 /obj/machinery/button/remote/blast_door{
 	id = "hangar_maint";
@@ -19316,14 +19238,6 @@
 "rvq" = (
 /turf/simulated/wall/prepainted/engineering,
 /area/engineering/locker_room)
-"rwh" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/northright{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/space)
 "rwT" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -21312,14 +21226,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/maintenance/security/lower)
-"tBs" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/portable_atmospherics/canister/helium,
-/turf/simulated/floor/tiled,
-/area/space)
 "tBK" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "Hangar Repair Bay";
@@ -23251,11 +23157,6 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/hallway/d4starboardforhall/endeavour)
-"vjF" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled,
-/area/space)
 "vjL" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -23769,14 +23670,6 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/engineering/hallway/lower)
-"vGP" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/door/window/northright{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled,
-/area/space)
 "vGV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
@@ -25140,14 +25033,6 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/hallway/d4afthall/endeavour)
-"wTf" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/northright{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/space)
 "wTv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 10
@@ -37297,14 +37182,14 @@ mKs
 jNg
 jNg
 jNg
-qRZ
 pQq
-wTf
-rwh
-vGP
-eQT
-ayC
-hZT
+pQq
+pQq
+pQq
+pQq
+pQq
+pQq
+pQq
 jNg
 jNg
 jNg
@@ -37491,14 +37376,14 @@ jNg
 jNg
 jNg
 jNg
-acp
-mlq
-vjF
-hoD
-rmP
-tBs
-gwn
-cLp
+pQq
+pQq
+pQq
+pQq
+pQq
+pQq
+pQq
+pQq
 jNg
 jNg
 jNg

--- a/maps/stations/endeavour/levels/deck4.dmm
+++ b/maps/stations/endeavour/levels/deck4.dmm
@@ -59,6 +59,11 @@
 /obj/machinery/air_alarm/south_mount,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/chief)
+"acp" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled,
+/area/space)
 "add" = (
 /obj/machinery/door/airlock/hatch{
 	req_one_access = null
@@ -561,6 +566,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
+"ayC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/hydrogen,
+/obj/machinery/door/window/northright{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/space)
 "azA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -1456,6 +1471,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/d4afthall/endeavour)
 "bkd" = (
@@ -1507,6 +1523,14 @@
 	},
 /turf/simulated/wall/prepainted/civilian,
 /area/crew_quarters/bar)
+"bnf" = (
+/obj/machinery/portable_atmospherics/canister/hydrogen,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "bny" = (
 /obj/effect/floor_decal/corner_oldtile/white/diagonal,
 /obj/machinery/appliance/mixer/candy,
@@ -1812,6 +1836,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/d4afthall/endeavour)
 "bEa" = (
@@ -1853,6 +1878,13 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/d4afthall/endeavour)
+"bEZ" = (
+/obj/machinery/portable_atmospherics/canister/helium,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "bGC" = (
 /turf/simulated/floor/reinforced/n20,
 /area/engineering/atmos)
@@ -2021,6 +2053,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/machinery/atmospherics/component/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/fireaxecabinet{
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
@@ -2521,9 +2557,10 @@
 /turf/simulated/floor/plating,
 /area/hallway/d4fwdportmaint/endeavour)
 "cjh" = (
-/obj/structure/closet/crate/mimic/closet/safe,
-/turf/simulated/floor/plating,
-/area/hallway/d4aftstrbdmaint/endeavour)
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "cjq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3162,6 +3199,13 @@
 /obj/item/flashlight/lamp/green/on,
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/heads/chief)
+"cLp" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/simulated/floor/tiled,
+/area/space)
 "cLC" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -5495,6 +5539,14 @@
 /obj/map_helper/paint/sun,
 /turf/simulated/floor/plating,
 /area/tcommsat/computer)
+"eQT" = (
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/northright{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/helium,
+/turf/simulated/floor/tiled,
+/area/space)
 "eRm" = (
 /obj/landmark/spawnpoint/job/botanist,
 /turf/simulated/floor/tiled,
@@ -6104,10 +6156,13 @@
 	},
 /area/tcommsat/chamber)
 "fym" = (
-/obj/structure/bed/padded,
-/obj/machinery/air_alarm/north_mount,
-/turf/simulated/floor/plating,
-/area/hallway/d4aftstrbdmaint/endeavour)
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/northright{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "fyE" = (
 /obj/machinery/telecomms/receiver/preset_right/endeavour,
 /turf/simulated/floor/tiled/dark{
@@ -6153,6 +6208,14 @@
 /obj/map_helper/access_helper/airlock/station/public,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/d4afthall/endeavour)
+"fzN" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/northright,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "fzO" = (
 /turf/simulated/wall/prepainted/civilian,
 /area/crew_quarters/barrestroom)
@@ -6965,9 +7028,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/d4porthall/endeavour)
 "gcr" = (
-/obj/item/strangerock,
-/turf/simulated/floor/plating,
-/area/hallway/d4aftstrbdmaint/endeavour)
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/northright{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "gdf" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -7232,9 +7299,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/d4porthall/endeavour)
 "gqV" = (
-/obj/structure/bed/padded,
-/turf/simulated/floor/plating,
-/area/hallway/d4aftstrbdmaint/endeavour)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/window/reinforced,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "grh" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/fueltank,
@@ -7292,6 +7363,13 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_cyborg_station)
+"gwn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/hydrogen,
+/turf/simulated/floor/tiled,
+/area/space)
 "gww" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -7376,6 +7454,14 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/bar)
+"gzu" = (
+/obj/machinery/portable_atmospherics/canister/helium,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/northright,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "gzJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8188,8 +8274,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/d4afthall/endeavour)
+"hoD" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled,
+/area/space)
 "hpu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 8
@@ -9009,6 +9101,14 @@
 /obj/machinery/air_alarm/north_mount,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/d4starboardafthall/endeavour)
+"hXp" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/northright{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "hYb" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -9055,6 +9155,16 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/portnacelle)
+"hZT" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window/northright{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/simulated/floor/tiled,
+/area/space)
 "ibo" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/structure/disposalpipe/segment{
@@ -9473,13 +9583,13 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/d4porthall/endeavour)
 "ivg" = (
-/obj/machinery/door/airlock/maintenance/engi,
-/obj/machinery/door/firedoor{
-	dir = 8
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/northright{
+	dir = 4
 	},
-/obj/map_helper/access_helper/airlock/station/maintenance,
-/turf/simulated/floor/plating,
-/area/hallway/d4aftstrbdmaint/endeavour)
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "ivx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10891,12 +11001,9 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/d4afthall/endeavour)
 "jDu" = (
-/obj/structure/bed/padded,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/hallway/d4aftstrbdmaint/endeavour)
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "jDF" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/lightorange/border,
@@ -12544,6 +12651,14 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/d4porthall/endeavour)
+"log" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "lou" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -12890,6 +13005,7 @@
 	dir = 8;
 	light_range = 12
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "lDl" = (
@@ -13684,6 +13800,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/engineering/break_room/lower)
+"mlq" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled,
+/area/space)
 "mlO" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -14076,6 +14197,12 @@
 "mCW" = (
 /turf/simulated/floor/plating,
 /area/engineering/workshop)
+"mDh" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "mDz" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -14866,6 +14993,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/d4afthall/endeavour)
+"noF" = (
+/obj/machinery/portable_atmospherics/canister/hydrogen,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/northright{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "npu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/machinery/telecomms/bus/preset_four,
@@ -16696,9 +16831,12 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "pbv" = (
-/obj/item/pickaxe/tyrmalin,
-/turf/simulated/floor/plating,
-/area/hallway/d4aftstrbdmaint/endeavour)
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "pbK" = (
 /obj/effect/floor_decal/corner_oldtile/white/diagonal,
 /obj/machinery/light/flamp/noshade{
@@ -17066,6 +17204,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "ptN" = (
@@ -17259,6 +17401,11 @@
 /obj/structure/sign/department/shield,
 /turf/simulated/wall/r_wall/prepainted/engineering,
 /area/engineering/shield_gen)
+"pDZ" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "pEa" = (
 /obj/structure/table/marble,
 /obj/machinery/door/firedoor{
@@ -17501,6 +17648,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/d4starboardforhall/endeavour)
+"pQq" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/northright{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/space)
 "pRw" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
@@ -18634,6 +18789,14 @@
 	},
 /turf/simulated/wall/r_wall/prepainted/engineering,
 /area/tcommsat/chamber)
+"qRZ" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/northright{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/space)
 "qSb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -18642,9 +18805,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/d4afthall/endeavour)
@@ -18664,6 +18826,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "qTm" = (
@@ -18955,9 +19118,13 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/substation/deck4forward/endeavour)
 "rmP" = (
-/obj/machinery/floodlight,
-/turf/simulated/floor/plating,
-/area/hallway/d4aftstrbdmaint/endeavour)
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/window/reinforced,
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/space)
 "rni" = (
 /obj/machinery/button/remote/blast_door{
 	id = "hangar_maint";
@@ -19095,6 +19262,13 @@
 /obj/structure/stairs/spawner/north,
 /turf/simulated/floor/tiled,
 /area/hallway/aft_stairs_four/endeavour)
+"rth" = (
+/obj/structure/sign/warning/compressed_gas{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "rtq" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
@@ -19132,9 +19306,24 @@
 /obj/map_helper/access_helper/airlock/station/maintenance,
 /turf/simulated/floor/plating,
 /area/hallway/d4aftstrbdmaint/endeavour)
+"ruF" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/door/window/northright{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "rvq" = (
 /turf/simulated/wall/prepainted/engineering,
 /area/engineering/locker_room)
+"rwh" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/northright{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/space)
 "rwT" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -20042,10 +20231,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "sxr" = (
-/obj/machinery/fire_alarm/east_mount{
-	dir = 4;
-	pixel_x = -21
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
@@ -20140,6 +20325,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel,
 /area/hallway/d4afthall/endeavour)
 "sCi" = (
@@ -21126,6 +21312,14 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/maintenance/security/lower)
+"tBs" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/portable_atmospherics/canister/helium,
+/turf/simulated/floor/tiled,
+/area/space)
 "tBK" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "Hangar Repair Bay";
@@ -21509,9 +21703,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/fireaxecabinet{
-	pixel_x = -32
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "tRS" = (
@@ -22345,10 +22536,6 @@
 /turf/simulated/floor/tiled/steel,
 /area/hallway/d4starboardafthall/endeavour)
 "uDT" = (
-/obj/machinery/air_alarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -22857,6 +23044,7 @@
 /obj/machinery/door/airlock/glass/atmos,
 /obj/machinery/door/firedoor/glass,
 /obj/map_helper/access_helper/airlock/station/engineering/department,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "vag" = (
@@ -23063,6 +23251,11 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/hallway/d4starboardforhall/endeavour)
+"vjF" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled,
+/area/space)
 "vjL" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -23576,6 +23769,14 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/engineering/hallway/lower)
+"vGP" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/door/window/northright{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled,
+/area/space)
 "vGV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
@@ -23962,6 +24163,7 @@
 /obj/machinery/atmospherics/component/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/machinery/air_alarm/east_mount,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "vWo" = (
@@ -24938,6 +25140,14 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/hallway/d4afthall/endeavour)
+"wTf" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/northright{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/space)
 "wTv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 10
@@ -26077,9 +26287,12 @@
 /turf/simulated/floor/plating,
 /area/hallway/d4fwdportmaint/endeavour)
 "xTD" = (
-/obj/item/pickaxe/icepick,
-/turf/simulated/floor/plating,
-/area/hallway/d4aftstrbdmaint/endeavour)
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos)
 "xTG" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -37084,14 +37297,14 @@ mKs
 jNg
 jNg
 jNg
-jNg
-jNg
-jNg
-jNg
-jNg
-jNg
-jNg
-jNg
+qRZ
+pQq
+wTf
+rwh
+vGP
+eQT
+ayC
+hZT
 jNg
 jNg
 jNg
@@ -37278,14 +37491,14 @@ jNg
 jNg
 jNg
 jNg
-jNg
-jNg
-jNg
-jNg
-jNg
-jNg
-jNg
-jNg
+acp
+mlq
+vjF
+hoD
+rmP
+tBs
+gwn
+cLp
 jNg
 jNg
 jNg
@@ -38438,12 +38651,12 @@ asH
 nLo
 alT
 pWf
-rmP
-uUN
-uUN
-uUN
-uUN
-uUN
+tqu
+tqu
+tqu
+tqu
+tqu
+tqu
 mKs
 jNg
 jNg
@@ -38632,12 +38845,12 @@ kkQ
 kkQ
 kkQ
 kkQ
-asH
-uUN
+tqu
+pDZ
 gqV
 cjh
 jDu
-uUN
+tqu
 jNg
 jNg
 jNg
@@ -38826,13 +39039,13 @@ jgy
 jgy
 kkQ
 kkQ
-kkQ
+tqu
 ivg
-kkQ
+hXp
 gcr
-kkQ
-uUN
-uUN
+ruF
+tqu
+tqu
 jNg
 jNg
 jNg
@@ -39020,14 +39233,14 @@ uyd
 uyd
 wqa
 euv
-kkQ
-uUN
-pbP
-kkQ
-gcr
+tqu
+rth
+kuh
+kuh
+kuh
 xTD
-uUN
-uUN
+tqu
+tqu
 jNg
 jNg
 jNg
@@ -39214,15 +39427,15 @@ tqu
 tqu
 wyp
 xWH
-pcf
-uUN
+tqu
+noF
 fym
-cjh
-gqV
-pcf
+kuh
+kuh
+fzN
 pbv
-uUN
-uUN
+tqu
+tqu
 bZN
 jNg
 jNg
@@ -39409,12 +39622,12 @@ tqu
 ycR
 vkX
 tqu
-tqu
-tqu
-tqu
-tqu
-tqu
-tqu
+bnf
+log
+mDh
+mDh
+gzu
+bEZ
 tqu
 tqu
 eAZ


### PR DESCRIPTION

## About The Pull Request

Adds a canister storage area in Endeavor's atmospherics, and fixes a disconnected disposals bin in the same area.

<img width="644" height="898" alt="image" src="https://github.com/user-attachments/assets/eecef300-12b9-40e7-b94d-1f94d5c4da37" />


## Why It's Good For The Game

Self-explanatory I think?

## Changelog
:cl:
add: Added a new gas canister storage area to the NSV Endeavor's atmospherics.
fix: Fixed a disconnected disposal chute in the NSV Endeavor's atmospherics.
/:cl:
