### PR TITLE
Adds another window to Atlas HoP Office

### DIFF
--- a/maps/stations/rift/map_files/rift-06-surface3.dmm
+++ b/maps/stations/rift/map_files/rift-06-surface3.dmm
@@ -12694,10 +12694,6 @@
 	name = "Head of Personnel RC";
 	pixel_y = 32
 	},
-/obj/machinery/keycard_auth{
-	pixel_x = -28;
-	pixel_y = 6
-	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "aNT" = (
@@ -13603,6 +13599,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
+	},
+/obj/machinery/fire_alarm/south_mount{
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hop)
@@ -20696,6 +20695,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
+"hVz" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/department/armory{
+	desc = "A warning sign for anyone entering the station.";
+	name = "SUBMIT WEAPONS PRIOR TO ENTRY";
+	pixel_x = -32
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/hallway/secondary/docking_hallway2)
 "hXj" = (
 /turf/simulated/wall/prepainted/exploration,
 /area/exploration/explorer_prep)
@@ -23516,19 +23535,11 @@
 /turf/simulated/floor/outdoors/snow/lythios43c,
 /area/rift/surfacebase/outside/outside3)
 "mVj" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 4
-	},
-/obj/structure/sign/department/armory{
-	desc = "A warning sign for anyone entering the station.";
-	name = "SUBMIT WEAPONS PRIOR TO ENTRY";
-	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27544,6 +27555,24 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"vac" = (
+/obj/spawner/window/low_wall/reinforced/electrochromic/firelocks{
+	id = "hop_office"
+	},
+/obj/map_helper/paint/commandblue,
+/obj/map_helper/electrochromatic_linker{
+	id = "hop-office"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "hop_office_shutters";
+	name = "HoP Office Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/hop)
 "vak" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/structure/window/reinforced,
@@ -28547,9 +28576,19 @@
 /obj/structure/bed/chair/bay/comfy/black,
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = 26
+	pixel_y = 26;
+	pixel_x = 4
 	},
 /obj/landmark/spawnpoint/job/head_of_personnel,
+/obj/machinery/keycard_auth{
+	pixel_y = 26;
+	pixel_x = -7
+	},
+/obj/machinery/button/windowtint{
+	id = "hop-office";
+	pixel_x = 11;
+	pixel_y = 27
+	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "wnH" = (
@@ -46476,7 +46515,7 @@ nNR
 aYR
 aYR
 aYR
-aYR
+hVz
 qdx
 aKq
 ahP
@@ -46864,8 +46903,8 @@ qxq
 qxq
 fin
 bPV
-bPV
-bPV
+vac
+vac
 bPV
 bPV
 bPV


### PR DESCRIPTION

## About The Pull Request

Adds another window to the HoP's office on the Atlas, giving their primary desk some natural light.

<img width="769" height="764" alt="image" src="https://github.com/user-attachments/assets/7958ba0a-e493-4af2-9631-ef30798779bc" />


<img width="866" height="969" alt="image" src="https://github.com/user-attachments/assets/eaa2cb19-0d42-4147-931a-3a9b0df161c9" />

## Why It's Good For The Game

Right now the HoP kind of gets sequestered away whenever they spend time at their normal desk and not their line desk. This helps fix that and adds a bit more variety to people walking past the hallway.

## Changelog
:cl:
add: Added another window to the Head of Personnel's office on the NSB Atlas.
/:cl:
