### PR TITLE
Requests consoles now announce over radio

### DIFF
--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -74,6 +74,11 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 	light_range = 0
 	var/datum/legacy_announcement/announcement = new
 
+	/// Radio channel on which to announce incoming messages. Usually the channel belonging to its department. If unset, it will not broadcast any messages.
+	var/channel
+	var/obj/item/radio/radio
+
+
 /obj/machinery/requests_console/Initialize(mapload, newdir)
 	. = ..()
 
@@ -81,6 +86,21 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 	announcement.newscast = 1
 
 	name = "[department] requests console"
+
+	if(channel)
+		//Checking for duplicates. Only one console per department should be transmitting.
+		//Essentially, if we're the first console of this department to initialize that has a radio, we will be the one to transmit.
+		var/departmentAlreadyHasRadio = FALSE
+		for(var/obj/machinery/requests_console/Console in allConsoles)
+			if(Console.department == department && Console.channel == channel)
+				departmentAlreadyHasRadio = TRUE
+				break
+		if(!departmentAlreadyHasRadio)
+			radio = new /obj/item/radio/headset/nanotrasen(src) //Required for the radio to have the proper encryption key.
+			radio.icon = 'icons/obj/robot_component.dmi'
+			radio.icon_state = "radio"
+			radio.channels = list(channel)
+
 	allConsoles += src
 	if(departmentType)
 		if(departmentType & RC_ASSIST)
@@ -89,7 +109,6 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 			req_console_supplies |= department
 		if(departmentType & RC_INFO)
 			req_console_information |= department
-
 	set_light(1)
 
 /obj/machinery/requests_console/Destroy()
@@ -316,42 +335,50 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 	name = "Cargo RC"
 	department = "Cargo Bay"
 	departmentType = RC_SUPPLY
+	channel = "Cargo"
 
 /obj/machinery/requests_console/preset/security
 	name = "Security RC"
 	department = "Security"
 	departmentType = RC_ASSIST
+	channel = "Security"
 
 /obj/machinery/requests_console/preset/engineering
 	name = "Engineering RC"
 	department = "Engineering"
 	departmentType = RC_ASSIST|RC_SUPPLY
+	channel = "Engineering"
 
 /obj/machinery/requests_console/preset/atmos
 	name = "Atmospherics RC"
 	department = "Atmospherics"
 	departmentType = RC_ASSIST|RC_SUPPLY
+	channel = "Engineering"
 
 /obj/machinery/requests_console/preset/medical
 	name = "Medical RC"
 	department = "Medical Department"
 	departmentType = RC_ASSIST|RC_SUPPLY
+	channel = "Medical"
 
 /obj/machinery/requests_console/preset/research
 	name = "Research RC"
 	department = "Research Department"
 	departmentType = RC_ASSIST|RC_SUPPLY
+	channel = "Science"
 
 /obj/machinery/requests_console/preset/janitor
 	name = "Janitor RC"
 	department = "Janitorial"
 	departmentType = RC_ASSIST
+	channel = "Service"
 
 /obj/machinery/requests_console/preset/bridge
 	name = "Bridge RC"
 	department = "Bridge"
 	departmentType = RC_ASSIST|RC_INFO
 	announcementConsole = 1
+	channel = "Command"
 
 // Heads
 
@@ -360,32 +387,38 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 	department = "Chief Engineer's Desk"
 	departmentType = RC_ASSIST|RC_INFO
 	announcementConsole = 1
+	channel = "Command"
 
 /obj/machinery/requests_console/preset/cmo
 	name = "Chief Medical Officer RC"
 	department = "Chief Medical Officer's Desk"
 	departmentType = RC_ASSIST|RC_INFO
 	announcementConsole = 1
+	channel = "Command"
 
 /obj/machinery/requests_console/preset/hos
 	name = "Head of Security RC"
 	department = "Head of Security's Desk"
 	departmentType = RC_ASSIST|RC_INFO
 	announcementConsole = 1
+	channel = "Command"
 
 /obj/machinery/requests_console/preset/rd
 	name = "Research Director RC"
 	department = "Research Director's Desk"
 	departmentType = RC_ASSIST|RC_INFO
 	announcementConsole = 1
+	channel = "Command"
 
 /obj/machinery/requests_console/preset/captain
 	name = "Captain RC"
 	department = "Captain's Desk"
 	departmentType = RC_ASSIST|RC_INFO
 	announcementConsole = 1
+	channel = "Command"
 
 /obj/machinery/requests_console/preset/ai
 	name = "AI RC"
 	department = "AI"
 	departmentType = RC_ASSIST|RC_INFO
+	channel = "AI Private"

--- a/code/game/machinery/telecomms/message_server.dm
+++ b/code/game/machinery/telecomms/message_server.dm
@@ -129,6 +129,8 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 							hearing_distance = 5,
 						)
 					Console.message_log += "<B><FONT color='red'>High Priority message from <A href='?src=\ref[Console];write=[sender]'>[sender]</A></FONT></B><BR>[authmsg]"
+					if(Console.radio)
+						Console.radio.autosay("High Priority message received from [sender].", Console, "department")
 				else
 					if(!Console.silent)
 						playsound(Console.loc, 'sound/machines/twobeep.ogg', 50, 1)
@@ -137,6 +139,8 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 							hearing_distance = 4,
 						)
 					Console.message_log += "<B>Message from <A href='?src=\ref[Console];write=[sender]'>[sender]</A></B><BR>[authmsg]"
+					if(Console.radio)
+						Console.radio.autosay("Message received from [sender].", Console, "department")
 			Console.set_light(2)
 
 


### PR DESCRIPTION

## About The Pull Request

Requests consoles will now announce incoming messages over a radio channel, if applicable. Each requests console now has a `channel` variable indicating the (plaintext) channel via which it should transmit messages. I've added channels to the preset designs, but mappers can easily adjust this when necessary.

Example of how this looks in-game:
<img width="762" height="154" alt="image" src="https://github.com/user-attachments/assets/14fbd34d-dfb7-4733-8ef8-e6ff0ae17584" />

Example of the greytide event (which is the most frequent "use" of a requests console):
<img width="895" height="27" alt="image" src="https://github.com/user-attachments/assets/925144d5-7196-443e-80b5-f5e51f057a38" />


## Why It's Good For The Game

Right now, requests consoles are pretty useless as even when someone wants to use them, it is extremely rare that the recipient actually realizes that they have received a message, much less reads it. This aims to alleviate that problem and provide a stronger reason to use request consoles to relay information, similar to how PDA relays are used to contact an entire department.

## Changelog
:cl:
add: Requests consoles will now transmit via their department's radio when they have received a new message.
/:cl:
